### PR TITLE
Fix OpenAI subscription modal flickering during OAuth flow

### DIFF
--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -50,6 +50,7 @@ interface Props {
   setBusy: Setter<boolean>;
   onBack: () => void;
   onUpdate: () => void;
+  onPollProviders?: () => void | Promise<void>;
   onClose: () => void;
   addKeyOpen?: Accessor<boolean>;
   setAddKeyOpen?: Setter<boolean>;
@@ -114,8 +115,9 @@ const OAuthDetailView: Component<Props> = (props) => {
 
   createEffect(() => {
     if (!pasteFlowActive()) return;
+    const poll = props.onPollProviders ?? props.onUpdate;
     const interval = window.setInterval(() => {
-      props.onUpdate();
+      poll();
     }, 2000);
     onCleanup(() => window.clearInterval(interval));
   });
@@ -312,7 +314,7 @@ const OAuthDetailView: Component<Props> = (props) => {
                   <video
                     src="/images/oauth-callback-example.mp4"
                     poster="/images/oauth-callback-example.png"
-                    preload="none"
+                    preload="auto"
                     autoplay
                     loop
                     muted
@@ -329,13 +331,12 @@ const OAuthDetailView: Component<Props> = (props) => {
             </p>
           </Show>
           <div class="provider-detail__field" style="margin-top: 12px;">
-            <textarea
+            <input
+              type="text"
               class="provider-detail__input"
               classList={{ 'provider-detail__input--error': !!pasteError() }}
               autocomplete="off"
               placeholder={callbackPlaceholder()}
-              rows={3}
-              style="resize: vertical;"
               value={pasteUrl()}
               onInput={(e) => {
                 setPasteUrl(e.currentTarget.value);

--- a/packages/frontend/src/components/ProviderDetailView.tsx
+++ b/packages/frontend/src/components/ProviderDetailView.tsx
@@ -40,6 +40,7 @@ export interface ProviderDetailViewProps {
   setValidationError: Setter<string | null>;
   onBack: () => void;
   onUpdate: () => void;
+  onPollProviders?: () => void | Promise<void>;
   onClose: () => void;
   initialAddKey?: boolean;
 }
@@ -395,6 +396,7 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
           setBusy={props.setBusy}
           onBack={props.onBack}
           onUpdate={props.onUpdate}
+          onPollProviders={props.onPollProviders}
           onClose={props.onClose}
           addKeyOpen={addKeyOpen}
           setAddKeyOpen={setAddKeyOpen}

--- a/packages/frontend/src/components/ProviderSelectContent.tsx
+++ b/packages/frontend/src/components/ProviderSelectContent.tsx
@@ -26,6 +26,7 @@ export interface ProviderSelectContentProps {
   customProviderPrefill?: CustomProviderPrefill | null;
   providerDeepLink?: ProviderDeepLink | null;
   onUpdate: () => void | Promise<void>;
+  onPollProviders?: () => void | Promise<void>;
   onClose?: () => void;
   showHeader?: boolean;
   showFooter?: boolean;
@@ -499,6 +500,7 @@ const ProviderSelectContent: Component<ProviderSelectContentProps> = (props) => 
             setValidationError={setValidationError}
             onBack={goBack}
             onUpdate={props.onUpdate}
+            onPollProviders={props.onPollProviders}
             onClose={closeHandler()}
             initialAddKey={addKeyIntent()}
           />

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -11,6 +11,7 @@ interface Props {
   providerDeepLink?: ProviderDeepLink | null;
   onClose: () => void;
   onUpdate: () => void | Promise<void>;
+  onPollProviders?: () => void | Promise<void>;
 }
 
 const ProviderSelectModal: Component<Props> = (props) => {
@@ -38,6 +39,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
           customProviderPrefill={props.customProviderPrefill}
           providerDeepLink={props.providerDeepLink}
           onUpdate={props.onUpdate}
+          onPollProviders={props.onPollProviders}
           onClose={props.onClose}
         />
       </div>

--- a/packages/frontend/src/components/RoutingModals.tsx
+++ b/packages/frontend/src/components/RoutingModals.tsx
@@ -67,6 +67,7 @@ interface RoutingModalsProps {
     providerKeyLabel?: string,
   ) => void;
   onProviderUpdate: () => Promise<void>;
+  onProviderPoll?: () => Promise<void>;
   onOpenProviderModal: () => void;
 }
 
@@ -315,17 +316,16 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
       </Show>
 
       <Show when={props.showProviderModal()}>
-        <Suspense fallback={null}>
-          <ProviderSelectModal
-            agentName={props.agentName()}
-            providers={props.connectedProviders()}
-            customProviders={props.customProviders()}
-            customProviderPrefill={props.customProviderPrefill}
-            providerDeepLink={props.providerDeepLink}
-            onClose={props.onProviderModalClose}
-            onUpdate={props.onProviderUpdate}
-          />
-        </Suspense>
+        <ProviderSelectModal
+          agentName={props.agentName()}
+          providers={props.connectedProviders()}
+          customProviders={props.customProviders()}
+          customProviderPrefill={props.customProviderPrefill}
+          providerDeepLink={props.providerDeepLink}
+          onClose={props.onProviderModalClose}
+          onUpdate={props.onProviderUpdate}
+          onPollProviders={props.onProviderPoll}
+        />
       </Show>
 
       <RoutingInstructionModal

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -374,6 +374,10 @@ const Routing: Component = () => {
     await refetchAll();
   };
 
+  const handleProviderPoll = async () => {
+    await refetchProviders();
+  };
+
   const handleSpecificityOverride = async (
     category: string,
     model: string,
@@ -442,7 +446,7 @@ const Routing: Component = () => {
             request
           </span>
         </div>
-        <Show when={!connectedProviders.loading}>
+        <Show when={connectedProviders.state !== 'pending'}>
           <div style="display: flex; gap: 8px;">
             <Show when={isEnabled()}>
               <button
@@ -472,7 +476,7 @@ const Routing: Component = () => {
         </Show>
       </div>
 
-      <Show when={!connectedProviders.loading} fallback={<RoutingLoadingSkeleton />}>
+      <Show when={connectedProviders.state !== 'pending'} fallback={<RoutingLoadingSkeleton />}>
         <Show
           when={hasProviders()}
           fallback={
@@ -546,7 +550,7 @@ const Routing: Component = () => {
                   customProviders={() => customProviders() ?? []}
                   activeProviders={activeProviders}
                   connectedProviders={() => connectedProviders() ?? []}
-                  tiersLoading={tiers.loading}
+                  tiersLoading={tiers.state === 'pending'}
                   changingTier={actions.changingTier}
                   resettingTier={actions.resettingTier}
                   resettingAll={actions.resettingAll}
@@ -740,6 +744,7 @@ const Routing: Component = () => {
         onOverride={handleOverride}
         onAddFallback={handleAddFallback}
         onProviderUpdate={handleProviderUpdate}
+        onProviderPoll={handleProviderPoll}
         onOpenProviderModal={openProviderModal}
       />
     </div>

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -361,7 +361,7 @@ describe('OAuthDetailView', () => {
     fireEvent.input(input, {
       target: {
         value:
-          'https://accounts.x.ai/oauth2/consent?response_type=code&state=consent-state\nmanual-xai-code-from-page',
+          'https://accounts.x.ai/oauth2/consent?response_type=code&state=consent-state manual-xai-code-from-page',
       },
     });
     fireEvent.click(screen.getByText('Connect'));
@@ -421,6 +421,21 @@ describe('OAuthDetailView', () => {
       expect(screen.getByText(/Copy the full URL/)).toBeDefined();
     });
     expect(container.querySelector('video[src="/images/oauth-callback-example.mp4"]')).not.toBeNull();
+  });
+
+  it('sets preload="auto" on the OAuth tutorial video so it plays immediately', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    const { container } = renderView();
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Copy the full URL/)).toBeDefined();
+    });
+    const video = container.querySelector('video[src="/images/oauth-callback-example.mp4"]');
+    expect(video).not.toBeNull();
+    expect(video!.getAttribute('preload')).toBe('auto');
   });
 
   it('does not show the callback-URL video tutorial for non-OpenAI providers (e.g. Gemini)', async () => {
@@ -507,6 +522,43 @@ describe('OAuthDetailView', () => {
     vi.advanceTimersByTime(2000);
 
     expect(onUpdate).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('uses onPollProviders instead of onUpdate for polling when provided', async () => {
+    vi.useFakeTimers();
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    const onPollProviders = vi.fn();
+    const [busy, setBusy] = createSignal(false);
+    const onBack = vi.fn();
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    render(() => (
+      <OAuthDetailView
+        provDef={provDef}
+        provId="openai"
+        agentName="test-agent"
+        connected={() => false}
+        selectedAuthType={() => 'subscription'}
+        busy={busy}
+        setBusy={setBusy}
+        onBack={onBack}
+        onUpdate={onUpdate}
+        onPollProviders={onPollProviders}
+        onClose={onClose}
+        activeKeys={() => []}
+      />
+    ));
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(2000);
+
+    expect(onPollProviders).toHaveBeenCalledTimes(1);
+    expect(onUpdate).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
 

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -142,6 +142,7 @@ vi.mock('../../src/components/RoutingModals.js', () => ({
       props.customProviders,
       props.connectedProviders,
       props.onOpenProviderModal,
+      props.onProviderPoll,
     ];
     void _read;
     return (
@@ -229,6 +230,12 @@ vi.mock('../../src/components/RoutingModals.js', () => ({
           onClick={() => (props.onProviderUpdate as () => Promise<void>)?.()}
         >
           provider-update
+        </button>
+        <button
+          data-testid="modal-trigger-provider-poll"
+          onClick={() => (props.onProviderPoll as () => Promise<void>)?.()}
+        >
+          provider-poll
         </button>
         <button
           data-testid="modal-trigger-provider-close"
@@ -867,6 +874,17 @@ describe('Routing page', () => {
     // The modal mock receives showProviderModal=true → it captures props.
     await waitFor(() => {
       expect(lastModalsProps).not.toBeNull();
+    });
+  });
+
+  it('provides a lightweight onProviderPoll that only refetches providers', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-trigger-provider-poll')).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId('modal-trigger-provider-poll'));
+    await waitFor(() => {
+      expect(mockGetProviders).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## ✨ What changed
- Removed Suspense wrapper around the provider modal that caused full unmount/remount on resource refetch
- Added a lightweight provider-only polling callback so the OAuth detection poll no longer refetches all 6 routing resources
- Changed the Routing page loading guards to only show skeleton on initial load, not during background refetches
- Fixed the OAuth tutorial video so it actually loads and plays (preload changed from "none" to "auto")
- Replaced the callback URL textarea with a standard text input to match the design system

## 💭 Why
When connecting an OpenAI subscription, the OAuth paste flow polls the backend every 2 seconds to detect when the connection succeeds. This polling triggered a full data refetch of 6 resources, and the Suspense boundary wrapping the modal re-triggered on each cycle, unmounting the entire modal, replaying slide-in animations, and resetting the video element before it could play. The result was a visibly flickering modal that made the OAuth flow feel broken.

## 👤 For users
- The OpenAI (and xAI, Gemini) subscription modal stays stable during the OAuth login flow
- The tutorial video showing how to copy the callback URL now plays correctly
- The callback URL input field matches the rest of the app's design

## 🔧 For operators
No operator impact.

## 🧪 How to test
1. Go to Routing, click "Connect providers", switch to the Subscription tab
2. Click on OpenAI, then click "Log in with OpenAI"
3. The modal should stay perfectly stable, no flickering, no animation replays
4. The tutorial video should play in a loop showing how to copy the callback URL
5. The callback URL input should look like a normal text field, not a resizable textarea