### PR TITLE
fix: support Claude Code subscription routing

### DIFF
--- a/.changeset/claude-code-subscription-routing.md
+++ b/.changeset/claude-code-subscription-routing.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Make Anthropic Claude Code subscription OAuth and routing match the Claude Code flow: exchange tokens through the Claude Code API host, avoid connect-time probes, and use Claude Code-compatible request headers. Also fix Anthropic OAuth pending-flow consumption so the saved provider keeps the correct agent and user IDs.

--- a/packages/backend/src/common/constants/subscription-clients.ts
+++ b/packages/backend/src/common/constants/subscription-clients.ts
@@ -17,5 +17,67 @@ export const CODEX_CLI_VERSION = '0.128.0';
 export const CODEX_CLI_ORIGINATOR = 'codex_cli_rs';
 export const CODEX_CLI_USER_AGENT = 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown';
 
+export const CLAUDE_CODE_USER_AGENT = 'claude-cli/2.1.92 (external, sdk-cli)';
+export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.80.0';
+export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v24.14.0';
+export const CLAUDE_CODE_BETA_FLAGS = [
+  'claude-code-20250219',
+  'oauth-2025-04-20',
+  'interleaved-thinking-2025-05-14',
+  'context-management-2025-06-27',
+  'prompt-caching-scope-2026-01-05',
+  'advanced-tool-use-2025-11-20',
+  'effort-2025-11-24',
+  'structured-outputs-2025-12-15',
+  'fast-mode-2026-02-01',
+  'redact-thinking-2026-02-12',
+  'token-efficient-tools-2026-03-28',
+].join(',');
+
+function claudeCodeStainlessArch(arch = process.arch): string {
+  switch (arch) {
+    case 'arm64':
+      return 'arm64';
+    case 'x64':
+      return 'x64';
+    default:
+      return `Other:${arch}`;
+  }
+}
+
+function claudeCodeStainlessOs(platform = process.platform): string {
+  switch (platform) {
+    case 'darwin':
+      return 'MacOS';
+    case 'linux':
+      return 'Linux';
+    case 'win32':
+      return 'Windows';
+    case 'freebsd':
+      return 'FreeBSD';
+    default:
+      return `Other:${platform}`;
+  }
+}
+
+export const buildClaudeCodeSubscriptionHeaders = (apiKey: string): Record<string, string> => ({
+  Authorization: `Bearer ${apiKey}`,
+  'Content-Type': 'application/json',
+  'anthropic-version': '2023-06-01',
+  'anthropic-beta': CLAUDE_CODE_BETA_FLAGS,
+  'anthropic-dangerous-direct-browser-access': 'true',
+  'user-agent': CLAUDE_CODE_USER_AGENT,
+  'x-app': 'cli',
+  'x-stainless-arch': claudeCodeStainlessArch(),
+  'x-stainless-helper-method': 'stream',
+  'x-stainless-lang': 'js',
+  'x-stainless-os': claudeCodeStainlessOs(),
+  'x-stainless-package-version': CLAUDE_CODE_STAINLESS_PACKAGE_VERSION,
+  'x-stainless-retry-count': '0',
+  'x-stainless-runtime': 'node',
+  'x-stainless-runtime-version': CLAUDE_CODE_STAINLESS_RUNTIME_VERSION,
+  'x-stainless-timeout': '600',
+});
+
 export const COPILOT_EDITOR_VERSION = 'vscode/1.100.0';
 export const COPILOT_PLUGIN_VERSION = 'copilot/1.300.0';

--- a/packages/backend/src/common/constants/subscription-clients.ts
+++ b/packages/backend/src/common/constants/subscription-clients.ts
@@ -20,19 +20,7 @@ export const CODEX_CLI_USER_AGENT = 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unk
 export const CLAUDE_CODE_USER_AGENT = 'claude-cli/2.1.92 (external, sdk-cli)';
 export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.80.0';
 export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v24.14.0';
-export const CLAUDE_CODE_BETA_FLAGS = [
-  'claude-code-20250219',
-  'oauth-2025-04-20',
-  'interleaved-thinking-2025-05-14',
-  'context-management-2025-06-27',
-  'prompt-caching-scope-2026-01-05',
-  'advanced-tool-use-2025-11-20',
-  'effort-2025-11-24',
-  'structured-outputs-2025-12-15',
-  'fast-mode-2026-02-01',
-  'redact-thinking-2026-02-12',
-  'token-efficient-tools-2026-03-28',
-].join(',');
+export const CLAUDE_CODE_BETA_FLAGS = ['claude-code-20250219', 'oauth-2025-04-20'].join(',');
 
 function claudeCodeStainlessArch(arch = process.arch): string {
   switch (arch) {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -15,12 +15,7 @@ jest.mock('../database/quality-score.util', () => ({
   computeQualityScore: jest.fn().mockReturnValue(3),
 }));
 
-jest.mock('./anthropic-subscription-probe', () => ({
-  filterBySubscriptionAccess: jest.fn().mockImplementation((models: unknown[]) => models),
-}));
-
 import { decrypt, getEncryptionSecret } from '../common/utils/crypto.util';
-import { filterBySubscriptionAccess } from './anthropic-subscription-probe';
 import { computeQualityScore } from '../database/quality-score.util';
 
 const mockDecrypt = decrypt as jest.MockedFunction<typeof decrypt>;
@@ -1339,7 +1334,7 @@ describe('ModelDiscoveryService', () => {
       );
     });
 
-    it('should not unwrap blob for non-OpenAI subscription providers', async () => {
+    it('should not unwrap blob for non-OAuth subscription providers', async () => {
       const blob = JSON.stringify({ t: 'access-token', r: 'refresh', e: Date.now() + 60000 });
       mockDecrypt.mockReturnValue(blob);
 
@@ -1347,30 +1342,23 @@ describe('ModelDiscoveryService', () => {
 
       await service.discoverModels(
         makeProvider({
-          provider: 'anthropic',
+          provider: 'qwen',
           auth_type: 'subscription',
           api_key_encrypted: 'encrypted-blob',
         }),
       );
 
-      // Should pass the raw JSON string for Anthropic (no unwrapping)
-      expect(fetcher.fetch).toHaveBeenCalledWith('anthropic', blob, 'subscription', undefined);
+      expect(fetcher.fetch).toHaveBeenCalledWith('qwen', blob, 'subscription', undefined);
     });
 
-    it('should call filterBySubscriptionAccess for Anthropic subscription providers', async () => {
-      const token = 'sk-ant-oat01-test-token';
-      mockDecrypt.mockReturnValue(token);
-
-      const models = [
-        makeModel({ id: 'claude-haiku-4-5-20251001', provider: 'anthropic' }),
-        makeModel({ id: 'claude-sonnet-4-6', provider: 'anthropic' }),
-      ];
-      fetcher.fetch.mockResolvedValue(models);
-
-      const mockFilter = filterBySubscriptionAccess as jest.MockedFunction<
-        typeof filterBySubscriptionAccess
-      >;
-      mockFilter.mockResolvedValue([models[0]]);
+    it('should use curated models for Anthropic subscription providers without live discovery probes', async () => {
+      mockDecrypt.mockReturnValue(
+        JSON.stringify({
+          t: 'access-token',
+          r: 'refresh',
+          e: Date.now() + 60000,
+        }),
+      );
 
       const result = await service.discoverModels(
         makeProvider({
@@ -1380,54 +1368,12 @@ describe('ModelDiscoveryService', () => {
         }),
       );
 
-      expect(mockFilter).toHaveBeenCalledWith(models, token);
-      expect(result.map((m) => m.id)).toEqual(['claude-haiku-4-5-20251001']);
-    });
-
-    it('should NOT call filterBySubscriptionAccess for Anthropic API key providers', async () => {
-      mockDecrypt.mockReturnValue('sk-ant-api03-test-key');
-
-      fetcher.fetch.mockResolvedValue([
-        makeModel({ id: 'claude-sonnet-4-6', provider: 'anthropic' }),
+      expect(fetcher.fetch).not.toHaveBeenCalled();
+      expect(result.map((m) => m.id)).toEqual([
+        'claude-opus-4',
+        'claude-sonnet-4',
+        'claude-haiku-4',
       ]);
-
-      const mockFilter = filterBySubscriptionAccess as jest.MockedFunction<
-        typeof filterBySubscriptionAccess
-      >;
-      mockFilter.mockClear();
-
-      await service.discoverModels(
-        makeProvider({
-          provider: 'anthropic',
-          auth_type: 'api_key',
-          api_key_encrypted: 'encrypted',
-        }),
-      );
-
-      expect(mockFilter).not.toHaveBeenCalled();
-    });
-
-    it('should NOT call filterBySubscriptionAccess for non-Anthropic subscription providers', async () => {
-      mockDecrypt.mockReturnValue(
-        JSON.stringify({ t: 'token', r: 'refresh', e: Date.now() + 60000 }),
-      );
-
-      fetcher.fetch.mockResolvedValue([makeModel({ id: 'gpt-4o', provider: 'openai' })]);
-
-      const mockFilter = filterBySubscriptionAccess as jest.MockedFunction<
-        typeof filterBySubscriptionAccess
-      >;
-      mockFilter.mockClear();
-
-      await service.discoverModels(
-        makeProvider({
-          provider: 'openai',
-          auth_type: 'subscription',
-          api_key_encrypted: 'encrypted',
-        }),
-      );
-
-      expect(mockFilter).not.toHaveBeenCalled();
     });
 
     it('should unwrap MiniMax OAuth blob and forward resource URL for subscription discovery', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -21,7 +21,6 @@ import {
 } from '../routing/xiaomi-region';
 import { getZaiCodingPlanBaseUrl } from '../routing/zai-region';
 import { CopilotTokenService } from '../routing/proxy/copilot-token.service';
-import { filterBySubscriptionAccess } from './anthropic-subscription-probe';
 import {
   findOpenRouterPrefix,
   lookupWithVariants,
@@ -101,6 +100,7 @@ export class ModelDiscoveryService {
     if (provider.auth_type === 'subscription' && apiKey) {
       if (
         lowerProvider === 'openai' ||
+        lowerProvider === 'anthropic' ||
         lowerProvider === 'minimax' ||
         lowerProvider === 'kiro' ||
         lowerProvider === 'xai'
@@ -154,12 +154,17 @@ export class ModelDiscoveryService {
 
     let raw: DiscoveredModel[];
 
-    // Subscription providers without a token: use curated fallback
-    if (provider.auth_type === 'subscription' && !apiKey) {
+    const useCuratedSubscriptionModels =
+      provider.auth_type === 'subscription' && (!apiKey || lowerProvider === 'anthropic');
+
+    // Subscription providers without a token use curated fallback. Anthropic
+    // subscription discovery is also static so connecting Claude Code does
+    // not spend live /models or /messages calls before the first real request.
+    if (useCuratedSubscriptionModels) {
       raw = buildSubscriptionFallbackModels(this.pricingSync, provider.provider);
       if (raw.length > 0) {
         this.logger.log(
-          `No token for subscription provider ${provider.provider} — using ${raw.length} fallback models`,
+          `Subscription provider ${provider.provider} — using ${raw.length} curated models`,
         );
       }
     } else {
@@ -214,13 +219,6 @@ export class ModelDiscoveryService {
     // always select them, even if the live API or OpenRouter didn't return them.
     if (provider.auth_type === 'subscription') {
       raw = supplementWithKnownModels(raw, provider.provider);
-    }
-
-    // Anthropic subscription tokens may only access certain model families
-    // (e.g. Pro = haiku only, Team = haiku + sonnet). Probe one model per
-    // family to filter out inaccessible models before showing them to the user.
-    if (lowerProvider === 'anthropic' && provider.auth_type === 'subscription' && apiKey) {
-      raw = await filterBySubscriptionAccess(raw, apiKey);
     }
 
     // Preserve the full AuthType union (api_key / subscription / local) —

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1278,7 +1278,7 @@ describe('ProviderModelFetcherService', () => {
       );
     });
 
-    it('should send bearer header + beta for subscription auth', async () => {
+    it('should send Claude Code-shaped bearer headers for subscription auth', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({ data: [] }),
@@ -1292,10 +1292,15 @@ describe('ProviderModelFetcherService', () => {
           headers: expect.objectContaining({
             'anthropic-version': '2023-06-01',
             Authorization: 'Bearer token',
-            'anthropic-beta': 'oauth-2025-04-20',
+            'anthropic-beta': expect.stringContaining('claude-code-20250219'),
+            'anthropic-dangerous-direct-browser-access': 'true',
+            'user-agent': expect.stringContaining('claude-cli/'),
+            'x-app': 'cli',
           }),
         }),
       );
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers['anthropic-beta']).toContain('oauth-2025-04-20');
     });
   });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -7,6 +7,7 @@ import {
   CODEX_CLI_VERSION,
   COPILOT_EDITOR_VERSION,
   COPILOT_PLUGIN_VERSION,
+  buildClaudeCodeSubscriptionHeaders,
 } from '../common/constants/subscription-clients';
 import { normalizeMinimaxSubscriptionBaseUrl } from '../routing/provider-base-url';
 import { getQwenCompatibleBaseUrl, normalizeQwenCompatibleBaseUrl } from '../routing/qwen-region';
@@ -636,8 +637,7 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
         'anthropic-version': '2023-06-01',
       };
       if (authType === 'subscription') {
-        headers['Authorization'] = `Bearer ${key}`;
-        headers['anthropic-beta'] = 'oauth-2025-04-20';
+        return buildClaudeCodeSubscriptionHeaders(key);
       } else {
         headers['x-api-key'] = key;
       }

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.config.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.config.ts
@@ -7,12 +7,13 @@
  *
  * The flow is PKCE with a manual paste-code step: Anthropic's redirect URI
  * is a console page that displays the authorization code (formatted as
- * `<code>#<state>`) for the user to copy back into Manifest.
+ * `<code>#<state>`) for the user to copy back into Manifest. Token exchange
+ * uses the Claude Code API host, matching Claude Code-compatible routers.
  */
 export const ANTHROPIC_OAUTH = {
   CLIENT_ID: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   AUTHORIZE_URL: 'https://claude.ai/oauth/authorize',
-  TOKEN_URL: 'https://console.anthropic.com/v1/oauth/token',
+  TOKEN_URL: 'https://api.anthropic.com/v1/oauth/token',
   REDIRECT_URI: 'https://console.anthropic.com/oauth/code/callback',
   SCOPE: 'org:create_api_key user:profile user:inference',
   /** Pending authorize state lives this long before the user must restart. */

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -209,8 +209,10 @@ describe('AnthropicOauthService', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [tokenUrl, init] = fetchMock.mock.calls[0];
       expect(tokenUrl).toBe(ANTHROPIC_OAUTH.TOKEN_URL);
+      expect(new URL(tokenUrl).origin).toBe('https://api.anthropic.com');
       expect(init.headers).toEqual({
         'Content-Type': 'application/json',
+        Accept: 'application/json',
         'User-Agent': 'anthropic',
       });
       const body = JSON.parse(init.body);
@@ -361,6 +363,7 @@ describe('AnthropicOauthService', () => {
       expect(blob).toEqual({ t: 'a2', r: 'r2', e: Date.now() + 1800 * 1000 });
       expect(fetchMock.mock.calls[0][1].headers).toEqual({
         'Content-Type': 'application/json',
+        Accept: 'application/json',
         'User-Agent': 'anthropic',
       });
     });

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -38,6 +38,7 @@ export class AnthropicOauthExchangeError extends Error {
 const PROVIDER = 'anthropic';
 const ANTHROPIC_OAUTH_TOKEN_HEADERS = {
   'Content-Type': 'application/json',
+  Accept: 'application/json',
   'User-Agent': 'anthropic',
 } as const;
 

--- a/packages/backend/src/routing/oauth/core/oauth-pending-flow.store.spec.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-pending-flow.store.spec.ts
@@ -73,6 +73,29 @@ describe('OAuthPendingFlowStore', () => {
     expect(query.mock.calls[0][0]).toContain('AND "expires_at" > NOW()');
   });
 
+  it('unwraps Postgres DELETE RETURNING tuples when consuming a pending flow', async () => {
+    const { store, query } = buildStore();
+    query.mockResolvedValue([
+      [
+        {
+          provider: 'anthropic',
+          state: 's1',
+          code_verifier: 'v1',
+          agent_id: 'agent-1',
+          user_id: 'user-1',
+          expires_at: new Date('2026-05-01T12:10:00Z'),
+        },
+      ],
+      1,
+    ]);
+
+    await expect(store.consume('anthropic', 's1', 'agent-1', 'user-1')).resolves.toMatchObject({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      verifier: 'v1',
+    });
+  });
+
   it('returns null when no pending flow matches', async () => {
     const { store, query } = buildStore();
     query.mockResolvedValue([]);

--- a/packages/backend/src/routing/oauth/core/oauth-pending-flow.store.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-pending-flow.store.ts
@@ -64,7 +64,7 @@ export class OAuthPendingFlowStore {
     agentId: string,
     userId: string,
   ): Promise<OAuthPendingFlowRecord | null> {
-    const rows = (await this.dataSource.query(
+    const result = await this.dataSource.query(
       `
         DELETE FROM "oauth_pending_flows"
         WHERE "provider" = $1
@@ -75,7 +75,8 @@ export class OAuthPendingFlowStore {
         RETURNING "provider", "state", "code_verifier", "agent_id", "user_id", "expires_at"
       `,
       [provider, state, agentId, userId],
-    )) as RawOAuthPendingFlow[];
+    );
+    const rows = queryRows<RawOAuthPendingFlow>(result);
 
     return rows[0] ? mapRow(rows[0]) : null;
   }
@@ -169,4 +170,16 @@ function mapRow(row: RawOAuthPendingFlow): OAuthPendingFlowRecord {
     userId: row.user_id,
     expiresAt,
   };
+}
+
+function queryRows<T>(result: unknown): T[] {
+  if (
+    Array.isArray(result) &&
+    result.length === 2 &&
+    Array.isArray(result[0]) &&
+    typeof result[1] === 'number'
+  ) {
+    return result[0] as T[];
+  }
+  return result as T[];
 }

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
@@ -48,7 +48,7 @@ describe('ProviderClient — strict header contract on auth-critical paths', () 
     expect(sentHeaders).not.toHaveProperty('anthropic-beta');
   });
 
-  it('Anthropic subscription path sends Authorization Bearer + oauth beta (and NO x-api-key)', async () => {
+  it('Anthropic subscription path sends Claude Code-shaped Bearer headers (and NO x-api-key)', async () => {
     mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
     await client.forward({
@@ -65,8 +65,21 @@ describe('ProviderClient — strict header contract on auth-critical paths', () 
       Authorization: 'Bearer sk-ant-oat-token',
       'Content-Type': 'application/json',
       'anthropic-version': '2023-06-01',
-      'anthropic-beta': 'oauth-2025-04-20',
+      'anthropic-beta': expect.stringContaining('claude-code-20250219'),
+      'anthropic-dangerous-direct-browser-access': 'true',
+      'user-agent': expect.stringContaining('claude-cli/'),
+      'x-app': 'cli',
+      'x-stainless-arch': expect.any(String),
+      'x-stainless-helper-method': 'stream',
+      'x-stainless-lang': 'js',
+      'x-stainless-os': expect.any(String),
+      'x-stainless-package-version': expect.any(String),
+      'x-stainless-retry-count': '0',
+      'x-stainless-runtime': 'node',
+      'x-stainless-runtime-version': expect.any(String),
+      'x-stainless-timeout': '600',
     });
+    expect(sentHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
     expect(sentHeaders).not.toHaveProperty('x-api-key');
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
@@ -80,6 +80,7 @@ describe('ProviderClient — strict header contract on auth-critical paths', () 
       'x-stainless-timeout': '600',
     });
     expect(sentHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
+    expect(sentHeaders['anthropic-beta']).not.toContain('prompt-caching-scope-2026-01-05');
     expect(sentHeaders).not.toHaveProperty('x-api-key');
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -313,10 +313,16 @@ describe('PROVIDER_ENDPOINTS', () => {
     expect(headers['Authorization']).toBeUndefined();
   });
 
-  it('anthropic uses Bearer + oauth beta header for subscription auth', () => {
+  it('anthropic uses Claude Code-shaped headers for subscription auth', () => {
     const headers = PROVIDER_ENDPOINTS['anthropic'].buildHeaders('skst-token', 'subscription');
     expect(headers['Authorization']).toBe('Bearer skst-token');
-    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20');
+    expect(headers['anthropic-beta']).toContain('claude-code-20250219');
+    expect(headers['anthropic-beta']).toContain('oauth-2025-04-20');
+    expect(headers['anthropic-dangerous-direct-browser-access']).toBe('true');
+    expect(headers['user-agent']).toContain('claude-cli/');
+    expect(headers['x-app']).toBe('cli');
+    expect(headers['x-stainless-runtime']).toBe('node');
+    expect(headers['x-stainless-lang']).toBe('js');
     expect(headers['x-api-key']).toBeUndefined();
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -184,6 +184,50 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
     expect(providerClient.forward).toHaveBeenCalledTimes(1);
   });
 
+  it('evicts an active cooldown when the cooldown cache is full', async () => {
+    const cooldowns = (service as unknown as { rateLimitCooldowns: Map<string, number> })
+      .rateLimitCooldowns;
+    const now = Date.now();
+    for (let i = 0; i < 2_000; i += 1) {
+      cooldowns.set(
+        `agent-1\u0000anthropic\u0000subscription\u0000Key ${i}\u0000model-${i}`,
+        now + i + 1,
+      );
+    }
+
+    providerClient.forward.mockResolvedValueOnce({
+      response: new Response('rate limit', {
+        status: 429,
+        headers: { 'retry-after': '120' },
+      }),
+      isGoogle: false,
+      isAnthropic: true,
+      isChatGpt: false,
+    });
+
+    await service.tryForwardToProvider({
+      provider: 'anthropic',
+      apiKey: 'sk-ant-oat-token',
+      model: 'claude-sonnet-4-6',
+      body,
+      stream: false,
+      sessionKey: 'sess-1',
+      agentId: 'agent-1',
+      providerKeyLabel: 'Claude Code',
+      authType: 'subscription',
+    });
+
+    expect(cooldowns.size).toBe(2_000);
+    expect(cooldowns.has('agent-1\u0000anthropic\u0000subscription\u0000Key 0\u0000model-0')).toBe(
+      false,
+    );
+    expect(
+      cooldowns.has(
+        'agent-1\u0000anthropic\u0000subscription\u0000Claude Code\u0000claude-sonnet-4-6',
+      ),
+    ).toBe(true);
+  });
+
   it('does NOT short-circuit on 401 auth errors — continues to next route (current contract)', async () => {
     // shouldTriggerFallback(401) === true, so an auth failure on the first
     // route keeps the loop going. This test pins that behavior: if anyone

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -187,11 +187,11 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
   it('evicts an active cooldown when the cooldown cache is full', async () => {
     const cooldowns = (service as unknown as { rateLimitCooldowns: Map<string, number> })
       .rateLimitCooldowns;
-    const now = Date.now();
+    const farFuture = Date.now() + 60_000;
     for (let i = 0; i < 2_000; i += 1) {
       cooldowns.set(
         `agent-1\u0000anthropic\u0000subscription\u0000Key ${i}\u0000model-${i}`,
-        now + i + 1,
+        farFuture + i,
       );
     }
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -151,6 +151,39 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
     expect(result.failures.map((f) => f.provider)).toEqual(['openai', 'anthropic']);
   });
 
+  it('cooldowns repeated 429 attempts for the same provider key and model', async () => {
+    providerClient.forward.mockResolvedValueOnce({
+      response: new Response('rate limit', {
+        status: 429,
+        headers: { 'retry-after': '120' },
+      }),
+      isGoogle: false,
+      isAnthropic: true,
+      isChatGpt: false,
+    });
+
+    const opts = {
+      provider: 'anthropic',
+      apiKey: 'sk-ant-oat-token',
+      model: 'claude-sonnet-4-6',
+      body,
+      stream: false,
+      sessionKey: 'sess-1',
+      agentId: 'agent-1',
+      providerKeyLabel: 'Claude Code',
+      authType: 'subscription',
+    };
+
+    const first = await service.tryForwardToProvider(opts);
+    const second = await service.tryForwardToProvider(opts);
+
+    expect(first.response.status).toBe(429);
+    expect(second.response.status).toBe(429);
+    expect(second.response.headers.get('retry-after')).toBe('120');
+    expect(await second.response.text()).toContain('temporarily cooling down');
+    expect(providerClient.forward).toHaveBeenCalledTimes(1);
+  });
+
   it('does NOT short-circuit on 401 auth errors — continues to next route (current contract)', async () => {
     // shouldTriggerFallback(401) === true, so an auth failure on the first
     // route keeps the loop going. This test pins that behavior: if anyone

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -5,6 +5,7 @@ import {
   CODEX_CLI_USER_AGENT,
   COPILOT_EDITOR_VERSION,
   COPILOT_PLUGIN_VERSION,
+  buildClaudeCodeSubscriptionHeaders,
 } from '../../common/constants/subscription-clients';
 import { normalizeProviderBaseUrl } from '../provider-base-url';
 import { getQwenCompatibleBaseUrl } from '../qwen-region';
@@ -65,16 +66,15 @@ const openaiHeaders = (apiKey: string) => ({
 const openaiPath = () => '/v1/chat/completions';
 
 const anthropicHeaders = (apiKey: string, authType?: string): Record<string, string> => {
+  if (authType === 'subscription') {
+    return buildClaudeCodeSubscriptionHeaders(apiKey);
+  }
+
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'anthropic-version': '2023-06-01',
   };
-  if (authType === 'subscription') {
-    headers['Authorization'] = `Bearer ${apiKey}`;
-    headers['anthropic-beta'] = 'oauth-2025-04-20';
-  } else {
-    headers['x-api-key'] = apiKey;
-  }
+  headers['x-api-key'] = apiKey;
   return headers;
 };
 

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -76,6 +76,10 @@ import {
   resolveApiKey,
 } from './oauth-credentials';
 
+const RATE_LIMIT_COOLDOWN_DEFAULT_MS = 60_000;
+const RATE_LIMIT_COOLDOWN_MAX_MS = 5 * 60_000;
+const MAX_RATE_LIMIT_COOLDOWNS = 2_000;
+
 export interface FailedFallback {
   model: string;
   provider: string;
@@ -92,6 +96,7 @@ export interface FailedFallback {
 @Injectable()
 export class ProxyFallbackService {
   private readonly logger = new Logger(ProxyFallbackService.name);
+  private readonly rateLimitCooldowns = new Map<string, number>();
 
   constructor(
     private readonly providerKeyService: ProviderKeyService,
@@ -336,9 +341,16 @@ export class ProxyFallbackService {
   }
 
   async tryForwardToProvider(opts: ForwardProviderOptions): Promise<ForwardResult> {
+    const cooldown = this.getActiveRateLimitCooldown(opts);
+    if (cooldown) {
+      return this.buildRateLimitCooldownForward(opts, cooldown);
+    }
+
     try {
       const forward = await this.forwardToProvider(opts);
-      return await this.retryOAuthSubscriptionAfterRejectedToken(opts, forward);
+      const result = await this.retryOAuthSubscriptionAfterRejectedToken(opts, forward);
+      this.recordRateLimitCooldown(opts, result.response);
+      return result;
     } catch (error) {
       if (opts.signal?.aborted) throw error;
       if (!isTransportError(error)) throw error;
@@ -356,6 +368,82 @@ export class ProxyFallbackService {
         isChatGpt: false,
       };
     }
+  }
+
+  private getActiveRateLimitCooldown(opts: ForwardProviderOptions): number | null {
+    const key = this.rateLimitCooldownKey(opts);
+    if (!key) return null;
+    const expiresAt = this.rateLimitCooldowns.get(key);
+    if (!expiresAt) return null;
+    if (expiresAt <= Date.now()) {
+      this.rateLimitCooldowns.delete(key);
+      return null;
+    }
+    return expiresAt;
+  }
+
+  private buildRateLimitCooldownForward(
+    opts: ForwardProviderOptions,
+    expiresAt: number,
+  ): ForwardResult {
+    const retryAfterSeconds = Math.max(1, Math.ceil((expiresAt - Date.now()) / 1000));
+    const message =
+      `Provider route temporarily cooling down after an upstream 429: ` +
+      `${opts.provider}/${opts.model}`;
+    return {
+      response: new Response(JSON.stringify({ error: { message } }), {
+        status: 429,
+        headers: {
+          'content-type': 'application/json',
+          'retry-after': String(retryAfterSeconds),
+        },
+      }),
+      isGoogle: false,
+      isAnthropic: false,
+      isChatGpt: false,
+    };
+  }
+
+  private recordRateLimitCooldown(opts: ForwardProviderOptions, response: Response): void {
+    if (response.status !== 429) return;
+    const key = this.rateLimitCooldownKey(opts);
+    if (!key) return;
+    if (this.rateLimitCooldowns.size >= MAX_RATE_LIMIT_COOLDOWNS) {
+      this.evictExpiredRateLimitCooldowns();
+    }
+    const ttlMs = this.parseRetryAfterMs(response.headers.get('retry-after'));
+    this.rateLimitCooldowns.set(key, Date.now() + ttlMs);
+  }
+
+  private evictExpiredRateLimitCooldowns(now = Date.now()): void {
+    for (const [key, expiresAt] of this.rateLimitCooldowns) {
+      if (expiresAt <= now) this.rateLimitCooldowns.delete(key);
+    }
+  }
+
+  private parseRetryAfterMs(retryAfter: string | null): number {
+    if (!retryAfter) return RATE_LIMIT_COOLDOWN_DEFAULT_MS;
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return Math.min(seconds * 1000, RATE_LIMIT_COOLDOWN_MAX_MS);
+    }
+    const retryAt = Date.parse(retryAfter);
+    if (Number.isNaN(retryAt)) return RATE_LIMIT_COOLDOWN_DEFAULT_MS;
+    return Math.min(
+      Math.max(retryAt - Date.now(), RATE_LIMIT_COOLDOWN_DEFAULT_MS),
+      RATE_LIMIT_COOLDOWN_MAX_MS,
+    );
+  }
+
+  private rateLimitCooldownKey(opts: ForwardProviderOptions): string | null {
+    if (!opts.agentId || !opts.authType) return null;
+    return [
+      opts.agentId,
+      opts.provider.toLowerCase(),
+      opts.authType,
+      opts.providerKeyLabel ?? '',
+      opts.model.toLowerCase(),
+    ].join('\u0000');
   }
 
   private async retryOAuthSubscriptionAfterRejectedToken(

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -410,6 +410,9 @@ export class ProxyFallbackService {
     if (!key) return;
     if (this.rateLimitCooldowns.size >= MAX_RATE_LIMIT_COOLDOWNS) {
       this.evictExpiredRateLimitCooldowns();
+      if (this.rateLimitCooldowns.size >= MAX_RATE_LIMIT_COOLDOWNS) {
+        this.evictOldestRateLimitCooldown();
+      }
     }
     const ttlMs = this.parseRetryAfterMs(response.headers.get('retry-after'));
     this.rateLimitCooldowns.set(key, Date.now() + ttlMs);
@@ -419,6 +422,17 @@ export class ProxyFallbackService {
     for (const [key, expiresAt] of this.rateLimitCooldowns) {
       if (expiresAt <= now) this.rateLimitCooldowns.delete(key);
     }
+  }
+
+  private evictOldestRateLimitCooldown(): void {
+    let oldestKey: string | null = null;
+    let oldestExpiresAt = Number.POSITIVE_INFINITY;
+    for (const [key, expiresAt] of this.rateLimitCooldowns) {
+      if (expiresAt >= oldestExpiresAt) continue;
+      oldestKey = key;
+      oldestExpiresAt = expiresAt;
+    }
+    if (oldestKey) this.rateLimitCooldowns.delete(oldestKey);
   }
 
   private parseRetryAfterMs(retryAfter: string | null): number {


### PR DESCRIPTION
### ✨ What changed
- Anthropic subscription discovery now uses curated Claude model families.
- Subscription requests use Claude Code headers and the API OAuth token host.
- Pending OAuth consume unwraps Postgres `DELETE ... RETURNING` tuples.
- Route 429s get a short cooldown before retry/fallback.

### 💭 Why
Connecting Claude was spending live Anthropic calls and could rate-limit the subscription before a real request. A Postgres result-shape mismatch also dropped `user_id` during OAuth completion.

### 👤 For users
Claude Code subscriptions can connect and route through `auto` without immediate rate-limit failures.

### 🔧 For operators
No migration or env change. Reconnect Anthropic if a local test row was saved before this fix.

### 📝 Notes
- Local smoke: `model: auto` -> `claude-haiku-4-5`, HTTP 200, `MANIFEST_SMOKE_OK`.
- Validation: focused backend Jest 426 tests, backend build, changeset status, `git diff --check`.
