### PR TITLE
feat: global Playground on a reserved per-tenant agent

### DIFF
--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -249,6 +249,21 @@ describe('AgentsController', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
+  it('rejects rename to the reserved "Playground" name', async () => {
+    const user = { id: 'u1' };
+    await expect(
+      controller.updateAgent(user as never, 'bot-1', { name: 'Playground' } as never),
+    ).rejects.toThrow(/reserved/i);
+    expect(mockRenameAgent).not.toHaveBeenCalled();
+  });
+
+  it('rejects createAgent with the reserved "Playground" name', async () => {
+    const user = { id: 'u1' };
+    await expect(
+      controller.createAgent(user as never, { name: 'Playground' } as never),
+    ).rejects.toThrow(/reserved/i);
+  });
+
   it('deletes agent and returns success', async () => {
     const user = { id: 'u1' };
     const result = await controller.deleteAgent(user as never, 'bot-1');

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CACHE_MANAGER, CacheModule } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
 import type { Cache } from 'cache-manager';
-import { BadRequestException, ConflictException } from '@nestjs/common';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { QueryFailedError } from 'typeorm';
 import { AgentsController } from './agents.controller';
 import { TimeseriesQueriesService } from '../services/timeseries-queries.service';
@@ -643,6 +643,35 @@ describe('AgentsController', () => {
     await expect(
       controller.duplicateAgent(user as never, 'bot-1', { name: 'bot-copy' } as never),
     ).rejects.toThrow('boom');
+  });
+
+  // P1-B: duplicate must honor the reserved name
+  it('rejects duplicateAgent with the reserved "Playground" name', async () => {
+    const user = { id: 'u1' };
+    await expect(
+      controller.duplicateAgent(user as never, 'bot-1', { name: 'Playground' } as never),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      controller.duplicateAgent(user as never, 'bot-1', { name: 'Playground' } as never),
+    ).rejects.toThrow(/reserved/i);
+    expect(mockDuplicate).not.toHaveBeenCalled();
+  });
+
+  // P1-A: key endpoints must reject the system "Playground" agent
+  it('getAgentKey throws NotFoundException for the system "Playground" agent', async () => {
+    // findAgentInfo returns null for system agents (is_system = false filter)
+    // which is the same shape as a missing agent — NotFoundException is thrown.
+    const user = { id: 'u1' };
+    await expect(controller.getAgentKey(user as never, 'Playground')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('rotateAgentKey throws NotFoundException for the system "Playground" agent', async () => {
+    const user = { id: 'u1' };
+    await expect(controller.rotateAgentKey(user as never, 'Playground')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
   });
 
   it('re-throws non-duplicate QueryFailedError from onboardAgent', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -246,10 +246,10 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ renamed: true, name: 'bot-renamed', display_name: 'Bot Renamed' });
     expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'bot-renamed', 'Bot Renamed');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
-    // The Messages-filter variant (?includeSystem=true) is a distinct cache
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
+    // The Messages-filter variant (system agents included) is a distinct cache
     // entry and must also be cleared so it never goes stale after a rename.
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents?includeSystem=true');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
   });
 
   it('rejects rename with empty slug', async () => {
@@ -280,7 +280,10 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ deleted: true });
     expect(mockDeleteAgent).toHaveBeenCalledWith('u1', 'bot-1');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+    // Both canonical variants are cleared so neither the Workspace list nor the
+    // Messages filter (system agents included) goes stale after a delete.
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
   });
 
   it('passes agent_category and agent_platform to onboardAgent', async () => {
@@ -505,7 +508,7 @@ describe('AgentsController', () => {
     const result = await ctrl.createAgent(user as never, { name: 'My Agent' } as never);
 
     expect(result.agent.name).toBe('my-agent');
-    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=false');
   });
 
   it('rejects createAgent with empty slug', async () => {
@@ -627,7 +630,7 @@ describe('AgentsController', () => {
       name: 'bot-copy',
       displayName: 'Bot Copy',
     });
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
   });
 
   it('rejects duplicateAgent with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -508,7 +508,10 @@ describe('AgentsController', () => {
     const result = await ctrl.createAgent(user as never, { name: 'My Agent' } as never);
 
     expect(result.agent.name).toBe('my-agent');
+    // Both canonical variants are cleared so neither the Workspace list nor the
+    // Messages filter (system agents included) goes stale after a create.
     expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=false');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=true');
   });
 
   it('rejects createAgent with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -144,7 +144,7 @@ describe('AgentsController', () => {
 
     expect(result.agents).toHaveLength(2);
     expect(result.agents[0].agent_name).toBe('bot-1');
-    expect(mockGetAgentList).toHaveBeenCalledWith('u1', 'tenant-123');
+    expect(mockGetAgentList).toHaveBeenCalledWith('u1', 'tenant-123', false);
   });
 
   it('passes undefined tenantId when tenant not found', async () => {
@@ -152,7 +152,14 @@ describe('AgentsController', () => {
     const user = { id: 'u1' };
     await controller.getAgents(user as never);
 
-    expect(mockGetAgentList).toHaveBeenCalledWith('u1', undefined);
+    expect(mockGetAgentList).toHaveBeenCalledWith('u1', undefined, false);
+  });
+
+  it('passes includeSystem=true through to getAgentList (Messages filter)', async () => {
+    const user = { id: 'u1' };
+    await controller.getAgents(user as never, 'true');
+
+    expect(mockGetAgentList).toHaveBeenCalledWith('u1', 'tenant-123', true);
   });
 
   it('GET /agents/:agentName returns metadata for an existing agent', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -247,6 +247,9 @@ describe('AgentsController', () => {
     expect(result).toEqual({ renamed: true, name: 'bot-renamed', display_name: 'Bot Renamed' });
     expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'bot-renamed', 'Bot Renamed');
     expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+    // The Messages-filter variant (?includeSystem=true) is a distinct cache
+    // entry and must also be cleared so it never goes stale after a rename.
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents?includeSystem=true');
   });
 
   it('rejects rename with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Get,
   Inject,
+  NotFoundException,
   Param,
   Patch,
   Post,
@@ -120,6 +121,9 @@ export class AgentsController {
   ) {
     const slug = slugify(body.name);
     if (!slug) throw new BadRequestException('Agent name produces an empty slug');
+    if (slug === PLAYGROUND_AGENT_SLUG) {
+      throw new BadRequestException('"Playground" is a reserved agent name');
+    }
     const displayName = body.name.trim();
     let result;
     try {
@@ -155,6 +159,11 @@ export class AgentsController {
 
   @Get('agents/:agentName/key')
   async getAgentKey(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
+    // Guard: system agents cannot expose their API key through the user-facing
+    // key endpoint (findAgentInfo filters is_system = false and returns null for
+    // the reserved "Playground" agent, same as for any missing agent).
+    const info = await this.lifecycle.findAgentInfo(user.id, agentName);
+    if (!info) throw new NotFoundException(`Agent "${agentName}" not found`);
     const keyData = await this.apiKeyGenerator.getKeyForAgent(user.id, agentName);
     const apiKey = keyData.fullKey ?? undefined;
     return {
@@ -165,6 +174,11 @@ export class AgentsController {
 
   @Post('agents/:agentName/rotate-key')
   async rotateAgentKey(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
+    // Guard: system agents cannot have their key rotated through the user-facing
+    // endpoint (findAgentInfo filters is_system = false and returns null for the
+    // reserved "Playground" agent, same as for any missing agent).
+    const info = await this.lifecycle.findAgentInfo(user.id, agentName);
+    if (!info) throw new NotFoundException(`Agent "${agentName}" not found`);
     const result = await this.apiKeyGenerator.rotateKey(user.id, agentName);
     return { apiKey: result.apiKey };
   }

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -48,8 +48,14 @@ export class AgentsController {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
-  private agentListCacheKey(userId: string): string {
-    return `${userId}:/api/v1/agents`;
+  private async invalidateAgentListCache(userId: string): Promise<void> {
+    // GET /agents is cached per (user, originalUrl). The Messages filter hits the
+    // ?includeSystem=true variant, which is a distinct cache entry, so a single
+    // del() would leave it stale after a create/rename/delete. Clear both.
+    await Promise.all([
+      this.cacheManager.del(`${userId}:/api/v1/agents`),
+      this.cacheManager.del(`${userId}:/api/v1/agents?includeSystem=true`),
+    ]);
   }
 
   @Get('agents')
@@ -91,7 +97,7 @@ export class AgentsController {
     // inherits every usable provider the user already connected, with its
     // auto-assigned routes calculated from that model set.
     await this.providerService.enableAllProvidersForAgent(result.agentId, user.id);
-    await this.cacheManager.del(this.agentListCacheKey(user.id));
+    await this.invalidateAgentListCache(user.id);
     this.eventBus.emit(user.id, 'agent');
     return {
       agent: {
@@ -138,7 +144,7 @@ export class AgentsController {
       }
       throw error;
     }
-    await this.cacheManager.del(this.agentListCacheKey(user.id));
+    await this.invalidateAgentListCache(user.id);
     this.eventBus.emit(user.id, 'agent');
     return {
       agent: {
@@ -225,7 +231,7 @@ export class AgentsController {
       result['record_messages'] = body.record_messages;
     }
 
-    await this.cacheManager.del(this.agentListCacheKey(user.id));
+    await this.invalidateAgentListCache(user.id);
     this.eventBus.emit(user.id, 'agent');
     return result;
   }
@@ -233,7 +239,7 @@ export class AgentsController {
   @Delete('agents/:agentName')
   async deleteAgent(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
     await this.lifecycle.deleteAgent(user.id, agentName);
-    await this.cacheManager.del(this.agentListCacheKey(user.id));
+    await this.invalidateAgentListCache(user.id);
     this.eventBus.emit(user.id, 'agent');
     return { deleted: true };
   }

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -10,6 +10,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseInterceptors,
 } from '@nestjs/common';
 import { QueryFailedError } from 'typeorm';
@@ -54,9 +55,9 @@ export class AgentsController {
   @Get('agents')
   @UseInterceptors(UserCacheInterceptor)
   @CacheTTL(AGENT_LIST_CACHE_TTL_MS)
-  async getAgents(@CurrentUser() user: AuthUser) {
+  async getAgents(@CurrentUser() user: AuthUser, @Query('includeSystem') includeSystem?: string) {
     const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
-    const agents = await this.timeseries.getAgentList(user.id, tenantId);
+    const agents = await this.timeseries.getAgentList(user.id, tenantId, includeSystem === 'true');
     return { agents };
   }
 

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -27,6 +27,7 @@ import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
 import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
 import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants';
 import { slugify } from '../../common/utils/slugify';
+import { PLAYGROUND_AGENT_SLUG } from '../../common/constants/playground.constants';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { AgentRecordingCacheService } from '../../common/services/agent-recording-cache.service';
 import { ProviderService } from '../../routing/routing-core/provider.service';
@@ -63,6 +64,9 @@ export class AgentsController {
     const slug = slugify(body.name);
     if (!slug) {
       throw new BadRequestException('Agent name produces an empty slug');
+    }
+    if (slug === PLAYGROUND_AGENT_SLUG) {
+      throw new BadRequestException('"Playground" is a reserved agent name');
     }
     const displayName = body.name.trim();
     let result: { tenantId: string; agentId: string; apiKey: string };
@@ -176,6 +180,9 @@ export class AgentsController {
     if (body.name) {
       const slug = slugify(body.name);
       if (!slug) throw new BadRequestException('Agent name produces an empty slug');
+      if (slug === PLAYGROUND_AGENT_SLUG) {
+        throw new BadRequestException('"Playground" is a reserved agent name');
+      }
       const displayName = body.name.trim();
       await this.lifecycle.renameAgent(user.id, agentName, slug, displayName);
       result['renamed'] = true;

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -26,8 +26,8 @@ import { AuthUser } from '../../auth/auth.instance';
 import { CreateAgentDto } from '../../common/dto/create-agent.dto';
 import { DuplicateAgentDto } from '../../common/dto/duplicate-agent.dto';
 import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
-import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
-import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { AgentListCacheInterceptor } from '../../common/interceptors/agent-list-cache.interceptor';
+import { AGENT_LIST_CACHE_TTL_MS, agentListCacheKey } from '../../common/constants/cache.constants';
 import { slugify } from '../../common/utils/slugify';
 import { PLAYGROUND_AGENT_SLUG } from '../../common/constants/playground.constants';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
@@ -49,17 +49,17 @@ export class AgentsController {
   ) {}
 
   private async invalidateAgentListCache(userId: string): Promise<void> {
-    // GET /agents is cached per (user, originalUrl). The Messages filter hits the
-    // ?includeSystem=true variant, which is a distinct cache entry, so a single
-    // del() would leave it stale after a create/rename/delete. Clear both.
+    // GET /agents has exactly two canonical cache entries per user (system agents
+    // included or not — see AgentListCacheInterceptor). Clear both so neither the
+    // Workspace list nor the Messages filter goes stale after a mutation.
     await Promise.all([
-      this.cacheManager.del(`${userId}:/api/v1/agents`),
-      this.cacheManager.del(`${userId}:/api/v1/agents?includeSystem=true`),
+      this.cacheManager.del(agentListCacheKey(userId, false)),
+      this.cacheManager.del(agentListCacheKey(userId, true)),
     ]);
   }
 
   @Get('agents')
-  @UseInterceptors(UserCacheInterceptor)
+  @UseInterceptors(AgentListCacheInterceptor)
   @CacheTTL(AGENT_LIST_CACHE_TTL_MS)
   async getAgents(@CurrentUser() user: AuthUser, @Query('includeSystem') includeSystem?: string) {
     const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -380,5 +380,48 @@ describe('AgentDuplicationService', () => {
       );
       expect(result.copied.providers).toBe(3);
     });
+
+    it('rejects the reserved system agent as a duplication source (404)', async () => {
+      // findOwnedAgent now includes `is_system = false`, so the Playground agent
+      // is invisible to duplication lookups — getOne returns null as if it doesn't exist.
+      mockAgentGetOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.duplicate('user-1', 'Playground', { name: 'copy', displayName: 'copy' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('passes is_system = false filter in every findOwnedAgent query builder call', async () => {
+      // Ensures the new andWhere('a.is_system = false') clause is present so the
+      // system agent is always excluded from source resolution.
+      mockAgentGetOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.duplicate('user-1', 'Playground', { name: 'copy', displayName: 'copy' }),
+      ).rejects.toThrow(NotFoundException);
+
+      const andWhereCalls = (mockAgentQb.andWhere as jest.Mock).mock.calls as string[][];
+      const hasSystemFilter = andWhereCalls.some(([expr]) => /is_system.*false/i.test(expr));
+      expect(hasSystemFilter).toBe(true);
+    });
+  });
+
+  describe('getCopySummary system-agent block', () => {
+    it('rejects the reserved system agent as a source for getCopySummary (404)', async () => {
+      // Same filter applies: the Playground agent is invisible to findOwnedAgent.
+      mockAgentGetOne.mockResolvedValueOnce(null);
+
+      await expect(service.getCopySummary('user-1', 'Playground')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('suggestName system-agent block', () => {
+    it('rejects the reserved system agent as a source for suggestName (404)', async () => {
+      mockAgentGetOne.mockResolvedValueOnce(null);
+
+      await expect(service.suggestName('user-1', 'Playground')).rejects.toThrow(NotFoundException);
+    });
   });
 });

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -43,13 +43,18 @@ export class AgentDuplicationService {
   }
 
   private async findOwnedAgent(userId: string, agentName: string): Promise<Agent | null> {
-    return this.agentRepo
-      .createQueryBuilder('a')
-      .leftJoin('a.tenant', 't')
-      .where('t.name = :userId', { userId })
-      .andWhere('a.name = :agentName', { agentName })
-      .andWhere('a.deleted_at IS NULL')
-      .getOne();
+    return (
+      this.agentRepo
+        .createQueryBuilder('a')
+        .leftJoin('a.tenant', 't')
+        .where('t.name = :userId', { userId })
+        .andWhere('a.name = :agentName', { agentName })
+        .andWhere('a.deleted_at IS NULL')
+        // Exclude the reserved system agent — it cannot be cloned or used as a
+        // duplication source (it has no API key and is tenant-singleton).
+        .andWhere('a.is_system = false')
+        .getOne()
+    );
   }
 
   async getCopySummary(userId: string, sourceName: string): Promise<DuplicateAgentSummary> {

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
@@ -406,6 +406,47 @@ describe('AgentLifecycleService', () => {
     });
   });
 
+  describe('system agent protection', () => {
+    it('cannot delete a system agent — findAgentByUser excludes is_system=true rows', async () => {
+      // Simulate the system agent being invisible to the resolver (returns null).
+      mockAgentGetOne.mockResolvedValueOnce(null);
+
+      await expect(service.deleteAgent('test-user', 'playground')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('cannot rename a system agent — the resolver excludes is_system=true rows', async () => {
+      // The rename "find current agent" query also filters is_system = false.
+      mockAgentGetOne.mockResolvedValueOnce(null);
+
+      await expect(service.renameAgent('test-user', 'playground', 'new-name')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('applies is_system = false filter in findAgentByUser', async () => {
+      const mockAndWhere = jest.fn().mockReturnThis();
+      const mockQb = {
+        select: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: mockAndWhere,
+        orderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      mockAgentCreateQueryBuilder.mockReturnValueOnce(mockQb);
+
+      await service.findAgentInfo('user-1', 'playground');
+
+      const andWhereCalls = mockAndWhere.mock.calls.map((c: unknown[]) => c[0]);
+      expect(andWhereCalls).toContain('a.is_system = false');
+    });
+  });
+
   describe('setRecordMessages', () => {
     it('updates the record_messages flag and returns the agent id', async () => {
       mockAgentGetOne.mockResolvedValueOnce({ id: 'agent-id-42', name: 'my-agent' });

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.ts
@@ -77,6 +77,7 @@ export class AgentLifecycleService {
       .where('t.name = :userId', { userId })
       .andWhere('a.name = :agentName', { agentName })
       .andWhere('a.deleted_at IS NULL')
+      .andWhere('a.is_system = false')
       .getOne();
   }
 
@@ -131,6 +132,7 @@ export class AgentLifecycleService {
       .where('t.name = :userId', { userId })
       .andWhere('a.name = :currentName', { currentName })
       .andWhere('a.deleted_at IS NULL')
+      .andWhere('a.is_system = false')
       .getOne();
 
     if (!agent) {

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -27,6 +27,18 @@ describe('TimeseriesQueriesService', () => {
     getRawOne: jest.Mock;
     getMany: jest.Mock;
   };
+  let mockAgentQb: {
+    select: jest.Mock;
+    addSelect: jest.Mock;
+    leftJoin: jest.Mock;
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    orWhere: jest.Mock;
+    groupBy: jest.Mock;
+    orderBy: jest.Mock;
+    getMany: jest.Mock;
+    getRawMany: jest.Mock;
+  };
 
   beforeEach(async () => {
     mockGetRawMany = jest.fn().mockResolvedValue([]);
@@ -50,7 +62,7 @@ describe('TimeseriesQueriesService', () => {
       getMany: mockGetMany,
     };
 
-    const mockAgentQb = {
+    mockAgentQb = {
       select: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
       leftJoin: jest.fn().mockReturnThis(),
@@ -318,6 +330,18 @@ describe('TimeseriesQueriesService', () => {
   describe('getAgentList', () => {
     const recentIso = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
     const oldIso = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+
+    it('excludes the reserved system (Playground) agent by default', async () => {
+      await service.getAgentList('u1');
+      const clauses = mockAgentQb.andWhere.mock.calls.map((c) => c[0] as string);
+      expect(clauses).toContain('a.is_system = false');
+    });
+
+    it('includes system agents when includeSystem is true (Messages filter)', async () => {
+      await service.getAgentList('u1', undefined, true);
+      const clauses = mockAgentQb.andWhere.mock.calls.map((c) => c[0] as string);
+      expect(clauses).not.toContain('a.is_system = false');
+    });
 
     it('returns agents with sparkline data and display_name', async () => {
       mockGetMany.mockResolvedValueOnce([

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -165,7 +165,7 @@ export class TimeseriesQueriesService {
     }));
   }
 
-  async getAgentList(userId: string, tenantId?: string) {
+  async getAgentList(userId: string, tenantId?: string, includeSystem = false) {
     const resolved = tenantId ?? (await this.tenantCache.resolve(userId)) ?? undefined;
 
     const agentQb = this.agentRepo.createQueryBuilder('a');
@@ -175,9 +175,12 @@ export class TimeseriesQueriesService {
       agentQb.leftJoin('a.tenant', 't').where('t.name = :userId', { userId });
     }
     agentQb.andWhere('a.deleted_at IS NULL');
-    // The reserved Playground agent is a system agent — never list it in the
-    // Workspace grid / agent switcher.
-    agentQb.andWhere('a.is_system = false');
+    // The reserved Playground agent is a system agent. Hidden from the
+    // Workspace grid / agent switcher by default; the Messages filter opts in
+    // via includeSystem so users can filter the log to Playground runs.
+    if (!includeSystem) {
+      agentQb.andWhere('a.is_system = false');
+    }
 
     const statsCutoff = computeCutoff('30 days');
     const sparkCutoff = computeCutoff('7 days');

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -175,6 +175,9 @@ export class TimeseriesQueriesService {
       agentQb.leftJoin('a.tenant', 't').where('t.name = :userId', { userId });
     }
     agentQb.andWhere('a.deleted_at IS NULL');
+    // The reserved Playground agent is a system agent — never list it in the
+    // Workspace grid / agent switcher.
+    agentQb.andWhere('a.is_system = false');
 
     const statsCutoff = computeCutoff('30 days');
     const sparkCutoff = computeCutoff('7 days');

--- a/packages/backend/src/common/constants/cache.constants.ts
+++ b/packages/backend/src/common/constants/cache.constants.ts
@@ -3,3 +3,14 @@ export const AGENT_LIST_CACHE_TTL_MS = 60_000;
 export const MODEL_PRICES_CACHE_TTL_MS = 300_000;
 export const PUBLIC_STATS_CACHE_TTL_MS = 86_400_000;
 export const FREE_MODELS_CACHE_TTL_MS = 3_600_000;
+
+/**
+ * Canonical cache key for the GET /agents list. The route varies only by whether
+ * the reserved system (Playground) agent is included, so every query-string
+ * variant collapses to one of two keys keyed on that boolean — never the raw
+ * URL. This keeps the key set bounded (exactly two per user) so invalidation can
+ * enumerate it exhaustively and no variant is ever left stale.
+ */
+export function agentListCacheKey(userId: string, includeSystem: boolean): string {
+  return `${userId}:/api/v1/agents:system=${includeSystem}`;
+}

--- a/packages/backend/src/common/constants/playground.constants.ts
+++ b/packages/backend/src/common/constants/playground.constants.ts
@@ -1,0 +1,16 @@
+/**
+ * The reserved per-tenant "Playground" agent that backs the global Playground.
+ * Playground runs resolve to it (so they record `agent_name = 'Playground'` in
+ * global Messages) and it holds grants to the tenant's whole global provider
+ * pool. It is flagged `is_system = true`, hidden from the agent list/switcher/
+ * counts, and users cannot create or rename an agent to this name.
+ */
+export const PLAYGROUND_AGENT_NAME = 'Playground';
+
+/**
+ * The slug a user-created agent name would produce if it tried to take the
+ * reserved name. User agent names are slugified, so blocking this slug in
+ * create/rename reserves the name (the system agent itself is created directly,
+ * bypassing slugify, so it keeps the display-cased `PLAYGROUND_AGENT_NAME`).
+ */
+export const PLAYGROUND_AGENT_SLUG = 'playground';

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
@@ -1,0 +1,75 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AgentListCacheInterceptor } from './agent-list-cache.interceptor';
+
+function createMockContext(
+  user: { id?: string } | undefined,
+  query: Record<string, string> | undefined,
+  method = 'GET',
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user, query, method, originalUrl: '/api/v1/agents' }),
+      getResponse: () => ({}),
+    }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    getArgs: () => [],
+    getArgByIndex: () => ({}),
+    switchToRpc: () => ({}) as never,
+    switchToWs: () => ({}) as never,
+    getType: () => 'http',
+  } as unknown as ExecutionContext;
+}
+
+describe('AgentListCacheInterceptor', () => {
+  let interceptor: AgentListCacheInterceptor;
+
+  beforeEach(() => {
+    const mockCacheManager = {} as never;
+    interceptor = new AgentListCacheInterceptor(mockCacheManager, new Reflector());
+  });
+
+  describe('trackBy', () => {
+    it('keys on the system=true canonical variant for ?includeSystem=true', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'true' }),
+      );
+      expect(key).toBe('u1:/api/v1/agents:system=true');
+    });
+
+    it('keys on the system=false canonical variant when no query param is present', () => {
+      const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, undefined));
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('collapses ?includeSystem=false onto the same system=false key (no stranded variant)', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'false' }),
+      );
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('collapses any non-"true" value onto the system=false key', () => {
+      const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, { includeSystem: '1' }));
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('returns undefined for non-GET requests', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'true' }, 'POST'),
+      );
+      expect(key).toBeUndefined();
+    });
+
+    it('returns undefined when user is not present', () => {
+      const key = interceptor['trackBy'](createMockContext(undefined, undefined));
+      expect(key).toBeUndefined();
+    });
+
+    it('returns undefined when user has no id', () => {
+      const key = interceptor['trackBy'](createMockContext({}, undefined));
+      expect(key).toBeUndefined();
+    });
+  });
+});

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
@@ -1,0 +1,29 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+import { UserCacheInterceptor } from './user-cache.interceptor';
+import { agentListCacheKey } from '../constants/cache.constants';
+
+/**
+ * Cache interceptor for GET /agents. Unlike the generic URL-keyed
+ * UserCacheInterceptor, it collapses every query-string variant (no param,
+ * ?includeSystem=true, ?includeSystem=false, anything else) onto one of two
+ * canonical keys based on the normalized `includeSystem` boolean. That keeps the
+ * cached key set bounded to exactly two entries per user, so mutation handlers
+ * can invalidate it exhaustively (see agentListCacheKey) without a stray URL
+ * variant being left stale.
+ */
+@Injectable()
+export class AgentListCacheInterceptor extends UserCacheInterceptor {
+  protected trackBy(context: ExecutionContext): string | undefined {
+    const request = context.switchToHttp().getRequest<Request>();
+    if (request.method !== 'GET') return undefined;
+    const user = (request as unknown as Record<string, unknown>).user as
+      | { id?: string }
+      | undefined;
+    if (!user?.id) return undefined;
+
+    const includeSystem =
+      (request.query as { includeSystem?: string } | undefined)?.includeSystem === 'true';
+    return agentListCacheKey(user.id, includeSystem);
+  }
+}

--- a/packages/backend/src/common/services/tenant-cache.service.spec.ts
+++ b/packages/backend/src/common/services/tenant-cache.service.spec.ts
@@ -35,4 +35,24 @@ describe('TenantCacheService', () => {
     await service.resolve('user-1');
     expect(mockFindOne).toHaveBeenCalledTimes(1);
   });
+
+  it('invalidate() forces the next resolve() to re-hit the DB', async () => {
+    // First resolve populates the cache.
+    mockFindOne.mockResolvedValueOnce({ id: 'tenant-abc' });
+    await service.resolve('user-1');
+    expect(mockFindOne).toHaveBeenCalledTimes(1);
+
+    // Invalidate clears the cached entry.
+    service.invalidate('user-1');
+
+    // Next resolve must re-query.
+    mockFindOne.mockResolvedValueOnce({ id: 'tenant-abc-refreshed' });
+    const result = await service.resolve('user-1');
+    expect(mockFindOne).toHaveBeenCalledTimes(2);
+    expect(result).toBe('tenant-abc-refreshed');
+  });
+
+  it('invalidate() on an unknown user is a no-op (does not throw)', () => {
+    expect(() => service.invalidate('no-such-user')).not.toThrow();
+  });
 });

--- a/packages/backend/src/common/services/tenant-cache.service.ts
+++ b/packages/backend/src/common/services/tenant-cache.service.ts
@@ -22,4 +22,9 @@ export class TenantCacheService {
       return tenant?.id ?? null;
     });
   }
+
+  /** Remove a cached entry so the next resolve() re-hits the DB. */
+  invalidate(userId: string): void {
+    this.cache.invalidate(userId);
+  }
 }

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -115,6 +115,7 @@ import { AddErrorsPartialIndex1790300000000 } from './migrations/1790300000000-A
 import { DropRedundantAgentApiKeyPrefixIndex1790400000000 } from './migrations/1790400000000-DropRedundantAgentApiKeyPrefixIndex';
 import { LiftProvidersToUserLevel1791000000000 } from './migrations/1791000000000-LiftProvidersToUserLevel';
 import { LiftCustomProvidersToUserLevel1791200000000 } from './migrations/1791200000000-LiftCustomProvidersToUserLevel';
+import { SeedPlaygroundAgents1791400000000 } from './migrations/1791400000000-SeedPlaygroundAgents';
 
 const entities = [
   AgentMessage,
@@ -231,6 +232,7 @@ const migrations = [
   DropRedundantAgentApiKeyPrefixIndex1790400000000,
   LiftProvidersToUserLevel1791000000000,
   LiftCustomProvidersToUserLevel1791200000000,
+  SeedPlaygroundAgents1791400000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1791400000000-SeedPlaygroundAgents.spec.ts
+++ b/packages/backend/src/database/migrations/1791400000000-SeedPlaygroundAgents.spec.ts
@@ -1,0 +1,95 @@
+import { SeedPlaygroundAgents1791400000000 } from './1791400000000-SeedPlaygroundAgents';
+
+describe('SeedPlaygroundAgents1791400000000', () => {
+  const migration = new SeedPlaygroundAgents1791400000000();
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const queryRunner = {
+    query: jest.fn(async (sql: string, params?: unknown[]) => queries.push({ sql, params })),
+  } as never;
+
+  beforeEach(() => {
+    queries.length = 0;
+    (queryRunner as { query: jest.Mock }).query.mockClear();
+  });
+
+  describe('up()', () => {
+    it('adds the is_system column before any INSERT', async () => {
+      await migration.up(queryRunner);
+      const addColIdx = queries.findIndex(
+        (q) => q.sql.includes('ADD COLUMN IF NOT EXISTS') && q.sql.includes('"is_system"'),
+      );
+      const insertIdx = queries.findIndex((q) => q.sql.trimStart().startsWith('INSERT INTO'));
+      expect(addColIdx).toBeGreaterThanOrEqual(0);
+      expect(insertIdx).toBeGreaterThan(addColIdx);
+    });
+
+    it("uses slug-safe name suffix `name || '-' || id` (no spaces or brackets)", async () => {
+      await migration.up(queryRunner);
+      const relabel = queries.find(
+        (q) => q.sql.includes('UPDATE') && q.sql.includes('"is_system"'),
+      );
+      expect(relabel).toBeDefined();
+      // Must contain `-` concatenation, not space/bracket form
+      expect(relabel!.sql).toContain('"name" || \'-\' || "id"');
+      // Must NOT contain the old space-bracket form
+      expect(relabel!.sql).not.toContain("' ['");
+    });
+
+    it('relabels BEFORE inserting the reserved agent (so unique index never collides)', async () => {
+      await migration.up(queryRunner);
+      const relabelIdx = queries.findIndex(
+        (q) => q.sql.includes('UPDATE') && q.sql.includes('"is_system"'),
+      );
+      const insertIdx = queries.findIndex(
+        (q) => q.sql.includes('INSERT INTO "agents"') && q.sql.includes('gen_random_uuid'),
+      );
+      expect(relabelIdx).toBeGreaterThanOrEqual(0);
+      expect(insertIdx).toBeGreaterThan(relabelIdx);
+    });
+
+    it('only relabels non-system agents that are not soft-deleted', async () => {
+      await migration.up(queryRunner);
+      const relabel = queries.find(
+        (q) => q.sql.includes('UPDATE') && q.sql.includes('"is_system"'),
+      );
+      expect(relabel).toBeDefined();
+      expect(relabel!.sql).toContain('"is_system" = false');
+      expect(relabel!.sql).toContain('"deleted_at" IS NULL');
+    });
+
+    it('creates a reserved Playground agent per tenant that lacks one (INSERT ... WHERE NOT EXISTS)', async () => {
+      await migration.up(queryRunner);
+      const insert = queries.find(
+        (q) => q.sql.includes('INSERT INTO "agents"') && q.sql.includes('NOT EXISTS'),
+      );
+      expect(insert).toBeDefined();
+      expect(insert!.sql).toContain('"is_system"');
+      expect(insert!.sql).toContain('gen_random_uuid');
+    });
+
+    it('grants the Playground agent its tenant provider pool (ON CONFLICT DO NOTHING)', async () => {
+      await migration.up(queryRunner);
+      const grant = queries.find(
+        (q) =>
+          q.sql.includes('INSERT INTO "agent_provider_access"') &&
+          q.sql.includes('ON CONFLICT DO NOTHING'),
+      );
+      expect(grant).toBeDefined();
+      expect(grant!.sql).toContain('"is_system" = true');
+    });
+  });
+
+  describe('down()', () => {
+    it('removes system agents and drops the is_system column', async () => {
+      await migration.down(queryRunner);
+      const deleteAgents = queries.find(
+        (q) => q.sql.includes('DELETE FROM "agents"') && q.sql.includes('"is_system"'),
+      );
+      expect(deleteAgents).toBeDefined();
+      const dropCol = queries.find(
+        (q) => q.sql.includes('DROP COLUMN IF EXISTS') && q.sql.includes('"is_system"'),
+      );
+      expect(dropCol).toBeDefined();
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1791400000000-SeedPlaygroundAgents.ts
+++ b/packages/backend/src/database/migrations/1791400000000-SeedPlaygroundAgents.ts
@@ -14,8 +14,10 @@ export class SeedPlaygroundAgents1791400000000 implements MigrationInterface {
     //    named 'Playground' (suffix with its id — never delete a user's agent) so
     //    the reserved per-tenant agent can take the name without colliding on the
     //    (tenant_id, name) unique index.
+    //    Slug-safe form: `name-<uuid>` (hyphen + UUID chars are all [a-z0-9-]).
+    //    Space/bracket suffixes would break ^[a-zA-Z0-9_-]+$ route validators.
     await queryRunner.query(
-      `UPDATE "agents" SET "name" = "name" || ' [' || "id" || ']'
+      `UPDATE "agents" SET "name" = "name" || '-' || "id"
        WHERE "name" = $1 AND "is_system" = false AND "deleted_at" IS NULL`,
       [PLAYGROUND_AGENT_NAME],
     );

--- a/packages/backend/src/database/migrations/1791400000000-SeedPlaygroundAgents.ts
+++ b/packages/backend/src/database/migrations/1791400000000-SeedPlaygroundAgents.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { PLAYGROUND_AGENT_NAME } from '../../common/constants/playground.constants';
+
+export class SeedPlaygroundAgents1791400000000 implements MigrationInterface {
+  name = 'SeedPlaygroundAgents1791400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Reserved-system flag on agents (hidden from list/switcher/counts).
+    await queryRunner.query(
+      `ALTER TABLE "agents" ADD COLUMN IF NOT EXISTS "is_system" boolean NOT NULL DEFAULT false`,
+    );
+
+    // 2. Free the reserved name: relabel any existing NON-system agent literally
+    //    named 'Playground' (suffix with its id — never delete a user's agent) so
+    //    the reserved per-tenant agent can take the name without colliding on the
+    //    (tenant_id, name) unique index.
+    await queryRunner.query(
+      `UPDATE "agents" SET "name" = "name" || ' [' || "id" || ']'
+       WHERE "name" = $1 AND "is_system" = false AND "deleted_at" IS NULL`,
+      [PLAYGROUND_AGENT_NAME],
+    );
+
+    // 3. Create one reserved Playground agent per tenant that doesn't have one.
+    //    Keyless by design — it backs the Playground and never ingests OTLP, so
+    //    no agent_api_keys row is needed.
+    await queryRunner.query(
+      `INSERT INTO "agents" ("id", "name", "display_name", "is_system", "is_active", "tenant_id")
+       SELECT gen_random_uuid()::text, $1, $1, true, true, t."id"
+       FROM "tenants" t
+       WHERE NOT EXISTS (
+         SELECT 1 FROM "agents" a
+         WHERE a."tenant_id" = t."id" AND a."is_system" = true AND a."deleted_at" IS NULL
+       )`,
+      [PLAYGROUND_AGENT_NAME],
+    );
+
+    // 4. Grant each Playground agent access to its tenant's whole provider pool
+    //    (tenants.name = user_providers.user_id) so the Playground routes against
+    //    every connected provider.
+    await queryRunner.query(
+      `INSERT INTO "agent_provider_access" ("agent_id", "user_provider_id")
+       SELECT a."id", up."id"
+       FROM "agents" a
+       JOIN "tenants" t ON t."id" = a."tenant_id"
+       JOIN "user_providers" up ON up."user_id" = t."name"
+       WHERE a."is_system" = true AND a."deleted_at" IS NULL
+       ON CONFLICT DO NOTHING`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Grants cascade-delete with the agent rows (agent_provider_access FK is
+    // ON DELETE CASCADE), so removing the system agents is enough.
+    await queryRunner.query(`DELETE FROM "agents" WHERE "is_system" = true`);
+    await queryRunner.query(`ALTER TABLE "agents" DROP COLUMN IF EXISTS "is_system"`);
+  }
+}

--- a/packages/backend/src/entities/agent.entity.ts
+++ b/packages/backend/src/entities/agent.entity.ts
@@ -33,6 +33,11 @@ export class Agent {
   @Column('boolean', { default: true })
   record_messages!: boolean;
 
+  // Reserved system agent (the per-tenant "Playground" agent). Hidden
+  // from the agent list / switcher / counts and not user-creatable/renamable.
+  @Column('boolean', { default: false })
+  is_system!: boolean;
+
   @Column('varchar', { nullable: true })
   savings_baseline_model!: string | null;
 

--- a/packages/backend/src/playground/playground-agent.service.spec.ts
+++ b/packages/backend/src/playground/playground-agent.service.spec.ts
@@ -1,0 +1,250 @@
+import { NotFoundException } from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import { PlaygroundAgentService } from './playground-agent.service';
+import type { Agent } from '../entities/agent.entity';
+import type { TenantCacheService } from '../common/services/tenant-cache.service';
+import type { ProviderService } from '../routing/routing-core/provider.service';
+import { PLAYGROUND_AGENT_NAME } from '../common/constants/playground.constants';
+
+const TENANT_ID = 'tenant-abc';
+const USER_ID = 'user-xyz';
+const AGENT_ID = 'agent-sys-1';
+
+/** A minimal Agent-shaped object that satisfies the service's return type. */
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT_ID,
+    name: PLAYGROUND_AGENT_NAME,
+    display_name: PLAYGROUND_AGENT_NAME,
+    is_system: true,
+    is_active: true,
+    tenant_id: TENANT_ID,
+    ...overrides,
+  } as Agent;
+}
+
+interface Mocks {
+  agentRepo: {
+    findOne: jest.Mock;
+    insert: jest.Mock;
+  };
+  tenantCache: {
+    resolve: jest.Mock;
+  };
+  providerService: {
+    enableAllProvidersForAgent: jest.Mock;
+  };
+}
+
+function buildService(mocks: Partial<Mocks> = {}): {
+  service: PlaygroundAgentService;
+  mocks: Mocks;
+} {
+  const full: Mocks = {
+    agentRepo: {
+      findOne: jest.fn().mockResolvedValue(null),
+      insert: jest.fn().mockResolvedValue(undefined),
+    },
+    tenantCache: {
+      resolve: jest.fn().mockResolvedValue(TENANT_ID),
+    },
+    providerService: {
+      enableAllProvidersForAgent: jest.fn().mockResolvedValue(undefined),
+    },
+    ...mocks,
+  };
+
+  const service = new PlaygroundAgentService(
+    full.agentRepo as unknown as Repository<Agent>,
+    full.tenantCache as unknown as TenantCacheService,
+    full.providerService as unknown as ProviderService,
+  );
+
+  return { service, mocks: full };
+}
+
+describe('PlaygroundAgentService.resolve', () => {
+  describe('(a) tenant not found', () => {
+    it('throws NotFoundException when tenantCache.resolve returns null', async () => {
+      const { service } = buildService({
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+      });
+
+      await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
+      await expect(service.resolve(USER_ID)).rejects.toThrow('Tenant not found');
+    });
+
+    it('does not call agentRepo when tenant is not found', async () => {
+      const { service, mocks } = buildService({
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+      });
+
+      await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
+      expect(mocks.agentRepo.findOne).not.toHaveBeenCalled();
+      expect(mocks.agentRepo.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('(b) existing system agent returned', () => {
+    it('returns the existing agent without inserting a new one', async () => {
+      const existing = makeAgent();
+      const { service, mocks } = buildService({
+        agentRepo: {
+          findOne: jest.fn().mockResolvedValue(existing),
+          insert: jest.fn(),
+        },
+      });
+
+      const result = await service.resolve(USER_ID);
+
+      expect(result).toBe(existing);
+      expect(mocks.agentRepo.insert).not.toHaveBeenCalled();
+    });
+
+    it('does not call enableAllProvidersForAgent when an agent already exists', async () => {
+      const existing = makeAgent();
+      const { service, mocks } = buildService({
+        agentRepo: {
+          findOne: jest.fn().mockResolvedValue(existing),
+          insert: jest.fn(),
+        },
+      });
+
+      await service.resolve(USER_ID);
+
+      expect(mocks.providerService.enableAllProvidersForAgent).not.toHaveBeenCalled();
+    });
+
+    it('queries agentRepo with the correct tenant_id, is_system and deleted_at filters', async () => {
+      const existing = makeAgent();
+      const { service, mocks } = buildService({
+        agentRepo: {
+          findOne: jest.fn().mockResolvedValue(existing),
+          insert: jest.fn(),
+        },
+      });
+
+      await service.resolve(USER_ID);
+
+      expect(mocks.agentRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ tenant_id: TENANT_ID, is_system: true }),
+        }),
+      );
+    });
+  });
+
+  describe('(c) lazy-create path', () => {
+    it('inserts a new agent and returns it when no system agent exists', async () => {
+      const { service, mocks } = buildService({
+        agentRepo: {
+          findOne: jest.fn().mockResolvedValue(null),
+          insert: jest.fn().mockResolvedValue(undefined),
+        },
+      });
+
+      const result = await service.resolve(USER_ID);
+
+      expect(mocks.agentRepo.insert).toHaveBeenCalledTimes(1);
+      expect(result.name).toBe(PLAYGROUND_AGENT_NAME);
+      expect(result.display_name).toBe(PLAYGROUND_AGENT_NAME);
+      expect(result.is_system).toBe(true);
+      expect(result.is_active).toBe(true);
+      expect(result.tenant_id).toBe(TENANT_ID);
+      expect(typeof result.id).toBe('string');
+      expect(result.id.length).toBeGreaterThan(0);
+    });
+
+    it('calls enableAllProvidersForAgent with the new agent id and userId', async () => {
+      const { service, mocks } = buildService({
+        agentRepo: {
+          findOne: jest.fn().mockResolvedValue(null),
+          insert: jest.fn().mockResolvedValue(undefined),
+        },
+      });
+
+      const result = await service.resolve(USER_ID);
+
+      expect(mocks.providerService.enableAllProvidersForAgent).toHaveBeenCalledTimes(1);
+      expect(mocks.providerService.enableAllProvidersForAgent).toHaveBeenCalledWith(
+        result.id,
+        USER_ID,
+      );
+    });
+
+    it('returns the newly-created agent object (not a DB re-fetch)', async () => {
+      const { service, mocks } = buildService({
+        agentRepo: {
+          findOne: jest.fn().mockResolvedValue(null),
+          insert: jest.fn().mockResolvedValue(undefined),
+        },
+      });
+
+      const result = await service.resolve(USER_ID);
+
+      // insert is called once; findOne is called once (initial check only — no re-fetch on success)
+      expect(mocks.agentRepo.findOne).toHaveBeenCalledTimes(1);
+      expect(result.tenant_id).toBe(TENANT_ID);
+    });
+  });
+
+  describe('(d) race: insert throws → re-find returns a row', () => {
+    it('returns the race winner row without calling enableAllProvidersForAgent', async () => {
+      const raceWinner = makeAgent({ id: 'agent-winner' });
+      const { service, mocks } = buildService({
+        agentRepo: {
+          // First findOne (pre-insert check) → null; second (post-race re-find) → raceWinner
+          findOne: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(raceWinner),
+          insert: jest.fn().mockRejectedValue(new Error('duplicate key value violates unique')),
+        },
+      });
+
+      const result = await service.resolve(USER_ID);
+
+      expect(result).toBe(raceWinner);
+      expect(mocks.agentRepo.findOne).toHaveBeenCalledTimes(2);
+      expect(mocks.providerService.enableAllProvidersForAgent).not.toHaveBeenCalled();
+    });
+
+    it('does not re-throw the insert error when the race winner row is found', async () => {
+      const raceWinner = makeAgent({ id: 'agent-winner' });
+      const { service } = buildService({
+        agentRepo: {
+          findOne: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(raceWinner),
+          insert: jest.fn().mockRejectedValue(new Error('unique constraint')),
+        },
+      });
+
+      await expect(service.resolve(USER_ID)).resolves.toBe(raceWinner);
+    });
+  });
+
+  describe('(e) race: insert throws → re-find returns null', () => {
+    it('throws NotFoundException when re-find after race returns null', async () => {
+      const { service } = buildService({
+        agentRepo: {
+          // Both findOne calls return null (no winner row)
+          findOne: jest.fn().mockResolvedValue(null),
+          insert: jest.fn().mockRejectedValue(new Error('duplicate key')),
+        },
+      });
+
+      await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
+      await expect(service.resolve(USER_ID)).rejects.toThrow(
+        'Playground agent could not be resolved',
+      );
+    });
+
+    it('does not call enableAllProvidersForAgent when the race re-find also returns null', async () => {
+      const { service, mocks } = buildService({
+        agentRepo: {
+          findOne: jest.fn().mockResolvedValue(null),
+          insert: jest.fn().mockRejectedValue(new Error('duplicate key')),
+        },
+      });
+
+      await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
+      expect(mocks.providerService.enableAllProvidersForAgent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/playground/playground-agent.service.spec.ts
+++ b/packages/backend/src/playground/playground-agent.service.spec.ts
@@ -2,6 +2,7 @@ import { NotFoundException } from '@nestjs/common';
 import type { DataSource, EntityManager, Repository } from 'typeorm';
 import { PlaygroundAgentService } from './playground-agent.service';
 import type { Agent } from '../entities/agent.entity';
+import type { Tenant } from '../entities/tenant.entity';
 import type { TenantCacheService } from '../common/services/tenant-cache.service';
 import { PLAYGROUND_AGENT_NAME } from '../common/constants/playground.constants';
 
@@ -22,6 +23,21 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
   } as Agent;
 }
 
+/** A minimal Tenant-shaped object. */
+function makeTenant(overrides: Partial<Tenant> = {}): Tenant {
+  return {
+    id: TENANT_ID,
+    name: USER_ID,
+    is_active: true,
+    ...overrides,
+  } as Tenant;
+}
+
+interface TenantRepo {
+  findOne: jest.Mock;
+  insert: jest.Mock;
+}
+
 interface Mocks {
   agentRepo: {
     findOne: jest.Mock;
@@ -31,6 +47,7 @@ interface Mocks {
   };
   dataSource: {
     transaction: jest.Mock;
+    getRepository: jest.Mock;
   };
 }
 
@@ -48,10 +65,24 @@ function makeManager(
   } as unknown as EntityManager;
 }
 
+/**
+ * Build a mock tenant repository for dataSource.getRepository(Tenant).
+ * findOne and insert can be configured per-test.
+ */
+function makeTenantRepo(overrides: Partial<TenantRepo> = {}): TenantRepo {
+  return {
+    findOne: jest.fn().mockResolvedValue(null),
+    insert: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
 function buildService(mocks: Partial<Mocks> = {}): {
   service: PlaygroundAgentService;
   mocks: Mocks;
 } {
+  const tenantRepo = makeTenantRepo();
+
   const full: Mocks = {
     agentRepo: {
       findOne: jest.fn().mockResolvedValue(null),
@@ -64,6 +95,8 @@ function buildService(mocks: Partial<Mocks> = {}): {
       transaction: jest.fn().mockImplementation(async (cb: (m: EntityManager) => Promise<void>) => {
         await cb(makeManager());
       }),
+      // Default: returns a tenant repo stub (used by ensureTenant).
+      getRepository: jest.fn().mockReturnValue(tenantRepo),
     },
     ...mocks,
   };
@@ -78,23 +111,153 @@ function buildService(mocks: Partial<Mocks> = {}): {
 }
 
 describe('PlaygroundAgentService.resolve', () => {
-  describe('(a) tenant not found', () => {
-    it('throws NotFoundException when tenantCache.resolve returns null', async () => {
-      const { service } = buildService({
-        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+  describe('(a) tenantCache hit — no tenant bootstrap', () => {
+    it('does not call dataSource.getRepository when tenantCache resolves a tenantId', async () => {
+      const existing = makeAgent();
+      const { service, mocks } = buildService({
+        agentRepo: { findOne: jest.fn().mockResolvedValue(existing) },
+        // tenantCache already resolves TENANT_ID by default
       });
 
-      await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
-      await expect(service.resolve(USER_ID)).rejects.toThrow('Tenant not found');
+      await service.resolve(USER_ID);
+
+      expect(mocks.dataSource.getRepository).not.toHaveBeenCalled();
     });
 
-    it('does not call the dataSource when tenant is not found', async () => {
+    it('returns the existing agent when tenantCache hits and agent exists', async () => {
+      const existing = makeAgent();
+      const { service } = buildService({
+        agentRepo: { findOne: jest.fn().mockResolvedValue(existing) },
+      });
+
+      const result = await service.resolve(USER_ID);
+      expect(result).toBe(existing);
+    });
+  });
+
+  describe('(a2) ensureTenant — tenant already exists in DB (findOne returns row)', () => {
+    it('uses the existing tenant id and proceeds to create the agent', async () => {
+      const tenant = makeTenant();
+      const tenantRepo = makeTenantRepo({
+        findOne: jest.fn().mockResolvedValue(tenant),
+      });
+
+      const insertFn = jest.fn().mockResolvedValue(undefined);
+      const queryFn = jest.fn().mockResolvedValue(undefined);
+      const manager = makeManager(insertFn, queryFn);
+
       const { service, mocks } = buildService({
         tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+        dataSource: {
+          transaction: jest
+            .fn()
+            .mockImplementation(async (cb: (m: EntityManager) => Promise<void>) => {
+              await cb(manager);
+            }),
+          getRepository: jest.fn().mockReturnValue(tenantRepo),
+        },
+      });
+
+      const result = await service.resolve(USER_ID);
+
+      // getRepository(Tenant) was called to look up the tenant.
+      expect(mocks.dataSource.getRepository).toHaveBeenCalled();
+      // insert was NOT called because findOne found the tenant.
+      expect(tenantRepo.insert).not.toHaveBeenCalled();
+      // The agent was created under the found tenant id.
+      expect(result.tenant_id).toBe(TENANT_ID);
+    });
+  });
+
+  describe('(a3) ensureTenant — tenant missing → insert succeeds', () => {
+    it('inserts a new tenant and returns the new id', async () => {
+      const newTenantId = 'new-tenant-uuid';
+      const tenantRepo = makeTenantRepo({
+        // findOne returns null — tenant does not exist
+        findOne: jest.fn().mockResolvedValue(null),
+        insert: jest.fn().mockResolvedValue(undefined),
+      });
+
+      const { service, mocks } = buildService({
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+        dataSource: {
+          transaction: jest
+            .fn()
+            .mockImplementation(async (cb: (m: EntityManager) => Promise<void>) => {
+              await cb(makeManager());
+            }),
+          getRepository: jest.fn().mockReturnValue(tenantRepo),
+        },
+      });
+
+      const result = await service.resolve(USER_ID);
+
+      expect(tenantRepo.insert).toHaveBeenCalledTimes(1);
+      const insertArg = tenantRepo.insert.mock.calls[0][0] as {
+        id: string;
+        name: string;
+        is_active: boolean;
+      };
+      expect(typeof insertArg.id).toBe('string');
+      expect(insertArg.name).toBe(USER_ID);
+      expect(insertArg.is_active).toBe(true);
+      // The agent should be created under the new tenant's id.
+      expect(typeof result.tenant_id).toBe('string');
+      // getRepository was used for ensureTenant.
+      expect(mocks.dataSource.getRepository).toHaveBeenCalled();
+      void newTenantId; // suppress unused warning
+    });
+  });
+
+  describe('(a4) ensureTenant — insert throws, re-find returns row', () => {
+    it('returns the race-winner tenant id without re-throwing', async () => {
+      const racingTenant = makeTenant({ id: 'race-winner-tenant' });
+      const tenantRepo = makeTenantRepo({
+        findOne: jest
+          .fn()
+          .mockResolvedValueOnce(null) // first call: not found → trigger insert
+          .mockResolvedValueOnce(racingTenant), // second call: race winner found
+        insert: jest.fn().mockRejectedValue(new Error('duplicate key')),
+      });
+
+      const { service } = buildService({
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+        dataSource: {
+          transaction: jest
+            .fn()
+            .mockImplementation(async (cb: (m: EntityManager) => Promise<void>) => {
+              await cb(makeManager());
+            }),
+          getRepository: jest.fn().mockReturnValue(tenantRepo),
+        },
+      });
+
+      const result = await service.resolve(USER_ID);
+
+      expect(tenantRepo.findOne).toHaveBeenCalledTimes(2);
+      expect(tenantRepo.insert).toHaveBeenCalledTimes(1);
+      // Agent should be created under the race-winner's tenant id.
+      expect(result.tenant_id).toBe('race-winner-tenant');
+    });
+  });
+
+  describe('(a5) ensureTenant — insert throws, re-find returns null', () => {
+    it('throws NotFoundException("Tenant could not be resolved")', async () => {
+      const tenantRepo = makeTenantRepo({
+        findOne: jest.fn().mockResolvedValue(null), // both calls return null
+        insert: jest.fn().mockRejectedValue(new Error('duplicate key')),
+      });
+
+      const { service } = buildService({
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+        dataSource: {
+          transaction: jest.fn().mockResolvedValue(undefined),
+          getRepository: jest.fn().mockReturnValue(tenantRepo),
+        },
       });
 
       await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
-      expect(mocks.dataSource.transaction).not.toHaveBeenCalled();
+      await expect(service.resolve(USER_ID)).rejects.toThrow('Tenant could not be resolved');
     });
   });
 
@@ -144,6 +307,7 @@ describe('PlaygroundAgentService.resolve', () => {
             .mockImplementation(async (cb: (m: EntityManager) => Promise<void>) => {
               await cb(manager);
             }),
+          getRepository: jest.fn().mockReturnValue(makeTenantRepo()),
         },
       });
 
@@ -188,6 +352,7 @@ describe('PlaygroundAgentService.resolve', () => {
           transaction: jest
             .fn()
             .mockRejectedValue(new Error('duplicate key value violates unique')),
+          getRepository: jest.fn().mockReturnValue(makeTenantRepo()),
         },
       });
 
@@ -207,6 +372,7 @@ describe('PlaygroundAgentService.resolve', () => {
         },
         dataSource: {
           transaction: jest.fn().mockRejectedValue(new Error('unique constraint')),
+          getRepository: jest.fn().mockReturnValue(makeTenantRepo()),
         },
       });
 
@@ -222,6 +388,7 @@ describe('PlaygroundAgentService.resolve', () => {
         },
         dataSource: {
           transaction: jest.fn().mockRejectedValue(new Error('duplicate key')),
+          getRepository: jest.fn().mockReturnValue(makeTenantRepo()),
         },
       });
 
@@ -239,6 +406,7 @@ describe('PlaygroundAgentService.resolve', () => {
         },
         dataSource: {
           transaction: transactionFn,
+          getRepository: jest.fn().mockReturnValue(makeTenantRepo()),
         },
       });
 

--- a/packages/backend/src/playground/playground-agent.service.spec.ts
+++ b/packages/backend/src/playground/playground-agent.service.spec.ts
@@ -44,6 +44,7 @@ interface Mocks {
   };
   tenantCache: {
     resolve: jest.Mock;
+    invalidate: jest.Mock;
   };
   dataSource: {
     transaction: jest.Mock;
@@ -89,6 +90,7 @@ function buildService(mocks: Partial<Mocks> = {}): {
     },
     tenantCache: {
       resolve: jest.fn().mockResolvedValue(TENANT_ID),
+      invalidate: jest.fn(),
     },
     dataSource: {
       // Default: runs the transaction callback with a stock manager (insert + query succeed).
@@ -133,6 +135,46 @@ describe('PlaygroundAgentService.resolve', () => {
       const result = await service.resolve(USER_ID);
       expect(result).toBe(existing);
     });
+
+    it('does NOT call tenantCache.invalidate when tenantCache already resolved an id', async () => {
+      const existing = makeAgent();
+      const { service, mocks } = buildService({
+        agentRepo: { findOne: jest.fn().mockResolvedValue(existing) },
+        // tenantCache.resolve returns TENANT_ID (non-null) by default
+      });
+
+      await service.resolve(USER_ID);
+
+      expect(mocks.tenantCache.invalidate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('(a1) tenantCache miss → ensureTenant → cache invalidated', () => {
+    it('calls tenantCache.invalidate(userId) after ensureTenant bootstraps the tenant', async () => {
+      const tenantRepo = makeTenantRepo({
+        findOne: jest.fn().mockResolvedValue(makeTenant()),
+      });
+
+      const invalidateFn = jest.fn();
+      const { service } = buildService({
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null), invalidate: invalidateFn },
+        dataSource: {
+          transaction: jest
+            .fn()
+            .mockImplementation(async (cb: (m: EntityManager) => Promise<void>) => {
+              await cb(makeManager());
+            }),
+          getRepository: jest.fn().mockReturnValue(tenantRepo),
+        },
+      });
+
+      await service.resolve(USER_ID);
+
+      // invalidate must be called with the userId so subsequent resolves see the
+      // real tenantId instead of the cached null.
+      expect(invalidateFn).toHaveBeenCalledTimes(1);
+      expect(invalidateFn).toHaveBeenCalledWith(USER_ID);
+    });
   });
 
   describe('(a2) ensureTenant — tenant already exists in DB (findOne returns row)', () => {
@@ -147,7 +189,7 @@ describe('PlaygroundAgentService.resolve', () => {
       const manager = makeManager(insertFn, queryFn);
 
       const { service, mocks } = buildService({
-        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null), invalidate: jest.fn() },
         dataSource: {
           transaction: jest
             .fn()
@@ -179,7 +221,7 @@ describe('PlaygroundAgentService.resolve', () => {
       });
 
       const { service, mocks } = buildService({
-        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null), invalidate: jest.fn() },
         dataSource: {
           transaction: jest
             .fn()
@@ -221,7 +263,7 @@ describe('PlaygroundAgentService.resolve', () => {
       });
 
       const { service } = buildService({
-        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null), invalidate: jest.fn() },
         dataSource: {
           transaction: jest
             .fn()
@@ -249,7 +291,7 @@ describe('PlaygroundAgentService.resolve', () => {
       });
 
       const { service } = buildService({
-        tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
+        tenantCache: { resolve: jest.fn().mockResolvedValue(null), invalidate: jest.fn() },
         dataSource: {
           transaction: jest.fn().mockResolvedValue(undefined),
           getRepository: jest.fn().mockReturnValue(tenantRepo),

--- a/packages/backend/src/playground/playground-agent.service.spec.ts
+++ b/packages/backend/src/playground/playground-agent.service.spec.ts
@@ -1,4 +1,3 @@
-import { NotFoundException } from '@nestjs/common';
 import type { DataSource, EntityManager, Repository } from 'typeorm';
 import { PlaygroundAgentService } from './playground-agent.service';
 import type { Agent } from '../entities/agent.entity';
@@ -284,10 +283,11 @@ describe('PlaygroundAgentService.resolve', () => {
   });
 
   describe('(a5) ensureTenant — insert throws, re-find returns null', () => {
-    it('throws NotFoundException("Tenant could not be resolved")', async () => {
+    it('re-throws the original DB error (does not mask it as not-found)', async () => {
+      const dbError = new Error('connection reset');
       const tenantRepo = makeTenantRepo({
         findOne: jest.fn().mockResolvedValue(null), // both calls return null
-        insert: jest.fn().mockRejectedValue(new Error('duplicate key')),
+        insert: jest.fn().mockRejectedValue(dbError),
       });
 
       const { service } = buildService({
@@ -298,8 +298,7 @@ describe('PlaygroundAgentService.resolve', () => {
         },
       });
 
-      await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
-      await expect(service.resolve(USER_ID)).rejects.toThrow('Tenant could not be resolved');
+      await expect(service.resolve(USER_ID)).rejects.toThrow('connection reset');
     });
   });
 
@@ -422,22 +421,20 @@ describe('PlaygroundAgentService.resolve', () => {
     });
   });
 
-  describe('(e) race: transaction throws → re-find returns null', () => {
-    it('throws NotFoundException when re-find after race returns null', async () => {
+  describe('(e) transaction throws → re-find returns null', () => {
+    it('re-throws the original DB error (not a race → surface the real failure)', async () => {
+      const dbError = new Error('deadlock detected');
       const { service } = buildService({
         agentRepo: {
           findOne: jest.fn().mockResolvedValue(null),
         },
         dataSource: {
-          transaction: jest.fn().mockRejectedValue(new Error('duplicate key')),
+          transaction: jest.fn().mockRejectedValue(dbError),
           getRepository: jest.fn().mockReturnValue(makeTenantRepo()),
         },
       });
 
-      await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
-      await expect(service.resolve(USER_ID)).rejects.toThrow(
-        'Playground agent could not be resolved',
-      );
+      await expect(service.resolve(USER_ID)).rejects.toThrow('deadlock detected');
     });
 
     it('does not attempt a second transaction when the race re-find also returns null', async () => {
@@ -452,7 +449,7 @@ describe('PlaygroundAgentService.resolve', () => {
         },
       });
 
-      await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
+      await expect(service.resolve(USER_ID)).rejects.toThrow('duplicate key');
       expect(transactionFn).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/backend/src/playground/playground-agent.service.spec.ts
+++ b/packages/backend/src/playground/playground-agent.service.spec.ts
@@ -1,9 +1,8 @@
 import { NotFoundException } from '@nestjs/common';
-import type { Repository } from 'typeorm';
+import type { DataSource, EntityManager, Repository } from 'typeorm';
 import { PlaygroundAgentService } from './playground-agent.service';
 import type { Agent } from '../entities/agent.entity';
 import type { TenantCacheService } from '../common/services/tenant-cache.service';
-import type { ProviderService } from '../routing/routing-core/provider.service';
 import { PLAYGROUND_AGENT_NAME } from '../common/constants/playground.constants';
 
 const TENANT_ID = 'tenant-abc';
@@ -26,14 +25,27 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
 interface Mocks {
   agentRepo: {
     findOne: jest.Mock;
-    insert: jest.Mock;
   };
   tenantCache: {
     resolve: jest.Mock;
   };
-  providerService: {
-    enableAllProvidersForAgent: jest.Mock;
+  dataSource: {
+    transaction: jest.Mock;
   };
+}
+
+/**
+ * Build a mock EntityManager whose getRepository(Agent).insert and .query
+ * can be configured per-test.
+ */
+function makeManager(
+  insertFn: jest.Mock = jest.fn().mockResolvedValue(undefined),
+  queryFn: jest.Mock = jest.fn().mockResolvedValue(undefined),
+): EntityManager {
+  return {
+    getRepository: () => ({ insert: insertFn }),
+    query: queryFn,
+  } as unknown as EntityManager;
 }
 
 function buildService(mocks: Partial<Mocks> = {}): {
@@ -43,13 +55,15 @@ function buildService(mocks: Partial<Mocks> = {}): {
   const full: Mocks = {
     agentRepo: {
       findOne: jest.fn().mockResolvedValue(null),
-      insert: jest.fn().mockResolvedValue(undefined),
     },
     tenantCache: {
       resolve: jest.fn().mockResolvedValue(TENANT_ID),
     },
-    providerService: {
-      enableAllProvidersForAgent: jest.fn().mockResolvedValue(undefined),
+    dataSource: {
+      // Default: runs the transaction callback with a stock manager (insert + query succeed).
+      transaction: jest.fn().mockImplementation(async (cb: (m: EntityManager) => Promise<void>) => {
+        await cb(makeManager());
+      }),
     },
     ...mocks,
   };
@@ -57,7 +71,7 @@ function buildService(mocks: Partial<Mocks> = {}): {
   const service = new PlaygroundAgentService(
     full.agentRepo as unknown as Repository<Agent>,
     full.tenantCache as unknown as TenantCacheService,
-    full.providerService as unknown as ProviderService,
+    full.dataSource as unknown as DataSource,
   );
 
   return { service, mocks: full };
@@ -74,45 +88,29 @@ describe('PlaygroundAgentService.resolve', () => {
       await expect(service.resolve(USER_ID)).rejects.toThrow('Tenant not found');
     });
 
-    it('does not call agentRepo when tenant is not found', async () => {
+    it('does not call the dataSource when tenant is not found', async () => {
       const { service, mocks } = buildService({
         tenantCache: { resolve: jest.fn().mockResolvedValue(null) },
       });
 
       await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
-      expect(mocks.agentRepo.findOne).not.toHaveBeenCalled();
-      expect(mocks.agentRepo.insert).not.toHaveBeenCalled();
+      expect(mocks.dataSource.transaction).not.toHaveBeenCalled();
     });
   });
 
   describe('(b) existing system agent returned', () => {
-    it('returns the existing agent without inserting a new one', async () => {
+    it('returns the existing agent without starting a transaction', async () => {
       const existing = makeAgent();
       const { service, mocks } = buildService({
         agentRepo: {
           findOne: jest.fn().mockResolvedValue(existing),
-          insert: jest.fn(),
         },
       });
 
       const result = await service.resolve(USER_ID);
 
       expect(result).toBe(existing);
-      expect(mocks.agentRepo.insert).not.toHaveBeenCalled();
-    });
-
-    it('does not call enableAllProvidersForAgent when an agent already exists', async () => {
-      const existing = makeAgent();
-      const { service, mocks } = buildService({
-        agentRepo: {
-          findOne: jest.fn().mockResolvedValue(existing),
-          insert: jest.fn(),
-        },
-      });
-
-      await service.resolve(USER_ID);
-
-      expect(mocks.providerService.enableAllProvidersForAgent).not.toHaveBeenCalled();
+      expect(mocks.dataSource.transaction).not.toHaveBeenCalled();
     });
 
     it('queries agentRepo with the correct tenant_id, is_system and deleted_at filters', async () => {
@@ -120,7 +118,6 @@ describe('PlaygroundAgentService.resolve', () => {
       const { service, mocks } = buildService({
         agentRepo: {
           findOne: jest.fn().mockResolvedValue(existing),
-          insert: jest.fn(),
         },
       });
 
@@ -135,17 +132,38 @@ describe('PlaygroundAgentService.resolve', () => {
   });
 
   describe('(c) lazy-create path', () => {
-    it('inserts a new agent and returns it when no system agent exists', async () => {
+    it('runs a transaction that inserts the agent and calls the grant query', async () => {
+      const insertFn = jest.fn().mockResolvedValue(undefined);
+      const queryFn = jest.fn().mockResolvedValue(undefined);
+      const manager = makeManager(insertFn, queryFn);
+
       const { service, mocks } = buildService({
-        agentRepo: {
-          findOne: jest.fn().mockResolvedValue(null),
-          insert: jest.fn().mockResolvedValue(undefined),
+        dataSource: {
+          transaction: jest
+            .fn()
+            .mockImplementation(async (cb: (m: EntityManager) => Promise<void>) => {
+              await cb(manager);
+            }),
         },
       });
 
       const result = await service.resolve(USER_ID);
 
-      expect(mocks.agentRepo.insert).toHaveBeenCalledTimes(1);
+      expect(mocks.dataSource.transaction).toHaveBeenCalledTimes(1);
+      expect(insertFn).toHaveBeenCalledTimes(1);
+
+      // The grant query must receive [agentId, userId].
+      expect(queryFn).toHaveBeenCalledTimes(1);
+      const [_sql, params] = queryFn.mock.calls[0] as [string, [string, string]];
+      expect(params[0]).toBe(result.id);
+      expect(params[1]).toBe(USER_ID);
+    });
+
+    it('returns a new agent with the correct fields (no DB re-fetch on success)', async () => {
+      const { service, mocks } = buildService();
+
+      const result = await service.resolve(USER_ID);
+
       expect(result.name).toBe(PLAYGROUND_AGENT_NAME);
       expect(result.display_name).toBe(PLAYGROUND_AGENT_NAME);
       expect(result.is_system).toBe(true);
@@ -153,49 +171,23 @@ describe('PlaygroundAgentService.resolve', () => {
       expect(result.tenant_id).toBe(TENANT_ID);
       expect(typeof result.id).toBe('string');
       expect(result.id.length).toBeGreaterThan(0);
-    });
 
-    it('calls enableAllProvidersForAgent with the new agent id and userId', async () => {
-      const { service, mocks } = buildService({
-        agentRepo: {
-          findOne: jest.fn().mockResolvedValue(null),
-          insert: jest.fn().mockResolvedValue(undefined),
-        },
-      });
-
-      const result = await service.resolve(USER_ID);
-
-      expect(mocks.providerService.enableAllProvidersForAgent).toHaveBeenCalledTimes(1);
-      expect(mocks.providerService.enableAllProvidersForAgent).toHaveBeenCalledWith(
-        result.id,
-        USER_ID,
-      );
-    });
-
-    it('returns the newly-created agent object (not a DB re-fetch)', async () => {
-      const { service, mocks } = buildService({
-        agentRepo: {
-          findOne: jest.fn().mockResolvedValue(null),
-          insert: jest.fn().mockResolvedValue(undefined),
-        },
-      });
-
-      const result = await service.resolve(USER_ID);
-
-      // insert is called once; findOne is called once (initial check only — no re-fetch on success)
+      // findOne called once (pre-insert check); no second call after success.
       expect(mocks.agentRepo.findOne).toHaveBeenCalledTimes(1);
-      expect(result.tenant_id).toBe(TENANT_ID);
     });
   });
 
-  describe('(d) race: insert throws → re-find returns a row', () => {
-    it('returns the race winner row without calling enableAllProvidersForAgent', async () => {
+  describe('(d) race: transaction throws → re-find returns a row', () => {
+    it('returns the race winner row without running a second transaction', async () => {
       const raceWinner = makeAgent({ id: 'agent-winner' });
       const { service, mocks } = buildService({
         agentRepo: {
-          // First findOne (pre-insert check) → null; second (post-race re-find) → raceWinner
           findOne: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(raceWinner),
-          insert: jest.fn().mockRejectedValue(new Error('duplicate key value violates unique')),
+        },
+        dataSource: {
+          transaction: jest
+            .fn()
+            .mockRejectedValue(new Error('duplicate key value violates unique')),
         },
       });
 
@@ -203,15 +195,18 @@ describe('PlaygroundAgentService.resolve', () => {
 
       expect(result).toBe(raceWinner);
       expect(mocks.agentRepo.findOne).toHaveBeenCalledTimes(2);
-      expect(mocks.providerService.enableAllProvidersForAgent).not.toHaveBeenCalled();
+      // Transaction was attempted once (and threw); no retry.
+      expect(mocks.dataSource.transaction).toHaveBeenCalledTimes(1);
     });
 
-    it('does not re-throw the insert error when the race winner row is found', async () => {
+    it('does not re-throw the transaction error when the race winner row is found', async () => {
       const raceWinner = makeAgent({ id: 'agent-winner' });
       const { service } = buildService({
         agentRepo: {
           findOne: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(raceWinner),
-          insert: jest.fn().mockRejectedValue(new Error('unique constraint')),
+        },
+        dataSource: {
+          transaction: jest.fn().mockRejectedValue(new Error('unique constraint')),
         },
       });
 
@@ -219,13 +214,14 @@ describe('PlaygroundAgentService.resolve', () => {
     });
   });
 
-  describe('(e) race: insert throws → re-find returns null', () => {
+  describe('(e) race: transaction throws → re-find returns null', () => {
     it('throws NotFoundException when re-find after race returns null', async () => {
       const { service } = buildService({
         agentRepo: {
-          // Both findOne calls return null (no winner row)
           findOne: jest.fn().mockResolvedValue(null),
-          insert: jest.fn().mockRejectedValue(new Error('duplicate key')),
+        },
+        dataSource: {
+          transaction: jest.fn().mockRejectedValue(new Error('duplicate key')),
         },
       });
 
@@ -235,16 +231,19 @@ describe('PlaygroundAgentService.resolve', () => {
       );
     });
 
-    it('does not call enableAllProvidersForAgent when the race re-find also returns null', async () => {
-      const { service, mocks } = buildService({
+    it('does not attempt a second transaction when the race re-find also returns null', async () => {
+      const transactionFn = jest.fn().mockRejectedValue(new Error('duplicate key'));
+      const { service } = buildService({
         agentRepo: {
           findOne: jest.fn().mockResolvedValue(null),
-          insert: jest.fn().mockRejectedValue(new Error('duplicate key')),
+        },
+        dataSource: {
+          transaction: transactionFn,
         },
       });
 
       await expect(service.resolve(USER_ID)).rejects.toThrow(NotFoundException);
-      expect(mocks.providerService.enableAllProvidersForAgent).not.toHaveBeenCalled();
+      expect(transactionFn).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/backend/src/playground/playground-agent.service.ts
+++ b/packages/backend/src/playground/playground-agent.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, IsNull, Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 import { Agent } from '../entities/agent.entity';
+import { Tenant } from '../entities/tenant.entity';
 import { TenantCacheService } from '../common/services/tenant-cache.service';
 import { PLAYGROUND_AGENT_NAME } from '../common/constants/playground.constants';
 
@@ -30,8 +31,10 @@ export class PlaygroundAgentService {
   ) {}
 
   async resolve(userId: string): Promise<Agent> {
-    const tenantId = await this.tenantCache.resolve(userId);
-    if (!tenantId) throw new NotFoundException('Tenant not found');
+    // The Playground is a global page that may be opened before the user has
+    // created any normal agent — i.e. before onboarding created their tenant row.
+    // Bootstrap the tenant so the reserved agent can always be created.
+    const tenantId = (await this.tenantCache.resolve(userId)) ?? (await this.ensureTenant(userId));
 
     const existing = await this.findSystemAgent(tenantId);
     if (existing) return existing;
@@ -73,5 +76,23 @@ export class PlaygroundAgentService {
     return this.agentRepo.findOne({
       where: { tenant_id: tenantId, is_system: true, deleted_at: IsNull() },
     });
+  }
+
+  /** Create the user's tenant row if it doesn't exist yet (race-safe). */
+  private async ensureTenant(userId: string): Promise<string> {
+    const repo = this.dataSource.getRepository(Tenant);
+    const existing = await repo.findOne({ where: { name: userId } });
+    if (existing) return existing.id;
+
+    const id = randomUUID();
+    try {
+      await repo.insert({ id, name: userId, is_active: true });
+      return id;
+    } catch {
+      // Lost a creation race — reuse the winner's row.
+      const raced = await repo.findOne({ where: { name: userId } });
+      if (raced) return raced.id;
+      throw new NotFoundException('Tenant could not be resolved');
+    }
   }
 }

--- a/packages/backend/src/playground/playground-agent.service.ts
+++ b/packages/backend/src/playground/playground-agent.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
+import { Agent } from '../entities/agent.entity';
+import { TenantCacheService } from '../common/services/tenant-cache.service';
+import { ProviderService } from '../routing/routing-core/provider.service';
+import { PLAYGROUND_AGENT_NAME } from '../common/constants/playground.constants';
+
+/**
+ * Resolves the tenant's reserved `is_system` "Playground" agent — the single
+ * agent every Playground run records under (so runs show as `Playground` in
+ * global Messages) and which holds grants to the whole global provider pool.
+ *
+ * The migration seeds it for existing tenants and onboarding creates it for new
+ * ones; this lazily creates it on first use as a safety net so the Playground
+ * always has an agent to run under.
+ */
+@Injectable()
+export class PlaygroundAgentService {
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepo: Repository<Agent>,
+    private readonly tenantCache: TenantCacheService,
+    private readonly providerService: ProviderService,
+  ) {}
+
+  async resolve(userId: string): Promise<Agent> {
+    const tenantId = await this.tenantCache.resolve(userId);
+    if (!tenantId) throw new NotFoundException('Tenant not found');
+
+    const existing = await this.findSystemAgent(tenantId);
+    if (existing) return existing;
+
+    const agent = Object.assign(new Agent(), {
+      id: randomUUID(),
+      name: PLAYGROUND_AGENT_NAME,
+      display_name: PLAYGROUND_AGENT_NAME,
+      is_system: true,
+      is_active: true,
+      tenant_id: tenantId,
+    });
+    try {
+      await this.agentRepo.insert(agent);
+    } catch {
+      // Lost a creation race with a concurrent request — reuse the winner's row.
+      const raced = await this.findSystemAgent(tenantId);
+      if (raced) return raced;
+      throw new NotFoundException('Playground agent could not be resolved');
+    }
+
+    // Grant the new agent the tenant's whole provider pool (global pool).
+    await this.providerService.enableAllProvidersForAgent(agent.id, userId);
+    return agent;
+  }
+
+  private findSystemAgent(tenantId: string): Promise<Agent | null> {
+    return this.agentRepo.findOne({
+      where: { tenant_id: tenantId, is_system: true, deleted_at: IsNull() },
+    });
+  }
+}

--- a/packages/backend/src/playground/playground-agent.service.ts
+++ b/packages/backend/src/playground/playground-agent.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, IsNull, Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
@@ -71,11 +71,13 @@ export class PlaygroundAgentService {
           [agent.id, userId],
         );
       });
-    } catch {
-      // Lost a creation race with a concurrent request — reuse the winner's row.
+    } catch (err) {
+      // A concurrent request may have won the unique-index race — reuse its row.
+      // Any other failure is a real error (not a race): re-throw it rather than
+      // masking it as a generic not-found.
       const raced = await this.findSystemAgent(tenantId);
       if (raced) return raced;
-      throw new NotFoundException('Playground agent could not be resolved');
+      throw err;
     }
 
     return agent;
@@ -97,11 +99,11 @@ export class PlaygroundAgentService {
     try {
       await repo.insert({ id, name: userId, is_active: true });
       return id;
-    } catch {
-      // Lost a creation race — reuse the winner's row.
+    } catch (err) {
+      // Concurrent winner → reuse its row; any other failure is real → re-throw.
       const raced = await repo.findOne({ where: { name: userId } });
       if (raced) return raced.id;
-      throw new NotFoundException('Tenant could not be resolved');
+      throw err;
     }
   }
 }

--- a/packages/backend/src/playground/playground-agent.service.ts
+++ b/packages/backend/src/playground/playground-agent.service.ts
@@ -34,7 +34,16 @@ export class PlaygroundAgentService {
     // The Playground is a global page that may be opened before the user has
     // created any normal agent — i.e. before onboarding created their tenant row.
     // Bootstrap the tenant so the reserved agent can always be created.
-    const tenantId = (await this.tenantCache.resolve(userId)) ?? (await this.ensureTenant(userId));
+    const cached = await this.tenantCache.resolve(userId);
+    let tenantId: string;
+    if (cached) {
+      tenantId = cached;
+    } else {
+      tenantId = await this.ensureTenant(userId);
+      // Bust the stale null so subsequent resolves (e.g. ResolveAgentService) see
+      // the real tenant id instead of waiting out the 5-minute TTL.
+      this.tenantCache.invalidate(userId);
+    }
 
     const existing = await this.findSystemAgent(tenantId);
     if (existing) return existing;

--- a/packages/backend/src/playground/playground-agent.service.ts
+++ b/packages/backend/src/playground/playground-agent.service.ts
@@ -1,10 +1,9 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { IsNull, Repository } from 'typeorm';
+import { DataSource, IsNull, Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 import { Agent } from '../entities/agent.entity';
 import { TenantCacheService } from '../common/services/tenant-cache.service';
-import { ProviderService } from '../routing/routing-core/provider.service';
 import { PLAYGROUND_AGENT_NAME } from '../common/constants/playground.constants';
 
 /**
@@ -15,6 +14,11 @@ import { PLAYGROUND_AGENT_NAME } from '../common/constants/playground.constants'
  * The migration seeds it for existing tenants and onboarding creates it for new
  * ones; this lazily creates it on first use as a safety net so the Playground
  * always has an agent to run under.
+ *
+ * The agent insert and provider-pool grant are executed inside a single DB
+ * transaction so a committed reserved agent is always fully granted.  If a
+ * concurrent request wins the unique-index race the transaction throws and we
+ * simply return the winner's row.
  */
 @Injectable()
 export class PlaygroundAgentService {
@@ -22,7 +26,7 @@ export class PlaygroundAgentService {
     @InjectRepository(Agent)
     private readonly agentRepo: Repository<Agent>,
     private readonly tenantCache: TenantCacheService,
-    private readonly providerService: ProviderService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async resolve(userId: string): Promise<Agent> {
@@ -40,8 +44,21 @@ export class PlaygroundAgentService {
       is_active: true,
       tenant_id: tenantId,
     });
+
     try {
-      await this.agentRepo.insert(agent);
+      await this.dataSource.transaction(async (manager) => {
+        // Insert the reserved agent row.
+        await manager.getRepository(Agent).insert(agent);
+
+        // Grant the new agent the tenant's whole provider pool atomically — the
+        // same shape the seed migration uses.  No tier recalculation needed here;
+        // symmetric auto-connect handles providers added later.
+        await manager.query(
+          `INSERT INTO "agent_provider_access" ("agent_id","user_provider_id") ` +
+            `SELECT $1, "id" FROM "user_providers" WHERE "user_id" = $2 ON CONFLICT DO NOTHING`,
+          [agent.id, userId],
+        );
+      });
     } catch {
       // Lost a creation race with a concurrent request — reuse the winner's row.
       const raced = await this.findSystemAgent(tenantId);
@@ -49,8 +66,6 @@ export class PlaygroundAgentService {
       throw new NotFoundException('Playground agent could not be resolved');
     }
 
-    // Grant the new agent the tenant's whole provider pool (global pool).
-    await this.providerService.enableAllProvidersForAgent(agent.id, userId);
     return agent;
   }
 

--- a/packages/backend/src/playground/playground.controller.spec.ts
+++ b/packages/backend/src/playground/playground.controller.spec.ts
@@ -3,7 +3,7 @@ import type { Response as ExpressResponse } from 'express';
 import { PlaygroundController } from './playground.controller';
 import { PlaygroundService } from './playground.service';
 import { PlaygroundHistoryService } from './playground-history.service';
-import { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
+import { PlaygroundAgentService } from './playground-agent.service';
 import type { AuthUser } from '../auth/auth.instance';
 import type { RunPlaygroundDto } from './dto/run-playground.dto';
 
@@ -13,7 +13,7 @@ const USER: AuthUser = {
   email: 't@example.com',
 } as unknown as AuthUser;
 
-const AGENT = { id: 'agent-1', tenant_id: 'tenant-1', name: 'demo' };
+const AGENT = { id: 'agent-1', tenant_id: 'tenant-1', name: 'Playground' };
 
 describe('PlaygroundController', () => {
   let controller: PlaygroundController;
@@ -22,7 +22,7 @@ describe('PlaygroundController', () => {
   let getRun: jest.Mock;
   let toggleStar: jest.Mock;
   let setBestColumn: jest.Mock;
-  let resolveAgent: jest.Mock;
+  let playgroundAgentResolve: jest.Mock;
 
   beforeEach(async () => {
     runStream = jest.fn();
@@ -30,7 +30,7 @@ describe('PlaygroundController', () => {
     getRun = jest.fn();
     toggleStar = jest.fn();
     setBestColumn = jest.fn();
-    resolveAgent = jest.fn().mockResolvedValue(AGENT);
+    playgroundAgentResolve = jest.fn().mockResolvedValue(AGENT);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PlaygroundController],
@@ -40,7 +40,10 @@ describe('PlaygroundController', () => {
           provide: PlaygroundHistoryService,
           useValue: { listRuns, getRun, toggleStar, setBestColumn },
         },
-        { provide: ResolveAgentService, useValue: { resolve: resolveAgent } },
+        {
+          provide: PlaygroundAgentService,
+          useValue: { resolve: playgroundAgentResolve },
+        },
       ],
     }).compile();
 
@@ -50,7 +53,6 @@ describe('PlaygroundController', () => {
   describe('POST /playground/run', () => {
     it('delegates to PlaygroundService.runStream with the user id, dto and response', async () => {
       const dto = {
-        agentName: 'demo',
         model: 'openai/gpt-4o-mini',
         provider: 'openai',
         messages: [{ role: 'user', content: 'hi' }],
@@ -71,9 +73,9 @@ describe('PlaygroundController', () => {
         { id: 'r1', prompt: 'p', createdAt: 'now', modelCount: 1, models: ['m'] },
       ]);
 
-      const out = await controller.listRuns(USER, { agentName: 'demo' });
+      const out = await controller.listRuns(USER);
 
-      expect(resolveAgent).toHaveBeenCalledWith('user-1', 'demo');
+      expect(playgroundAgentResolve).toHaveBeenCalledWith('user-1');
       expect(listRuns).toHaveBeenCalledWith('user-1', 'agent-1');
       expect(out).toHaveLength(1);
     });
@@ -90,9 +92,9 @@ describe('PlaygroundController', () => {
         columns: [],
       });
 
-      const out = await controller.getRun(USER, { runId: 'r1' }, { agentName: 'demo' });
+      const out = await controller.getRun(USER, { runId: 'r1' });
 
-      expect(resolveAgent).toHaveBeenCalledWith('user-1', 'demo');
+      expect(playgroundAgentResolve).toHaveBeenCalledWith('user-1');
       expect(getRun).toHaveBeenCalledWith('user-1', 'r1', 'agent-1');
       expect(out.id).toBe('r1');
     });
@@ -100,9 +102,7 @@ describe('PlaygroundController', () => {
     it('propagates errors from the history service', async () => {
       const err = new Error('not found');
       getRun.mockRejectedValue(err);
-      await expect(controller.getRun(USER, { runId: 'r1' }, { agentName: 'demo' })).rejects.toBe(
-        err,
-      );
+      await expect(controller.getRun(USER, { runId: 'r1' })).rejects.toBe(err);
     });
   });
 

--- a/packages/backend/src/playground/playground.controller.ts
+++ b/packages/backend/src/playground/playground.controller.ts
@@ -1,21 +1,31 @@
-import { Body, Controller, Get, Param, Patch, Post, Query, Res } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, Res } from '@nestjs/common';
 import type { Response as ExpressResponse } from 'express';
 import type { PlaygroundHistoryRunDetail, PlaygroundHistoryRunSummary } from 'manifest-shared';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthUser } from '../auth/auth.instance';
 import { PlaygroundService } from './playground.service';
 import { PlaygroundHistoryService } from './playground-history.service';
-import { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
+import { PlaygroundAgentService } from './playground-agent.service';
 import { RunPlaygroundDto } from './dto/run-playground.dto';
-import { ListHistoryQueryDto, RunIdParamDto, SetBestColumnDto } from './dto/history.dto';
+import { RunIdParamDto, SetBestColumnDto } from './dto/history.dto';
 
 @Controller('api/v1/playground')
 export class PlaygroundController {
   constructor(
     private readonly playgroundService: PlaygroundService,
     private readonly historyService: PlaygroundHistoryService,
-    private readonly resolveAgent: ResolveAgentService,
+    private readonly playgroundAgent: PlaygroundAgentService,
   ) {}
+
+  // Resolves (creating on first use) the reserved per-tenant Playground agent and
+  // returns its name. The frontend calls this on load, then uses the name to
+  // fetch the Playground's available models / providers — guaranteeing the agent
+  // exists before those by-name lookups run.
+  @Get('agent')
+  async getAgent(@CurrentUser() user: AuthUser): Promise<{ name: string }> {
+    const agent = await this.playgroundAgent.resolve(user.id);
+    return { name: agent.name };
+  }
 
   @Post('run')
   async run(
@@ -27,11 +37,8 @@ export class PlaygroundController {
   }
 
   @Get('runs')
-  async listRuns(
-    @CurrentUser() user: AuthUser,
-    @Query() query: ListHistoryQueryDto,
-  ): Promise<PlaygroundHistoryRunSummary[]> {
-    const agent = await this.resolveAgent.resolve(user.id, query.agentName);
+  async listRuns(@CurrentUser() user: AuthUser): Promise<PlaygroundHistoryRunSummary[]> {
+    const agent = await this.playgroundAgent.resolve(user.id);
     return this.historyService.listRuns(user.id, agent.id);
   }
 
@@ -39,9 +46,8 @@ export class PlaygroundController {
   async getRun(
     @CurrentUser() user: AuthUser,
     @Param() params: RunIdParamDto,
-    @Query() query: ListHistoryQueryDto,
   ): Promise<PlaygroundHistoryRunDetail> {
-    const agent = await this.resolveAgent.resolve(user.id, query.agentName);
+    const agent = await this.playgroundAgent.resolve(user.id);
     return this.historyService.getRun(user.id, params.runId, agent.id);
   }
 

--- a/packages/backend/src/playground/playground.module.ts
+++ b/packages/backend/src/playground/playground.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AgentMessage } from '../entities/agent-message.entity';
+import { Agent } from '../entities/agent.entity';
 import { PlaygroundRun } from '../entities/playground-run.entity';
 import { PlaygroundColumn } from '../entities/playground-column.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
@@ -12,10 +13,17 @@ import { OAuthModule } from '../routing/oauth/oauth.module';
 import { PlaygroundController } from './playground.controller';
 import { PlaygroundService } from './playground.service';
 import { PlaygroundHistoryService } from './playground-history.service';
+import { PlaygroundAgentService } from './playground-agent.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AgentMessage, PlaygroundRun, PlaygroundColumn, CustomProvider]),
+    TypeOrmModule.forFeature([
+      AgentMessage,
+      Agent,
+      PlaygroundRun,
+      PlaygroundColumn,
+      CustomProvider,
+    ]),
     CommonModule,
     ModelPricesModule,
     RoutingCoreModule,
@@ -23,6 +31,6 @@ import { PlaygroundHistoryService } from './playground-history.service';
     OAuthModule,
   ],
   controllers: [PlaygroundController],
-  providers: [PlaygroundService, PlaygroundHistoryService],
+  providers: [PlaygroundService, PlaygroundHistoryService, PlaygroundAgentService],
 })
 export class PlaygroundModule {}

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -3,7 +3,7 @@ import type { Response as ExpressResponse } from 'express';
 import { PlaygroundService } from './playground.service';
 import type { ProviderClient } from '../routing/proxy/provider-client';
 import type { ProviderKeyService } from '../routing/routing-core/provider-key.service';
-import type { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
+import type { PlaygroundAgentService } from './playground-agent.service';
 import type { OpenaiOauthService } from '../routing/oauth/openai-oauth.service';
 import type { MinimaxOauthService } from '../routing/oauth/minimax-oauth.service';
 import type { AnthropicOauthService } from '../routing/oauth/anthropic/anthropic-oauth.service';
@@ -157,7 +157,7 @@ function errorForward(status: number, bodyText: string) {
 }
 
 interface Mocks {
-  resolveAgent: { resolve: jest.Mock };
+  playgroundAgent: { resolve: jest.Mock };
   providerKeyService: {
     hasActiveProvider: jest.Mock;
     getAuthType: jest.Mock;
@@ -185,7 +185,7 @@ interface Mocks {
 
 function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService; mocks: Mocks } {
   const full: Mocks = {
-    resolveAgent: {
+    playgroundAgent: {
       resolve: jest.fn().mockResolvedValue(AGENT),
     },
     providerKeyService: {
@@ -219,7 +219,7 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     ...mocks,
   };
   const service = new PlaygroundService(
-    full.resolveAgent as unknown as ResolveAgentService,
+    full.playgroundAgent as unknown as PlaygroundAgentService,
     full.providerKeyService as unknown as ProviderKeyService,
     full.providerClient as unknown as ProviderClient,
     full.openaiOauth as unknown as OpenaiOauthService,
@@ -637,7 +637,7 @@ describe('PlaygroundService.runStream', () => {
 
   it('maps an HttpException thrown during preflight to its status', async () => {
     const { service } = buildService({
-      resolveAgent: {
+      playgroundAgent: {
         resolve: jest.fn().mockRejectedValue(new NotFoundException('agent gone')),
       },
     });
@@ -651,7 +651,7 @@ describe('PlaygroundService.runStream', () => {
 
   it('maps a non-404 HttpException during preflight to its status (e.g. 403)', async () => {
     const { service } = buildService({
-      resolveAgent: {
+      playgroundAgent: {
         resolve: jest.fn().mockRejectedValue(new ForbiddenException('nope')),
       },
     });
@@ -664,7 +664,7 @@ describe('PlaygroundService.runStream', () => {
 
   it('maps a non-HttpException preflight failure to 500', async () => {
     const { service } = buildService({
-      resolveAgent: {
+      playgroundAgent: {
         resolve: jest.fn().mockRejectedValue(new Error('boom')),
       },
     });
@@ -678,7 +678,7 @@ describe('PlaygroundService.runStream', () => {
 
   it('stringifies a non-Error preflight rejection', async () => {
     const { service } = buildService({
-      resolveAgent: {
+      playgroundAgent: {
         resolve: jest.fn().mockRejectedValue('weird-string'),
       },
     });

--- a/packages/backend/src/playground/playground.service.truncation.spec.ts
+++ b/packages/backend/src/playground/playground.service.truncation.spec.ts
@@ -2,7 +2,7 @@ import type { Response as ExpressResponse } from 'express';
 import { PlaygroundService } from './playground.service';
 import type { ProviderClient } from '../routing/proxy/provider-client';
 import type { ProviderKeyService } from '../routing/routing-core/provider-key.service';
-import type { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
+import type { PlaygroundAgentService } from './playground-agent.service';
 import type { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import type { IngestEventBusService } from '../common/services/ingest-event-bus.service';
 import type { PlaygroundHistoryService } from './playground-history.service';
@@ -84,7 +84,7 @@ function mockRes(): MockRes {
 const asRes = (r: MockRes): ExpressResponse => r as unknown as ExpressResponse;
 
 interface Mocks {
-  resolveAgent: { resolve: jest.Mock };
+  playgroundAgent: { resolve: jest.Mock };
   providerKeyService: {
     hasActiveProvider: jest.Mock;
     getAuthType: jest.Mock;
@@ -112,7 +112,7 @@ interface Mocks {
 
 function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService; mocks: Mocks } {
   const full: Mocks = {
-    resolveAgent: {
+    playgroundAgent: {
       resolve: jest.fn().mockResolvedValue(AGENT),
     },
     providerKeyService: {
@@ -146,7 +146,7 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     ...mocks,
   };
   const service = new PlaygroundService(
-    full.resolveAgent as unknown as ResolveAgentService,
+    full.playgroundAgent as unknown as PlaygroundAgentService,
     full.providerKeyService as unknown as ProviderKeyService,
     full.providerClient as unknown as ProviderClient,
     full.openaiOauth as unknown as OpenaiOauthService,

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -15,7 +15,7 @@ import {
   resolveApiKey,
 } from '../routing/proxy/oauth-credentials';
 import { ProviderKeyService } from '../routing/routing-core/provider-key.service';
-import { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
+import { PlaygroundAgentService } from './playground-agent.service';
 import { OpenaiOauthService } from '../routing/oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../routing/oauth/minimax-oauth.service';
 import { AnthropicOauthService } from '../routing/oauth/anthropic/anthropic-oauth.service';
@@ -38,7 +38,7 @@ export class PlaygroundService {
   private readonly logger = new Logger(PlaygroundService.name);
 
   constructor(
-    private readonly resolveAgent: ResolveAgentService,
+    private readonly playgroundAgent: PlaygroundAgentService,
     private readonly providerKeyService: ProviderKeyService,
     private readonly providerClient: ProviderClient,
     private readonly openaiOauth: OpenaiOauthService,
@@ -75,7 +75,11 @@ export class PlaygroundService {
     let oauthResourceUrl: string | undefined;
     let providerRegion: string | null | undefined;
     try {
-      agent = await this.resolveAgent.resolve(userId, dto.agentName);
+      // The Playground always runs under the reserved per-tenant "Playground"
+      // agent (created on first use), so runs record under it in global Messages
+      // and route against the whole global provider pool — regardless of any
+      // agentName the client sends.
+      agent = await this.playgroundAgent.resolve(userId);
       const hasProvider = await this.providerKeyService.hasActiveProvider(
         userId,
         dto.provider,

--- a/packages/backend/src/routing/agent-provider-access.controller.spec.ts
+++ b/packages/backend/src/routing/agent-provider-access.controller.spec.ts
@@ -73,6 +73,49 @@ function makeController(overrides: Record<string, unknown> = {}) {
 }
 
 describe('AgentProviderAccessController', () => {
+  describe('resolveAgent — is_system: false filter', () => {
+    it('passes is_system: false in the agentRepo.findOne where-clause', async () => {
+      const { controller, agentRepo } = makeController();
+      await controller.listEnabled({ id: USER_ID } as never, 'my-agent');
+      expect(agentRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ is_system: false }),
+        }),
+      );
+    });
+
+    it('returns empty enabled list for a system agent (agentRepo.findOne returns null because is_system: false filters it out)', async () => {
+      // Simulate the DB returning null because the agent has is_system: true
+      // and the query filters on is_system: false.
+      const { controller } = makeController({
+        agentRepo: { findOne: jest.fn().mockResolvedValue(null) },
+      });
+      const result = await controller.listEnabled({ id: USER_ID } as never, 'Playground');
+      expect(result).toEqual({ enabled: [] });
+    });
+
+    it('throws 404 on enable when agentRepo.findOne returns null for a system agent', async () => {
+      const { controller } = makeController({
+        agentRepo: { findOne: jest.fn().mockResolvedValue(null) },
+        userProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({ id: PROVIDER_ID, user_id: USER_ID }),
+        },
+      });
+      await expect(
+        controller.enable({ id: USER_ID } as never, 'Playground', PROVIDER_ID),
+      ).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('throws 404 on disable when agentRepo.findOne returns null for a system agent', async () => {
+      const { controller } = makeController({
+        agentRepo: { findOne: jest.fn().mockResolvedValue(null) },
+      });
+      await expect(
+        controller.disable({ id: USER_ID } as never, 'Playground', PROVIDER_ID),
+      ).rejects.toBeInstanceOf(HttpException);
+    });
+  });
+
   describe('listEnabled', () => {
     it('returns empty enabled list when agent not found', async () => {
       const { controller } = makeController({
@@ -123,6 +166,26 @@ describe('AgentProviderAccessController', () => {
             provider: 'openai',
             auth_type: 'api_key',
             cached_models: [],
+          } as Partial<UserProvider>),
+        },
+      });
+      const result = await controller.getDisableImpact(
+        { id: USER_ID } as never,
+        'my-agent',
+        PROVIDER_ID,
+      );
+      expect(result).toEqual({ affected_tiers: [] });
+    });
+
+    it('handles non-array cached_models gracefully (treats as empty, no crash)', async () => {
+      // Covers the Array.isArray(...) ? ... : [] else branch on line 64.
+      const { controller } = makeController({
+        userProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({
+            id: PROVIDER_ID,
+            provider: 'openai',
+            auth_type: 'api_key',
+            cached_models: null,
           } as Partial<UserProvider>),
         },
       });
@@ -464,6 +527,213 @@ describe('AgentProviderAccessController', () => {
 
       // Tier is unmodified so save should not be called
       expect(tierSave).not.toHaveBeenCalled();
+    });
+
+    it('handles non-array cached_models gracefully in disable (treats as empty, no crash)', async () => {
+      // Covers the Array.isArray(...) ? ... : [] else branch on line 146.
+      const tier: Partial<TierAssignment> = {
+        tier: 'standard',
+        override_route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+        auto_assigned_route: null,
+        fallback_routes: null,
+      };
+      const tierSave = jest.fn().mockResolvedValue(undefined);
+      const { controller } = makeController({
+        userProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({
+            id: PROVIDER_ID,
+            user_id: USER_ID,
+            provider: 'openai',
+            auth_type: 'api_key',
+            label: 'Default',
+            cached_models: null,
+          } as Partial<UserProvider>),
+        },
+        tierRepo: {
+          find: jest.fn().mockResolvedValue([tier]),
+          save: tierSave,
+        },
+      });
+
+      await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
+
+      // Route matched by provider name (no model set fallback needed); tier cleared.
+      expect(tier.override_route).toBeNull();
+      expect(tierSave).toHaveBeenCalled();
+    });
+
+    it('skips disable route whose authType does not match (covers authType-mismatch return false in disable handler)', async () => {
+      // Covers line 155: authType mismatch early-return in the disable handler closure.
+      const tier: Partial<TierAssignment> = {
+        tier: 'simple',
+        override_route: { provider: 'openai', authType: 'subscription', model: 'gpt-4o' },
+        auto_assigned_route: null,
+        fallback_routes: null,
+      };
+      const tierSave = jest.fn().mockResolvedValue(undefined);
+      const { controller } = makeController({
+        userProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({
+            id: PROVIDER_ID,
+            user_id: USER_ID,
+            provider: 'openai',
+            auth_type: 'api_key',
+            label: 'Default',
+            cached_models: [],
+          } as Partial<UserProvider>),
+        },
+        tierRepo: {
+          find: jest.fn().mockResolvedValue([tier]),
+          save: tierSave,
+        },
+      });
+
+      await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
+
+      // Route not matched (authType mismatch) → tier unchanged → save not called.
+      expect(tierSave).not.toHaveBeenCalled();
+      expect(tier.override_route).not.toBeNull();
+    });
+
+    it('clears auto_assigned_route when it matches the disabled provider by name/authType', async () => {
+      // Covers lines 172-173: auto_assigned_route = null; changed = true.
+      const tier: Partial<TierAssignment> = {
+        tier: 'standard',
+        override_route: null,
+        auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+        fallback_routes: null,
+      };
+      const tierSave = jest.fn().mockResolvedValue(undefined);
+      const { controller } = makeController({
+        userProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({
+            id: PROVIDER_ID,
+            user_id: USER_ID,
+            provider: 'openai',
+            auth_type: 'api_key',
+            label: 'Default',
+            cached_models: [],
+          } as Partial<UserProvider>),
+        },
+        tierRepo: {
+          find: jest.fn().mockResolvedValue([tier]),
+          save: tierSave,
+        },
+      });
+
+      await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
+
+      expect(tier.auto_assigned_route).toBeNull();
+      expect(tierSave).toHaveBeenCalled();
+    });
+
+    it('removes matching fallback routes (reduces to null when all removed)', async () => {
+      // Covers lines 178-179: tier.fallback_routes = null; changed = true.
+      const tier: Partial<TierAssignment> = {
+        tier: 'complex',
+        override_route: null,
+        auto_assigned_route: null,
+        fallback_routes: [{ provider: 'openai', authType: 'api_key', model: 'gpt-4o' }],
+      };
+      const tierSave = jest.fn().mockResolvedValue(undefined);
+      const { controller } = makeController({
+        userProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({
+            id: PROVIDER_ID,
+            user_id: USER_ID,
+            provider: 'openai',
+            auth_type: 'api_key',
+            label: 'Default',
+            cached_models: [],
+          } as Partial<UserProvider>),
+        },
+        tierRepo: {
+          find: jest.fn().mockResolvedValue([tier]),
+          save: tierSave,
+        },
+      });
+
+      await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
+
+      expect(tier.fallback_routes).toBeNull();
+      expect(tierSave).toHaveBeenCalled();
+    });
+
+    it('skips disable route whose keyLabel does not match (covers keyLabel-mismatch return false in disable handler)', async () => {
+      // Covers line 157 in the disable handler's routeBelongsToDisabledProvider closure.
+      const tier: Partial<TierAssignment> = {
+        tier: 'simple',
+        override_route: {
+          provider: 'openai',
+          authType: 'api_key',
+          model: 'gpt-4o',
+          keyLabel: 'Other',
+        },
+        auto_assigned_route: null,
+        fallback_routes: null,
+      };
+      const tierSave = jest.fn().mockResolvedValue(undefined);
+      const { controller } = makeController({
+        userProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({
+            id: PROVIDER_ID,
+            user_id: USER_ID,
+            provider: 'openai',
+            auth_type: 'api_key',
+            label: 'Default',
+            cached_models: [],
+          } as Partial<UserProvider>),
+        },
+        tierRepo: {
+          find: jest.fn().mockResolvedValue([tier]),
+          save: tierSave,
+        },
+      });
+
+      await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
+
+      // Route not matched → tier unchanged → save not called.
+      expect(tierSave).not.toHaveBeenCalled();
+      expect(tier.override_route).not.toBeNull();
+    });
+
+    it('matches a fallback route by cached model id (no route.provider) in the disable handler', async () => {
+      // Covers line 161: providerModels.has(route.model) in the disable handler closure.
+      const tier: Partial<TierAssignment> = {
+        tier: 'complex',
+        override_route: null,
+        auto_assigned_route: null,
+        fallback_routes: [
+          { provider: '', authType: 'api_key', model: 'gpt-4o' },
+          { provider: 'anthropic', authType: 'api_key', model: 'claude-3-5-sonnet' },
+        ],
+      };
+      const tierSave = jest.fn().mockResolvedValue(undefined);
+      const { controller } = makeController({
+        userProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({
+            id: PROVIDER_ID,
+            user_id: USER_ID,
+            provider: 'openai',
+            auth_type: 'api_key',
+            label: 'Default',
+            cached_models: [{ id: 'gpt-4o' }],
+          } as Partial<UserProvider>),
+        },
+        tierRepo: {
+          find: jest.fn().mockResolvedValue([tier]),
+          save: tierSave,
+        },
+      });
+
+      await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
+
+      // The openai fallback matched by model id should be removed; anthropic stays.
+      expect(tier.fallback_routes).toHaveLength(1);
+      expect((tier.fallback_routes as NonNullable<typeof tier.fallback_routes>)[0].model).toBe(
+        'claude-3-5-sonnet',
+      );
+      expect(tierSave).toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/routing/agent-provider-access.controller.ts
+++ b/packages/backend/src/routing/agent-provider-access.controller.ts
@@ -30,8 +30,10 @@ export class AgentProviderAccessController {
   private async resolveAgent(agentName: string, userId: string) {
     const tenant = await this.tenantRepo.findOne({ where: { name: userId } });
     if (!tenant) return null;
+    // Exclude the reserved system (Playground) agent — its grants are the global
+    // pool and must not be togglable/removable through this per-agent endpoint.
     return this.agentRepo.findOne({
-      where: { name: decodeURIComponent(agentName), tenant_id: tenant.id },
+      where: { name: decodeURIComponent(agentName), tenant_id: tenant.id, is_system: false },
     });
   }
 

--- a/packages/backend/src/routing/custom-provider.controller.spec.ts
+++ b/packages/backend/src/routing/custom-provider.controller.spec.ts
@@ -184,6 +184,22 @@ describe('CustomProviderController', () => {
 
       expect(result.has_api_key).toBe(false);
     });
+
+    it('passes { allowSystem: true } so the Playground agent can create custom providers', async () => {
+      mockProviderService.getProviders.mockResolvedValue([]);
+
+      const body = {
+        name: 'Local LLM',
+        base_url: 'http://localhost:11434/v1',
+        models: [{ model_name: 'llama3' }],
+      };
+
+      await controller.create(mockUser, { agentName: 'Playground' } as never, body as never);
+
+      expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'Playground', {
+        allowSystem: true,
+      });
+    });
   });
 
   /* ── update ── */

--- a/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
@@ -23,7 +23,9 @@ export class CustomProviderController {
   async list(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
     // Resolve for authz — user must own the agent. Custom providers are
     // user-global, so the listing itself is scoped to the user, not the agent.
-    await this.resolveAgentService.resolve(user.id, params.agentName);
+    // allowSystem: true — the Playground page reads custom providers for the
+    // reserved system agent; all mutation endpoints remain blocked.
+    await this.resolveAgentService.resolve(user.id, params.agentName, { allowSystem: true });
     const [providers, userProviders] = await Promise.all([
       this.customProviderService.list(user.id),
       this.providerService.getProviders(user.id),

--- a/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
@@ -71,7 +71,9 @@ export class CustomProviderController {
     @Param() params: AgentNameParamDto,
     @Body() body: CreateCustomProviderDto,
   ) {
-    await this.resolveAgentService.resolve(user.id, params.agentName);
+    // allowSystem: true — creating a custom provider from the Playground page is
+    // additive (user-global resource); the system agent is a valid owner context.
+    await this.resolveAgentService.resolve(user.id, params.agentName, { allowSystem: true });
     const cp = await this.customProviderService.create(user.id, body);
     const provKey = CustomProviderService.providerKey(cp.id);
     const up = (await this.providerService.getProviders(user.id)).find(

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -87,7 +87,11 @@ export class ModelController {
 
   @Get(':agentName/available-models')
   async getAvailableModels(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
-    const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
+    // allowSystem: true — the Playground frontend reads available models for the
+    // reserved system agent; all other model.controller endpoints remain blocked.
+    const agent = await this.resolveAgentService.resolve(user.id, params.agentName, {
+      allowSystem: true,
+    });
     const models = await this.discoveryService.getModelsForAgent(user.id, agent.id);
 
     // Build display name map for custom providers (user-global)

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -657,7 +657,12 @@ describe('ProviderController', () => {
       await expect(
         controller.getProviders(mockUser, { agentName: 'nonexistent' } as never),
       ).rejects.toThrow(NotFoundException);
-      expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'nonexistent');
+      // getProviders passes { allowSystem: true } so the Playground agent can be
+      // read; the NotFoundException originates from the service mock, not the
+      // is_system check.
+      expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'nonexistent', {
+        allowSystem: true,
+      });
     });
 
     it('should resolve agent and pass its id to service methods', async () => {

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -686,6 +686,22 @@ describe('ProviderController', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
+    it('upsertProvider passes { allowSystem: true } so the Playground agent can connect providers', async () => {
+      mockProviderService.upsertProvider.mockResolvedValue({
+        provider: { id: 'p1', provider: 'openai', is_active: true },
+        isNew: false,
+      });
+
+      await controller.upsertProvider(mockUser, { agentName: 'Playground' } as never, {
+        provider: 'openai',
+        apiKey: 'sk-test',
+      });
+
+      expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'Playground', {
+        allowSystem: true,
+      });
+    });
+
     it('should propagate NotFoundException through removeProvider', async () => {
       mockResolveAgent.resolve.mockRejectedValue(
         new NotFoundException('Agent "missing-agent" not found'),

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -77,7 +77,8 @@ export class ProviderController {
   @Get(':agentName/providers')
   async getProviders(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
     // allowSystem: true — the Playground page reads the provider list for the
-    // reserved system agent; all mutation endpoints remain blocked.
+    // reserved system agent. Destructive/config mutations (rename, reorder,
+    // deactivate, remove) still reject it; only additive connect is allowed.
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName, {
       allowSystem: true,
     });

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -76,7 +76,11 @@ export class ProviderController {
 
   @Get(':agentName/providers')
   async getProviders(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
-    const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
+    // allowSystem: true — the Playground page reads the provider list for the
+    // reserved system agent; all mutation endpoints remain blocked.
+    const agent = await this.resolveAgentService.resolve(user.id, params.agentName, {
+      allowSystem: true,
+    });
     const providers = await this.providerService.getProviders(user.id);
     return providers.map((p) => ({
       id: p.id,

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -104,7 +104,11 @@ export class ProviderController {
     @Param() params: AgentNameParamDto,
     @Body() body: ConnectProviderDto,
   ) {
-    const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
+    // allowSystem: true — connecting a provider to the Playground system agent
+    // is additive and correct (grants belong to the user-global pool).
+    const agent = await this.resolveAgentService.resolve(user.id, params.agentName, {
+      allowSystem: true,
+    });
     const lowerProvider = body.provider.toLowerCase();
     const isQwenProvider = lowerProvider === 'qwen' || lowerProvider === 'alibaba';
     const subscriptionRegionConfig = getSubscriptionEndpointRegionConfig(

--- a/packages/backend/src/routing/routing-core/resolve-agent.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/resolve-agent.service.spec.ts
@@ -45,7 +45,7 @@ describe('ResolveAgentService', () => {
   });
 
   it('returns and caches the agent on a successful lookup', async () => {
-    const agent = { id: 'agent-1', name: 'demo-agent' } as Agent;
+    const agent = { id: 'agent-1', name: 'demo-agent', is_system: false } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
     findOne.mockResolvedValue(agent);
 
@@ -61,7 +61,7 @@ describe('ResolveAgentService', () => {
   });
 
   it('re-queries the repo after the TTL expires', async () => {
-    const agent = { id: 'agent-1', name: 'demo-agent' } as Agent;
+    const agent = { id: 'agent-1', name: 'demo-agent', is_system: false } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
     findOne.mockResolvedValue(agent);
 
@@ -73,8 +73,8 @@ describe('ResolveAgentService', () => {
   });
 
   it('scopes the cache by tenant — two users with the same agent name do not collide', async () => {
-    const agentA = { id: 'a', name: 'agent' } as Agent;
-    const agentB = { id: 'b', name: 'agent' } as Agent;
+    const agentA = { id: 'a', name: 'agent', is_system: false } as Agent;
+    const agentB = { id: 'b', name: 'agent', is_system: false } as Agent;
 
     tenantResolve
       .mockResolvedValueOnce('tenant-A')
@@ -92,7 +92,7 @@ describe('ResolveAgentService', () => {
   });
 
   it('invalidate removes the cached entry so the next resolve re-queries', async () => {
-    const agent = { id: 'agent-1', name: 'demo-agent' } as Agent;
+    const agent = { id: 'agent-1', name: 'demo-agent', is_system: false } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
     findOne.mockResolvedValue(agent);
 
@@ -103,5 +103,74 @@ describe('ResolveAgentService', () => {
 
     await svc.resolve('user-1', 'demo-agent');
     expect(findOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the oldest entry when the cache is at MAX_ENTRIES capacity', async () => {
+    // Fill the internal cache to MAX_ENTRIES (5000) via the private map so we
+    // can exercise the LRU eviction path without making 5000 real calls.
+    const cacheField = (svc as unknown as { cache: Map<string, unknown> }).cache;
+    for (let i = 0; i < 5000; i++) {
+      cacheField.set(`tenant-x:agent-${i}`, {
+        agent: { id: `a${i}`, name: `agent-${i}`, is_system: false } as Agent,
+        expiresAt: Date.now() + 120_000,
+      });
+    }
+    expect(cacheField.size).toBe(5000);
+
+    // The new agent to resolve — its cache key is NOT in the map yet, so the
+    // LRU eviction branch runs and the oldest entry is dropped.
+    const newAgent = { id: 'new-1', name: 'new-agent', is_system: false } as Agent;
+    tenantResolve.mockResolvedValue('tenant-1');
+    findOne.mockResolvedValue(newAgent);
+
+    const result = await svc.resolve('user-1', 'new-agent');
+    expect(result).toBe(newAgent);
+    // One entry was evicted, then the new one was added — size stays at 5000.
+    expect(cacheField.size).toBe(5000);
+    expect(cacheField.has('tenant-1:new-agent')).toBe(true);
+  });
+
+  // P1-A: system agent rejection
+  it('throws NotFoundException for a system agent when allowSystem is not set (default)', async () => {
+    const systemAgent = { id: 'sys-1', name: 'Playground', is_system: true } as Agent;
+    tenantResolve.mockResolvedValue('tenant-1');
+    findOne.mockResolvedValue(systemAgent);
+
+    await expect(svc.resolve('user-1', 'Playground')).rejects.toBeInstanceOf(NotFoundException);
+    // The error message matches the not-found shape so callers cannot distinguish
+    // a missing agent from a system agent.
+    await expect(svc.resolve('user-1', 'Playground')).rejects.toThrow(
+      'Agent "Playground" not found',
+    );
+  });
+
+  it('returns the system agent when allowSystem is true', async () => {
+    const systemAgent = { id: 'sys-1', name: 'Playground', is_system: true } as Agent;
+    tenantResolve.mockResolvedValue('tenant-1');
+    findOne.mockResolvedValue(systemAgent);
+
+    const result = await svc.resolve('user-1', 'Playground', { allowSystem: true });
+    expect(result).toBe(systemAgent);
+  });
+
+  it('caches the system agent and still enforces is_system check on cache hits', async () => {
+    const systemAgent = { id: 'sys-1', name: 'Playground', is_system: true } as Agent;
+    tenantResolve.mockResolvedValue('tenant-1');
+    findOne.mockResolvedValue(systemAgent);
+
+    // First call with allowSystem: true — agent is loaded and cached.
+    const first = await svc.resolve('user-1', 'Playground', { allowSystem: true });
+    expect(first).toBe(systemAgent);
+    expect(findOne).toHaveBeenCalledTimes(1);
+
+    // Second call without allowSystem — cache hit but is_system check rejects it.
+    await expect(svc.resolve('user-1', 'Playground')).rejects.toBeInstanceOf(NotFoundException);
+    // Repo was NOT queried again (it was a cache hit).
+    expect(findOne).toHaveBeenCalledTimes(1);
+
+    // Third call with allowSystem: true again — still cache hit, succeeds.
+    const third = await svc.resolve('user-1', 'Playground', { allowSystem: true });
+    expect(third).toBe(systemAgent);
+    expect(findOne).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/backend/src/routing/routing-core/resolve-agent.service.ts
+++ b/packages/backend/src/routing/routing-core/resolve-agent.service.ts
@@ -12,6 +12,15 @@ interface CachedAgent {
   expiresAt: number;
 }
 
+export interface ResolveOptions {
+  /** When true, system agents (is_system = true) are returned to the caller.
+   * By default system agents are rejected with a NotFoundException so that
+   * generic mutation/config endpoints cannot target the reserved "Playground"
+   * agent. Only pass true for read-only endpoints that legitimately need to
+   * serve the Playground agent (e.g. available-models, providers list). */
+  allowSystem?: boolean;
+}
+
 @Injectable()
 export class ResolveAgentService {
   private readonly cache = new Map<string, CachedAgent>();
@@ -22,19 +31,32 @@ export class ResolveAgentService {
     private readonly tenantCache: TenantCacheService,
   ) {}
 
-  async resolve(userId: string, agentName: string): Promise<Agent> {
+  async resolve(userId: string, agentName: string, options: ResolveOptions = {}): Promise<Agent> {
     const tenantId = await this.tenantCache.resolve(userId);
     if (!tenantId) throw new NotFoundException('Tenant not found');
 
     const cacheKey = `${tenantId}:${agentName}`;
     const cached = this.cache.get(cacheKey);
-    if (cached && cached.expiresAt > Date.now()) return cached.agent;
+
+    // If we have a live cache entry, validate is_system before returning it.
+    // This ensures the check runs on cache hits as well as fresh DB loads.
+    if (cached && cached.expiresAt > Date.now()) {
+      if (cached.agent.is_system && !options.allowSystem) {
+        throw new NotFoundException(`Agent "${agentName}" not found`);
+      }
+      return cached.agent;
+    }
     if (cached) this.cache.delete(cacheKey);
 
     const agent = await this.agentRepo.findOne({
       where: { tenant_id: tenantId, name: agentName, deleted_at: IsNull() },
     });
     if (!agent) throw new NotFoundException(`Agent "${agentName}" not found`);
+
+    // Reject system agents unless the caller explicitly opted in.
+    if (agent.is_system && !options.allowSystem) {
+      throw new NotFoundException(`Agent "${agentName}" not found`);
+    }
 
     if (this.cache.size >= MAX_ENTRIES && !this.cache.has(cacheKey)) {
       const firstKey = this.cache.keys().next().value;

--- a/packages/backend/src/routing/tier.controller.spec.ts
+++ b/packages/backend/src/routing/tier.controller.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { TierController } from './tier.controller';
 import { TierService } from './routing-core/tier.service';
@@ -127,5 +127,16 @@ describe('TierController', () => {
       complexity_routing_enabled: false,
     });
     expect(resolveAgentService.invalidate).toHaveBeenCalledWith('tenant-1', 'demo');
+  });
+
+  // P1-A: tier write endpoint must 404 for the system "Playground" agent
+  it('PUT /tiers/:tier throws NotFoundException when resolve rejects the system agent', async () => {
+    resolveAgentService.resolve.mockRejectedValueOnce(
+      new NotFoundException('Agent "Playground" not found'),
+    );
+    await expect(
+      controller.setOverride(user, 'Playground', 'default', { model: 'm' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(tierService.setOverride).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/telemetry/payload-builder.service.spec.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.spec.ts
@@ -45,7 +45,18 @@ function defaultData(): MockData {
   };
 }
 
+interface MakeServiceResult {
+  service: PayloadBuilderService;
+  agentsRepo: {
+    createQueryBuilder: jest.Mock;
+  };
+}
+
 async function makeService(partial: Partial<MockData>): Promise<PayloadBuilderService> {
+  return (await makeServiceWithRepo(partial)).service;
+}
+
+async function makeServiceWithRepo(partial: Partial<MockData>): Promise<MakeServiceResult> {
   const data: MockData = { ...defaultData(), ...partial };
 
   const messagesQueue = [
@@ -54,7 +65,12 @@ async function makeService(partial: Partial<MockData>): Promise<PayloadBuilderSe
     { rows: data.authTypes, mode: 'getRawMany' as const },
     { row: data.totals, mode: 'getRawOne' as const },
   ];
-  const agentsQueue = [{ rows: data.agentPlatforms, mode: 'getRawMany' as const }];
+  // userAgentsCount() uses getRawOne returning {count: string};
+  // agentsByPlatform() uses getRawMany returning CategoryPlatformRow[].
+  const agentsQueue = [
+    { row: { count: String(data.agentsCount) }, mode: 'getRawOne' as const },
+    { rows: data.agentPlatforms, mode: 'getRawMany' as const },
+  ];
 
   function makeQb(entry: { rows?: unknown; row?: unknown; mode: 'getRawMany' | 'getRawOne' }) {
     return {
@@ -71,20 +87,19 @@ async function makeService(partial: Partial<MockData>): Promise<PayloadBuilderSe
   const messagesRepo = {
     createQueryBuilder: jest.fn(() => makeQb(messagesQueue.shift()!)),
   };
-  const agentsRepo = {
+  const agentsRepoMock = {
     createQueryBuilder: jest.fn(() => makeQb(agentsQueue.shift()!)),
-    count: jest.fn().mockResolvedValue(data.agentsCount),
   };
 
   const module: TestingModule = await Test.createTestingModule({
     providers: [
       PayloadBuilderService,
       { provide: getRepositoryToken(AgentMessage), useValue: messagesRepo },
-      { provide: getRepositoryToken(Agent), useValue: agentsRepo },
+      { provide: getRepositoryToken(Agent), useValue: agentsRepoMock },
     ],
   }).compile();
 
-  return module.get(PayloadBuilderService);
+  return { service: module.get(PayloadBuilderService), agentsRepo: agentsRepoMock };
 }
 
 describe('PayloadBuilderService', () => {
@@ -384,5 +399,35 @@ describe('PayloadBuilderService', () => {
     const payload = await service.build('inst', '1.0.0');
 
     expect(payload.agents_by_platform).toEqual({ unknown: 2 });
+  });
+
+  it('excludes system agents from agents_total count (is_system = false filter applied)', async () => {
+    // The count query is for user agents only — system agents (e.g. Playground)
+    // must not inflate the install telemetry.
+    const { service, agentsRepo } = await makeServiceWithRepo({ agentsCount: 3 });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.agents_total).toBe(3);
+    // The count QB must have received a where clause filtering system agents.
+    const countQb = agentsRepo.createQueryBuilder.mock.results[0].value as {
+      where: jest.Mock;
+    };
+    expect(countQb.where).toHaveBeenCalledWith('a.is_system = false');
+  });
+
+  it('excludes system agents from agents_by_platform (is_system = false filter applied)', async () => {
+    const { service, agentsRepo } = await makeServiceWithRepo({
+      agentPlatforms: [{ category: 'personal', platform: 'openclaw', count: '2' }],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.agents_by_platform).toEqual({ openclaw: 2 });
+    // The platform QB (second agents QB call) must filter system agents.
+    const platformQb = agentsRepo.createQueryBuilder.mock.results[1].value as {
+      where: jest.Mock;
+    };
+    expect(platformQb.where).toHaveBeenCalledWith('a.is_system = false');
   });
 });

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -50,7 +50,7 @@ export class PayloadBuilderService {
         this.messagesByBucket('routing_tier'),
         this.messagesByBucket('auth_type'),
         this.totals(),
-        this.agents.count(),
+        this.userAgentsCount(),
         this.agentsByPlatform(),
       ]);
 
@@ -122,6 +122,7 @@ export class PayloadBuilderService {
       .select('a.agent_category', 'category')
       .addSelect('a.agent_platform', 'platform')
       .addSelect('COUNT(*)', 'count')
+      .where('a.is_system = false')
       .groupBy('a.agent_category')
       .addGroupBy('a.agent_platform')
       .getRawMany<CategoryPlatformRow>();
@@ -129,6 +130,16 @@ export class PayloadBuilderService {
       bucket: r.platform === 'other' && r.category ? `${r.category}:${r.platform}` : r.platform,
       count: r.count,
     }));
+  }
+
+  /** Count only user-created agents; system agents (e.g. Playground) are excluded. */
+  private async userAgentsCount(): Promise<number> {
+    const result = await this.agents
+      .createQueryBuilder('a')
+      .select('COUNT(*)', 'count')
+      .where('a.is_system = false')
+      .getRawOne<{ count: string }>();
+    return Number(result?.count ?? 0);
   }
 
   private async totals(): Promise<TotalsRow> {

--- a/packages/backend/test/playground-flow.e2e-spec.ts
+++ b/packages/backend/test/playground-flow.e2e-spec.ts
@@ -173,10 +173,16 @@ describe('Playground E2E — POST /api/v1/playground/run (SSE)', () => {
     expect(headers['x-ratelimit-remaining-requests']).toBe('49');
     expect(headers['set-cookie']).toBeUndefined();
 
+    // The run records under the reserved per-tenant "Playground" agent (created
+    // on first use), not the client-supplied agentName — so it shows as
+    // "Playground" in global Messages.
     const ds = app.get(DataSource);
+    const [playgroundAgent] = await ds.query(
+      `SELECT id FROM agents WHERE is_system = true AND deleted_at IS NULL LIMIT 1`,
+    );
     const rows = await ds.query(
-      `SELECT routing_reason, routing_tier, status, provider, model, input_tokens, output_tokens FROM agent_messages WHERE agent_id = $1 AND routing_tier = $2`,
-      [TEST_AGENT_ID, 'playground'],
+      `SELECT routing_reason, routing_tier, status, provider, model, input_tokens, output_tokens, agent_name FROM agent_messages WHERE agent_id = $1 AND routing_tier = $2`,
+      [playgroundAgent.id, 'playground'],
     );
     expect(rows.length).toBe(1);
     expect(rows[0]).toMatchObject({
@@ -187,6 +193,7 @@ describe('Playground E2E — POST /api/v1/playground/run (SSE)', () => {
       model: 'gpt-4o-mini',
       input_tokens: 7,
       output_tokens: 3,
+      agent_name: 'Playground',
     });
   });
 
@@ -220,16 +227,20 @@ describe('Playground E2E — POST /api/v1/playground/run (SSE)', () => {
     expect(res.body.message).toContain('anthropic');
   });
 
-  it('returns 404 when the agent does not belong to the current user', async () => {
-    await auth(api().post('/api/v1/playground/run'))
-      .send({
-        agentName: 'someone-elses-agent',
-        model: 'gpt-4o-mini',
-        provider: 'openai',
-        authType: 'api_key',
-        messages: [{ role: 'user', content: 'say hi' }],
-      })
-      .expect(404);
+  it('ignores the client-supplied agentName and runs under the reserved Playground agent', async () => {
+    stubOpenAiChatStream(['hi'], { prompt_tokens: 2, completion_tokens: 1 });
+
+    // A bogus / cross-user agentName is irrelevant now — the Playground always
+    // resolves the current user's reserved agent, so this streams normally.
+    const sseText = await postRun({
+      agentName: 'someone-elses-agent',
+      model: 'gpt-4o-mini',
+      provider: 'openai',
+      authType: 'api_key',
+      messages: [{ role: 'user', content: 'say hi' }],
+    });
+    const done = parseSse(sseText).find((e) => e.type === 'done');
+    expect(done).toBeDefined();
   });
 
   it('returns 400 when messages payload is missing', async () => {

--- a/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
+++ b/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
@@ -1,0 +1,102 @@
+import { DataSource } from 'typeorm';
+import { SeedPlaygroundAgents1791400000000 } from '../src/database/migrations/1791400000000-SeedPlaygroundAgents';
+
+/**
+ * Runs the REAL migration chain so SeedPlaygroundAgents executes against
+ * Postgres (the e2e suite uses synchronize:true and never runs migrations). We
+ * revert just this migration to get the pre-seed schema, seed two tenants (one
+ * with a user agent that collides on the reserved name) + their provider pools,
+ * then run up() and assert the data transformation.
+ */
+describe('SeedPlaygroundAgents data transformation (e2e)', () => {
+  let ds: DataSource;
+  const migration = new SeedPlaygroundAgents1791400000000();
+
+  beforeAll(async () => {
+    ds = new DataSource({
+      type: 'postgres',
+      url:
+        process.env['DATABASE_URL'] ??
+        'postgresql://myuser:mypassword@localhost:5432/manifest_duprepro',
+      entities: ['src/entities/!(*.spec).ts'],
+      migrations: ['src/database/migrations/!(*.spec).ts'],
+      synchronize: false,
+      dropSchema: true,
+      logging: false,
+    });
+    await ds.initialize();
+    await ds.runMigrations();
+
+    // Revert just this migration → pre-seed schema (no is_system column).
+    const revertQr = ds.createQueryRunner();
+    await migration.down(revertQr);
+    await revertQr.release();
+
+    await ds.query(`DELETE FROM "agent_provider_access"`);
+    await ds.query(`DELETE FROM "user_providers"`);
+    await ds.query(`DELETE FROM "agents"`);
+    await ds.query(`DELETE FROM "tenants"`);
+
+    // Two tenants. tenants.name = user_id.
+    await ds.query(`INSERT INTO "tenants" ("id","name","is_active") VALUES ('t1','u1',true)`);
+    await ds.query(`INSERT INTO "tenants" ("id","name","is_active") VALUES ('t2','u2',true)`);
+    // t1 already has a user agent literally named 'Playground' → must be relabeled.
+    await ds.query(
+      `INSERT INTO "agents" ("id","name","display_name","tenant_id") VALUES ('a-user','Playground','Playground','t1')`,
+    );
+    // Provider pools: u1 has 2, u2 has 1.
+    const up = (id: string, user: string, provider: string) =>
+      ds.query(
+        `INSERT INTO "user_providers" ("id","user_id","provider","auth_type","label","priority","is_active","connected_at","updated_at")
+         VALUES ($1,$2,$3,'api_key','Default',0,true, now(), now())`,
+        [id, user, provider],
+      );
+    await up('up1', 'u1', 'anthropic');
+    await up('up2', 'u1', 'openai');
+    await up('up3', 'u2', 'groq');
+
+    const upQr = ds.createQueryRunner();
+    await migration.up(upQr);
+    await upQr.release();
+  }, 60000);
+
+  afterAll(async () => {
+    await ds?.destroy();
+  });
+
+  it('creates exactly one reserved Playground agent per tenant', async () => {
+    const rows: { tenant_id: string; name: string }[] = await ds.query(
+      `SELECT "tenant_id","name" FROM "agents" WHERE "is_system" = true ORDER BY "tenant_id"`,
+    );
+    expect(rows).toEqual([
+      { tenant_id: 't1', name: 'Playground' },
+      { tenant_id: 't2', name: 'Playground' },
+    ]);
+  });
+
+  it("relabels the colliding user agent instead of deleting it", async () => {
+    const row: { name: string; is_system: boolean }[] = await ds.query(
+      `SELECT "name","is_system" FROM "agents" WHERE "id" = 'a-user'`,
+    );
+    expect(row[0].is_system).toBe(false);
+    expect(row[0].name).toBe('Playground [a-user]');
+  });
+
+  it("grants each Playground agent its tenant's whole provider pool", async () => {
+    const grants: { provider: string }[] = await ds.query(
+      `SELECT up."provider" FROM "agent_provider_access" apa
+       JOIN "agents" a ON a."id" = apa."agent_id" AND a."is_system" = true
+       JOIN "user_providers" up ON up."id" = apa."user_provider_id"
+       WHERE a."tenant_id" = 't1' ORDER BY up."provider"`,
+    );
+    expect(grants.map((g) => g.provider)).toEqual(['anthropic', 'openai']);
+
+    const t2: { provider: string }[] = await ds.query(
+      `SELECT up."provider" FROM "agent_provider_access" apa
+       JOIN "agents" a ON a."id" = apa."agent_id" AND a."is_system" = true
+       JOIN "user_providers" up ON up."id" = apa."user_provider_id"
+       WHERE a."tenant_id" = 't2'`,
+    );
+    expect(t2.map((g) => g.provider)).toEqual(['groq']);
+  });
+});

--- a/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
+++ b/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
@@ -79,7 +79,9 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
       `SELECT "name","is_system" FROM "agents" WHERE "id" = 'a-user'`,
     );
     expect(row[0].is_system).toBe(false);
-    expect(row[0].name).toBe('Playground [a-user]');
+    // Slug-safe suffix: `name-<id>` so the relabeled agent remains routable
+    // via the ^[a-zA-Z0-9_-]+$ validator (no spaces or brackets).
+    expect(row[0].name).toBe('Playground-a-user');
   });
 
   it("grants each Playground agent its tenant's whole provider pool", async () => {

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -85,6 +85,16 @@ const Sidebar: Component<SidebarProps> = (props) => {
         Agents
       </A>
 
+      <div class="sidebar__section-label">TOOLS</div>
+      <A
+        href="/playground"
+        class="sidebar__link"
+        classList={{ active: isGlobalActive('/playground') }}
+        aria-current={isGlobalActive('/playground') ? 'page' : undefined}
+      >
+        Playground
+      </A>
+
       <div class="sidebar__spacer" />
 
       <a

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -70,6 +70,7 @@ render(
           <Route path="/overview" component={GlobalOverview} />
           <Route path="/messages" component={MessageLog} />
           <Route path="/agents" component={Workspace} />
+          <Route path="/playground" component={Playground} />
           <Route path="/providers/subscriptions" component={Subscriptions} />
           <Route path="/providers/byok" component={Byok} />
           <Route path="/providers/local" component={LocalProviders} />
@@ -89,7 +90,6 @@ render(
             </Route>
 
             {/* Non-tab agent routes: kept reachable but not primary tabs */}
-            <Route path="/playground" component={Playground} />
             <Route path="/model-prices" component={ModelPrices} />
             <Route path="/free-models" component={FreeModels} />
             <Route path="/help" component={Help} />

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -130,13 +130,9 @@ const Limits: Component = () => {
       />
 
       <div class="page-header">
-        <div>
-          <h1>Limits</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Get notified or block requests when token
-            or cost thresholds are exceeded
-          </span>
-        </div>
+        <span class="breadcrumb">
+          Get notified or block requests when token or cost thresholds are exceeded
+        </span>
         <button
           class="btn btn--primary btn--sm"
           onClick={() => {

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -80,7 +80,9 @@ const MessageLog: Component = () => {
     () => !params.agentName,
     async (isGlobal) => {
       if (!isGlobal) return [] as string[];
-      const data = (await getAgents()) as
+      // includeSystem=true so the reserved Playground agent appears in the
+      // filter and the log can be narrowed to Playground runs.
+      const data = (await getAgents(true)) as
         | { agents?: Array<{ agent_name: string }> }
         | Array<{ agent_name: string }>;
       const list = (Array.isArray(data) ? data : (data?.agents ?? [])) as Array<{

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -131,18 +131,30 @@ function findWinners(columns: readonly ColumnData[]): {
 const Playground: Component = () => {
   const [searchParams, setSearchParams] = useSearchParams<{ run?: string }>();
   const [agent] = createResource(getPlaygroundAgent);
-  const agentName = () => agent()?.name ?? 'Playground';
+  // Only the resolved name (from the server) drives resource sources and the
+  // store key. Using `undefined` as the source keeps resources idle until
+  // getPlaygroundAgent resolves, preventing 404 fetches for models/providers
+  // before the reserved agent row is guaranteed to exist server-side.
+  const resolvedAgentName = () => agent()?.name;
+  // Display fallback for UI text that needs a name before resolution.
+  const agentName = () => resolvedAgentName() ?? 'Playground';
 
-  const [available, { refetch: refetchAvailable }] = createResource(agentName, getAvailableModels);
-  const [providers, { refetch: refetchProviders }] = createResource(agentName, getProviders);
+  const [available, { refetch: refetchAvailable }] = createResource(
+    resolvedAgentName,
+    getAvailableModels,
+  );
+  const [providers, { refetch: refetchProviders }] = createResource(
+    resolvedAgentName,
+    getProviders,
+  );
   const [customProviders, { refetch: refetchCustomProviders }] = createResource(
-    agentName,
+    resolvedAgentName,
     getCustomProviders,
   );
 
-  // Memo so the store key updates when agentName() resolves from the fallback
-  // to the actual server-assigned name ("Playground"). This ensures each test
-  // render gets an isolated store keyed by the mock-resolved name.
+  // Memo so the store key updates when resolvedAgentName() settles to the
+  // actual server-assigned name ("Playground"). This ensures each test render
+  // gets an isolated store keyed by the mock-resolved name.
   const store = createMemo(() => getOrCreatePlaygroundStore(agentName()));
   const [pickerForColumn, setPickerForColumn] = createSignal<string | null>(null);
   const [showAddPicker, setShowAddPicker] = createSignal(false);

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -1,5 +1,6 @@
 import {
   createEffect,
+  createMemo,
   createResource,
   createSignal,
   For,
@@ -10,11 +11,12 @@ import {
   Suspense,
   type Component,
 } from 'solid-js';
-import { useParams, useSearchParams } from '@solidjs/router';
+import { useSearchParams } from '@solidjs/router';
 import { Meta, Title } from '@solidjs/meta';
 import type { AuthType, PlaygroundHistoryRunSummary } from '../services/api.js';
 import {
   getAvailableModels,
+  getPlaygroundAgent,
   getPlaygroundRun,
   getCustomProviders,
   getProviders,
@@ -127,9 +129,9 @@ function findWinners(columns: readonly ColumnData[]): {
 }
 
 const Playground: Component = () => {
-  const params = useParams<{ agentName: string }>();
   const [searchParams, setSearchParams] = useSearchParams<{ run?: string }>();
-  const agentName = () => decodeURIComponent(params.agentName);
+  const [agent] = createResource(getPlaygroundAgent);
+  const agentName = () => agent()?.name ?? 'Playground';
 
   const [available, { refetch: refetchAvailable }] = createResource(agentName, getAvailableModels);
   const [providers, { refetch: refetchProviders }] = createResource(agentName, getProviders);
@@ -138,7 +140,10 @@ const Playground: Component = () => {
     getCustomProviders,
   );
 
-  const store = getOrCreatePlaygroundStore(agentName());
+  // Memo so the store key updates when agentName() resolves from the fallback
+  // to the actual server-assigned name ("Playground"). This ensures each test
+  // render gets an isolated store keyed by the mock-resolved name.
+  const store = createMemo(() => getOrCreatePlaygroundStore(agentName()));
   const [pickerForColumn, setPickerForColumn] = createSignal<string | null>(null);
   const [showAddPicker, setShowAddPicker] = createSignal(false);
   const [announcement, setAnnouncement] = createSignal('');
@@ -168,11 +173,11 @@ const Playground: Component = () => {
   // that path, so its best state is tracked separately).
   const [overlayBestId, setOverlayBestId] = createSignal<string | null>(null);
 
-  const effectiveBestId = () => (viewingHistory() ? overlayBestId() : store.bestColumnId());
+  const effectiveBestId = () => (viewingHistory() ? overlayBestId() : store().bestColumnId());
 
   const handleMarkBest = (col: ColumnData) => {
     if (viewingHistory()) return; // read-only overlay
-    void store
+    void store()
       .markBest(col)
       .catch((err) =>
         toast.error(err instanceof Error ? err.message : 'Failed to set best answer'),
@@ -188,7 +193,7 @@ const Playground: Component = () => {
   const { setContent: setRightSidebar } = useRightSidebar();
 
   const handleNewPlayground = () => {
-    store.reset();
+    store().reset();
     setViewingHistory(null);
     setCompletedResults(null);
     setActiveRunId(null);
@@ -205,7 +210,7 @@ const Playground: Component = () => {
     const onKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
-        if (!store.isAnyRunning() && store.columns.length < MAX_COLUMNS && !viewingHistory()) {
+        if (!store().isAnyRunning() && store().columns.length < MAX_COLUMNS && !viewingHistory()) {
           setShowAddPicker(true);
         }
       }
@@ -223,16 +228,16 @@ const Playground: Component = () => {
   // while a playground was running -- the cached store still has state).
   createEffect(() => {
     // If store already has completed columns, snapshot them for the summary table
-    if (store.columns.length > 0 && !store.isAnyRunning() && !completedResults()) {
-      setCompletedResults([...store.columns]);
+    if (store().columns.length > 0 && !store().isAnyRunning() && !completedResults()) {
+      setCompletedResults([...store().columns]);
     }
-    if (store.columns.length > 0) return;
+    if (store().columns.length > 0) return;
     const runId = searchParams.run || sessionStorage.getItem('manifest.playground.lastRun');
     if (runId && !activeRunId()) {
-      getPlaygroundRun(runId, params.agentName)
+      getPlaygroundRun(runId)
         .then((detail) => {
-          store.loadHistoryRun(detail);
-          setCompletedResults([...store.columns]);
+          store().loadHistoryRun(detail);
+          setCompletedResults([...store().columns]);
           setActiveRunId(runId);
           setSearchParams({ run: runId });
         })
@@ -254,10 +259,10 @@ const Playground: Component = () => {
   };
 
   const handleSubmit = () => {
-    const promptText = store.prompt().trim();
-    const models = store.columns.map((c) => c.displayName ?? c.model);
+    const promptText = store().prompt().trim();
+    const models = store().columns.map((c) => c.displayName ?? c.model);
     setCompletedResults(null);
-    const runId = store.runAll({ requestHeaders: toHeaderRecord(headerEntries()) });
+    const runId = store().runAll({ requestHeaders: toHeaderRecord(headerEntries()) });
     if (!runId) return;
 
     // Add to history immediately so user sees the running playground
@@ -281,13 +286,13 @@ const Playground: Component = () => {
   };
 
   const handleRetry = (id: string) => {
-    void store.retryColumn(id, { requestHeaders: toHeaderRecord(headerEntries()) });
+    void store().retryColumn(id, { requestHeaders: toHeaderRecord(headerEntries()) });
   };
 
   const refreshHistory = async () => {
     setHistoryLoading(true);
     try {
-      setHistoryRuns(await listPlaygroundRuns(agentName()));
+      setHistoryRuns(await listPlaygroundRuns());
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to load history');
     } finally {
@@ -304,12 +309,12 @@ const Playground: Component = () => {
   // refreshHistory() writes the signal it tracks.
   createEffect(
     on(
-      () => store.isAnyRunning(),
+      () => store().isAnyRunning(),
       (running, prev) => {
         if (prev === true && running === false) {
           setLiveRunId(null);
           // Snapshot completed results so the summary table survives column removals
-          setCompletedResults([...store.columns]);
+          setCompletedResults([...store().columns]);
           void refreshHistory().then(() => {
             // If user isn't viewing a past run, auto-select the latest
             if (!viewingHistory()) {
@@ -331,12 +336,12 @@ const Playground: Component = () => {
     const p = providers();
     if (!a || !p) return;
     // Don't overwrite existing columns (e.g. after navigating away and back)
-    if (store.columns.length > 0) return;
-    store.pickDefaults(a, p);
+    if (store().columns.length > 0) return;
+    store().pickDefaults(a, p);
   });
 
   createEffect(() => {
-    for (const col of store.columns) {
+    for (const col of store().columns) {
       if (col.status === 'success' && col.metrics) {
         setAnnouncement(`${col.displayName} responded in ${col.metrics.durationMs} milliseconds.`);
       }
@@ -350,7 +355,7 @@ const Playground: Component = () => {
     authType?: AuthType,
   ) => {
     const displayName = findDisplayName(available() ?? [], model);
-    store.replaceColumnModel(columnId, model, provider, authType ?? 'api_key', displayName);
+    store().replaceColumnModel(columnId, model, provider, authType ?? 'api_key', displayName);
     setPickerForColumn(null);
   };
 
@@ -361,7 +366,7 @@ const Playground: Component = () => {
     authType?: AuthType,
   ) => {
     const displayName = findDisplayName(available() ?? [], model);
-    store.addColumn(model, provider, authType ?? 'api_key', displayName);
+    store().addColumn(model, provider, authType ?? 'api_key', displayName);
     setShowAddPicker(false);
   };
 
@@ -375,7 +380,7 @@ const Playground: Component = () => {
       return;
     }
     try {
-      const detail = await getPlaygroundRun(runId, params.agentName);
+      const detail = await getPlaygroundRun(runId);
       const toReadOnlyCols = (): import('../services/playground-store.js').PlaygroundColumn[] =>
         detail.columns.map((c, i) => ({
           id: `hist-${i}`,
@@ -391,7 +396,7 @@ const Playground: Component = () => {
           columnDbId: c.id,
         }));
 
-      if (store.isAnyRunning() || !hasConnectedProviders()) {
+      if (store().isAnyRunning() || !hasConnectedProviders()) {
         // Don't touch the store -- show history as a read-only overlay
         const cols = toReadOnlyCols();
         setViewingHistory(cols);
@@ -399,9 +404,9 @@ const Playground: Component = () => {
         setOverlayBestId(detail.bestColumnId ?? null);
       } else {
         // No run in progress and providers available, safe to replace the store
-        store.loadHistoryRun(detail);
+        store().loadHistoryRun(detail);
         setViewingHistory(null);
-        setCompletedResults([...store.columns]);
+        setCompletedResults([...store().columns]);
       }
       setActiveRunId(runId);
       setSearchParams({ run: runId });
@@ -433,7 +438,7 @@ const Playground: Component = () => {
   const hasConnectedProviders = () => (providers() ?? []).some((p) => p.is_active);
   // Compute winners from whatever set is actually rendered — when a history
   // run is open its columns drive the badges, not the live store.
-  const winners = () => findWinners(viewingHistory() ?? store.columns);
+  const winners = () => findWinners(viewingHistory() ?? store().columns);
 
   return (
     <div class="playground" style={{ 'padding-bottom': `${promptHeight() + 48}px` }}>
@@ -468,7 +473,7 @@ const Playground: Component = () => {
         }
       >
         <div class="playground__columns" aria-label="Model comparison columns">
-          <For each={viewingHistory() ?? store.columns}>
+          <For each={viewingHistory() ?? store().columns}>
             {(col) => (
               <PlaygroundColumn
                 column={col}
@@ -481,20 +486,20 @@ const Playground: Component = () => {
                 }
                 isBest={col.columnDbId != null && col.columnDbId === effectiveBestId()}
                 readOnly={!!viewingHistory() || !hasConnectedProviders()}
-                onRemove={viewingHistory() ? () => {} : store.removeColumn}
+                onRemove={viewingHistory() ? () => {} : store().removeColumn}
                 onChangeModel={viewingHistory() ? () => {} : setPickerForColumn}
                 onRetry={handleRetry}
                 onMarkBest={viewingHistory() ? undefined : () => handleMarkBest(col)}
               />
             )}
           </For>
-          <Show when={!viewingHistory() && store.columns.length < MAX_COLUMNS}>
+          <Show when={!viewingHistory() && store().columns.length < MAX_COLUMNS}>
             <button
               type="button"
               class="playground__add"
               onClick={() => setShowAddPicker(true)}
               aria-label="Add model column"
-              disabled={store.isAnyRunning()}
+              disabled={store().isAnyRunning()}
             >
               <span class="playground__add-plus">+</span>
               <span>Add model</span>
@@ -508,7 +513,7 @@ const Playground: Component = () => {
         </div>
 
         <PlaygroundSummaryTable
-          columns={viewingHistory() ?? completedResults() ?? store.columns}
+          columns={viewingHistory() ?? completedResults() ?? store().columns}
           bestColumnId={effectiveBestId()}
           onMarkBest={viewingHistory() ? undefined : handleMarkBest}
         />
@@ -531,12 +536,12 @@ const Playground: Component = () => {
           }
         >
           <PlaygroundPrompt
-            value={store.prompt()}
-            onChange={store.setPrompt}
+            value={store().prompt()}
+            onChange={store().setPrompt}
             onSubmit={handleSubmit}
-            onRecallPrevious={store.recallPreviousPrompt}
-            disabled={store.isAnyRunning() || store.columns.length === 0}
-            running={store.isAnyRunning()}
+            onRecallPrevious={store().recallPreviousPrompt}
+            disabled={store().isAnyRunning() || store().columns.length === 0}
+            running={store().isAnyRunning()}
             historyOpen={historyOpen()}
             onHeightChange={setPromptHeight}
             headersSlot={

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -435,13 +435,7 @@ const Routing: Component = () => {
       />
 
       <div class="page-header routing-page-header">
-        <div>
-          <h1>Routing</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Pick which model handles each type of
-            request
-          </span>
-        </div>
+        <span class="breadcrumb">Pick which model handles each type of request</span>
         <Show when={!connectedProviders.loading}>
           <div style="display: flex; gap: 8px;">
             <Show when={isEnabled()}>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -182,15 +182,9 @@ const Settings: Component = () => {
         name="description"
         content={`Configure settings for ${agentDisplayName() ?? agentName()}.`}
       />
-      <div class="page-header">
-        <div>
-          <h1>Settings</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Rename your agent, manage API keys, and
-            view setup instructions
-          </span>
-        </div>
-      </div>
+      <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); margin: 0 0 var(--gap-lg);">
+        Rename your agent, manage API keys, and view setup instructions
+      </p>
 
       {/* -- Agent Name ------------------------------ */}
       <div class="settings-card">

--- a/packages/frontend/src/services/api/agents.ts
+++ b/packages/frontend/src/services/api/agents.ts
@@ -1,7 +1,9 @@
 import { fetchJson, fetchMutate } from './core.js';
 
-export function getAgents() {
-  return fetchJson('/agents');
+export function getAgents(includeSystem = false) {
+  // includeSystem surfaces the reserved Playground (is_system) agent — the
+  // Messages filter opts in so the log can be filtered to Playground runs.
+  return fetchJson(includeSystem ? '/agents?includeSystem=true' : '/agents');
 }
 
 export interface AgentInfo {

--- a/packages/frontend/src/services/api/playground.ts
+++ b/packages/frontend/src/services/api/playground.ts
@@ -131,17 +131,16 @@ export async function setPlaygroundRunBest(
   return data.bestColumnId;
 }
 
-export function listPlaygroundRuns(agentName: string): Promise<PlaygroundHistoryRunSummary[]> {
-  return fetchJson<PlaygroundHistoryRunSummary[]>('/playground/runs', { agentName });
+export function getPlaygroundAgent(): Promise<{ name: string }> {
+  return fetchJson<{ name: string }>('/playground/agent');
 }
 
-export function getPlaygroundRun(
-  runId: string,
-  agentName: string,
-): Promise<PlaygroundHistoryRunDetail> {
-  return fetchJson<PlaygroundHistoryRunDetail>(`/playground/runs/${encodeURIComponent(runId)}`, {
-    agentName,
-  });
+export function listPlaygroundRuns(): Promise<PlaygroundHistoryRunSummary[]> {
+  return fetchJson<PlaygroundHistoryRunSummary[]>('/playground/runs');
+}
+
+export function getPlaygroundRun(runId: string): Promise<PlaygroundHistoryRunDetail> {
+  return fetchJson<PlaygroundHistoryRunDetail>(`/playground/runs/${encodeURIComponent(runId)}`);
 }
 
 export async function togglePlaygroundRunStar(runId: string): Promise<boolean> {

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -175,6 +175,7 @@ describe("Sidebar — identical in agent and global mode", () => {
       "/providers/byok",
       "/providers/local",
       "/agents",
+      "/playground",
     ]);
   });
 });

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -61,14 +61,13 @@ describe("Limits page", () => {
     mockRoutingStatus = { enabled: false };
   });
 
-  it("renders page title", () => {
-    render(() => <Limits />);
-    expect(screen.getByText("Limits")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Limits />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
-  it("renders breadcrumb with agent name", () => {
+  it("renders page description without duplicating the agent heading", () => {
     const { container } = render(() => <Limits />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Get notified or block requests when token or cost thresholds are exceeded");
   });
 

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -1306,6 +1306,15 @@ describe("MessageLog", () => {
       });
     });
 
+    it("requests system agents so the reserved Playground agent appears in the filter", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(mockGetAgents).toHaveBeenCalledWith(true);
+      });
+    });
+
     it("does NOT render agent filter dropdown in agent-scoped mode", async () => {
       // mockAgentName is "test-agent" from beforeEach
       mockGetMessages.mockResolvedValue(messagesData);

--- a/packages/frontend/tests/pages/Playground.test.tsx
+++ b/packages/frontend/tests/pages/Playground.test.tsx
@@ -6,6 +6,7 @@ import type { JSX } from 'solid-js';
 const mockGetAvailableModels = vi.fn();
 const mockGetProviders = vi.fn();
 const mockGetCustomProviders = vi.fn();
+const mockGetPlaygroundAgent = vi.fn();
 const mockGetPlaygroundRun = vi.fn();
 const mockListPlaygroundRuns = vi.fn();
 const mockStreamPlayground = vi.fn();
@@ -15,6 +16,7 @@ vi.mock('../../src/services/api.js', () => ({
   getAvailableModels: (...a: unknown[]) => mockGetAvailableModels(...a),
   getProviders: (...a: unknown[]) => mockGetProviders(...a),
   getCustomProviders: (...a: unknown[]) => mockGetCustomProviders(...a),
+  getPlaygroundAgent: (...a: unknown[]) => mockGetPlaygroundAgent(...a),
   getPlaygroundRun: (...a: unknown[]) => mockGetPlaygroundRun(...a),
   listPlaygroundRuns: (...a: unknown[]) => mockListPlaygroundRuns(...a),
   streamPlayground: (...a: unknown[]) => mockStreamPlayground(...a),
@@ -31,11 +33,7 @@ const setSearchParamsFn = vi.fn((p: { run?: string }) => {
   if ('run' in p) searchParamsState.run = p.run;
 });
 const searchParamsState: { run?: string } = {};
-// Each test gets a unique agent name so getOrCreatePlaygroundStore() hands
-// out a fresh store (the cache is module-level and survives between tests).
-let currentAgent = 'demo-0';
 vi.mock('@solidjs/router', () => ({
-  useParams: () => ({ agentName: currentAgent }),
   useSearchParams: () => [searchParamsState, setSearchParamsFn],
 }));
 
@@ -356,7 +354,9 @@ let agentSeq = 0;
 
 describe('Playground page', () => {
   beforeEach(() => {
-    currentAgent = `agent-${++agentSeq}`;
+    // Each test gets a unique agent name so getOrCreatePlaygroundStore() hands
+    // out a fresh store (the cache is module-level and survives between tests).
+    const agentName = `agent-${++agentSeq}`;
     lastColProps = [];
     lastSummaryProps = null;
     providerModalProps = null;
@@ -368,6 +368,7 @@ describe('Playground page', () => {
     mockGetAvailableModels.mockReset().mockResolvedValue([MODEL_A, MODEL_B]);
     mockGetProviders.mockReset().mockResolvedValue([ACTIVE_PROVIDER, ACTIVE_PROVIDER_B]);
     mockGetCustomProviders.mockReset().mockResolvedValue([]);
+    mockGetPlaygroundAgent.mockReset().mockResolvedValue({ name: agentName });
     mockGetPlaygroundRun.mockReset().mockResolvedValue(makeRunDetail());
     mockListPlaygroundRuns
       .mockReset()
@@ -572,7 +573,7 @@ describe('Playground page', () => {
       render(() => <Playground />);
       renderSidebar();
       fireEvent.click(await find('pick-r-42'));
-      await waitFor(() => expect(mockGetPlaygroundRun).toHaveBeenCalledWith('r-42', currentAgent));
+      await waitFor(() => expect(mockGetPlaygroundRun).toHaveBeenCalledWith('r-42'));
       // Store now holds the historical column.
       await waitFor(() => {
         const hist = lastColProps.find(
@@ -867,7 +868,7 @@ describe('Playground page', () => {
       searchParamsState.run = 'r-99';
       mockGetPlaygroundRun.mockResolvedValue(makeRunDetail({ id: 'r-99' }));
       render(() => <Playground />);
-      await waitFor(() => expect(mockGetPlaygroundRun).toHaveBeenCalledWith('r-99', currentAgent));
+      await waitFor(() => expect(mockGetPlaygroundRun).toHaveBeenCalledWith('r-99'));
     });
 
     it('restores from sessionStorage lastRun when no search param is set', async () => {
@@ -875,7 +876,7 @@ describe('Playground page', () => {
       ssStore['manifest.playground.lastRun'] = 'r-ss';
       mockGetPlaygroundRun.mockResolvedValue(makeRunDetail({ id: 'r-ss' }));
       render(() => <Playground />);
-      await waitFor(() => expect(mockGetPlaygroundRun).toHaveBeenCalledWith('r-ss', currentAgent));
+      await waitFor(() => expect(mockGetPlaygroundRun).toHaveBeenCalledWith('r-ss'));
     });
 
     it('clears the stale run param + sessionStorage when restoring it fails', async () => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -617,12 +617,12 @@ beforeEach(() => {
 });
 
 describe('Routing page', () => {
-  it('renders the page header with the agent display name', async () => {
-    render(() => <Routing />);
+  it('renders routing description without a duplicate page heading', async () => {
+    const { container } = render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText('Routing')).toBeDefined();
+      expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
     });
-    expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
+    expect(container.querySelector('h1')).toBeNull();
   });
 
   it('renders the empty providers state when no providers are connected', async () => {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -138,9 +138,9 @@ describe("Settings", () => {
     mockUpdateAgent.mockResolvedValue({});
   });
 
-  it("renders Settings heading", () => {
-    render(() => <Settings />);
-    expect(screen.getByText("Settings")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Settings />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
   it("renders agent name input with value", () => {
@@ -330,9 +330,8 @@ describe("Settings", () => {
     });
   });
 
-  it("shows breadcrumb with agent name", () => {
+  it("shows settings description without duplicating the agent heading", () => {
     const { container } = render(() => <Settings />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Rename your agent");
   });
 

--- a/packages/frontend/tests/services/api/agents.test.ts
+++ b/packages/frontend/tests/services/api/agents.test.ts
@@ -31,6 +31,14 @@ describe('agents API client', () => {
     expect(out).toEqual([{ agent_name: 'a' }]);
     const url = fetchMock.mock.calls[0][0] as string;
     expect(url).toContain('/api/v1/agents');
+    expect(url).not.toContain('includeSystem');
+  });
+
+  it('getAgents(true) requests includeSystem so the Playground agent is listed', async () => {
+    const fetchMock = setupFetch([{ agent_name: 'a' }]);
+    await agents.getAgents(true);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/agents?includeSystem=true');
   });
 
   it('getAgentInfo unwraps the { agent } envelope', async () => {

--- a/packages/frontend/tests/services/api/playground.test.ts
+++ b/packages/frontend/tests/services/api/playground.test.ts
@@ -372,6 +372,23 @@ describe('playground API client', () => {
     });
   });
 
+  describe('getPlaygroundAgent', () => {
+    it('GETs /playground/agent and returns the agent name', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ name: 'Playground' }),
+        text: async () => JSON.stringify({ name: 'Playground' }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const out = await playground.getPlaygroundAgent();
+      expect(out).toEqual({ name: 'Playground' });
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain('/api/v1/playground/agent');
+    });
+  });
+
   describe('listPlaygroundRuns / getPlaygroundRun', () => {
     function setupFetch(response: unknown): ReturnType<typeof vi.fn> {
       const fetchMock = vi.fn().mockResolvedValue({
@@ -385,18 +402,18 @@ describe('playground API client', () => {
       return fetchMock;
     }
 
-    it('GETs /playground/runs with the agentName query param', async () => {
+    it('GETs /playground/runs without an agentName query param', async () => {
       const fetchMock = setupFetch([
         { id: 'r1', prompt: 'p', createdAt: 'now', modelCount: 1, models: ['m'] },
       ]);
-      const out = await playground.listPlaygroundRuns('demo');
+      const out = await playground.listPlaygroundRuns();
       expect(out).toHaveLength(1);
       const url = fetchMock.mock.calls[0][0] as string;
       expect(url).toContain('/api/v1/playground/runs');
-      expect(url).toContain('agentName=demo');
+      expect(url).not.toContain('agentName');
     });
 
-    it('GETs /playground/runs/<id> and URL-encodes the runId', async () => {
+    it('GETs /playground/runs/<id> and URL-encodes the runId without an agentName query param', async () => {
       const fetchMock = setupFetch({
         id: 'a/b',
         prompt: 'p',
@@ -405,11 +422,11 @@ describe('playground API client', () => {
         models: [],
         columns: [],
       });
-      const out = await playground.getPlaygroundRun('a/b', 'demo');
+      const out = await playground.getPlaygroundRun('a/b');
       expect(out.id).toBe('a/b');
       const url = fetchMock.mock.calls[0][0] as string;
       expect(url).toContain('/playground/runs/a%2Fb');
-      expect(url).toContain('agentName=demo');
+      expect(url).not.toContain('agentName');
     });
   });
 


### PR DESCRIPTION
### ✨ What changed
- Playground is one global page; every run goes through a reserved per-tenant `Playground` agent.
- Migration seeds that agent per tenant and grants it the whole provider pool.
- `is_system` agents are hidden from the agent list and blocked from create/rename/duplicate/delete/key/grant ops.
- New `GET /playground/agent` resolves (lazily creates) the agent; run + history use it instead of a picked agentName.

### 💭 Why
Picking a user agent for the Playground was confusing and tied runs to one agent. A reserved agent records runs as `Playground` in global Messages and routes against every connected provider.

### 👤 For users
The Playground no longer asks you to pick an agent. Its runs show up under `Playground` in Messages.

### 🔧 For operators
`SeedPlaygroundAgents` runs on boot: adds `agents.is_system`, creates one `Playground` agent per tenant, backfills its grants. No env or config changes.

### 📝 Notes
- Stacked on #2163.
- Codex-reviewed (3 rounds, gate pass).