### PR TITLE
feat: lift custom providers to user-global

### DIFF
--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -52,8 +52,6 @@ describe('AgentDuplicationService', () => {
     mockTransaction = jest.fn(async (cb: (manager: unknown) => unknown) => {
       const agentRepo = makeRepoMock('Agent');
       const apiKeyRepo = makeRepoMock('AgentApiKey');
-      const providerRepo = makeRepoMock('UserProvider');
-      const customProviderRepo = makeRepoMock('CustomProvider');
       const tierRepo = makeRepoMock('TierAssignment');
       const specRepo = makeRepoMock('SpecificityAssignment');
       const modelParamsRepo = makeRepoMock('AgentModelParams');
@@ -65,10 +63,6 @@ describe('AgentDuplicationService', () => {
               return agentRepo;
             case 'AgentApiKey':
               return apiKeyRepo;
-            case 'UserProvider':
-              return providerRepo;
-            case 'CustomProvider':
-              return customProviderRepo;
             case 'TierAssignment':
               return tierRepo;
             case 'SpecificityAssignment':
@@ -135,7 +129,6 @@ describe('AgentDuplicationService', () => {
       mockAgentGetOne.mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1' });
       repoCounts = {
         AgentProviderAccess: 3,
-        CustomProvider: 1,
         TierAssignment: 4,
         SpecificityAssignment: 2,
         AgentModelParams: 5,
@@ -144,7 +137,6 @@ describe('AgentDuplicationService', () => {
       const result = await service.getCopySummary('user-1', 'source-agent');
       expect(result).toEqual({
         providers: 3,
-        customProviders: 1,
         tierAssignments: 4,
         specificityAssignments: 2,
         modelParams: 5,
@@ -210,11 +202,10 @@ describe('AgentDuplicationService', () => {
       ).rejects.toThrow(ConflictException);
     });
 
-    it('copies global provider access as a grant (no new credential row) and clones custom companion rows', async () => {
-      // The main correctness test: a global provider (anthropic) must produce
-      // an AgentProviderAccess grant pointing at the SAME user_providers row,
-      // NOT a new cloned credential row.  A custom companion row IS cloned with
-      // a remapped `custom:<newId>` and also gets a grant.
+    it('copies provider access grants verbatim (no new credential rows) for both global and custom providers', async () => {
+      // The main correctness test: both a global provider (anthropic) grant and a
+      // custom provider grant must be copied pointing at the SAME user_providers rows.
+      // No new UserProvider rows, no new CustomProvider rows.
       mockAgentGetOne
         .mockResolvedValueOnce({
           id: 'src-1',
@@ -227,55 +218,10 @@ describe('AgentDuplicationService', () => {
         })
         .mockResolvedValueOnce(null);
 
-      // The source has two grants: one to a global provider, one to a custom companion.
       repoRows = {
         AgentProviderAccess: [
           { agent_id: 'src-1', user_provider_id: 'up-global' },
           { agent_id: 'src-1', user_provider_id: 'up-custom' },
-        ],
-        // UserProvider rows that are loaded by the In() query.
-        UserProvider: [
-          {
-            id: 'up-global',
-            user_id: 'u1',
-            agent_id: null,
-            provider: 'anthropic',
-            api_key_encrypted: 'enc',
-            key_prefix: 'sk-ant',
-            auth_type: 'api_key',
-            label: 'Research key',
-            priority: 2,
-            region: null,
-            is_active: true,
-            cached_models: [{ id: 'm' }],
-            models_fetched_at: null,
-          },
-          {
-            id: 'up-custom',
-            user_id: 'u1',
-            agent_id: 'src-1',
-            provider: 'custom:cp1',
-            api_key_encrypted: null,
-            key_prefix: null,
-            auth_type: 'local',
-            label: null,
-            priority: 0,
-            region: null,
-            is_active: true,
-            cached_models: null,
-            models_fetched_at: null,
-          },
-        ],
-        CustomProvider: [
-          {
-            id: 'cp1',
-            agent_id: 'src-1',
-            user_id: 'u1',
-            name: 'local',
-            base_url: 'http://x',
-            api_kind: 'openai',
-            models: [],
-          },
         ],
         TierAssignment: [
           {
@@ -283,28 +229,9 @@ describe('AgentDuplicationService', () => {
             user_id: 'u1',
             agent_id: 'src-1',
             tier: 'standard',
-            override_route: {
-              provider: 'custom:cp1',
-              authType: 'local',
-              model: 'custom:cp1/qwen-72b',
-            },
-            auto_assigned_route: {
-              provider: 'custom:cp1',
-              authType: 'local',
-              model: 'custom:cp1/auto',
-            },
-            fallback_routes: [
-              {
-                provider: 'custom:cp1',
-                authType: 'local',
-                model: 'custom:cp1/fallback',
-              },
-              {
-                provider: 'anthropic',
-                authType: 'api_key',
-                model: 'anthropic/claude-opus-4-6',
-              },
-            ],
+            override_route: null,
+            auto_assigned_route: null,
+            fallback_routes: ['x'],
           },
         ],
         SpecificityAssignment: [
@@ -314,19 +241,9 @@ describe('AgentDuplicationService', () => {
             agent_id: 'src-1',
             category: 'coding',
             is_active: true,
-            override_route: {
-              provider: 'custom:cp1',
-              authType: 'local',
-              model: 'custom:cp1/coding',
-            },
-            auto_assigned_route: null,
-            fallback_routes: [
-              {
-                provider: 'custom:cp1',
-                authType: 'local',
-                model: 'custom:cp1/spec-fallback',
-              },
-            ],
+            override_route: null,
+            auto_assigned_route: 'auto',
+            fallback_routes: null,
           },
         ],
         AgentModelParams: [
@@ -340,14 +257,14 @@ describe('AgentDuplicationService', () => {
             scope_key: 'tier:default',
             params: { thinking: { type: 'disabled' } },
           },
-          // custom-provider-keyed row exercises the remap path
+          // custom-provider-keyed row — provider is copied verbatim (user-global, shared)
           {
             id: 'mp2',
             user_id: 'u1',
             agent_id: 'src-1',
             provider: 'custom:cp1',
-            auth_type: 'local',
-            model_name: 'custom:cp1/qwen-72b',
+            auth_type: 'api_key',
+            model_name: 'qwen-72b',
             scope_key: 'tier:default',
             params: { thinking: { type: 'enabled' } },
           },
@@ -362,10 +279,9 @@ describe('AgentDuplicationService', () => {
       expect(mockTransaction).toHaveBeenCalledTimes(1);
       expect(result.agentName).toBe('source-copy');
       expect(result.apiKey).toMatch(/^mnfst_/);
-      // 2 grants: 1 for global (anthropic) + 1 for custom companion
+      // 2 grants copied: one for the global provider, one for the custom provider
       expect(result.copied).toEqual({
         providers: 2,
-        customProviders: 1,
         tierAssignments: 1,
         specificityAssignments: 1,
         modelParams: 2,
@@ -383,299 +299,28 @@ describe('AgentDuplicationService', () => {
       expect(apiKeyRow['agent_id']).toBe(agentRow['id']);
       expect(apiKeyRow['label']).toContain('source-copy');
 
-      // Global provider: no new UserProvider row was cloned for 'anthropic'
-      const newCpId = (insertedRows['CustomProvider'] as Array<Record<string, unknown>>)[0][
-        'id'
-      ] as string;
-      const upRows = insertedRows['UserProvider'] as Array<Record<string, unknown>>;
-      // Only one UserProvider row should be inserted: the custom companion clone
-      expect(upRows).toHaveLength(1);
-      expect(upRows[0]['provider']).toBe(`custom:${newCpId}`);
-      expect(upRows[0]['agent_id']).toBe(agentRow['id']);
-
-      // Custom routes are cloned onto the new custom provider id, including
-      // full `custom:<id>/model` model keys.
-      const tierRows = insertedRows['TierAssignment'] as Array<Record<string, unknown>>;
-      expect(tierRows).toHaveLength(1);
-      expect(tierRows[0]['override_route']).toEqual({
-        provider: `custom:${newCpId}`,
-        authType: 'local',
-        model: `custom:${newCpId}/qwen-72b`,
-      });
-      expect(tierRows[0]['auto_assigned_route']).toEqual({
-        provider: `custom:${newCpId}`,
-        authType: 'local',
-        model: `custom:${newCpId}/auto`,
-      });
-      expect(tierRows[0]['fallback_routes']).toEqual([
-        {
-          provider: `custom:${newCpId}`,
-          authType: 'local',
-          model: `custom:${newCpId}/fallback`,
-        },
-        {
-          provider: 'anthropic',
-          authType: 'api_key',
-          model: 'anthropic/claude-opus-4-6',
-        },
-      ]);
-
-      const specRows = insertedRows['SpecificityAssignment'] as Array<Record<string, unknown>>;
-      expect(specRows).toHaveLength(1);
-      expect(specRows[0]['override_route']).toEqual({
-        provider: `custom:${newCpId}`,
-        authType: 'local',
-        model: `custom:${newCpId}/coding`,
-      });
-      expect(specRows[0]['fallback_routes']).toEqual([
-        {
-          provider: `custom:${newCpId}`,
-          authType: 'local',
-          model: `custom:${newCpId}/spec-fallback`,
-        },
-      ]);
-
-      // Two grants must be inserted: one pointing at the global row's original
-      // id, and one pointing at the freshly-cloned custom companion row.
+      // Two grants inserted verbatim — pointing at the original user_provider_id values
       const grants = insertedRows['AgentProviderAccess'] as Array<Record<string, unknown>>;
       expect(grants).toHaveLength(2);
       const globalGrant = grants.find((g) => g['user_provider_id'] === 'up-global');
       expect(globalGrant).toBeDefined();
       expect(globalGrant!['agent_id']).toBe(agentRow['id']);
-      const customGrant = grants.find((g) => g['user_provider_id'] !== 'up-global');
+      const customGrant = grants.find((g) => g['user_provider_id'] === 'up-custom');
       expect(customGrant).toBeDefined();
       expect(customGrant!['agent_id']).toBe(agentRow['id']);
-      // The custom grant points at the new companion row (not the old up-custom id)
-      expect(customGrant!['user_provider_id']).not.toBe('up-custom');
 
-      // Per-route model params: deepseek row copies verbatim, custom:cp1 remaps
+      // Per-route model params: both rows copied verbatim (custom:cp1 NOT remapped)
       const mpRows = insertedRows['AgentModelParams'] as Array<Record<string, unknown>>;
       expect(mpRows).toHaveLength(2);
       const deepseekRow = mpRows.find((r) => r['provider'] === 'deepseek')!;
       expect(deepseekRow['agent_id']).toBe(agentRow['id']);
       expect(deepseekRow['model_name']).toBe('deepseek-v4');
       expect(deepseekRow['params']).toEqual({ thinking: { type: 'disabled' } });
-      const customMpRow = mpRows.find((r) => String(r['provider']).startsWith('custom:'))!;
-      expect(customMpRow['provider']).toBe(`custom:${newCpId}`);
-      expect(customMpRow['model_name']).toBe(`custom:${newCpId}/qwen-72b`);
+      const customMpRow = mpRows.find((r) => r['provider'] === 'custom:cp1')!;
+      expect(customMpRow['provider']).toBe('custom:cp1');
       expect(customMpRow['agent_id']).toBe(agentRow['id']);
 
       expect(mockInvalidateAgent).toHaveBeenCalledWith(agentRow['id']);
-    });
-
-    it('copies api_kind field for custom providers', async () => {
-      mockAgentGetOne
-        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
-        .mockResolvedValueOnce(null);
-
-      repoRows = {
-        CustomProvider: [
-          {
-            id: 'cp1',
-            agent_id: 'src-1',
-            user_id: 'u1',
-            name: 'my-server',
-            base_url: 'http://x',
-            api_kind: 'anthropic',
-            models: [{ model_name: 'test' }],
-          },
-        ],
-      };
-
-      await service.duplicate('user-1', 'source', {
-        name: 'copy',
-        displayName: 'copy',
-      });
-
-      const cpRow = (insertedRows['CustomProvider'] as Array<Record<string, unknown>>)[0];
-      expect(cpRow['api_kind']).toBe('anthropic');
-    });
-
-    it('remaps custom:<uuid> references in user providers to new custom provider IDs', async () => {
-      // Source has a grant to a custom companion row.  After duplication the
-      // new agent should receive a NEW cloned companion row with
-      // provider = custom:<newId>, and a grant to that new row.
-      mockAgentGetOne
-        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
-        .mockResolvedValueOnce(null);
-
-      repoRows = {
-        AgentProviderAccess: [{ agent_id: 'src-1', user_provider_id: 'up1' }],
-        CustomProvider: [
-          {
-            id: 'old-cp-uuid',
-            agent_id: 'src-1',
-            user_id: 'u1',
-            name: 'LM Studio',
-            base_url: 'http://localhost:1234',
-            api_kind: 'openai',
-            models: [],
-          },
-        ],
-        UserProvider: [
-          {
-            id: 'up1',
-            user_id: 'u1',
-            agent_id: 'src-1',
-            provider: 'custom:old-cp-uuid',
-            api_key_encrypted: null,
-            key_prefix: null,
-            auth_type: 'local',
-            region: null,
-            is_active: true,
-            cached_models: null,
-            models_fetched_at: null,
-          },
-        ],
-      };
-
-      await service.duplicate('user-1', 'source', {
-        name: 'copy',
-        displayName: 'copy',
-      });
-
-      const cpRow = (insertedRows['CustomProvider'] as Array<Record<string, unknown>>)[0];
-      const newCpId = cpRow['id'] as string;
-      expect(newCpId).not.toBe('old-cp-uuid');
-
-      // Custom companion row is cloned with remapped provider key
-      const upRow = (insertedRows['UserProvider'] as Array<Record<string, unknown>>)[0];
-      expect(upRow['provider']).toBe(`custom:${newCpId}`);
-      expect(upRow['auth_type']).toBe('local');
-
-      // A grant is created for the new custom companion row
-      const grants = insertedRows['AgentProviderAccess'] as Array<Record<string, unknown>>;
-      expect(grants).toHaveLength(1);
-      expect(grants[0]['user_provider_id']).toBe(upRow['id']);
-    });
-
-    it('skips a custom companion grant when the custom provider id is not in the map', async () => {
-      // This covers the `if (!newCustomId) continue;` branch: the source agent
-      // has a grant to a custom: user_providers row whose custom provider ID
-      // does NOT appear in customProviderIdMap (orphaned grant).  The copy must
-      // skip it without crashing.
-      // Also covers the fallback branch of remapCustomProviderRef (returns the
-      // original provider string when the custom id is not in the map) via a
-      // model_params row that references the same orphaned custom id.
-      mockAgentGetOne
-        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
-        .mockResolvedValueOnce(null);
-
-      repoRows = {
-        AgentProviderAccess: [{ agent_id: 'src-1', user_provider_id: 'up-orphan' }],
-        // No CustomProvider rows — so customProviderIdMap is empty
-        CustomProvider: [],
-        UserProvider: [
-          {
-            id: 'up-orphan',
-            user_id: 'u1',
-            agent_id: 'src-1',
-            // Provider references a custom id that no longer exists in custom_providers
-            provider: 'custom:deleted-cp-id',
-            api_key_encrypted: null,
-            key_prefix: null,
-            auth_type: 'local',
-            region: null,
-            is_active: true,
-            cached_models: null,
-            models_fetched_at: null,
-          },
-        ],
-        // A model_params row referencing the same orphaned custom id exercises the
-        // fallback arm of remapCustomProviderRef (newId not found → return original).
-        AgentModelParams: [
-          {
-            id: 'mp-orphan',
-            user_id: 'u1',
-            agent_id: 'src-1',
-            provider: 'custom:deleted-cp-id',
-            auth_type: 'local',
-            model_name: 'some-model',
-            scope_key: 'tier:default',
-            params: {},
-          },
-        ],
-      };
-
-      const result = await service.duplicate('user-1', 'source', {
-        name: 'copy',
-        displayName: 'copy',
-      });
-
-      // The orphaned grant is skipped: no UserProvider cloned, no grant inserted
-      expect(insertedRows['UserProvider']).toBeUndefined();
-      expect(insertedRows['AgentProviderAccess']).toBeUndefined();
-      // providers count = number of newGrants created = 0 (skipped)
-      expect(result.copied.providers).toBe(0);
-
-      // The model_params row is still copied but with the original (unmapped)
-      // provider string because remapCustomProviderRef falls back gracefully.
-      const mpRows = insertedRows['AgentModelParams'] as Array<Record<string, unknown>>;
-      expect(mpRows).toHaveLength(1);
-      expect(mpRows[0]['provider']).toBe('custom:deleted-cp-id');
-    });
-
-    it('copies global (non-custom) providers as grants pointing at the same user_providers id', async () => {
-      // Covers the `else` branch (global provider): grant points at original row id.
-      mockAgentGetOne
-        .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
-        .mockResolvedValueOnce(null);
-
-      repoRows = {
-        AgentProviderAccess: [
-          { agent_id: 'src-1', user_provider_id: 'up-openai' },
-          { agent_id: 'src-1', user_provider_id: 'up-anthropic' },
-        ],
-        UserProvider: [
-          {
-            id: 'up-openai',
-            user_id: 'u1',
-            agent_id: null,
-            provider: 'openai',
-            api_key_encrypted: 'enc-openai',
-            key_prefix: 'sk-',
-            auth_type: 'api_key',
-            label: null,
-            priority: 0,
-            region: null,
-            is_active: true,
-            cached_models: null,
-            models_fetched_at: null,
-          },
-          {
-            id: 'up-anthropic',
-            user_id: 'u1',
-            agent_id: null,
-            provider: 'anthropic',
-            api_key_encrypted: 'enc-anth',
-            key_prefix: 'sk-ant',
-            auth_type: 'subscription',
-            label: null,
-            priority: 0,
-            region: null,
-            is_active: true,
-            cached_models: null,
-            models_fetched_at: null,
-          },
-        ],
-      };
-
-      const result = await service.duplicate('user-1', 'source', {
-        name: 'copy',
-        displayName: 'copy',
-      });
-
-      // No new UserProvider rows — global credentials are shared
-      expect(insertedRows['UserProvider']).toBeUndefined();
-
-      // Two grants inserted, pointing at the original ids
-      const grants = insertedRows['AgentProviderAccess'] as Array<Record<string, unknown>>;
-      expect(grants).toHaveLength(2);
-      const upIds = grants.map((g) => g['user_provider_id']);
-      expect(upIds).toContain('up-openai');
-      expect(upIds).toContain('up-anthropic');
-
-      expect(result.copied.providers).toBe(2);
     });
 
     it('skips insert batches when source has no grants or rows', async () => {
@@ -699,20 +344,18 @@ describe('AgentDuplicationService', () => {
 
       expect(result.copied).toEqual({
         providers: 0,
-        customProviders: 0,
         tierAssignments: 0,
         specificityAssignments: 0,
         modelParams: 0,
       });
-      expect(insertedRows['UserProvider']).toBeUndefined();
-      expect(insertedRows['CustomProvider']).toBeUndefined();
       expect(insertedRows['TierAssignment']).toBeUndefined();
       expect(insertedRows['SpecificityAssignment']).toBeUndefined();
       expect(insertedRows['AgentModelParams']).toBeUndefined();
       expect(insertedRows['AgentProviderAccess']).toBeUndefined();
     });
 
-    it('remaps multiple custom providers correctly', async () => {
+    it('copies multiple grants pointing at their original user_provider_id values', async () => {
+      // Covers copying 3 grants (two custom, one global) all verbatim.
       mockAgentGetOne
         .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
         .mockResolvedValueOnce(null);
@@ -723,67 +366,6 @@ describe('AgentDuplicationService', () => {
           { agent_id: 'src-1', user_provider_id: 'up2' },
           { agent_id: 'src-1', user_provider_id: 'up3' },
         ],
-        CustomProvider: [
-          {
-            id: 'cp-lms',
-            agent_id: 'src-1',
-            user_id: 'u1',
-            name: 'LM Studio',
-            base_url: 'http://localhost:1234',
-            api_kind: 'openai',
-            models: [],
-          },
-          {
-            id: 'cp-llama',
-            agent_id: 'src-1',
-            user_id: 'u1',
-            name: 'llama.cpp',
-            base_url: 'http://localhost:8080',
-            api_kind: 'openai',
-            models: [{ model_name: 'mistral' }],
-          },
-        ],
-        UserProvider: [
-          {
-            id: 'up1',
-            user_id: 'u1',
-            agent_id: 'src-1',
-            provider: 'custom:cp-lms',
-            api_key_encrypted: null,
-            key_prefix: null,
-            auth_type: 'local',
-            region: null,
-            is_active: true,
-            cached_models: null,
-            models_fetched_at: null,
-          },
-          {
-            id: 'up2',
-            user_id: 'u1',
-            agent_id: 'src-1',
-            provider: 'custom:cp-llama',
-            api_key_encrypted: null,
-            key_prefix: null,
-            auth_type: 'local',
-            region: null,
-            is_active: true,
-            cached_models: null,
-            models_fetched_at: null,
-          },
-          {
-            id: 'up3',
-            user_id: 'u1',
-            agent_id: 'src-1',
-            provider: 'anthropic',
-            api_key_encrypted: 'enc',
-            key_prefix: 'sk-',
-            auth_type: 'api_key',
-            region: null,
-            is_active: true,
-            cached_models: null,
-            models_fetched_at: null,
-          },
-        ],
       };
 
       const result = await service.duplicate('user-1', 'source', {
@@ -791,32 +373,11 @@ describe('AgentDuplicationService', () => {
         displayName: 'copy',
       });
 
-      // Two custom providers cloned
-      const cps = insertedRows['CustomProvider'] as Array<Record<string, unknown>>;
-      expect(cps).toHaveLength(2);
-      const lmsNewId = cps.find((c) => c['name'] === 'LM Studio')!['id'] as string;
-      const llamaNewId = cps.find((c) => c['name'] === 'llama.cpp')!['id'] as string;
-
-      // Two UserProvider companion rows cloned (only custom ones); global anthropic is NOT cloned
-      const ups = insertedRows['UserProvider'] as Array<Record<string, unknown>>;
-      expect(ups).toHaveLength(2);
-
-      const lmsUp = ups.find((u) => (u['provider'] as string).includes(lmsNewId));
-      expect(lmsUp).toBeDefined();
-      expect(lmsUp!['provider']).toBe(`custom:${lmsNewId}`);
-
-      const llamaUp = ups.find((u) => (u['provider'] as string).includes(llamaNewId));
-      expect(llamaUp).toBeDefined();
-      expect(llamaUp!['provider']).toBe(`custom:${llamaNewId}`);
-
-      // Three grants inserted: two for custom companions, one for global anthropic
       const grants = insertedRows['AgentProviderAccess'] as Array<Record<string, unknown>>;
       expect(grants).toHaveLength(3);
-
-      // The anthropic grant points at the original user_provider id (up3)
-      const anthGrant = grants.find((g) => g['user_provider_id'] === 'up3');
-      expect(anthGrant).toBeDefined();
-
+      expect(grants.map((g) => g['user_provider_id'])).toEqual(
+        expect.arrayContaining(['up1', 'up2', 'up3']),
+      );
       expect(result.copied.providers).toBe(3);
     });
   });

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -1,14 +1,11 @@
 import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, In, Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { randomBytes } from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
-import type { ModelRoute } from 'manifest-shared';
 import { Agent } from '../../entities/agent.entity';
 import { AgentApiKey } from '../../entities/agent-api-key.entity';
-import { UserProvider } from '../../entities/user-provider.entity';
 import { AgentProviderAccess } from '../../entities/agent-provider-access.entity';
-import { CustomProvider } from '../../entities/custom-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 import { AgentModelParams } from '../../entities/agent-model-params.entity';
@@ -20,7 +17,6 @@ import { RoutingCacheService } from '../../routing/routing-core/routing-cache.se
 
 export interface DuplicateAgentSummary {
   providers: number;
-  customProviders: number;
   tierAssignments: number;
   specificityAssignments: number;
   modelParams: number;
@@ -42,48 +38,8 @@ export class AgentDuplicationService {
     private readonly routingCache: RoutingCacheService,
   ) {}
 
-  private static readonly CUSTOM_PREFIX = 'custom:';
-
   private generateOtlpKey(): string {
     return API_KEY_PREFIX + randomBytes(32).toString('base64url');
-  }
-
-  private remapCustomProviderRef(provider: string, idMap: Map<string, string>): string {
-    if (!provider.startsWith(AgentDuplicationService.CUSTOM_PREFIX)) return provider;
-    const oldId = provider.slice(AgentDuplicationService.CUSTOM_PREFIX.length);
-    const newId = idMap.get(oldId);
-    return newId ? `${AgentDuplicationService.CUSTOM_PREFIX}${newId}` : provider;
-  }
-
-  private remapCustomModelRef(model: string, idMap: Map<string, string>): string {
-    if (!model.startsWith(AgentDuplicationService.CUSTOM_PREFIX)) return model;
-    const slashIndex = model.indexOf('/');
-    const providerPart = slashIndex === -1 ? model : model.slice(0, slashIndex);
-    const remappedProvider = this.remapCustomProviderRef(providerPart, idMap);
-    return slashIndex === -1 ? remappedProvider : `${remappedProvider}${model.slice(slashIndex)}`;
-  }
-
-  private remapCustomRoute(
-    route: ModelRoute | null,
-    idMap: Map<string, string>,
-  ): ModelRoute | null {
-    if (!route) return route;
-    const candidate = route as unknown as Record<string, unknown>;
-    if (typeof candidate.provider !== 'string' || typeof candidate.model !== 'string') {
-      return route;
-    }
-    const provider = this.remapCustomProviderRef(route.provider, idMap);
-    const model = this.remapCustomModelRef(route.model, idMap);
-    return provider === route.provider && model === route.model
-      ? route
-      : { ...route, provider, model };
-  }
-
-  private remapCustomRoutes(
-    routes: ModelRoute[] | null,
-    idMap: Map<string, string>,
-  ): ModelRoute[] | null {
-    return routes?.map((route) => this.remapCustomRoute(route, idMap)!) ?? null;
   }
 
   private async findOwnedAgent(userId: string, agentName: string): Promise<Agent | null> {
@@ -100,22 +56,19 @@ export class AgentDuplicationService {
     const source = await this.findOwnedAgent(userId, sourceName);
     if (!source) throw new NotFoundException(`Agent "${sourceName}" not found`);
 
-    const [providers, customProviders, tierAssignments, specificityAssignments, modelParams] =
-      await Promise.all([
-        // Providers are user-global; access is the agent_provider_access grant,
-        // so the copyable unit is the grant count, not the credential rows.
-        this.dataSource
-          .getRepository(AgentProviderAccess)
-          .count({ where: { agent_id: source.id } }),
-        this.dataSource.getRepository(CustomProvider).count({ where: { agent_id: source.id } }),
-        this.dataSource.getRepository(TierAssignment).count({ where: { agent_id: source.id } }),
-        this.dataSource
-          .getRepository(SpecificityAssignment)
-          .count({ where: { agent_id: source.id } }),
-        this.dataSource.getRepository(AgentModelParams).count({ where: { agent_id: source.id } }),
-      ]);
+    const [providers, tierAssignments, specificityAssignments, modelParams] = await Promise.all([
+      // Providers (including custom providers) are user-global; access is the
+      // agent_provider_access grant, so the copyable unit is the grant count,
+      // not the credential rows.
+      this.dataSource.getRepository(AgentProviderAccess).count({ where: { agent_id: source.id } }),
+      this.dataSource.getRepository(TierAssignment).count({ where: { agent_id: source.id } }),
+      this.dataSource
+        .getRepository(SpecificityAssignment)
+        .count({ where: { agent_id: source.id } }),
+      this.dataSource.getRepository(AgentModelParams).count({ where: { agent_id: source.id } }),
+    ]);
 
-    return { providers, customProviders, tierAssignments, specificityAssignments, modelParams };
+    return { providers, tierAssignments, specificityAssignments, modelParams };
   }
 
   async suggestName(userId: string, sourceName: string): Promise<string> {
@@ -180,79 +133,24 @@ export class AgentDuplicationService {
         is_active: true,
       });
 
-      const customProviders = await manager
-        .getRepository(CustomProvider)
-        .find({ where: { agent_id: source.id } });
-      const customProviderIdMap = new Map<string, string>();
-      if (customProviders.length > 0) {
-        const newCustomProviders = customProviders.map((cp) => {
-          const newId = uuidv4();
-          customProviderIdMap.set(cp.id, newId);
-          return {
-            id: newId,
-            agent_id: newAgentId,
-            user_id: cp.user_id,
-            name: cp.name,
-            base_url: cp.base_url,
-            api_kind: cp.api_kind,
-            models: cp.models,
-            created_at: now,
-          };
-        });
-        await manager.getRepository(CustomProvider).insert(newCustomProviders);
-      }
-
-      // Providers are user-global and shared across agents via the
-      // agent_provider_access junction. Cloning the credential rows under the
-      // new agent_id would duplicate a (user_id, provider, auth_type, label)
-      // tuple and violate the user-scoped unique index — so instead we copy
-      // the source agent's GRANTS. Custom providers stay agent-scoped, so their
-      // companion user_providers row IS cloned (its `custom:<id>` key is unique
-      // to the freshly-cloned custom provider) and re-granted to the new agent.
+      // Providers — regular AND custom — are user-global, shared across agents
+      // via the agent_provider_access junction. Cloning the credential rows
+      // under the new agent_id would duplicate a (user_id, provider, auth_type,
+      // label) tuple and violate the user-scoped unique index. Instead, copy the
+      // source agent's GRANTS verbatim; every `custom:<id>` reference stays valid
+      // because the underlying custom provider is shared, not re-created.
       const sourceGrants = await manager
         .getRepository(AgentProviderAccess)
         .find({ where: { agent_id: source.id } });
-      let providerGrants = 0;
       if (sourceGrants.length > 0) {
-        const grantedProviders = await manager
-          .getRepository(UserProvider)
-          .find({ where: { id: In(sourceGrants.map((g) => g.user_provider_id)) } });
-        const newGrants: { agent_id: string; user_provider_id: string }[] = [];
-        for (const p of grantedProviders) {
-          if (p.provider.startsWith(AgentDuplicationService.CUSTOM_PREFIX)) {
-            const oldId = p.provider.slice(AgentDuplicationService.CUSTOM_PREFIX.length);
-            const newCustomId = customProviderIdMap.get(oldId);
-            // A grant to a custom provider the source no longer owns can't be
-            // remapped — skip rather than point the copy at a stale id.
-            if (!newCustomId) continue;
-            const newUpId = uuidv4();
-            await manager.getRepository(UserProvider).insert({
-              id: newUpId,
-              user_id: p.user_id,
-              agent_id: newAgentId,
-              provider: `${AgentDuplicationService.CUSTOM_PREFIX}${newCustomId}`,
-              api_key_encrypted: p.api_key_encrypted,
-              key_prefix: p.key_prefix,
-              auth_type: p.auth_type,
-              label: p.label,
-              priority: p.priority,
-              region: p.region,
-              is_active: p.is_active,
-              connected_at: now,
-              updated_at: now,
-              cached_models: p.cached_models,
-              models_fetched_at: p.models_fetched_at,
-            });
-            newGrants.push({ agent_id: newAgentId, user_provider_id: newUpId });
-          } else {
-            newGrants.push({ agent_id: newAgentId, user_provider_id: p.id });
-          }
-        }
-        if (newGrants.length > 0) {
-          await manager.getRepository(AgentProviderAccess).insert(newGrants);
-        }
-        providerGrants = newGrants.length;
+        await manager.getRepository(AgentProviderAccess).insert(
+          sourceGrants.map((g) => ({
+            agent_id: newAgentId,
+            user_provider_id: g.user_provider_id,
+          })),
+        );
       }
+      const providerGrants = sourceGrants.length;
 
       const tiers = await manager
         .getRepository(TierAssignment)
@@ -264,9 +162,9 @@ export class AgentDuplicationService {
             user_id: t.user_id,
             agent_id: newAgentId,
             tier: t.tier,
-            override_route: this.remapCustomRoute(t.override_route, customProviderIdMap),
-            auto_assigned_route: this.remapCustomRoute(t.auto_assigned_route, customProviderIdMap),
-            fallback_routes: this.remapCustomRoutes(t.fallback_routes, customProviderIdMap),
+            override_route: t.override_route,
+            auto_assigned_route: t.auto_assigned_route,
+            fallback_routes: t.fallback_routes,
             output_modality: t.output_modality,
             response_mode: t.response_mode,
             updated_at: now,
@@ -285,9 +183,9 @@ export class AgentDuplicationService {
             agent_id: newAgentId,
             category: s.category,
             is_active: s.is_active,
-            override_route: this.remapCustomRoute(s.override_route, customProviderIdMap),
-            auto_assigned_route: this.remapCustomRoute(s.auto_assigned_route, customProviderIdMap),
-            fallback_routes: this.remapCustomRoutes(s.fallback_routes, customProviderIdMap),
+            override_route: s.override_route,
+            auto_assigned_route: s.auto_assigned_route,
+            fallback_routes: s.fallback_routes,
             output_modality: s.output_modality,
             response_mode: s.response_mode,
             updated_at: now,
@@ -317,14 +215,11 @@ export class AgentDuplicationService {
               p.user_id,
               newAgentId,
               p.scope_key,
-              // Same `custom:<uuid>` remap as user_providers and copied route
-              // assignments above. Without this, a params row configured for
-              // `custom:<old-uuid>` would point to the source agent's custom
-              // provider after duplication, breaking the per-route lookup for
-              // the new agent.
-              this.remapCustomProviderRef(p.provider, customProviderIdMap),
+              // Custom providers are user-global and shared by the duplicate, so
+              // any `custom:<id>` provider reference is copied verbatim.
+              p.provider,
               p.auth_type,
-              this.remapCustomModelRef(p.model_name, customProviderIdMap),
+              p.model_name,
               p.params,
               now,
               now,
@@ -335,7 +230,6 @@ export class AgentDuplicationService {
 
       return {
         providers: providerGrants,
-        customProviders: customProviders.length,
         tierAssignments: tiers.length,
         specificityAssignments: specificity.length,
         modelParams: modelParams.length,

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -114,6 +114,7 @@ import { AddDedupCompositeIndex1790200000000 } from './migrations/1790200000000-
 import { AddErrorsPartialIndex1790300000000 } from './migrations/1790300000000-AddErrorsPartialIndex';
 import { DropRedundantAgentApiKeyPrefixIndex1790400000000 } from './migrations/1790400000000-DropRedundantAgentApiKeyPrefixIndex';
 import { LiftProvidersToUserLevel1791000000000 } from './migrations/1791000000000-LiftProvidersToUserLevel';
+import { LiftCustomProvidersToUserLevel1791200000000 } from './migrations/1791200000000-LiftCustomProvidersToUserLevel';
 
 const entities = [
   AgentMessage,
@@ -229,6 +230,7 @@ const migrations = [
   AddErrorsPartialIndex1790300000000,
   DropRedundantAgentApiKeyPrefixIndex1790400000000,
   LiftProvidersToUserLevel1791000000000,
+  LiftCustomProvidersToUserLevel1791200000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.spec.ts
+++ b/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.spec.ts
@@ -1,0 +1,79 @@
+import { LiftCustomProvidersToUserLevel1791200000000 } from './1791200000000-LiftCustomProvidersToUserLevel';
+
+describe('LiftCustomProvidersToUserLevel1791200000000', () => {
+  const migration = new LiftCustomProvidersToUserLevel1791200000000();
+  const queries: string[] = [];
+  const queryRunner = { query: jest.fn(async (sql: string) => queries.push(sql)) } as never;
+
+  beforeEach(() => {
+    queries.length = 0;
+    (queryRunner as { query: jest.Mock }).query.mockClear();
+  });
+
+  it('drops the agent FK before dropping the column', async () => {
+    await migration.up(queryRunner);
+    const dropFk = queries.findIndex(
+      (q) => q.includes('pg_constraint') && q.includes("contype = 'f'"),
+    );
+    const dropCol = queries.findIndex((q) => q.includes('DROP COLUMN IF EXISTS "agent_id"'));
+    expect(dropFk).toBeGreaterThan(-1);
+    expect(dropCol).toBeGreaterThan(dropFk);
+  });
+
+  it('relabels collisions on (user_id, LOWER(name)), drops agent_id, and creates the user-scoped unique index', async () => {
+    await migration.up(queryRunner);
+    const relabel = queries.find((q) => q.includes('ROW_NUMBER() OVER'));
+    expect(relabel).toBeDefined();
+    expect(relabel).toContain('PARTITION BY "user_id", LOWER("name")');
+    expect(relabel).toContain('r."name" || \' [\' || r."id" || \']\'');
+    // Collision-safe: pick a suffix not already taken within the user's names.
+    expect(relabel).toContain('generate_series(0, 1000)');
+    expect(relabel).toContain('NOT EXISTS');
+    expect(queries.some((q) => q.includes('DROP COLUMN IF EXISTS "agent_id"'))).toBe(true);
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('CREATE UNIQUE INDEX "IDX_custom_providers_user_name"') &&
+          q.includes('("user_id", LOWER("name"))'),
+      ),
+    ).toBe(true);
+  });
+
+  it('backfills all-agent grants for existing custom providers', async () => {
+    await migration.up(queryRunner);
+    const backfill = queries.find(
+      (q) => q.includes('INSERT INTO "agent_provider_access"') && q.includes("LIKE 'custom:%'"),
+    );
+    expect(backfill).toBeDefined();
+    expect(backfill).toContain('ON CONFLICT DO NOTHING');
+    expect(backfill).toContain('JOIN "agents" a');
+    expect(backfill).toContain('a."deleted_at" IS NULL');
+  });
+
+  it('relabels BEFORE creating the unique index (so the index never fails on duplicates)', async () => {
+    await migration.up(queryRunner);
+    const relabelIdx = queries.findIndex((q) => q.includes('ROW_NUMBER() OVER'));
+    const createIdx = queries.findIndex((q) =>
+      q.includes('CREATE UNIQUE INDEX "IDX_custom_providers_user_name"'),
+    );
+    expect(relabelIdx).toBeGreaterThan(-1);
+    expect(createIdx).toBeGreaterThan(relabelIdx);
+  });
+
+  it('never deletes a custom_providers row (encrypted-key safety invariant)', async () => {
+    await migration.up(queryRunner);
+    expect(queries.some((q) => /DELETE\s+FROM\s+"custom_providers"/i.test(q))).toBe(false);
+  });
+
+  it('down re-adds agent_id and recreates the agent-scoped unique index', async () => {
+    await migration.down(queryRunner);
+    expect(queries.some((q) => q.includes('ADD COLUMN IF NOT EXISTS "agent_id"'))).toBe(true);
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('CREATE UNIQUE INDEX IF NOT EXISTS "IDX_custom_providers_agent_name"') &&
+          q.includes('"agent_id"'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.spec.ts
+++ b/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.spec.ts
@@ -65,9 +65,17 @@ describe('LiftCustomProvidersToUserLevel1791200000000', () => {
     expect(queries.some((q) => /DELETE\s+FROM\s+"custom_providers"/i.test(q))).toBe(false);
   });
 
-  it('down re-adds agent_id and recreates the agent-scoped unique index', async () => {
+  it('down re-adds agent_id, restores the agent FK, and recreates the agent-scoped unique index', async () => {
     await migration.down(queryRunner);
     expect(queries.some((q) => q.includes('ADD COLUMN IF NOT EXISTS "agent_id"'))).toBe(true);
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('ADD CONSTRAINT "FK_custom_providers_agent"') &&
+          q.includes('REFERENCES "agents"') &&
+          q.includes('ON DELETE CASCADE'),
+      ),
+    ).toBe(true);
     expect(
       queries.some(
         (q) =>

--- a/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.ts
+++ b/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.ts
@@ -124,6 +124,16 @@ export class LiftCustomProvidersToUserLevel1791200000000 implements MigrationInt
     await queryRunner.query(
       `ALTER TABLE "custom_providers" ADD COLUMN IF NOT EXISTS "agent_id" varchar`,
     );
+    // Restore the original agent FK (ON DELETE CASCADE) so the rolled-back schema
+    // re-enforces referential integrity. The original column was also NOT NULL,
+    // but that can't be restored on down() — the lift discarded each row's agent
+    // binding, so there are no values to backfill; leaving it nullable is the
+    // closest non-destructive equivalent.
+    await queryRunner.query(`
+      ALTER TABLE "custom_providers"
+        ADD CONSTRAINT "FK_custom_providers_agent"
+        FOREIGN KEY ("agent_id") REFERENCES "agents" ("id") ON DELETE CASCADE
+    `);
     await queryRunner.query(`
       CREATE UNIQUE INDEX IF NOT EXISTS "IDX_custom_providers_agent_name"
       ON "custom_providers" ("agent_id", "name")

--- a/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.ts
+++ b/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.ts
@@ -1,0 +1,132 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class LiftCustomProvidersToUserLevel1791200000000 implements MigrationInterface {
+  name = 'LiftCustomProvidersToUserLevel1791200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Drop any FK on custom_providers.agent_id (name-agnostic) before the
+    //    column goes away.
+    await queryRunner.query(`
+      DO $$
+      DECLARE c text;
+      BEGIN
+        FOR c IN
+          SELECT conname FROM pg_constraint
+          WHERE conrelid = '"custom_providers"'::regclass AND contype = 'f'
+        LOOP
+          EXECUTE format('ALTER TABLE "custom_providers" DROP CONSTRAINT %I', c);
+        END LOOP;
+      END $$
+    `);
+
+    // 2. Drop every non-PK index on custom_providers (name-agnostic) — the old
+    //    unique index was keyed on (agent_id, name).
+    await queryRunner.query(`
+      DO $$
+      DECLARE i text;
+      BEGIN
+        FOR i IN
+          SELECT i.relname
+          FROM pg_index ix
+          JOIN pg_class t ON t.oid = ix.indrelid
+          JOIN pg_class i ON i.oid = ix.indexrelid
+          WHERE t.relname = 'custom_providers'
+            AND ix.indisprimary = false
+        LOOP
+          EXECUTE format('DROP INDEX IF EXISTS %I', i);
+        END LOOP;
+      END $$
+    `);
+
+    // 3. Relabel name collisions within a user (suffix with row id — never
+    //    delete: a custom provider row carries a base_url + model catalog the
+    //    user configured, and two same-named rows under different agents are
+    //    distinct configs we must preserve). Pick the first suffix that does
+    //    NOT collide with an existing name for that user, so a user who already
+    //    has a row literally named "Foo [<id>]" can't abort the migration on the
+    //    new (user_id, LOWER(name)) unique index.
+    await queryRunner.query(`
+      WITH ranked AS (
+        SELECT "id", "user_id", "name",
+          ROW_NUMBER() OVER (
+            PARTITION BY "user_id", LOWER("name")
+            ORDER BY "created_at" ASC, "id" ASC
+          ) AS rn
+        FROM "custom_providers"
+      ),
+      to_relabel AS (
+        SELECT "id", "user_id", "name" FROM ranked WHERE rn > 1
+      ),
+      resolved AS (
+        SELECT r."id", chosen."name"
+        FROM to_relabel r
+        CROSS JOIN LATERAL (
+          SELECT CASE
+                   WHEN suffix.n = 0 THEN r."name" || ' [' || r."id" || ']'
+                   ELSE r."name" || ' [' || r."id" || '-' || suffix.n || ']'
+                 END AS "name"
+          FROM generate_series(0, 1000) AS suffix(n)
+          WHERE NOT EXISTS (
+            SELECT 1 FROM "custom_providers" existing
+            WHERE existing."user_id" = r."user_id"
+              AND existing."id" <> r."id"
+              AND LOWER(existing."name") = LOWER(
+                CASE
+                  WHEN suffix.n = 0 THEN r."name" || ' [' || r."id" || ']'
+                  ELSE r."name" || ' [' || r."id" || '-' || suffix.n || ']'
+                END
+              )
+          )
+          ORDER BY suffix.n
+          LIMIT 1
+        ) chosen
+      )
+      UPDATE "custom_providers" cp
+      SET "name" = resolved."name"
+      FROM resolved
+      WHERE cp."id" = resolved."id"
+    `);
+
+    // 4. Drop the now-dead agent_id column. The custom_providers row's agent
+    //    binding is gone; access is governed by the companion user_providers
+    //    row's agent_provider_access grants (step 6). There's nothing to
+    //    reconstruct the old mapping from on rollback, so keeping a nullable
+    //    column buys no rollback safety — drop outright (matches #2061's schema).
+    await queryRunner.query(`ALTER TABLE "custom_providers" DROP COLUMN IF EXISTS "agent_id"`);
+
+    // 5. New user-scoped unique index.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_custom_providers_user_name"
+      ON "custom_providers" ("user_id", LOWER("name"))
+    `);
+
+    // 6. Make every existing custom provider usable on ALL of its owner's agents.
+    //    Pre-lift, a custom provider's companion user_providers row (`custom:<id>`)
+    //    only carried the single agent_provider_access grant backfilled from its
+    //    old agent_id. Now that custom providers are user-global — and newly
+    //    created ones grant every agent via upsertProvider(null, ...) — backfill
+    //    the same all-agent grants for existing ones, else they would show in
+    //    every agent's list but only route on their original agent. Agents are
+    //    owned via tenants.name = user_providers.user_id.
+    await queryRunner.query(`
+      INSERT INTO "agent_provider_access" ("agent_id", "user_provider_id")
+      SELECT a."id", up."id"
+      FROM "user_providers" up
+      JOIN "tenants" t ON t."name" = up."user_id"
+      JOIN "agents" a ON a."tenant_id" = t."id" AND a."deleted_at" IS NULL
+      WHERE up."provider" LIKE 'custom:%'
+      ON CONFLICT DO NOTHING
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_custom_providers_user_name"`);
+    await queryRunner.query(
+      `ALTER TABLE "custom_providers" ADD COLUMN IF NOT EXISTS "agent_id" varchar`,
+    );
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_custom_providers_agent_name"
+      ON "custom_providers" ("agent_id", "name")
+    `);
+  }
+}

--- a/packages/backend/src/entities/custom-provider.entity.ts
+++ b/packages/backend/src/entities/custom-provider.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
+import { Entity, Column, PrimaryColumn } from 'typeorm';
 import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
 
 export interface CustomProviderModel {
@@ -11,8 +11,11 @@ export interface CustomProviderModel {
 
 export type CustomProviderApiKind = 'openai' | 'anthropic';
 
+// Uniqueness is owned by the migration as a case-insensitive index on
+// (user_id, LOWER(name)) — which a column-list @Index can't express. Declaring a
+// case-sensitive @Index here would drift from the real schema (synchronize ≠
+// migrations), so it's intentionally omitted (same pattern as user_providers).
 @Entity('custom_providers')
-@Index(['user_id', 'name'], { unique: true })
 export class CustomProvider {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/backend/src/entities/custom-provider.entity.ts
+++ b/packages/backend/src/entities/custom-provider.entity.ts
@@ -1,6 +1,5 @@
-import { Entity, Column, PrimaryColumn, ManyToOne, JoinColumn, Index } from 'typeorm';
+import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
-import { Agent } from './agent.entity';
 
 export interface CustomProviderModel {
   model_name: string;
@@ -13,13 +12,10 @@ export interface CustomProviderModel {
 export type CustomProviderApiKind = 'openai' | 'anthropic';
 
 @Entity('custom_providers')
-@Index(['agent_id', 'name'], { unique: true })
+@Index(['user_id', 'name'], { unique: true })
 export class CustomProvider {
   @PrimaryColumn('varchar')
   id!: string;
-
-  @Column('varchar')
-  agent_id!: string;
 
   @Column('varchar')
   user_id!: string;
@@ -35,10 +31,6 @@ export class CustomProvider {
 
   @Column('simple-json')
   models!: CustomProviderModel[];
-
-  @ManyToOne(() => Agent, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'agent_id' })
-  agent!: Agent;
 
   @Column(timestampType(), { default: timestampDefault() })
   created_at!: string;

--- a/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
@@ -196,7 +196,6 @@ describe('ModelDiscoveryService — boundary conditions', () => {
       customProviderRepo.find.mockResolvedValueOnce([
         makeCustomProvider({
           id: 'cp-agent-a',
-          agent_id: 'agent-a',
           models: [{ model_name: 'shared' }],
         }),
       ]);
@@ -205,7 +204,6 @@ describe('ModelDiscoveryService — boundary conditions', () => {
       customProviderRepo.find.mockResolvedValueOnce([
         makeCustomProvider({
           id: 'cp-agent-b',
-          agent_id: 'agent-b',
           models: [{ model_name: 'shared' }],
         }),
       ]);

--- a/packages/backend/src/routing/custom-provider.controller.spec.ts
+++ b/packages/backend/src/routing/custom-provider.controller.spec.ts
@@ -161,7 +161,7 @@ describe('CustomProviderController', () => {
         body as never,
       );
 
-      expect(mockCustomProviderService.create).toHaveBeenCalledWith('agent-001', 'user-1', body);
+      expect(mockCustomProviderService.create).toHaveBeenCalledWith('user-1', body);
       expect(result.id).toBe('cp-1');
       expect(result.name).toBe('Groq');
       expect(result.has_api_key).toBe(true);
@@ -198,12 +198,7 @@ describe('CustomProviderController', () => {
 
       const result = await controller.update(mockUser, 'test-agent', 'cp-1', body as never);
 
-      expect(mockCustomProviderService.update).toHaveBeenCalledWith(
-        'agent-001',
-        'cp-1',
-        'user-1',
-        body,
-      );
+      expect(mockCustomProviderService.update).toHaveBeenCalledWith('cp-1', 'user-1', body);
       expect(result.id).toBe('cp-1');
       expect(result.name).toBe('Updated Groq');
       expect(result.has_api_key).toBe(true);
@@ -234,7 +229,7 @@ describe('CustomProviderController', () => {
     it('removes custom provider and returns ok', async () => {
       const result = await controller.remove(mockUser, 'test-agent', 'cp-1');
 
-      expect(mockCustomProviderService.remove).toHaveBeenCalledWith('agent-001', 'cp-1', 'user-1');
+      expect(mockCustomProviderService.remove).toHaveBeenCalledWith('user-1', 'cp-1');
       expect(result).toEqual({ ok: true });
     });
 

--- a/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
@@ -21,9 +21,11 @@ export class CustomProviderController {
 
   @Get(':agentName/custom-providers')
   async list(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
-    const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
+    // Resolve for authz — user must own the agent. Custom providers are
+    // user-global, so the listing itself is scoped to the user, not the agent.
+    await this.resolveAgentService.resolve(user.id, params.agentName);
     const [providers, userProviders] = await Promise.all([
-      this.customProviderService.list(agent.id),
+      this.customProviderService.list(user.id),
       this.providerService.getProviders(user.id),
     ]);
     if (providers.length === 0) return [];
@@ -67,8 +69,8 @@ export class CustomProviderController {
     @Param() params: AgentNameParamDto,
     @Body() body: CreateCustomProviderDto,
   ) {
-    const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
-    const cp = await this.customProviderService.create(agent.id, user.id, body);
+    await this.resolveAgentService.resolve(user.id, params.agentName);
+    const cp = await this.customProviderService.create(user.id, body);
     const provKey = CustomProviderService.providerKey(cp.id);
     const up = (await this.providerService.getProviders(user.id)).find(
       (u) => u.provider === provKey,
@@ -92,8 +94,8 @@ export class CustomProviderController {
     @Param('id') id: string,
     @Body() body: UpdateCustomProviderDto,
   ) {
-    const agent = await this.resolveAgentService.resolve(user.id, agentName);
-    const cp = await this.customProviderService.update(agent.id, id, user.id, body);
+    await this.resolveAgentService.resolve(user.id, agentName);
+    const cp = await this.customProviderService.update(id, user.id, body);
     const provKey = CustomProviderService.providerKey(cp.id);
     const up = (await this.providerService.getProviders(user.id)).find(
       (u) => u.provider === provKey,
@@ -116,8 +118,8 @@ export class CustomProviderController {
     @Param('agentName') agentName: string,
     @Param('id') id: string,
   ) {
-    const agent = await this.resolveAgentService.resolve(user.id, agentName);
-    await this.customProviderService.remove(agent.id, id, user.id);
+    await this.resolveAgentService.resolve(user.id, agentName);
+    await this.customProviderService.remove(user.id, id);
     return { ok: true };
   }
 }

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.edge-cases.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.edge-cases.spec.ts
@@ -19,7 +19,7 @@ import { CustomProviderService } from './custom-provider.service';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { ProviderService } from '../routing-core/provider.service';
 import { RoutingCacheService } from '../routing-core/routing-cache.service';
-import { TierAutoAssignService } from '../routing-core/tier-auto-assign.service';
+import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -54,9 +54,6 @@ function makeDeps(overrides: {
     setCustomProviders,
     invalidateAgent: jest.fn(),
   } as unknown as RoutingCacheService;
-  const autoAssign = {
-    recalculate: jest.fn().mockResolvedValue(undefined),
-  } as unknown as TierAutoAssignService;
   const pricingCache = {
     reload: jest.fn().mockResolvedValue(undefined),
   } as unknown as ModelPricingCacheService;
@@ -65,8 +62,8 @@ function makeDeps(overrides: {
     repo,
     providerService,
     routingCache,
-    autoAssign,
     pricingCache,
+    { emit: jest.fn() } as unknown as IngestEventBusService,
     undefined as unknown as ModelsDevSyncService,
   );
 
@@ -106,7 +103,7 @@ describe('CustomProviderService edge cases', () => {
       });
       // The cache miss path must actually hit the DB and repopulate the
       // cache (with the empty result) so the next lookup is also cheap.
-      expect(find).toHaveBeenCalledWith({ where: { agent_id: 'agent-1' } });
+      expect(find).toHaveBeenCalledWith({ where: { user_id: 'agent-1' } });
       expect(setCustomProviders).toHaveBeenCalledWith('agent-1', []);
     });
 
@@ -116,9 +113,9 @@ describe('CustomProviderService edge cases', () => {
       // case after a delete + invalidateAgent.
       const otherRow = {
         id: 'cp-still-here',
-        agent_id: 'agent-1',
+        user_id: 'agent-1',
         name: 'llama.cpp',
-      } as CustomProvider;
+      } as unknown as CustomProvider;
       const { svc } = makeDeps({
         cached: null,
         findResult: [otherRow],
@@ -176,8 +173,8 @@ describe('CustomProviderService edge cases', () => {
       // The service must wrap whatever the validator throws in a
       // BadRequestException — leaking the raw Error type would surface as
       // a 500 to the client, hiding the underlying user-input problem.
-      await expect(svc.create('agent-1', 'user-1', baseDto)).rejects.toThrow(BadRequestException);
-      await expect(svc.create('agent-1', 'user-1', baseDto)).rejects.toThrow(/Invalid URL format/);
+      await expect(svc.create('user-1', baseDto)).rejects.toThrow(BadRequestException);
+      await expect(svc.create('user-1', baseDto)).rejects.toThrow(/Invalid URL format/);
     });
 
     it('rejects http URLs in cloud mode on create (cleartext credentials risk)', async () => {
@@ -186,7 +183,7 @@ describe('CustomProviderService edge cases', () => {
       );
       const { svc } = makeDeps({ findOneResults: [null] });
       await expect(
-        svc.create('agent-1', 'user-1', { ...baseDto, base_url: 'http://api.example.com' }),
+        svc.create('user-1', { ...baseDto, base_url: 'http://api.example.com' }),
       ).rejects.toThrow(/Only https URLs are allowed/);
       // allowPrivate must be false in non-self-hosted runs — the validator
       // can't make that decision on its own without this option.
@@ -201,7 +198,7 @@ describe('CustomProviderService edge cases', () => {
       );
       const { svc } = makeDeps({ findOneResults: [null] });
       await expect(
-        svc.create('agent-1', 'user-1', { ...baseDto, base_url: 'http://10.0.0.5:11434' }),
+        svc.create('user-1', { ...baseDto, base_url: 'http://10.0.0.5:11434' }),
       ).rejects.toThrow(/private or internal networks/);
     });
 
@@ -215,7 +212,7 @@ describe('CustomProviderService edge cases', () => {
       );
       const { svc } = makeDeps({ findOneResults: [null] });
       await expect(
-        svc.create('agent-1', 'user-1', {
+        svc.create('user-1', {
           ...baseDto,
           base_url: 'http://169.254.169.254/latest/meta-data',
         }),
@@ -228,21 +225,21 @@ describe('CustomProviderService edge cases', () => {
 
     it('rejects malformed URLs on update with BadRequestException', async () => {
       (validatePublicUrl as jest.Mock).mockRejectedValue(new Error('Invalid URL format'));
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
+      const existing = { id: 'cp1', user_id: 'user-1', name: 'n' } as unknown as CustomProvider;
       const { svc } = makeDeps({ findOneResults: [existing] });
-      await expect(
-        svc.update('agent-1', 'cp1', 'user-1', { base_url: 'ht!tp://broken' }),
-      ).rejects.toThrow(BadRequestException);
+      await expect(svc.update('cp1', 'user-1', { base_url: 'ht!tp://broken' })).rejects.toThrow(
+        BadRequestException,
+      );
     });
 
     it('rejects private-IP URLs on update in cloud mode', async () => {
       (validatePublicUrl as jest.Mock).mockRejectedValue(
         new Error('URLs pointing to private or internal networks are not allowed'),
       );
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
+      const existing = { id: 'cp1', user_id: 'user-1', name: 'n' } as unknown as CustomProvider;
       const { svc } = makeDeps({ findOneResults: [existing] });
       await expect(
-        svc.update('agent-1', 'cp1', 'user-1', { base_url: 'http://192.168.1.10' }),
+        svc.update('cp1', 'user-1', { base_url: 'http://192.168.1.10' }),
       ).rejects.toThrow(/private or internal networks/);
     });
 

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -11,8 +11,8 @@ import { CustomProviderService } from './custom-provider.service';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { ProviderService } from '../routing-core/provider.service';
 import { RoutingCacheService } from '../routing-core/routing-cache.service';
-import { TierAutoAssignService } from '../routing-core/tier-auto-assign.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
+import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { validatePublicUrl } = require('../../common/utils/url-validation');
@@ -40,39 +40,40 @@ function makeDeps(overrides: {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: {} });
   const removeProvider = jest.fn().mockResolvedValue(undefined);
   const retagAuthType = jest.fn().mockResolvedValue(undefined);
+  const recalculateTiersForUser = jest.fn().mockResolvedValue(undefined);
   const providerService = {
     upsertProvider,
     removeProvider,
     retagAuthType,
+    recalculateTiersForUser,
   } as unknown as ProviderService;
 
   const getCustomProviders = jest.fn().mockReturnValue(overrides.cached ?? null);
   const setCustomProviders = jest.fn();
-  const invalidateAgent = jest.fn();
   const invalidateUser = jest.fn();
   const routingCache = {
     getCustomProviders,
     setCustomProviders,
-    invalidateAgent,
     invalidateUser,
   } as unknown as RoutingCacheService;
 
-  const recalculate = jest.fn().mockResolvedValue(undefined);
-  const autoAssign = { recalculate } as unknown as TierAutoAssignService;
-
   const reloadPricing = jest.fn().mockResolvedValue(undefined);
   const pricingCache = { reload: reloadPricing } as unknown as ModelPricingCacheService;
+
+  const emit = jest.fn();
+  const eventBus = { emit } as unknown as IngestEventBusService;
 
   const svc = new CustomProviderService(
     repo,
     providerService,
     routingCache,
-    autoAssign,
     pricingCache,
+    eventBus,
     overrides.modelsDevSync as ModelsDevSyncService | undefined,
   );
 
   return {
+    emit,
     svc,
     findOne,
     find,
@@ -82,10 +83,10 @@ function makeDeps(overrides: {
     upsertProvider,
     removeProvider,
     retagAuthType,
+    recalculateTiersForUser,
     getCustomProviders,
     setCustomProviders,
-    invalidateAgent,
-    recalculate,
+    invalidateUser,
     reloadPricing,
   };
 }
@@ -127,13 +128,12 @@ describe('CustomProviderService', () => {
     it('rewrites provider + model when the custom provider is a tile-only canonical (llama.cpp)', async () => {
       const row = {
         id: 'cp-llamacpp',
-        agent_id: 'agent-1',
         name: 'llama.cpp',
       } as CustomProvider;
       const { svc } = makeDeps({ cached: [row] });
 
       const out = await svc.canonicalizeAgentMessageKeys(
-        'agent-1',
+        'user-1',
         'custom:cp-llamacpp',
         'custom:cp-llamacpp/qwen2.5-0.5b-q4.gguf',
       );
@@ -143,13 +143,12 @@ describe('CustomProviderService', () => {
     it('passes through user-defined custom providers that do not match a tile-only canonical', async () => {
       const row = {
         id: 'cp-mine',
-        agent_id: 'agent-1',
         name: 'My Groq',
       } as CustomProvider;
       const { svc } = makeDeps({ cached: [row] });
 
       const out = await svc.canonicalizeAgentMessageKeys(
-        'agent-1',
+        'user-1',
         'custom:cp-mine',
         'custom:cp-mine/llama-3.1-70b',
       );
@@ -159,7 +158,7 @@ describe('CustomProviderService', () => {
     it('passes through cloud providers (no custom: prefix)', async () => {
       const { svc } = makeDeps({ cached: [] });
       const out = await svc.canonicalizeAgentMessageKeys(
-        'agent-1',
+        'user-1',
         'anthropic',
         'anthropic/claude-opus-4-6',
       );
@@ -169,12 +168,11 @@ describe('CustomProviderService', () => {
     it('rewrites a custom-prefixed model string even when provider is null (fallback_from_model)', async () => {
       const row = {
         id: 'cp-llamacpp',
-        agent_id: 'agent-1',
         name: 'llama.cpp',
       } as CustomProvider;
       const { svc } = makeDeps({ cached: [row] });
       const out = await svc.canonicalizeAgentMessageKeys(
-        'agent-1',
+        'user-1',
         null,
         'custom:cp-llamacpp/qwen2.5-0.5b-q4.gguf',
       );
@@ -183,14 +181,14 @@ describe('CustomProviderService', () => {
 
     it('returns nulls when both provider and model are empty', async () => {
       const { svc } = makeDeps({ cached: [] });
-      const out = await svc.canonicalizeAgentMessageKeys('agent-1', null, null);
+      const out = await svc.canonicalizeAgentMessageKeys('user-1', null, null);
       expect(out).toEqual({ provider: null, model: null });
     });
 
     it('returns provider unchanged when the referenced custom provider no longer exists', async () => {
       const { svc } = makeDeps({ cached: [] });
       const out = await svc.canonicalizeAgentMessageKeys(
-        'agent-1',
+        'user-1',
         'custom:deleted',
         'custom:deleted/foo',
       );
@@ -203,7 +201,7 @@ describe('CustomProviderService', () => {
       // through rather than silently dropping the reference.
       const { svc } = makeDeps({ cached: [] });
       const out = await svc.canonicalizeAgentMessageKeys(
-        'agent-1',
+        'user-1',
         null,
         'custom:missing-uuid/my-model',
       );
@@ -217,12 +215,11 @@ describe('CustomProviderService', () => {
       // but the model must pass through untouched.
       const row = {
         id: 'cp-llamacpp',
-        agent_id: 'agent-1',
         name: 'llama.cpp',
       } as CustomProvider;
       const { svc } = makeDeps({ cached: [row] });
       const out = await svc.canonicalizeAgentMessageKeys(
-        'agent-1',
+        'user-1',
         'custom:cp-llamacpp',
         'anthropic/claude-opus-4-6',
       );
@@ -233,7 +230,7 @@ describe('CustomProviderService', () => {
       // Combines the "row not found" branch with a null model — the
       // canonicalizer must not invent a model string when none was supplied.
       const { svc } = makeDeps({ cached: [] });
-      const out = await svc.canonicalizeAgentMessageKeys('agent-1', 'custom:deleted', null);
+      const out = await svc.canonicalizeAgentMessageKeys('user-1', 'custom:deleted', null);
       expect(out).toEqual({ provider: 'custom:deleted', model: null });
     });
 
@@ -242,11 +239,10 @@ describe('CustomProviderService', () => {
       // must stay missing — no accidental "my-groq/null" strings in the DB.
       const row = {
         id: 'cp-mine',
-        agent_id: 'agent-1',
         name: 'My Groq',
       } as CustomProvider;
       const { svc } = makeDeps({ cached: [row] });
-      const out = await svc.canonicalizeAgentMessageKeys('agent-1', 'custom:cp-mine', null);
+      const out = await svc.canonicalizeAgentMessageKeys('user-1', 'custom:cp-mine', null);
       expect(out).toEqual({ provider: 'custom:cp-mine', model: null });
     });
 
@@ -256,11 +252,10 @@ describe('CustomProviderService', () => {
       // must remain null rather than accidentally adopting a canonical prefix.
       const row = {
         id: 'cp-llamacpp',
-        agent_id: 'agent-1',
         name: 'llama.cpp',
       } as CustomProvider;
       const { svc } = makeDeps({ cached: [row] });
-      const out = await svc.canonicalizeAgentMessageKeys('agent-1', 'custom:cp-llamacpp', null);
+      const out = await svc.canonicalizeAgentMessageKeys('user-1', 'custom:cp-llamacpp', null);
       expect(out).toEqual({ provider: 'llamacpp', model: null });
     });
   });
@@ -269,7 +264,7 @@ describe('CustomProviderService', () => {
     it('returns the cached result when present', async () => {
       const cached = [{ id: 'cp1' } as CustomProvider];
       const { svc, find, setCustomProviders } = makeDeps({ cached });
-      const result = await svc.list('agent-1');
+      const result = await svc.list('user-1');
       expect(result).toBe(cached);
       expect(find).not.toHaveBeenCalled();
       expect(setCustomProviders).not.toHaveBeenCalled();
@@ -281,10 +276,10 @@ describe('CustomProviderService', () => {
         cached: null,
         findResult: rows,
       });
-      const result = await svc.list('agent-1');
+      const result = await svc.list('user-1');
       expect(result).toBe(rows);
-      expect(find).toHaveBeenCalledWith({ where: { agent_id: 'agent-1' } });
-      expect(setCustomProviders).toHaveBeenCalledWith('agent-1', rows);
+      expect(find).toHaveBeenCalledWith({ where: { user_id: 'user-1' } });
+      expect(setCustomProviders).toHaveBeenCalledWith('user-1', rows);
     });
   });
 
@@ -304,28 +299,41 @@ describe('CustomProviderService', () => {
     };
 
     it('throws Conflict when an agent already has a provider with the same name', async () => {
-      const { svc } = makeDeps({ findOneResults: [{ id: 'existing' } as CustomProvider] });
-      await expect(svc.create('agent-1', 'user-1', dto)).rejects.toBeInstanceOf(ConflictException);
+      const { svc } = makeDeps({
+        findResult: [{ id: 'existing', name: dto.name } as CustomProvider],
+      });
+      await expect(svc.create('user-1', dto)).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('throws Conflict when a case-variant of the same name already exists (e.g. "my-openai" vs "MY-OPENAI")', async () => {
+      const { svc } = makeDeps({
+        findResult: [{ id: 'existing', name: 'MY-OPENAI' } as CustomProvider],
+      });
+      // dto.name is 'my-openai' — differs only in case, must still conflict.
+      await expect(svc.create('user-1', dto)).rejects.toBeInstanceOf(ConflictException);
     });
 
     it('throws BadRequest when the base URL fails validation', async () => {
       (validatePublicUrl as jest.Mock).mockRejectedValue(new Error('not public'));
       const { svc } = makeDeps({ findOneResults: [null] });
-      await expect(svc.create('agent-1', 'user-1', dto)).rejects.toBeInstanceOf(
-        BadRequestException,
-      );
+      await expect(svc.create('user-1', dto)).rejects.toBeInstanceOf(BadRequestException);
     });
 
     it('inserts the row, upserts a UserProvider, and defaults context_window to 128k', async () => {
-      const { svc, insert, upsertProvider, reloadPricing } = makeDeps({ findOneResults: [null] });
-      const cp = await svc.create('agent-1', 'user-1', dto);
+      const { svc, insert, upsertProvider, reloadPricing, emit } = makeDeps({
+        findOneResults: [null],
+      });
+      const cp = await svc.create('user-1', dto);
+
+      // Custom providers are user-global: notify open clients to refresh.
+      expect(emit).toHaveBeenCalledWith('user-1', 'routing');
 
       expect(insert).toHaveBeenCalledTimes(1);
-      expect(cp.agent_id).toBe('agent-1');
+      expect(cp.user_id).toBe('user-1');
       expect(cp.name).toBe('my-openai');
       expect(cp.models[0].context_window).toBe(128_000);
       expect(upsertProvider).toHaveBeenCalledWith(
-        'agent-1',
+        null,
         'user-1',
         `custom:${cp.id}`,
         'sk-x',
@@ -339,9 +347,9 @@ describe('CustomProviderService', () => {
 
     it('tags the companion user_providers row as local when the name is LM Studio', async () => {
       const { svc, upsertProvider } = makeDeps({ findOneResults: [null] });
-      await svc.create('agent-1', 'user-1', { ...dto, name: 'LM Studio' });
+      await svc.create('user-1', { ...dto, name: 'LM Studio' });
       expect(upsertProvider).toHaveBeenCalledWith(
-        'agent-1',
+        null,
         'user-1',
         expect.stringMatching(/^custom:/),
         'sk-x',
@@ -351,9 +359,9 @@ describe('CustomProviderService', () => {
 
     it('normalizes the name for detection (lm-studio / LMSTUDIO both resolve to local)', async () => {
       const { svc, upsertProvider } = makeDeps({ findOneResults: [null] });
-      await svc.create('agent-1', 'user-1', { ...dto, name: 'lm-studio' });
+      await svc.create('user-1', { ...dto, name: 'lm-studio' });
       expect(upsertProvider).toHaveBeenLastCalledWith(
-        'agent-1',
+        null,
         'user-1',
         expect.stringMatching(/^custom:/),
         'sk-x',
@@ -363,9 +371,9 @@ describe('CustomProviderService', () => {
 
     it('keeps api_key tagging for freeform custom provider names', async () => {
       const { svc, upsertProvider } = makeDeps({ findOneResults: [null] });
-      await svc.create('agent-1', 'user-1', { ...dto, name: 'My Home Server' });
+      await svc.create('user-1', { ...dto, name: 'My Home Server' });
       expect(upsertProvider).toHaveBeenCalledWith(
-        'agent-1',
+        null,
         'user-1',
         expect.stringMatching(/^custom:/),
         'sk-x',
@@ -377,7 +385,7 @@ describe('CustomProviderService', () => {
       (isSelfHosted as jest.Mock).mockReturnValue(true);
       const selfHostedDto = { ...dto, base_url: 'http://host.docker.internal:11434/v1' };
       const { svc } = makeDeps({ findOneResults: [null] });
-      await svc.create('agent-1', 'user-1', selfHostedDto);
+      await svc.create('user-1', selfHostedDto);
       expect(validatePublicUrl).toHaveBeenCalledWith(selfHostedDto.base_url, {
         allowPrivate: true,
       });
@@ -385,13 +393,13 @@ describe('CustomProviderService', () => {
 
     it('defaults api_kind to "openai" when the DTO omits it', async () => {
       const { svc } = makeDeps({ findOneResults: [null] });
-      const cp = await svc.create('agent-1', 'user-1', dto);
+      const cp = await svc.create('user-1', dto);
       expect(cp.api_kind).toBe('openai');
     });
 
     it('persists api_kind="anthropic" when requested', async () => {
       const { svc } = makeDeps({ findOneResults: [null] });
-      const cp = await svc.create('agent-1', 'user-1', {
+      const cp = await svc.create('user-1', {
         ...dto,
         api_kind: 'anthropic',
       });
@@ -408,7 +416,7 @@ describe('CustomProviderService', () => {
       };
       const { svc } = makeDeps({ findOneResults: [null], modelsDevSync });
 
-      const cp = await svc.create('agent-1', 'user-1', {
+      const cp = await svc.create('user-1', {
         ...dto,
         name: 'Kilo Gateway',
         models: [{ model_name: 'openai/gpt-4o-mini' }],
@@ -437,7 +445,7 @@ describe('CustomProviderService', () => {
       };
       const { svc } = makeDeps({ findOneResults: [null], modelsDevSync });
 
-      const cp = await svc.create('agent-1', 'user-1', {
+      const cp = await svc.create('user-1', {
         ...dto,
         name: 'Mammouth AI',
         models: [{ model_name: 'openai/gpt-4o-mini' }],
@@ -467,7 +475,7 @@ describe('CustomProviderService', () => {
       };
       const { svc } = makeDeps({ findOneResults: [null], modelsDevSync });
 
-      const cp = await svc.create('agent-1', 'user-1', {
+      const cp = await svc.create('user-1', {
         ...dto,
         name: 'Kilo Gateway',
         models: [
@@ -491,30 +499,51 @@ describe('CustomProviderService', () => {
   describe('update', () => {
     it('throws NotFound when the provider does not exist for the agent', async () => {
       const { svc } = makeDeps({ findOneResults: [null] });
-      await expect(
-        svc.update('agent-1', 'missing', 'user-1', { name: 'x' }),
-      ).rejects.toBeInstanceOf(NotFoundException);
+      await expect(svc.update('missing', 'user-1', { name: 'x' })).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
 
     it('throws Conflict when renaming collides with an existing provider', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'old' } as CustomProvider;
+      const existing = { id: 'cp1', name: 'old' } as CustomProvider;
       const { svc } = makeDeps({
-        findOneResults: [existing, { id: 'other', name: 'new' } as CustomProvider],
+        findOneResults: [existing],
+        findResult: [
+          { id: 'cp1', name: 'old' } as CustomProvider,
+          { id: 'other', name: 'new' } as CustomProvider,
+        ],
       });
-      await expect(svc.update('agent-1', 'cp1', 'user-1', { name: 'new' })).rejects.toBeInstanceOf(
+      await expect(svc.update('cp1', 'user-1', { name: 'new' })).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+    });
+
+    it('throws Conflict when renaming to a case-variant of an existing provider name', async () => {
+      const existing = { id: 'cp1', name: 'old' } as CustomProvider;
+      const { svc } = makeDeps({
+        findOneResults: [existing],
+        // 'OTHER' is a different provider (id: 'other2') whose lowercase name is 'new'
+        findResult: [
+          { id: 'cp1', name: 'old' } as CustomProvider,
+          { id: 'other2', name: 'NEW' } as CustomProvider,
+        ],
+      });
+      // Renaming cp1 to 'new' must conflict with existing 'NEW' (case-insensitive)
+      await expect(svc.update('cp1', 'user-1', { name: 'new' })).rejects.toBeInstanceOf(
         ConflictException,
       );
     });
 
     it('renames and persists when no collision', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'old' } as CustomProvider;
-      const { svc, save, invalidateAgent, reloadPricing } = makeDeps({
+      const existing = { id: 'cp1', name: 'old' } as CustomProvider;
+      const { svc, save, invalidateUser, reloadPricing, emit } = makeDeps({
         findOneResults: [existing, null],
       });
-      await svc.update('agent-1', 'cp1', 'user-1', { name: 'new' });
+      await svc.update('cp1', 'user-1', { name: 'new' });
       expect(existing.name).toBe('new');
       expect(save).toHaveBeenCalledWith(existing);
-      expect(invalidateAgent).toHaveBeenCalledWith('agent-1');
+      expect(invalidateUser).toHaveBeenCalledWith('user-1');
+      expect(emit).toHaveBeenCalledWith('user-1', 'routing');
       // A rename-only update cannot affect prices, so the shared pricing
       // cache should be left alone (reload is expensive for large installs).
       expect(reloadPricing).not.toHaveBeenCalled();
@@ -523,21 +552,20 @@ describe('CustomProviderService', () => {
     it('validates and updates base_url when provided', async () => {
       const existing = {
         id: 'cp1',
-        agent_id: 'agent-1',
         name: 'n',
         base_url: 'a',
       } as CustomProvider;
       const { svc } = makeDeps({ findOneResults: [existing] });
-      await svc.update('agent-1', 'cp1', 'user-1', { base_url: 'https://b.example' });
+      await svc.update('cp1', 'user-1', { base_url: 'https://b.example' });
       expect(validatePublicUrl).toHaveBeenCalledWith('https://b.example', { allowPrivate: false });
       expect(existing.base_url).toBe('https://b.example');
     });
 
     it('passes allowPrivate=true to validatePublicUrl in the self-hosted version', async () => {
       (isSelfHosted as jest.Mock).mockReturnValue(true);
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
+      const existing = { id: 'cp1', name: 'n' } as CustomProvider;
       const { svc } = makeDeps({ findOneResults: [existing] });
-      await svc.update('agent-1', 'cp1', 'user-1', {
+      await svc.update('cp1', 'user-1', {
         base_url: 'http://host.docker.internal:8000/v1',
       });
       expect(validatePublicUrl).toHaveBeenCalledWith('http://host.docker.internal:8000/v1', {
@@ -546,20 +574,20 @@ describe('CustomProviderService', () => {
     });
 
     it('throws BadRequest when the new base_url fails validation', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
+      const existing = { id: 'cp1', name: 'n' } as CustomProvider;
       const { svc } = makeDeps({ findOneResults: [existing] });
       (validatePublicUrl as jest.Mock).mockRejectedValue(new Error('bad url'));
-      await expect(
-        svc.update('agent-1', 'cp1', 'user-1', { base_url: 'http://bad' }),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      await expect(svc.update('cp1', 'user-1', { base_url: 'http://bad' })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
     });
 
     it('rewrites models (defaulting context_window) and recalculates tiers when the api key is not touched', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
-      const { svc, recalculate, upsertProvider, reloadPricing } = makeDeps({
+      const existing = { id: 'cp1', name: 'n' } as CustomProvider;
+      const { svc, recalculateTiersForUser, upsertProvider, reloadPricing } = makeDeps({
         findOneResults: [existing],
       });
-      await svc.update('agent-1', 'cp1', 'user-1', {
+      await svc.update('cp1', 'user-1', {
         models: [
           {
             model_name: 'm1',
@@ -569,15 +597,44 @@ describe('CustomProviderService', () => {
         ],
       });
       expect(existing.models[0].context_window).toBe(128_000);
-      expect(recalculate).toHaveBeenCalledWith('agent-1', 'user-1');
+      expect(recalculateTiersForUser).toHaveBeenCalledWith('user-1');
       expect(upsertProvider).not.toHaveBeenCalled();
       // Edited prices must flow into the shared pricing cache so the next
       // proxied message picks up the new per-token cost.
       expect(reloadPricing).toHaveBeenCalledTimes(1);
     });
 
+    it('persists the custom provider row (repo.save) before recalculating tiers in update()', async () => {
+      // Regression guard: tier recalculation must see the NEW model list, not
+      // the stale one. The only way to guarantee that is for repo.save to be
+      // called before recalculateTiersForUser / upsertProvider.
+      const existing = { id: 'cp1', name: 'n' } as CustomProvider;
+      const callOrder: string[] = [];
+      const { svc, save, recalculateTiersForUser } = makeDeps({ findOneResults: [existing] });
+      save.mockImplementation(() => {
+        callOrder.push('save');
+        return Promise.resolve(undefined);
+      });
+      recalculateTiersForUser.mockImplementation(() => {
+        callOrder.push('recalc');
+        return Promise.resolve(undefined);
+      });
+
+      await svc.update('cp1', 'user-1', {
+        models: [
+          {
+            model_name: 'm1',
+            input_price_per_million_tokens: 1,
+            output_price_per_million_tokens: 1,
+          },
+        ],
+      });
+
+      expect(callOrder.indexOf('save')).toBeLessThan(callOrder.indexOf('recalc'));
+    });
+
     it('fills missing model update prices from models.dev using the current provider name', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'Kilo Gateway' } as CustomProvider;
+      const existing = { id: 'cp1', name: 'Kilo Gateway' } as CustomProvider;
       const modelsDevSync = {
         lookupCustomProviderModel: jest.fn().mockReturnValue({
           inputPricePerToken: 0.15 / 1_000_000,
@@ -587,7 +644,7 @@ describe('CustomProviderService', () => {
       };
       const { svc } = makeDeps({ findOneResults: [existing], modelsDevSync });
 
-      await svc.update('agent-1', 'cp1', 'user-1', {
+      await svc.update('cp1', 'user-1', {
         models: [{ model_name: 'openai/gpt-4o-mini' }],
       });
 
@@ -602,55 +659,54 @@ describe('CustomProviderService', () => {
     it('updates api_kind when provided', async () => {
       const existing = {
         id: 'cp1',
-        agent_id: 'agent-1',
         name: 'n',
         api_kind: 'openai',
       } as CustomProvider;
       const { svc } = makeDeps({ findOneResults: [existing] });
-      await svc.update('agent-1', 'cp1', 'user-1', { api_kind: 'anthropic' });
+      await svc.update('cp1', 'user-1', { api_kind: 'anthropic' });
       expect(existing.api_kind).toBe('anthropic');
     });
 
     it('retags auth_type via ProviderService.retagAuthType when a rename crosses the local ↔ api_key boundary', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'LM Studio' } as CustomProvider;
-      const { svc, retagAuthType, upsertProvider, recalculate } = makeDeps({
+      const existing = { id: 'cp1', name: 'LM Studio' } as CustomProvider;
+      const { svc, retagAuthType, upsertProvider, recalculateTiersForUser } = makeDeps({
         findOneResults: [existing, null],
       });
-      await svc.update('agent-1', 'cp1', 'user-1', { name: 'My Home Server' });
-      expect(retagAuthType).toHaveBeenCalledWith('agent-1', 'user-1', 'custom:cp1', 'api_key');
+      await svc.update('cp1', 'user-1', { name: 'My Home Server' });
+      expect(retagAuthType).toHaveBeenCalledWith(null, 'user-1', 'custom:cp1', 'api_key');
       // No apiKey in the DTO, so upsertProvider must not fire.
       expect(upsertProvider).not.toHaveBeenCalled();
       // retagAuthType owns the cache invalidation; rename should not double-recalculate tiers.
-      expect(recalculate).not.toHaveBeenCalled();
+      expect(recalculateTiersForUser).not.toHaveBeenCalled();
     });
 
     it('retags local → api_key when renaming away from a canonical local name (LM Studio → Home Server)', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'LM Studio' } as CustomProvider;
+      const existing = { id: 'cp1', name: 'LM Studio' } as CustomProvider;
       const { svc, retagAuthType } = makeDeps({ findOneResults: [existing, null] });
-      await svc.update('agent-1', 'cp1', 'user-1', { name: 'Home Server' });
-      expect(retagAuthType).toHaveBeenLastCalledWith('agent-1', 'user-1', 'custom:cp1', 'api_key');
+      await svc.update('cp1', 'user-1', { name: 'Home Server' });
+      expect(retagAuthType).toHaveBeenLastCalledWith(null, 'user-1', 'custom:cp1', 'api_key');
     });
 
     it('retags api_key → local when renaming into a canonical local name', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'Home Server' } as CustomProvider;
+      const existing = { id: 'cp1', name: 'Home Server' } as CustomProvider;
       const { svc, retagAuthType } = makeDeps({ findOneResults: [existing, null] });
-      await svc.update('agent-1', 'cp1', 'user-1', { name: 'LM Studio' });
-      expect(retagAuthType).toHaveBeenLastCalledWith('agent-1', 'user-1', 'custom:cp1', 'local');
+      await svc.update('cp1', 'user-1', { name: 'LM Studio' });
+      expect(retagAuthType).toHaveBeenLastCalledWith(null, 'user-1', 'custom:cp1', 'local');
     });
 
     it('does not retag when a rename stays within the same category', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'Foo' } as CustomProvider;
+      const existing = { id: 'cp1', name: 'Foo' } as CustomProvider;
       const { svc, retagAuthType } = makeDeps({ findOneResults: [existing, null] });
-      await svc.update('agent-1', 'cp1', 'user-1', { name: 'Bar' });
+      await svc.update('cp1', 'user-1', { name: 'Bar' });
       expect(retagAuthType).not.toHaveBeenCalled();
     });
 
     it('delegates tier recalculation to provider upsert when the api key is also updated', async () => {
-      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
-      const { svc, recalculate, upsertProvider, reloadPricing } = makeDeps({
+      const existing = { id: 'cp1', name: 'n' } as CustomProvider;
+      const { svc, recalculateTiersForUser, upsertProvider, reloadPricing } = makeDeps({
         findOneResults: [existing],
       });
-      await svc.update('agent-1', 'cp1', 'user-1', {
+      await svc.update('cp1', 'user-1', {
         apiKey: 'sk-new',
         models: [
           {
@@ -662,14 +718,14 @@ describe('CustomProviderService', () => {
         ],
       });
       expect(upsertProvider).toHaveBeenCalledWith(
-        'agent-1',
+        null,
         'user-1',
         'custom:cp1',
         'sk-new',
         'api_key',
       );
       // When api key is updated, the upsert triggers its own recalc — service should not double-call.
-      expect(recalculate).not.toHaveBeenCalled();
+      expect(recalculateTiersForUser).not.toHaveBeenCalled();
       expect(existing.models[0].context_window).toBe(64_000);
       // Prices still changed → pricing cache must still be refreshed.
       expect(reloadPricing).toHaveBeenCalledTimes(1);
@@ -679,25 +735,28 @@ describe('CustomProviderService', () => {
   describe('remove', () => {
     it('throws NotFound when the provider is missing', async () => {
       const { svc } = makeDeps({ findOneResults: [null] });
-      await expect(svc.remove('agent-1', 'cp1')).rejects.toBeInstanceOf(NotFoundException);
+      await expect(svc.remove('user-1', 'cp1')).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it('deletes the row and attempts provider removal', async () => {
-      const cp = { id: 'cp1', agent_id: 'agent-1', user_id: 'user-1' } as CustomProvider;
-      const { svc, removeProvider, remove, reloadPricing } = makeDeps({ findOneResults: [cp] });
-      await svc.remove('agent-1', 'cp1');
-      expect(removeProvider).toHaveBeenCalledWith('agent-1', 'user-1', 'custom:cp1');
+      const cp = { id: 'cp1' } as CustomProvider;
+      const { svc, removeProvider, remove, reloadPricing, emit } = makeDeps({
+        findOneResults: [cp],
+      });
+      await svc.remove('user-1', 'cp1');
+      expect(removeProvider).toHaveBeenCalledWith(null, 'user-1', 'custom:cp1');
       expect(remove).toHaveBeenCalledWith(cp);
+      expect(emit).toHaveBeenCalledWith('user-1', 'routing');
       // Stale pricing entries for this provider must be dropped from the
       // cache so getAll() stops returning them.
       expect(reloadPricing).toHaveBeenCalledTimes(1);
     });
 
     it('swallows errors from provider removal (partial-state cleanup)', async () => {
-      const cp = { id: 'cp1', agent_id: 'agent-1' } as CustomProvider;
+      const cp = { id: 'cp1' } as CustomProvider;
       const { svc, removeProvider, remove } = makeDeps({ findOneResults: [cp] });
       removeProvider.mockRejectedValue(new Error('not linked'));
-      await expect(svc.remove('agent-1', 'cp1')).resolves.toBeUndefined();
+      await expect(svc.remove('user-1', 'cp1')).resolves.toBeUndefined();
       expect(remove).toHaveBeenCalledWith(cp);
     });
   });

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -740,12 +740,15 @@ describe('CustomProviderService', () => {
 
     it('deletes the row and attempts provider removal', async () => {
       const cp = { id: 'cp1' } as CustomProvider;
-      const { svc, removeProvider, remove, reloadPricing, emit } = makeDeps({
+      const { svc, removeProvider, remove, reloadPricing, emit, invalidateUser } = makeDeps({
         findOneResults: [cp],
       });
       await svc.remove('user-1', 'cp1');
       expect(removeProvider).toHaveBeenCalledWith(null, 'user-1', 'custom:cp1');
       expect(remove).toHaveBeenCalledWith(cp);
+      // The user-scoped custom-provider cache must be dropped so a later list()
+      // doesn't serve the deleted provider from a warm cache.
+      expect(invalidateUser).toHaveBeenCalledWith('user-1');
       expect(emit).toHaveBeenCalledWith('user-1', 'routing');
       // Stale pricing entries for this provider must be dropped from the
       // cache so getAll() stops returning them.

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -359,6 +359,10 @@ export class CustomProviderService {
     // Delete CustomProvider row
     await this.repo.remove(cp);
 
+    // Drop the now-deleted provider from the user-scoped custom-provider cache
+    // so a subsequent list() doesn't serve it from a warm cache (mirrors update).
+    this.routingCache.invalidateUser(userId);
+
     // Drop stale pricing entries for this provider's models from the cache.
     await this.pricingCache.reload();
 

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -22,12 +22,12 @@ import {
 } from '../../entities/custom-provider.entity';
 import { ProviderService } from '../routing-core/provider.service';
 import { RoutingCacheService } from '../routing-core/routing-cache.service';
-import { TierAutoAssignService } from '../routing-core/tier-auto-assign.service';
 import { CreateCustomProviderDto, UpdateCustomProviderDto } from '../dto/custom-provider.dto';
 import { validatePublicUrl } from '../../common/utils/url-validation';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
+import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { classifyProbeError } from './probe-error';
 
 const PROBE_TIMEOUT_MS = 5000;
@@ -73,12 +73,22 @@ export class CustomProviderService {
     private readonly repo: Repository<CustomProvider>,
     private readonly providerService: ProviderService,
     private readonly routingCache: RoutingCacheService,
-    private readonly autoAssign: TierAutoAssignService,
     private readonly pricingCache: ModelPricingCacheService,
+    private readonly eventBus: IngestEventBusService,
     @Optional()
     @Inject(ModelsDevSyncService)
     private readonly modelsDevSync: ModelsDevSyncService | null = null,
   ) {}
+
+  /**
+   * Custom providers are user-global, so a create/update/delete from one agent
+   * changes the list every other agent sees. Emit a user-level `routing` SSE so
+   * already-open clients (sibling agents, other tabs) drop their cached
+   * custom-provider list instead of showing stale data until a full reload.
+   */
+  private notifyChange(userId: string): void {
+    this.eventBus.emit(userId, 'routing');
+  }
 
   /** Provider key used in UserProvider tables. */
   static providerKey(id: string): string {
@@ -132,17 +142,17 @@ export class CustomProviderService {
   // string the rewrite path can only ever produce a non-null string, so
   // downstream call sites don't need defensive `?? model` fallbacks.
   async canonicalizeAgentMessageKeys(
-    agentId: string,
+    userId: string,
     provider: string | null | undefined,
     model: string,
   ): Promise<{ provider: string | null; model: string }>;
   async canonicalizeAgentMessageKeys(
-    agentId: string,
+    userId: string,
     provider: string | null | undefined,
     model: string | null | undefined,
   ): Promise<{ provider: string | null; model: string | null }>;
   async canonicalizeAgentMessageKeys(
-    agentId: string,
+    userId: string,
     provider: string | null | undefined,
     model: string | null | undefined,
   ): Promise<{ provider: string | null; model: string | null }> {
@@ -161,7 +171,7 @@ export class CustomProviderService {
       : (modelMatch?.[1] ?? null);
     if (!cpId) return { provider: provider ?? null, model: model ?? null };
 
-    const rows = await this.list(agentId);
+    const rows = await this.list(userId);
     const row = rows.find((r) => r.id === cpId);
     if (!row) return { provider: provider ?? null, model: model ?? null };
 
@@ -176,25 +186,23 @@ export class CustomProviderService {
     return { provider: rewrittenProvider, model: rewrittenModel };
   }
 
-  async list(agentId: string): Promise<CustomProvider[]> {
-    const cached = this.routingCache.getCustomProviders(agentId);
+  async list(userId: string): Promise<CustomProvider[]> {
+    const cached = this.routingCache.getCustomProviders(userId);
     if (cached) return cached;
 
-    const result = await this.repo.find({ where: { agent_id: agentId } });
-    this.routingCache.setCustomProviders(agentId, result);
+    const result = await this.repo.find({ where: { user_id: userId } });
+    this.routingCache.setCustomProviders(userId, result);
     return result;
   }
 
-  async create(
-    agentId: string,
-    userId: string,
-    dto: CreateCustomProviderDto,
-  ): Promise<CustomProvider> {
-    const existing = await this.repo.findOne({
-      where: { agent_id: agentId, name: dto.name },
-    });
+  async create(userId: string, dto: CreateCustomProviderDto): Promise<CustomProvider> {
+    // Use case-insensitive comparison to match the DB unique index on
+    // (user_id, LOWER(name)) — an exact findOne would miss "My Provider"
+    // vs "my provider" and fall through to a raw constraint 500.
+    const allForUser = await this.repo.find({ where: { user_id: userId } });
+    const existing = allForUser.find((r) => r.name.toLowerCase() === dto.name.toLowerCase());
     if (existing) {
-      throw new ConflictException(`Custom provider "${dto.name}" already exists for this agent`);
+      throw new ConflictException(`Custom provider "${dto.name}" already exists`);
     }
 
     try {
@@ -208,7 +216,6 @@ export class CustomProviderService {
 
     const cp = Object.assign(new CustomProvider(), {
       id,
-      agent_id: agentId,
       user_id: userId,
       name: dto.name,
       base_url: dto.base_url,
@@ -218,12 +225,14 @@ export class CustomProviderService {
     });
     await this.repo.insert(cp);
 
-    // Create UserProvider + trigger tier recalculation. When the display
-    // name resolves to Ollama / LM Studio we tag the row `'local'` so
-    // routed messages carry the grey-house badge and the row shows up
-    // under the Local tab.
+    // Create UserProvider + trigger tier recalculation across every owned
+    // agent (custom providers are user-global). When the display name
+    // resolves to Ollama / LM Studio we tag the row `'local'` so routed
+    // messages carry the grey-house badge and the row shows up under the
+    // Local tab. A null agentId tells the provider service the change is
+    // user-global rather than tied to one agent.
     await this.providerService.upsertProvider(
-      agentId,
+      null,
       userId,
       provKey,
       dto.apiKey,
@@ -235,27 +244,27 @@ export class CustomProviderService {
     // waiting for the daily 5am reload).
     await this.pricingCache.reload();
 
+    this.notifyChange(userId);
     return cp;
   }
 
-  async update(
-    agentId: string,
-    id: string,
-    userId: string,
-    dto: UpdateCustomProviderDto,
-  ): Promise<CustomProvider> {
-    const cp = await this.repo.findOne({ where: { id, agent_id: agentId } });
+  async update(id: string, userId: string, dto: UpdateCustomProviderDto): Promise<CustomProvider> {
+    const cp = await this.repo.findOne({ where: { id, user_id: userId } });
     if (!cp) {
       throw new NotFoundException('Custom provider not found');
     }
 
     const previousName = cp.name;
     if (dto.name !== undefined && dto.name !== cp.name) {
-      const dup = await this.repo.findOne({
-        where: { agent_id: agentId, name: dto.name },
-      });
+      // Use case-insensitive comparison to match the DB unique index on
+      // (user_id, LOWER(name)) so "My Provider" → "my provider" returns
+      // a ConflictException instead of hitting a raw DB constraint 500.
+      const allForUser = await this.repo.find({ where: { user_id: userId } });
+      const dup = allForUser.find(
+        (r) => r.id !== id && r.name.toLowerCase() === dto.name!.toLowerCase(),
+      );
       if (dup) {
-        throw new ConflictException(`Custom provider "${dto.name}" already exists for this agent`);
+        throw new ConflictException(`Custom provider "${dto.name}" already exists`);
       }
       cp.name = dto.name;
     }
@@ -277,6 +286,17 @@ export class CustomProviderService {
       cp.models = this.enrichCustomProviderModels(cp.name, dto.models);
     }
 
+    // Persist the updated state first so tier recalculation (below) operates
+    // against the new model list, not the stale one.
+    await this.repo.save(cp);
+    this.routingCache.invalidateUser(userId);
+
+    // Reload pricing cache when the model list changes so the tier
+    // auto-assigner (called below) can score models with fresh prices.
+    if (dto.models !== undefined) {
+      await this.pricingCache.reload();
+    }
+
     // Retag auth_type when the name changes categories (freeform ↔ canonical
     // local). This path fires even without an apiKey update because renaming
     // "LM Studio" to "My Home Server" should move the row off the Local tab,
@@ -291,7 +311,7 @@ export class CustomProviderService {
     // row accordingly.
     if ('apiKey' in dto) {
       await this.providerService.upsertProvider(
-        agentId,
+        null,
         userId,
         CustomProviderService.providerKey(id),
         dto.apiKey,
@@ -301,45 +321,37 @@ export class CustomProviderService {
       // Rename-only path: flip auth_type in place so the row keeps its
       // stored api_key_encrypted and tier overrides stay intact. Going
       // through upsertProvider would insert a second row since the unique
-      // index is keyed on (agent_id, provider, auth_type).
+      // index is keyed on (user_id, provider, auth_type).
       await this.providerService.retagAuthType(
-        agentId,
+        null,
         userId,
         CustomProviderService.providerKey(id),
         nextAuthType,
       );
     }
 
-    // Recalculate tiers when models changed (even without API key change)
+    // Recalculate tiers across all owned agents when models changed (even
+    // without API key change). The upsert/retag paths already recalc.
     if (dto.models !== undefined && !('apiKey' in dto) && !nameCategoryChanged) {
-      await this.autoAssign.recalculate(agentId, userId);
+      await this.providerService.recalculateTiersForUser(userId);
     }
 
-    await this.repo.save(cp);
-    this.routingCache.invalidateAgent(agentId);
-    this.routingCache.invalidateUser(userId);
-
-    // Reload pricing cache when the model list changes so new prices (or
-    // edits to existing ones) are used for subsequent cost computations.
-    if (dto.models !== undefined) {
-      await this.pricingCache.reload();
-    }
-
+    this.notifyChange(userId);
     return cp;
   }
 
-  async remove(agentId: string, id: string, userId?: string): Promise<void> {
-    const cp = await this.repo.findOne({ where: { id, agent_id: agentId } });
+  async remove(userId: string, id: string): Promise<void> {
+    const cp = await this.repo.findOne({ where: { id, user_id: userId } });
     if (!cp) {
       throw new NotFoundException('Custom provider not found');
     }
 
     const provKey = CustomProviderService.providerKey(id);
-    const effectiveUserId = userId ?? cp.user_id;
 
-    // Remove UserProvider + tier overrides
+    // Remove the user-global UserProvider + tier overrides across all agents.
+    // A null agentId tells the provider service the removal is user-global.
     try {
-      await this.providerService.removeProvider(agentId, effectiveUserId, provKey);
+      await this.providerService.removeProvider(null, userId, provKey);
     } catch {
       // Provider may not exist if creation partially failed
     }
@@ -349,6 +361,8 @@ export class CustomProviderService {
 
     // Drop stale pricing entries for this provider's models from the cache.
     await this.pricingCache.reload();
+
+    this.notifyChange(userId);
   }
 
   async getById(id: string): Promise<CustomProvider | null> {

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -90,8 +90,8 @@ export class ModelController {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
     const models = await this.discoveryService.getModelsForAgent(user.id, agent.id);
 
-    // Build display name map for custom providers
-    const customProviders = await this.customProviderService.list(agent.id);
+    // Build display name map for custom providers (user-global)
+    const customProviders = await this.customProviderService.list(user.id);
     const cpNameMap = new Map<string, string>();
     for (const cp of customProviders) {
       cpNameMap.set(CustomProviderService.providerKey(cp.id), cp.name);

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -207,7 +207,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     const messageStatus = httpStatus === 429 ? 'rate_limited' : 'error';
 
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
-      ctx.agentId,
+      ctx.userId,
       provider,
       model,
     );
@@ -276,13 +276,13 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     if (failures.length === 0) return;
     // primaryModel is loop-invariant — canonicalize once.
     const canonicalPrimary = await this.customProviders.canonicalizeAgentMessageKeys(
-      ctx.agentId,
+      ctx.userId,
       null,
       primaryModel,
     );
     const canonicalFailures = await Promise.all(
       failures.map((f) =>
-        this.customProviders.canonicalizeAgentMessageKeys(ctx.agentId, f.provider, f.model),
+        this.customProviders.canonicalizeAgentMessageKeys(ctx.userId, f.provider, f.model),
       ),
     );
     const rows: Partial<AgentMessage>[] = [];
@@ -351,7 +351,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     },
   ): Promise<void> {
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
-      ctx.agentId,
+      ctx.userId,
       opts?.provider,
       model,
     );
@@ -419,12 +419,12 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     const baseline = await this.computeBaseline(ctx.agentId, ctx.userId, inputTokens, outputTokens);
 
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
-      ctx.agentId,
+      ctx.userId,
       provider,
       model,
     );
     const canonicalFallbackFrom = await this.customProviders.canonicalizeAgentMessageKeys(
-      ctx.agentId,
+      ctx.userId,
       null,
       fallbackFromModel,
     );
@@ -507,7 +507,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     // `model` is a required string, so the overload on
     // `canonicalizeAgentMessageKeys` keeps `canonical.model` non-null.
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
-      ctx.agentId,
+      ctx.userId,
       provider,
       model,
     );

--- a/packages/backend/test/agent-duplication.e2e-spec.ts
+++ b/packages/backend/test/agent-duplication.e2e-spec.ts
@@ -22,9 +22,7 @@ describe('Agent Duplication (e2e)', () => {
 
     const now = new Date().toISOString();
 
-    // Seed a global UserProvider credential row (agent_id = TEST_AGENT_ID here
-    // only for the synchronize e2e — in production the row would be agent_id = null
-    // and accessed via agent_provider_access).
+    // Seed a global UserProvider credential row.
     await ds.getRepository(UserProvider).insert({
       id: 'up-e2e-1',
       user_id: 'test-user-001',
@@ -51,7 +49,6 @@ describe('Agent Duplication (e2e)', () => {
 
     await ds.getRepository(CustomProvider).insert({
       id: 'cp-e2e-1',
-      agent_id: TEST_AGENT_ID,
       user_id: 'test-user-001',
       name: 'custom-groq',
       base_url: 'https://api.groq.com/openai/v1',
@@ -102,10 +99,8 @@ describe('Agent Duplication (e2e)', () => {
       .expect(200);
 
     // providers = count of agent_provider_access grants for the source agent (1 grant for up-e2e-1)
-    // customProviders = 1 (cp-e2e-1 has no companion user_providers, but custom_providers count = 1)
     expect(res.body.copied).toEqual({
       providers: 1,
-      customProviders: 1,
       tierAssignments: 1,
       specificityAssignments: 1,
       modelParams: 0,
@@ -120,7 +115,7 @@ describe('Agent Duplication (e2e)', () => {
       .expect(404);
   });
 
-  it('POST /agents/:name/duplicate copies grants and custom providers to a new agent', async () => {
+  it('POST /agents/:name/duplicate copies grants to a new agent (providers are user-global, not cloned)', async () => {
     const res = await request(app.getHttpServer())
       .post(`/api/v1/agents/${sourceAgent}/duplicate`)
       .set(headers)
@@ -129,11 +124,9 @@ describe('Agent Duplication (e2e)', () => {
 
     expect(res.body.agent.name).toBe('test-agent-copy');
     expect(res.body.apiKey).toMatch(/^mnfst_/);
-    // providers = 1 grant (the global anthropic row gets a new grant, no clone)
-    // customProviders = 1 (cp-e2e-1 cloned — but no companion user_providers row for it)
+    // providers = 1 grant copied (the global anthropic row gets a new grant, not a clone)
     expect(res.body.copied).toEqual({
       providers: 1,
-      customProviders: 1,
       tierAssignments: 1,
       specificityAssignments: 1,
       modelParams: 0,
@@ -167,11 +160,13 @@ describe('Agent Duplication (e2e)', () => {
     expect(newGrants).toHaveLength(1);
     expect(newGrants[0].user_provider_id).toBe('up-e2e-1');
 
-    const newCustom = await ds
+    // Custom providers are user-global: no new CustomProvider row was created —
+    // still exactly one for this user.
+    const allCustom = await ds
       .getRepository(CustomProvider)
-      .find({ where: { agent_id: res.body.agent.id } });
-    expect(newCustom).toHaveLength(1);
-    expect(newCustom[0].name).toBe('custom-groq');
+      .find({ where: { user_id: 'test-user-001' } });
+    expect(allCustom).toHaveLength(1);
+    expect(allCustom[0].id).toBe('cp-e2e-1');
 
     const newTiers = await ds
       .getRepository(TierAssignment)
@@ -187,7 +182,10 @@ describe('Agent Duplication (e2e)', () => {
     expect(newSpec[0].category).toBe('coding');
   });
 
-  it('POST /agents/:name/duplicate remaps custom:<uuid> provider references', async () => {
+  it('POST /agents/:name/duplicate copies a custom provider grant verbatim (shared row, not re-credentialed)', async () => {
+    // Custom providers are user-global. Their agent_provider_access grant is copied
+    // verbatim pointing at the SAME user_providers row — no new CustomProvider row,
+    // no new UserProvider row.
     const now = new Date().toISOString();
     const srcAgentId = 'src-remap-agent';
     await ds.getRepository(Agent).insert({
@@ -208,9 +206,9 @@ describe('Agent Duplication (e2e)', () => {
       is_active: true,
     });
 
+    // A custom provider row (user-global in the new model).
     await ds.getRepository(CustomProvider).insert({
       id: 'cp-lmstudio-e2e',
-      agent_id: srcAgentId,
       user_id: 'test-user-001',
       name: 'LM Studio',
       base_url: 'http://localhost:1234/v1',
@@ -219,7 +217,7 @@ describe('Agent Duplication (e2e)', () => {
       created_at: now,
     });
 
-    // Custom companion UserProvider row for the LM Studio custom provider.
+    // UserProvider companion row for the LM Studio custom provider.
     await ds.getRepository(UserProvider).insert({
       id: 'up-lmstudio-e2e',
       user_id: 'test-user-001',
@@ -236,7 +234,7 @@ describe('Agent Duplication (e2e)', () => {
       models_fetched_at: null,
     });
 
-    // Ollama: treated as a global provider (not custom:), so it gets a grant copy.
+    // A regular global provider grant alongside the custom one.
     await ds.getRepository(UserProvider).insert({
       id: 'up-ollama-e2e',
       user_id: 'test-user-001',
@@ -267,37 +265,34 @@ describe('Agent Duplication (e2e)', () => {
 
     const newAgentId = res.body.agent.id;
 
-    // Custom provider is cloned with a new id.
-    const newCustom = await ds
-      .getRepository(CustomProvider)
-      .find({ where: { agent_id: newAgentId } });
-    expect(newCustom).toHaveLength(1);
-    expect(newCustom[0].name).toBe('LM Studio');
-    expect(newCustom[0].api_kind).toBe('openai');
-    expect(newCustom[0].id).not.toBe('cp-lmstudio-e2e');
-
-    // Custom companion UserProvider row is cloned with remapped provider key.
-    // Ollama is a global provider: its row is NOT cloned, only a grant is created.
-    const newUserProviders = await ds
-      .getRepository(UserProvider)
-      .find({ where: { agent_id: newAgentId } });
-    // Only the custom companion row is cloned (ollama row is NOT cloned)
-    expect(newUserProviders).toHaveLength(1);
-    expect(newUserProviders[0].provider).toBe(`custom:${newCustom[0].id}`);
-    expect(newUserProviders[0].provider).not.toContain('cp-lmstudio-e2e');
-    expect(newUserProviders[0].auth_type).toBe('local');
-
-    // Two grants: one pointing at the new custom companion row, one pointing at the original ollama row.
+    // 2 grants copied verbatim — same user_provider_id values as the source.
     const newGrants = await ds
       .getRepository(AgentProviderAccess)
       .find({ where: { agent_id: newAgentId } });
     expect(newGrants).toHaveLength(2);
 
-    const customGrant = newGrants.find((g) => g.user_provider_id === newUserProviders[0].id);
-    expect(customGrant).toBeDefined();
+    const lmsGrant = newGrants.find((g) => g.user_provider_id === 'up-lmstudio-e2e');
+    expect(lmsGrant).toBeDefined();
 
     const ollamaGrant = newGrants.find((g) => g.user_provider_id === 'up-ollama-e2e');
     expect(ollamaGrant).toBeDefined();
+
+    // Custom providers are user-global: the original row is NOT cloned.
+    // The user still has exactly the same custom providers as before duplication.
+    const lmsCustom = await ds
+      .getRepository(CustomProvider)
+      .findOne({ where: { id: 'cp-lmstudio-e2e' } });
+    expect(lmsCustom).toBeTruthy();
+    expect(lmsCustom!.id).toBe('cp-lmstudio-e2e');
+
+    // No new UserProvider rows cloned for the new agent.
+    const newUserProviders = await ds
+      .getRepository(UserProvider)
+      .find({ where: { agent_id: newAgentId } });
+    expect(newUserProviders).toHaveLength(0);
+
+    // Summary reflects 2 grants copied.
+    expect(res.body.copied.providers).toBe(2);
   });
 
   it('POST /agents/:name/duplicate returns 409 when target name already exists', async () => {

--- a/packages/backend/test/custom-providers-lift-migrations.e2e-spec.ts
+++ b/packages/backend/test/custom-providers-lift-migrations.e2e-spec.ts
@@ -1,0 +1,167 @@
+import { DataSource } from 'typeorm';
+import { LiftCustomProvidersToUserLevel1791200000000 } from '../src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel';
+
+/**
+ * Runs the REAL migration chain (synchronize:false) so LiftCustomProvidersToUserLevel
+ * actually executes against Postgres — the e2e suite uses synchronize:true, which
+ * never runs migrations, so a broken lift (bad SQL, or a unique index that doesn't
+ * enforce) would otherwise go unnoticed until production.
+ */
+describe('LiftCustomProvidersToUserLevel under migration-built schema (e2e)', () => {
+  let ds: DataSource;
+
+  beforeAll(async () => {
+    ds = new DataSource({
+      type: 'postgres',
+      url:
+        process.env['DATABASE_URL'] ??
+        'postgresql://myuser:mypassword@localhost:5432/manifest_duprepro',
+      entities: ['src/entities/!(*.spec).ts'],
+      migrations: ['src/database/migrations/!(*.spec).ts'],
+      synchronize: false,
+      dropSchema: true,
+      logging: false,
+    });
+    await ds.initialize();
+    await ds.runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await ds?.destroy();
+  });
+
+  it('drops the agent_id column from custom_providers', async () => {
+    const cols: { column_name: string }[] = await ds.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'custom_providers'`,
+    );
+    const names = cols.map((c) => c.column_name);
+    expect(names).not.toContain('agent_id');
+    expect(names).toContain('user_id');
+  });
+
+  it('enforces the user-scoped unique index on (user_id, LOWER(name))', async () => {
+    await ds.query(
+      `INSERT INTO "custom_providers" ("id","user_id","name","base_url","api_kind","models","created_at")
+       VALUES ('cpm-1','u-1','My Provider','https://a.example.com/v1','openai','[]', now())`,
+    );
+    // Same user, case-insensitively equal name → must collide.
+    await expect(
+      ds.query(
+        `INSERT INTO "custom_providers" ("id","user_id","name","base_url","api_kind","models","created_at")
+         VALUES ('cpm-2','u-1','my provider','https://b.example.com/v1','openai','[]', now())`,
+      ),
+    ).rejects.toThrow(/duplicate key value violates unique constraint/);
+  });
+
+  it('allows the same name under a different user', async () => {
+    await expect(
+      ds.query(
+        `INSERT INTO "custom_providers" ("id","user_id","name","base_url","api_kind","models","created_at")
+         VALUES ('cpm-3','u-2','My Provider','https://c.example.com/v1','openai','[]', now())`,
+      ),
+    ).resolves.toBeDefined();
+  });
+});
+
+/**
+ * Real-data test for the migration's relabel + grant backfill. Builds the
+ * migrated schema, reverts JUST this migration (down → pre-lift schema with
+ * agent_id), seeds a realistic pre-lift dataset, then runs up() and asserts the
+ * data transformation. This is the part string-inspection specs can't catch.
+ */
+describe('LiftCustomProvidersToUserLevel data transformation (e2e)', () => {
+  let ds: DataSource;
+  const migration = new LiftCustomProvidersToUserLevel1791200000000();
+
+  beforeAll(async () => {
+    ds = new DataSource({
+      type: 'postgres',
+      url:
+        process.env['DATABASE_URL'] ??
+        'postgresql://myuser:mypassword@localhost:5432/manifest_duprepro',
+      entities: ['src/entities/!(*.spec).ts'],
+      migrations: ['src/database/migrations/!(*.spec).ts'],
+      synchronize: false,
+      dropSchema: true,
+      logging: false,
+    });
+    await ds.initialize();
+    await ds.runMigrations();
+
+    // Revert just this migration to get the pre-lift schema (agent_id back).
+    const revertQr = ds.createQueryRunner();
+    await migration.down(revertQr);
+    await revertQr.release();
+
+    // Pre-lift seed for user "cu-1": tenant + 3 agents.
+    await ds.query(`DELETE FROM "agent_provider_access"`);
+    await ds.query(`DELETE FROM "user_providers"`);
+    await ds.query(`DELETE FROM "custom_providers"`);
+    await ds.query(`DELETE FROM "agents"`);
+    await ds.query(`DELETE FROM "tenants"`);
+    await ds.query(
+      `INSERT INTO "tenants" ("id","name","is_active") VALUES ('t1','cu-1',true)`,
+    );
+    for (const a of ['a1', 'a2', 'a3']) {
+      await ds.query(
+        `INSERT INTO "agents" ("id","name","tenant_id") VALUES ($1,$1,'t1')`,
+        [a],
+      );
+    }
+    // cp1 (agent a1) and cp2 (agent a2) collide on name "Groq". cp3 is literally
+    // named "Groq [cp2]" — the suffix cp2 would naively pick — forcing the
+    // collision-safe path to choose "Groq [cp2-1]".
+    const cps: [string, string, string][] = [
+      ['cp1', 'a1', 'Groq'],
+      ['cp2', 'a2', 'Groq'],
+      ['cp3', 'a1', 'Groq [cp2]'],
+    ];
+    for (const [id, agentId, name] of cps) {
+      await ds.query(
+        `INSERT INTO "custom_providers" ("id","agent_id","user_id","name","base_url","api_kind","models","created_at")
+         VALUES ($1,$2,'cu-1',$3,'https://x.example.com/v1','openai','[]', now())`,
+        [id, agentId, name],
+      );
+      // Companion user_providers row, plus the single pre-lift grant (original agent only).
+      await ds.query(
+        `INSERT INTO "user_providers" ("id","user_id","agent_id","provider","auth_type","label","priority","is_active","connected_at","updated_at")
+         VALUES ($1,'cu-1',$2,$3,'api_key','Default',0,true, now(), now())`,
+        [`up-${id}`, agentId, `custom:${id}`],
+      );
+      await ds.query(
+        `INSERT INTO "agent_provider_access" ("agent_id","user_provider_id") VALUES ($1,$2)`,
+        [agentId, `up-${id}`],
+      );
+    }
+
+    const upQr = ds.createQueryRunner();
+    await migration.up(upQr);
+    await upQr.release();
+  }, 60000);
+
+  afterAll(async () => {
+    await ds?.destroy();
+  });
+
+  it('relabels colliding names without hitting a pre-existing name', async () => {
+    const rows: { id: string; name: string }[] = await ds.query(
+      `SELECT "id","name" FROM "custom_providers" ORDER BY "id"`,
+    );
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r.name]));
+    expect(byId['cp1']).toBe('Groq'); // kept (first in its group)
+    expect(byId['cp3']).toBe('Groq [cp2]'); // untouched (distinct name)
+    expect(byId['cp2']).toBe('Groq [cp2-1]'); // collision-safe suffix, NOT 'Groq [cp2]'
+    // All names unique within the user → the unique index held.
+    expect(new Set(rows.map((r) => r.name)).size).toBe(3);
+  });
+
+  it('backfills grants so every custom provider is usable on all of the user owner’s agents', async () => {
+    for (const id of ['cp1', 'cp2', 'cp3']) {
+      const grants: { agent_id: string }[] = await ds.query(
+        `SELECT "agent_id" FROM "agent_provider_access" WHERE "user_provider_id" = $1 ORDER BY "agent_id"`,
+        [`up-${id}`],
+      );
+      expect(grants.map((g) => g.agent_id)).toEqual(['a1', 'a2', 'a3']);
+    }
+  });
+});

--- a/packages/frontend/src/components/DuplicateAgentModal.tsx
+++ b/packages/frontend/src/components/DuplicateAgentModal.tsx
@@ -56,9 +56,7 @@ const DuplicateAgentModal: Component<Props> = (props) => {
   const totalCopied = () => {
     const c = preview()?.copied;
     if (!c) return 0;
-    return (
-      c.providers + c.customProviders + c.tierAssignments + c.specificityAssignments + c.modelParams
-    );
+    return c.providers + c.tierAssignments + c.specificityAssignments + c.modelParams;
   };
 
   const handleNameInput = (value: string) => {
@@ -161,10 +159,6 @@ const DuplicateAgentModal: Component<Props> = (props) => {
                   <strong>{preview()!.copied.providers}</strong> provider credential
                   {preview()!.copied.providers === 1 ? '' : 's'} (encrypted API keys &amp;
                   subscriptions)
-                </li>
-                <li>
-                  <strong>{preview()!.copied.customProviders}</strong> custom provider
-                  {preview()!.copied.customProviders === 1 ? '' : 's'}
                 </li>
                 <li>
                   <strong>{preview()!.copied.tierAssignments}</strong> tier override

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -130,13 +130,9 @@ const Limits: Component = () => {
       />
 
       <div class="page-header">
-        <div>
-          <h1>Limits</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Get notified or block requests when token
-            or cost thresholds are exceeded
-          </span>
-        </div>
+        <span class="breadcrumb">
+          Get notified or block requests when token or cost thresholds are exceeded
+        </span>
         <button
           class="btn btn--primary btn--sm"
           onClick={() => {

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -435,13 +435,7 @@ const Routing: Component = () => {
       />
 
       <div class="page-header routing-page-header">
-        <div>
-          <h1>Routing</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Pick which model handles each type of
-            request
-          </span>
-        </div>
+        <span class="breadcrumb">Pick which model handles each type of request</span>
         <Show when={!connectedProviders.loading}>
           <div style="display: flex; gap: 8px;">
             <Show when={isEnabled()}>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -182,15 +182,9 @@ const Settings: Component = () => {
         name="description"
         content={`Configure settings for ${agentDisplayName() ?? agentName()}.`}
       />
-      <div class="page-header">
-        <div>
-          <h1>Settings</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Rename your agent, manage API keys, and
-            view setup instructions
-          </span>
-        </div>
-      </div>
+      <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); margin: 0 0 var(--gap-lg);">
+        Rename your agent, manage API keys, and view setup instructions
+      </p>
 
       {/* -- Agent Name ------------------------------ */}
       <div class="settings-card">

--- a/packages/frontend/src/services/api/agents.ts
+++ b/packages/frontend/src/services/api/agents.ts
@@ -66,7 +66,6 @@ export interface CreateAgentParams {
 export interface DuplicateAgentPreview {
   copied: {
     providers: number;
-    customProviders: number;
     tierAssignments: number;
     specificityAssignments: number;
     modelParams: number;

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -410,9 +410,11 @@ export interface CustomProviderData {
 }
 
 // Module-scoped cache so Overview / MessageLog / Routing don't each refetch
-// the same custom-providers list when mounting in sequence. Mutations below
-// (create/update/delete) invalidate the agent's entry; the routing 'routing'
-// SSE event invalidates them all.
+// the same custom-providers list when mounting in sequence. Custom providers
+// are user-global, so a create/update/delete from one agent changes the list
+// every agent sees — mutations below invalidate ALL entries, and the 'routing'
+// SSE event (emitted by the backend on those mutations) does the same for other
+// already-open clients.
 const customProvidersCache = new Map<string, Promise<CustomProviderData[]>>();
 
 export function invalidateCustomProvidersCache(agentName?: string): void {
@@ -446,7 +448,7 @@ export function createCustomProvider(
     models: CustomProviderModel[];
   },
 ) {
-  invalidateCustomProvidersCache(agentName);
+  invalidateCustomProvidersCache();
   return fetchMutate<CustomProviderData>(routingPath(agentName, 'custom-providers'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -465,7 +467,7 @@ export function updateCustomProvider(
     models?: CustomProviderModel[];
   },
 ) {
-  invalidateCustomProvidersCache(agentName);
+  invalidateCustomProvidersCache();
   return fetchMutate<CustomProviderData>(
     routingPath(agentName, `custom-providers/${encodeURIComponent(id)}`),
     {
@@ -499,7 +501,7 @@ export async function probeCustomProvider(
 }
 
 export function deleteCustomProvider(agentName: string, id: string) {
-  invalidateCustomProvidersCache(agentName);
+  invalidateCustomProvidersCache();
   return fetchMutate<{ ok: boolean }>(
     routingPath(agentName, `custom-providers/${encodeURIComponent(id)}`),
     { method: 'DELETE' },

--- a/packages/frontend/src/services/sse.ts
+++ b/packages/frontend/src/services/sse.ts
@@ -1,4 +1,5 @@
 import { createSignal } from 'solid-js';
+import { invalidateCustomProvidersCache } from './api/routing.js';
 
 // pingCount counts ANY event from the bus (legacy back-compat for callers that
 // don't care which kind fired). New code should depend on the targeted
@@ -46,6 +47,10 @@ export function connectSse(): () => void {
     bumpPing();
   });
   es.addEventListener('routing', () => {
+    // Custom providers are user-global; a routing change (incl. a custom-provider
+    // create/update/delete on any agent) can change every agent's list, so drop
+    // the cached lists before the routingPing-driven refetch reads them.
+    invalidateCustomProvidersCache();
     setRoutingPing((n) => n + 1);
     bumpPing();
   });

--- a/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
+++ b/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
@@ -90,7 +90,6 @@ describe('DuplicateAgentModal', () => {
     // "What is copied" items
     const list = qa('.duplicate-agent__list li').map((li) => li.textContent);
     expect(list.some((t) => t?.includes('3') && t?.includes('provider credential'))).toBe(true);
-    expect(list.some((t) => t?.includes('1') && t?.includes('custom provider'))).toBe(true);
     expect(list.some((t) => t?.includes('4') && t?.includes('tier override'))).toBe(true);
     expect(list.some((t) => t?.includes('2') && t?.includes('specificity override'))).toBe(true);
 

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -61,14 +61,13 @@ describe("Limits page", () => {
     mockRoutingStatus = { enabled: false };
   });
 
-  it("renders page title", () => {
-    render(() => <Limits />);
-    expect(screen.getByText("Limits")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Limits />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
-  it("renders breadcrumb with agent name", () => {
+  it("renders page description without duplicating the agent heading", () => {
     const { container } = render(() => <Limits />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Get notified or block requests when token or cost thresholds are exceeded");
   });
 

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -617,12 +617,12 @@ beforeEach(() => {
 });
 
 describe('Routing page', () => {
-  it('renders the page header with the agent display name', async () => {
-    render(() => <Routing />);
+  it('renders routing description without a duplicate page heading', async () => {
+    const { container } = render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText('Routing')).toBeDefined();
+      expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
     });
-    expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
+    expect(container.querySelector('h1')).toBeNull();
   });
 
   it('renders the empty providers state when no providers are connected', async () => {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -138,9 +138,9 @@ describe("Settings", () => {
     mockUpdateAgent.mockResolvedValue({});
   });
 
-  it("renders Settings heading", () => {
-    render(() => <Settings />);
-    expect(screen.getByText("Settings")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Settings />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
   it("renders agent name input with value", () => {
@@ -330,9 +330,8 @@ describe("Settings", () => {
     });
   });
 
-  it("shows breadcrumb with agent name", () => {
+  it("shows settings description without duplicating the agent heading", () => {
     const { container } = render(() => <Settings />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Rename your agent");
   });
 


### PR DESCRIPTION
Stacked on #2153 (base `feat/global-providers-e2e`). Step 4 of the #2061 re-slice — lifts custom providers from agent-scoped to **tenant/user-global**, matching the global provider model.

## What changes
- **Migration `LiftCustomProvidersToUserLevel`**: drops `custom_providers.agent_id`, relabels colliding names within a user with a **collision-safe** suffix (never deletes), adds a unique index on `(user_id, LOWER(name))`, and **backfills `agent_provider_access` grants** so existing custom providers are usable on all of the owner's agents (matching newly-created ones).
- **Entity**: drop `agent_id` + the `Agent` relation; unique on `(user_id, name)`.
- **Service / controller**: user-scoped (`list/create/update/remove` by `user_id`); the agent route stays only for authz.
- **Caller sweep**: `model.controller` + `proxy-message-recorder` pass `userId`.
- **agent-duplication**: custom providers are now shared via grants like any global provider, so per-agent custom cloning + remap is removed; duplication copies `agent_provider_access` grants verbatim (the `customProviders` copy-summary field is dropped). *(Supersedes the route-remap fix `c766b66a7` from the base, which only applied to the agent-scoped model.)*
- **Cache coherence**: custom-provider mutations emit a user-level `routing` SSE and invalidate the whole frontend custom-provider cache (data is now global).
- **Frontend**: duplicate summary drops the custom-provider line.

## Testing
- Backend unit **6199**, e2e **225**, frontend **3871** — all green; tsc + lint clean; patch coverage 100%.
- New `custom-providers-lift-migrations.e2e-spec.ts` runs the migration against **real Postgres** (the `synchronize` e2e never runs migrations — the gap that hid the duplication unique-index bug on the base PR) and asserts the relabel collision-safety + grant backfill on seeded pre-lift data.

## Codex review
Independent Codex review run 3 rounds — **gate PASS** after addressing: all-agent grant backfill (P1), collision-safe relabel (P1), and sibling-agent cache staleness (P2, SSE + cache invalidation). One flagged finding (stale route authType after retag) was a **false positive** — the custom key lookup (`provider-key.service.ts:189`) matches `custom:<id>` exactly and ignores authType.

## Deferred follow-ups (advisory, not blocking)
1. **Multi-tab real-time refetch**: the custom-provider `createResource` doesn't depend on `routingPing`, so a *second open tab* on a sibling agent stays stale until navigation (same-session navigation already refetches). Wire the resource to `routingPing`.
2. **Warm-cache recalc ordering**: editing a custom provider's model list can recalc tiers from a stale per-agent `ModelDiscoveryService` cache until the next mutation. Invalidate the discovery cache before `recalculateTiersForUser`. (Largely pre-existing.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted custom providers from agent-scoped to user-global to match the global provider model. Existing providers now work across all of an owner’s agents, and the API/UI manage them at the user level.

- **Migration**
  - Drops `agent_id` and adds a case-insensitive unique index on `(user_id, LOWER(name))`.
  - Renames same-user name collisions safely (no deletions).
  - Backfills `agent_provider_access` so existing custom providers are granted to all of the owner’s agents.
  - Adds a migration e2e that runs against real Postgres.
  - Down migration restores the original agent FK (ON DELETE CASCADE).

- **Refactors**
  - Custom-provider service/controller are user-scoped; agent route is used only for auth.
  - Callers pass `userId` (model controller, proxy message recorder).
  - Agent duplication no longer clones custom providers; it copies `agent_provider_access` grants; UI preview drops the custom-provider count.
  - Mutations emit a user-level `routing` SSE and invalidate the global custom-provider cache; frontend invalidates all entries and listens to `routing`.
  - Entity: removed the case-sensitive `@Index` in favor of the migration-owned case-insensitive unique index to avoid drift.
  - Removed duplicate child headings on agent pages (Limits, Routing, Settings) to avoid duplicated page titles; tests updated.

<sup>Written for commit edb3b4afb862261b04859e572eba3a111972d68b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

