### PR TITLE
feat: provider analytics and rate-limit tracking (backend)

### DIFF
--- a/packages/backend/src/analytics/analytics.module.ts
+++ b/packages/backend/src/analytics/analytics.module.ts
@@ -35,6 +35,9 @@ import { AgentsController } from './controllers/agents.controller';
 import { AgentAnalyticsController } from './controllers/agent-analytics.controller';
 import { SavingsController } from './controllers/savings.controller';
 import { SavingsQueryService } from './services/savings-query.service';
+import { RateLimitsController } from './controllers/rate-limits.controller';
+import { ProviderAnalyticsController } from './controllers/provider-analytics.controller';
+import { ProxyModule } from '../routing/proxy/proxy.module';
 
 @Module({
   imports: [
@@ -57,6 +60,7 @@ import { SavingsQueryService } from './services/savings-query.service';
     OtlpModule,
     RoutingCoreModule,
     ModelPricesModule,
+    ProxyModule,
   ],
   controllers: [
     OverviewController,
@@ -66,6 +70,8 @@ import { SavingsQueryService } from './services/savings-query.service';
     AgentsController,
     AgentAnalyticsController,
     SavingsController,
+    RateLimitsController,
+    ProviderAnalyticsController,
   ],
   providers: [
     AggregationService,

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -34,6 +34,15 @@ function mockTimeseries(): Record<string, jest.Mock> {
     getCostByModel: jest.fn().mockResolvedValue([]),
     getRecentActivity: jest.fn().mockResolvedValue([]),
     getActiveSkills: jest.fn().mockResolvedValue([]),
+    getPerAgentTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getPerAgentMessageTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getPerAgentCostTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getPerProviderTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getPerProviderMessageTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getPerProviderCostTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getPerModelTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getPerModelMessageTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getPerModelCostTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
   };
 }
 
@@ -214,5 +223,96 @@ describe('OverviewController', () => {
     );
 
     expect(result.has_providers).toBe(false);
+  });
+
+  describe('per-agent / per-provider / per-model timeseries endpoints', () => {
+    const user = { id: 'u1' } as never;
+
+    it('getPerAgentTimeseries delegates with hourly range', async () => {
+      await controller.getPerAgentTimeseries({ range: '24h' }, user);
+      expect(ts.getPerAgentTimeseries).toHaveBeenCalledWith('24h', 'u1', true, 'tenant-123');
+    });
+
+    it('getPerAgentMessageTimeseries defaults range to 24h', async () => {
+      await controller.getPerAgentMessageTimeseries({}, user);
+      expect(ts.getPerAgentMessageTimeseries).toHaveBeenCalledWith('24h', 'u1', true, 'tenant-123');
+    });
+
+    it('getPerAgentCostTimeseries delegates with daily range', async () => {
+      await controller.getPerAgentCostTimeseries({ range: '7d' }, user);
+      expect(ts.getPerAgentCostTimeseries).toHaveBeenCalledWith('7d', 'u1', false, 'tenant-123');
+    });
+
+    it('getPerProviderTimeseries forwards agent_name', async () => {
+      await controller.getPerProviderTimeseries({ range: '24h', agent_name: 'bot-1' }, user);
+      expect(ts.getPerProviderTimeseries).toHaveBeenCalledWith(
+        '24h',
+        'u1',
+        true,
+        'tenant-123',
+        'bot-1',
+      );
+    });
+
+    it('getPerProviderMessageTimeseries defaults range and undefined agent', async () => {
+      await controller.getPerProviderMessageTimeseries({}, user);
+      expect(ts.getPerProviderMessageTimeseries).toHaveBeenCalledWith(
+        '24h',
+        'u1',
+        true,
+        'tenant-123',
+        undefined,
+      );
+    });
+
+    it('getPerProviderCostTimeseries delegates', async () => {
+      await controller.getPerProviderCostTimeseries({ range: '30d', agent_name: 'bot-1' }, user);
+      expect(ts.getPerProviderCostTimeseries).toHaveBeenCalledWith(
+        '30d',
+        'u1',
+        false,
+        'tenant-123',
+        'bot-1',
+      );
+    });
+
+    it('getPerModelTimeseries delegates', async () => {
+      await controller.getPerModelTimeseries({ range: '24h' }, user);
+      expect(ts.getPerModelTimeseries).toHaveBeenCalledWith(
+        '24h',
+        'u1',
+        true,
+        'tenant-123',
+        undefined,
+      );
+    });
+
+    it('getPerModelMessageTimeseries delegates', async () => {
+      await controller.getPerModelMessageTimeseries({ range: '7d', agent_name: 'bot-1' }, user);
+      expect(ts.getPerModelMessageTimeseries).toHaveBeenCalledWith(
+        '7d',
+        'u1',
+        false,
+        'tenant-123',
+        'bot-1',
+      );
+    });
+
+    it('getPerModelCostTimeseries delegates', async () => {
+      await controller.getPerModelCostTimeseries({ range: '24h', agent_name: 'bot-1' }, user);
+      expect(ts.getPerModelCostTimeseries).toHaveBeenCalledWith(
+        '24h',
+        'u1',
+        true,
+        'tenant-123',
+        'bot-1',
+      );
+    });
+
+    it('falls back to undefined tenantId when unresolved', async () => {
+      mockTenantResolve.mockResolvedValueOnce(null);
+      await controller.getPerAgentTimeseries({ range: '24h' }, user);
+      expect(ts.getPerAgentTimeseries).toHaveBeenCalledWith('24h', 'u1', true, undefined);
+    });
   });
 });

--- a/packages/backend/src/analytics/controllers/overview.controller.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.ts
@@ -65,6 +65,105 @@ export class OverviewController {
     };
   }
 
+  @Get('overview/per-agent-timeseries')
+  async getPerAgentTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
+    const range = query.range ?? '24h';
+    const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    return this.timeseries.getPerAgentTimeseries(range, user.id, hourly, tenantId);
+  }
+
+  @Get('overview/per-agent-message-timeseries')
+  async getPerAgentMessageTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
+    const range = query.range ?? '24h';
+    const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    return this.timeseries.getPerAgentMessageTimeseries(range, user.id, hourly, tenantId);
+  }
+
+  @Get('overview/per-agent-cost-timeseries')
+  async getPerAgentCostTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
+    const range = query.range ?? '24h';
+    const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    return this.timeseries.getPerAgentCostTimeseries(range, user.id, hourly, tenantId);
+  }
+
+  @Get('overview/per-provider-timeseries')
+  async getPerProviderTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
+    const range = query.range ?? '24h';
+    const agentName = query.agent_name;
+    const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    return this.timeseries.getPerProviderTimeseries(range, user.id, hourly, tenantId, agentName);
+  }
+
+  @Get('overview/per-provider-message-timeseries')
+  async getPerProviderMessageTimeseries(
+    @Query() query: RangeQueryDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    const range = query.range ?? '24h';
+    const agentName = query.agent_name;
+    const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    return this.timeseries.getPerProviderMessageTimeseries(
+      range,
+      user.id,
+      hourly,
+      tenantId,
+      agentName,
+    );
+  }
+
+  @Get('overview/per-provider-cost-timeseries')
+  async getPerProviderCostTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
+    const range = query.range ?? '24h';
+    const agentName = query.agent_name;
+    const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    return this.timeseries.getPerProviderCostTimeseries(
+      range,
+      user.id,
+      hourly,
+      tenantId,
+      agentName,
+    );
+  }
+
+  @Get('overview/per-model-cost-timeseries')
+  async getPerModelCostTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
+    const range = query.range ?? '24h';
+    const agentName = query.agent_name;
+    const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    return this.timeseries.getPerModelCostTimeseries(range, user.id, hourly, tenantId, agentName);
+  }
+
+  @Get('overview/per-model-timeseries')
+  async getPerModelTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
+    const range = query.range ?? '24h';
+    const agentName = query.agent_name;
+    const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    return this.timeseries.getPerModelTimeseries(range, user.id, hourly, tenantId, agentName);
+  }
+
+  @Get('overview/per-model-message-timeseries')
+  async getPerModelMessageTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
+    const range = query.range ?? '24h';
+    const agentName = query.agent_name;
+    const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    return this.timeseries.getPerModelMessageTimeseries(
+      range,
+      user.id,
+      hourly,
+      tenantId,
+      agentName,
+    );
+  }
+
   private async hasActiveProviders(userId: string, agentName?: string): Promise<boolean> {
     if (!agentName) return false;
     try {

--- a/packages/backend/src/analytics/controllers/overview.controller.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.ts
@@ -67,34 +67,25 @@ export class OverviewController {
 
   @Get('overview/per-agent-timeseries')
   async getPerAgentTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
-    const range = query.range ?? '24h';
-    const hourly = isHourlyRange(range);
-    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const { range, hourly, tenantId } = await this.deriveTimeseriesArgs(query, user);
     return this.timeseries.getPerAgentTimeseries(range, user.id, hourly, tenantId);
   }
 
   @Get('overview/per-agent-message-timeseries')
   async getPerAgentMessageTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
-    const range = query.range ?? '24h';
-    const hourly = isHourlyRange(range);
-    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const { range, hourly, tenantId } = await this.deriveTimeseriesArgs(query, user);
     return this.timeseries.getPerAgentMessageTimeseries(range, user.id, hourly, tenantId);
   }
 
   @Get('overview/per-agent-cost-timeseries')
   async getPerAgentCostTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
-    const range = query.range ?? '24h';
-    const hourly = isHourlyRange(range);
-    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const { range, hourly, tenantId } = await this.deriveTimeseriesArgs(query, user);
     return this.timeseries.getPerAgentCostTimeseries(range, user.id, hourly, tenantId);
   }
 
   @Get('overview/per-provider-timeseries')
   async getPerProviderTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
-    const range = query.range ?? '24h';
-    const agentName = query.agent_name;
-    const hourly = isHourlyRange(range);
-    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const { range, hourly, tenantId, agentName } = await this.deriveTimeseriesArgs(query, user);
     return this.timeseries.getPerProviderTimeseries(range, user.id, hourly, tenantId, agentName);
   }
 
@@ -103,10 +94,7 @@ export class OverviewController {
     @Query() query: RangeQueryDto,
     @CurrentUser() user: AuthUser,
   ) {
-    const range = query.range ?? '24h';
-    const agentName = query.agent_name;
-    const hourly = isHourlyRange(range);
-    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const { range, hourly, tenantId, agentName } = await this.deriveTimeseriesArgs(query, user);
     return this.timeseries.getPerProviderMessageTimeseries(
       range,
       user.id,
@@ -118,10 +106,7 @@ export class OverviewController {
 
   @Get('overview/per-provider-cost-timeseries')
   async getPerProviderCostTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
-    const range = query.range ?? '24h';
-    const agentName = query.agent_name;
-    const hourly = isHourlyRange(range);
-    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const { range, hourly, tenantId, agentName } = await this.deriveTimeseriesArgs(query, user);
     return this.timeseries.getPerProviderCostTimeseries(
       range,
       user.id,
@@ -133,28 +118,19 @@ export class OverviewController {
 
   @Get('overview/per-model-cost-timeseries')
   async getPerModelCostTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
-    const range = query.range ?? '24h';
-    const agentName = query.agent_name;
-    const hourly = isHourlyRange(range);
-    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const { range, hourly, tenantId, agentName } = await this.deriveTimeseriesArgs(query, user);
     return this.timeseries.getPerModelCostTimeseries(range, user.id, hourly, tenantId, agentName);
   }
 
   @Get('overview/per-model-timeseries')
   async getPerModelTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
-    const range = query.range ?? '24h';
-    const agentName = query.agent_name;
-    const hourly = isHourlyRange(range);
-    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const { range, hourly, tenantId, agentName } = await this.deriveTimeseriesArgs(query, user);
     return this.timeseries.getPerModelTimeseries(range, user.id, hourly, tenantId, agentName);
   }
 
   @Get('overview/per-model-message-timeseries')
   async getPerModelMessageTimeseries(@Query() query: RangeQueryDto, @CurrentUser() user: AuthUser) {
-    const range = query.range ?? '24h';
-    const agentName = query.agent_name;
-    const hourly = isHourlyRange(range);
-    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const { range, hourly, tenantId, agentName } = await this.deriveTimeseriesArgs(query, user);
     return this.timeseries.getPerModelMessageTimeseries(
       range,
       user.id,
@@ -162,6 +138,25 @@ export class OverviewController {
       tenantId,
       agentName,
     );
+  }
+
+  /**
+   * Shared derivation of the (range, hourly, tenantId, agentName) tuple every
+   * `overview/per-*-timeseries` endpoint needs. Extracted so the per-endpoint
+   * methods can't drift in how they default the range, compute `hourly`, or
+   * resolve the tenant.
+   */
+  private async deriveTimeseriesArgs(
+    query: RangeQueryDto,
+    user: AuthUser,
+  ): Promise<{ range: string; hourly: boolean; tenantId: string | undefined; agentName?: string }> {
+    const range = query.range ?? '24h';
+    return {
+      range,
+      hourly: isHourlyRange(range),
+      tenantId: (await this.tenantCache.resolve(user.id)) ?? undefined,
+      agentName: query.agent_name,
+    };
   }
 
   private async hasActiveProviders(userId: string, agentName?: string): Promise<boolean> {

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
@@ -1,0 +1,390 @@
+import { ProviderAnalyticsController } from './provider-analytics.controller';
+import type { AggregationService } from '../services/aggregation.service';
+import type { TimeseriesQueriesService } from '../services/timeseries-queries.service';
+import type { TenantCacheService } from '../../common/services/tenant-cache.service';
+import type { Repository } from 'typeorm';
+import type { UserProvider } from '../../entities/user-provider.entity';
+import type { AgentMessage } from '../../entities/agent-message.entity';
+import type { Tenant } from '../../entities/tenant.entity';
+import type { AuthUser } from '../../auth/auth.instance';
+
+const user = { id: 'u1' } as AuthUser;
+
+interface ConnectionDetailFull {
+  connection: { last_used_at: string | null; [k: string]: unknown };
+  agents: Array<Record<string, unknown>>;
+  model_usage: Array<Record<string, unknown>>;
+  recent_messages: Array<Record<string, unknown>>;
+}
+
+/**
+ * A chainable QueryBuilder mock whose terminal getRawOne/getRawMany return
+ * values are supplied per-instance. The controller builds a fresh builder for
+ * each query, so each createQueryBuilder() call shifts the next scripted result.
+ */
+function makeQb(result: { rawOne?: unknown; rawMany?: unknown[] }) {
+  const qb: Record<string, jest.Mock> = {
+    select: jest.fn(),
+    addSelect: jest.fn(),
+    leftJoin: jest.fn(),
+    where: jest.fn(),
+    andWhere: jest.fn(),
+    groupBy: jest.fn(),
+    orderBy: jest.fn(),
+    limit: jest.fn(),
+    getRawOne: jest.fn().mockResolvedValue(result.rawOne),
+    getRawMany: jest.fn().mockResolvedValue(result.rawMany ?? []),
+  };
+  for (const k of Object.keys(qb)) {
+    if (!k.startsWith('getRaw')) qb[k].mockReturnValue(qb);
+  }
+  return qb;
+}
+
+describe('ProviderAnalyticsController', () => {
+  let aggregation: { getSummaryMetrics: jest.Mock };
+  let timeseries: {
+    getTimeseries: jest.Mock;
+    getPerAgentTimeseries: jest.Mock;
+    getPerAgentMessageTimeseries: jest.Mock;
+    getPerAgentCostTimeseries: jest.Mock;
+    getAgentNamesByAuthType: jest.Mock;
+  };
+  let tenantCache: { resolve: jest.Mock };
+  let providerRepo: { findOne: jest.Mock };
+  let messageRepo: { createQueryBuilder: jest.Mock };
+  let tenantRepo: { findOne: jest.Mock };
+  let controller: ProviderAnalyticsController;
+
+  beforeEach(() => {
+    aggregation = {
+      getSummaryMetrics: jest.fn().mockResolvedValue({
+        messages: { value: 5 },
+        tokens: { tokens_today: { value: 100 } },
+      }),
+    };
+    timeseries = {
+      getTimeseries: jest
+        .fn()
+        .mockResolvedValue({ tokenUsage: [{ hour: '01' }], messageUsage: [{ hour: '01' }] }),
+      getPerAgentTimeseries: jest.fn().mockResolvedValue({ agents: ['a'], timeseries: [] }),
+      getPerAgentMessageTimeseries: jest.fn().mockResolvedValue({ agents: ['a'], timeseries: [] }),
+      getPerAgentCostTimeseries: jest.fn().mockResolvedValue({ agents: ['a'], timeseries: [] }),
+      getAgentNamesByAuthType: jest.fn().mockResolvedValue(['agent-1']),
+    };
+    tenantCache = { resolve: jest.fn().mockResolvedValue('tenant-1') };
+    providerRepo = { findOne: jest.fn() };
+    messageRepo = { createQueryBuilder: jest.fn() };
+    tenantRepo = { findOne: jest.fn() };
+
+    controller = new ProviderAnalyticsController(
+      aggregation as unknown as AggregationService,
+      timeseries as unknown as TimeseriesQueriesService,
+      tenantCache as unknown as TenantCacheService,
+      providerRepo as unknown as Repository<UserProvider>,
+      messageRepo as unknown as Repository<AgentMessage>,
+      tenantRepo as unknown as Repository<Tenant>,
+    );
+  });
+
+  describe('getAnalytics', () => {
+    it('returns summary + timeseries for default range (24h, hourly)', async () => {
+      const out = await controller.getAnalytics(user, 'subscription');
+      expect(aggregation.getSummaryMetrics).toHaveBeenCalledWith(
+        '24h',
+        'u1',
+        'tenant-1',
+        undefined,
+        'subscription',
+        undefined,
+      );
+      expect(timeseries.getTimeseries).toHaveBeenCalledWith(
+        '24h',
+        'u1',
+        true,
+        'tenant-1',
+        undefined,
+        'subscription',
+        undefined,
+      );
+      expect(out.summary.messages).toEqual({ value: 5 });
+      expect(out.token_usage).toEqual([{ hour: '01' }]);
+    });
+
+    it('honors 7d range (non-hourly) and agent + provider filters', async () => {
+      await controller.getAnalytics(user, 'api_key', '7d', 'agent-x', 'openai');
+      expect(timeseries.getTimeseries).toHaveBeenCalledWith(
+        '7d',
+        'u1',
+        false,
+        'tenant-1',
+        'agent-x',
+        'api_key',
+        'openai',
+      );
+    });
+
+    it('honors 30d range', async () => {
+      await controller.getAnalytics(user, undefined, '30d');
+      expect(aggregation.getSummaryMetrics).toHaveBeenCalledWith(
+        '30d',
+        'u1',
+        'tenant-1',
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('falls back to undefined tenantId when unresolved', async () => {
+      tenantCache.resolve.mockResolvedValue(null);
+      await controller.getAnalytics(user, 'subscription');
+      expect(timeseries.getTimeseries).toHaveBeenCalledWith(
+        '24h',
+        'u1',
+        true,
+        undefined,
+        undefined,
+        'subscription',
+        undefined,
+      );
+    });
+  });
+
+  describe('per-agent timeseries endpoints', () => {
+    it('getPerAgentTimeseries delegates with hourly default', async () => {
+      const out = await controller.getPerAgentTimeseries(user, 'subscription', 'openai');
+      expect(timeseries.getPerAgentTimeseries).toHaveBeenCalledWith(
+        '24h',
+        'u1',
+        true,
+        'tenant-1',
+        'subscription',
+        'openai',
+      );
+      expect(out).toEqual({ agents: ['a'], timeseries: [] });
+    });
+
+    it('getPerAgentMessageTimeseries honors 30d', async () => {
+      await controller.getPerAgentMessageTimeseries(user, 'subscription', 'openai', '30d');
+      expect(timeseries.getPerAgentMessageTimeseries).toHaveBeenCalledWith(
+        '30d',
+        'u1',
+        false,
+        'tenant-1',
+        'subscription',
+        'openai',
+      );
+    });
+
+    it('getPerAgentCostTimeseries honors 7d', async () => {
+      await controller.getPerAgentCostTimeseries(user, 'api_key', 'anthropic', '7d');
+      expect(timeseries.getPerAgentCostTimeseries).toHaveBeenCalledWith(
+        '7d',
+        'u1',
+        false,
+        'tenant-1',
+        'api_key',
+        'anthropic',
+      );
+    });
+  });
+
+  describe('getAgents', () => {
+    it('returns agent names with explicit auth_type', async () => {
+      const out = await controller.getAgents(user, 'api_key');
+      expect(timeseries.getAgentNamesByAuthType).toHaveBeenCalledWith('api_key', 'u1', 'tenant-1');
+      expect(out).toEqual({ agents: ['agent-1'] });
+    });
+
+    it('defaults auth_type to subscription', async () => {
+      await controller.getAgents(user);
+      expect(timeseries.getAgentNamesByAuthType).toHaveBeenCalledWith(
+        'subscription',
+        'u1',
+        'tenant-1',
+      );
+    });
+  });
+
+  describe('getConnectionDetail', () => {
+    it('returns empty shape when connection_id is missing', async () => {
+      const out = await controller.getConnectionDetail(user, undefined);
+      expect(out).toEqual({ connection: null, agents: [], recent_messages: [] });
+    });
+
+    it('returns empty shape when the connection is not found / not owned', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+      const out = await controller.getConnectionDetail(user, 'c1');
+      expect(providerRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 'c1', user_id: 'u1' },
+      });
+      expect(out).toEqual({ connection: null, agents: [], recent_messages: [] });
+    });
+
+    it('returns connection-only shape when tenant is missing', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'c1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'My OpenAI',
+        cached_models: [{ id: 'm1' }, { id: 'm2' }],
+        key_prefix: 'sk-abc',
+        connected_at: '2026-01-01',
+      });
+      tenantRepo.findOne.mockResolvedValue(null);
+
+      const out = (await controller.getConnectionDetail(
+        user,
+        'c1',
+      )) as unknown as ConnectionDetailFull;
+      expect(out.connection).toMatchObject({ id: 'c1', cached_model_count: 2 });
+      expect(out.agents).toEqual([]);
+      expect(out.model_usage).toEqual([]);
+      expect(out.recent_messages).toEqual([]);
+    });
+
+    it('aggregates agents, models and recent messages with percentages', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'c1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'My OpenAI',
+        cached_models: null, // non-array -> count 0
+        key_prefix: 'sk-abc',
+        connected_at: '2026-01-01',
+        is_active: true,
+      });
+      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+
+      const lastUsedDate = new Date('2026-02-01T10:00:00Z');
+      // Query order in controller: lastUsed, agentRows, modelRows, recentMessages
+      messageRepo.createQueryBuilder
+        .mockReturnValueOnce(makeQb({ rawOne: { last_used_at: lastUsedDate } }))
+        .mockReturnValueOnce(
+          makeQb({
+            rawMany: [
+              {
+                agent_name: 'agent-a',
+                tokens: 80,
+                cost: 1.5,
+                messages: 3,
+                last_used: lastUsedDate,
+                agent_platform: 'openclaw',
+              },
+              {
+                agent_name: 'agent-b',
+                tokens: 20,
+                cost: 0.5,
+                messages: 1,
+                last_used: '2026-02-01T09:00:00Z',
+                agent_platform: null,
+              },
+            ],
+          }),
+        )
+        .mockReturnValueOnce(
+          makeQb({
+            rawMany: [
+              { model: 'gpt-4o', tokens: 60, cost: 1.0, messages: 2 },
+              { model: 'gpt-4o-mini', tokens: 40, cost: 0.2, messages: 2 },
+            ],
+          }),
+        )
+        .mockReturnValueOnce(makeQb({ rawMany: [{ id: 'msg-1' }] }));
+
+      const out = (await controller.getConnectionDetail(
+        user,
+        'c1',
+      )) as unknown as ConnectionDetailFull;
+
+      expect(out.connection).toMatchObject({
+        id: 'c1',
+        cached_model_count: 0,
+        is_active: true,
+        last_used_at: lastUsedDate.toISOString(),
+      });
+      // agent percentages: 80/100=80, 20/100=20
+      expect(out.agents[0]).toMatchObject({
+        agent_name: 'agent-a',
+        agent_platform: 'openclaw',
+        pct_of_total: 80,
+        last_used: lastUsedDate.toISOString(),
+      });
+      expect(out.agents[1]).toMatchObject({
+        agent_name: 'agent-b',
+        agent_platform: null,
+        pct_of_total: 20,
+        last_used: '2026-02-01T09:00:00Z',
+      });
+      // model percentages: 60/100=60, 40/100=40
+      expect(out.model_usage[0]).toMatchObject({ model: 'gpt-4o', pct_of_total: 60 });
+      expect(out.model_usage[1]).toMatchObject({ model: 'gpt-4o-mini', pct_of_total: 40 });
+      expect(out.recent_messages).toEqual([{ id: 'msg-1' }]);
+    });
+
+    it('handles zero totals (pct 0), null last_used and string last_used_at', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'c1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'My OpenAI',
+        cached_models: null,
+        key_prefix: null,
+        connected_at: '2026-01-01',
+        is_active: false,
+      });
+      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+
+      messageRepo.createQueryBuilder
+        // last_used_at as a raw string (not a Date)
+        .mockReturnValueOnce(makeQb({ rawOne: { last_used_at: '2026-02-01T00:00:00Z' } }))
+        .mockReturnValueOnce(
+          makeQb({
+            rawMany: [{ agent_name: 'agent-a', tokens: 0, cost: 0, messages: 0, last_used: null }],
+          }),
+        )
+        .mockReturnValueOnce(
+          makeQb({ rawMany: [{ model: 'gpt-4o', tokens: 0, cost: 0, messages: 0 }] }),
+        )
+        .mockReturnValueOnce(makeQb({ rawMany: [] }));
+
+      const out = (await controller.getConnectionDetail(
+        user,
+        'c1',
+      )) as unknown as ConnectionDetailFull;
+      expect(out.connection.last_used_at).toBe('2026-02-01T00:00:00Z');
+      expect(out.agents[0].pct_of_total).toBe(0);
+      expect(out.agents[0].last_used).toBeNull();
+      expect(out.model_usage[0].pct_of_total).toBe(0);
+    });
+
+    it('returns null last_used_at when no rows have ever been recorded', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'c1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'My OpenAI',
+        cached_models: [],
+        key_prefix: 'sk',
+        connected_at: '2026-01-01',
+        is_active: true,
+      });
+      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+
+      messageRepo.createQueryBuilder
+        .mockReturnValueOnce(makeQb({ rawOne: { last_used_at: null } }))
+        .mockReturnValueOnce(makeQb({ rawMany: [] }))
+        .mockReturnValueOnce(makeQb({ rawMany: [] }))
+        .mockReturnValueOnce(makeQb({ rawMany: [] }));
+
+      const out = (await controller.getConnectionDetail(
+        user,
+        'c1',
+      )) as unknown as ConnectionDetailFull;
+      expect(out.connection.last_used_at).toBeNull();
+      expect(out.agents).toEqual([]);
+      expect(out.model_usage).toEqual([]);
+    });
+  });
+});

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
@@ -5,7 +5,6 @@ import type { TenantCacheService } from '../../common/services/tenant-cache.serv
 import type { Repository } from 'typeorm';
 import type { UserProvider } from '../../entities/user-provider.entity';
 import type { AgentMessage } from '../../entities/agent-message.entity';
-import type { Tenant } from '../../entities/tenant.entity';
 import type { AuthUser } from '../../auth/auth.instance';
 
 const user = { id: 'u1' } as AuthUser;
@@ -53,7 +52,6 @@ describe('ProviderAnalyticsController', () => {
   let tenantCache: { resolve: jest.Mock };
   let providerRepo: { findOne: jest.Mock };
   let messageRepo: { createQueryBuilder: jest.Mock };
-  let tenantRepo: { findOne: jest.Mock };
   let controller: ProviderAnalyticsController;
 
   beforeEach(() => {
@@ -75,7 +73,6 @@ describe('ProviderAnalyticsController', () => {
     tenantCache = { resolve: jest.fn().mockResolvedValue('tenant-1') };
     providerRepo = { findOne: jest.fn() };
     messageRepo = { createQueryBuilder: jest.fn() };
-    tenantRepo = { findOne: jest.fn() };
 
     controller = new ProviderAnalyticsController(
       aggregation as unknown as AggregationService,
@@ -83,7 +80,6 @@ describe('ProviderAnalyticsController', () => {
       tenantCache as unknown as TenantCacheService,
       providerRepo as unknown as Repository<UserProvider>,
       messageRepo as unknown as Repository<AgentMessage>,
-      tenantRepo as unknown as Repository<Tenant>,
     );
   });
 
@@ -100,6 +96,7 @@ describe('ProviderAnalyticsController', () => {
         'subscription',
         undefined,
         true,
+        undefined,
       );
       expect(timeseries.getTimeseries).toHaveBeenCalledWith(
         '24h',
@@ -110,6 +107,7 @@ describe('ProviderAnalyticsController', () => {
         'subscription',
         undefined,
         true,
+        undefined,
       );
       expect(out.summary.messages).toEqual({ value: 5 });
       expect(out.token_usage).toEqual([{ hour: '01' }]);
@@ -126,6 +124,7 @@ describe('ProviderAnalyticsController', () => {
         'api_key',
         'openai',
         true,
+        undefined,
       );
     });
 
@@ -139,6 +138,7 @@ describe('ProviderAnalyticsController', () => {
         undefined,
         undefined,
         true,
+        undefined,
       );
     });
 
@@ -154,6 +154,32 @@ describe('ProviderAnalyticsController', () => {
         'subscription',
         undefined,
         true,
+        undefined,
+      );
+    });
+
+    it('scopes summary + timeseries to a connection label', async () => {
+      await controller.getAnalytics(user, 'api_key', '7d', undefined, 'openai', 'Work');
+      expect(aggregation.getSummaryMetrics).toHaveBeenCalledWith(
+        '7d',
+        'u1',
+        'tenant-1',
+        undefined,
+        'api_key',
+        'openai',
+        true,
+        'Work',
+      );
+      expect(timeseries.getTimeseries).toHaveBeenCalledWith(
+        '7d',
+        'u1',
+        false,
+        'tenant-1',
+        undefined,
+        'api_key',
+        'openai',
+        true,
+        'Work',
       );
     });
   });
@@ -168,6 +194,7 @@ describe('ProviderAnalyticsController', () => {
         'tenant-1',
         'subscription',
         'openai',
+        undefined,
       );
       expect(out).toEqual({ agents: ['a'], timeseries: [] });
     });
@@ -181,6 +208,7 @@ describe('ProviderAnalyticsController', () => {
         'tenant-1',
         'subscription',
         'openai',
+        undefined,
       );
     });
 
@@ -193,6 +221,40 @@ describe('ProviderAnalyticsController', () => {
         'tenant-1',
         'api_key',
         'anthropic',
+        undefined,
+      );
+    });
+
+    it('forwards the connection label to every per-agent timeseries query', async () => {
+      await controller.getPerAgentTimeseries(user, 'api_key', 'openai', '7d', 'Work');
+      await controller.getPerAgentMessageTimeseries(user, 'api_key', 'openai', '7d', 'Work');
+      await controller.getPerAgentCostTimeseries(user, 'api_key', 'openai', '7d', 'Work');
+      expect(timeseries.getPerAgentTimeseries).toHaveBeenCalledWith(
+        '7d',
+        'u1',
+        false,
+        'tenant-1',
+        'api_key',
+        'openai',
+        'Work',
+      );
+      expect(timeseries.getPerAgentMessageTimeseries).toHaveBeenCalledWith(
+        '7d',
+        'u1',
+        false,
+        'tenant-1',
+        'api_key',
+        'openai',
+        'Work',
+      );
+      expect(timeseries.getPerAgentCostTimeseries).toHaveBeenCalledWith(
+        '7d',
+        'u1',
+        false,
+        'tenant-1',
+        'api_key',
+        'openai',
+        'Work',
       );
     });
   });
@@ -215,18 +277,39 @@ describe('ProviderAnalyticsController', () => {
   });
 
   describe('getConnectionDetail', () => {
-    it('returns empty shape when connection_id is missing', async () => {
+    it('returns empty shape (incl. model_usage) when connection_id is missing', async () => {
       const out = await controller.getConnectionDetail(user, undefined);
-      expect(out).toEqual({ connection: null, agents: [], recent_messages: [] });
+      expect(out).toEqual({ connection: null, agents: [], model_usage: [], recent_messages: [] });
     });
 
-    it('returns empty shape when the connection is not found / not owned', async () => {
+    it('returns empty shape (incl. model_usage) when the connection is not found / not owned', async () => {
       providerRepo.findOne.mockResolvedValue(null);
       const out = await controller.getConnectionDetail(user, 'c1');
       expect(providerRepo.findOne).toHaveBeenCalledWith({
         where: { id: 'c1', user_id: 'u1' },
       });
-      expect(out).toEqual({ connection: null, agents: [], recent_messages: [] });
+      expect(out).toEqual({ connection: null, agents: [], model_usage: [], recent_messages: [] });
+    });
+
+    it('resolves the tenant via TenantCacheService, not a per-request tenant query', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'c1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'My OpenAI',
+        cached_models: null,
+        key_prefix: 'sk-abc',
+        connected_at: '2026-01-01',
+        is_active: true,
+      });
+      messageRepo.createQueryBuilder
+        .mockReturnValueOnce(makeQb({ rawOne: { last_used_at: null } }))
+        .mockReturnValueOnce(makeQb({ rawMany: [] }))
+        .mockReturnValueOnce(makeQb({ rawMany: [] }))
+        .mockReturnValueOnce(makeQb({ rawMany: [] }));
+
+      await controller.getConnectionDetail(user, 'c1');
+      expect(tenantCache.resolve).toHaveBeenCalledWith('u1');
     });
 
     it('returns connection-only shape when tenant is missing', async () => {
@@ -239,7 +322,7 @@ describe('ProviderAnalyticsController', () => {
         key_prefix: 'sk-abc',
         connected_at: '2026-01-01',
       });
-      tenantRepo.findOne.mockResolvedValue(null);
+      tenantCache.resolve.mockResolvedValue(null);
 
       const out = (await controller.getConnectionDetail(
         user,
@@ -262,7 +345,7 @@ describe('ProviderAnalyticsController', () => {
         connected_at: '2026-01-01',
         is_active: true,
       });
-      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+      tenantCache.resolve.mockResolvedValue('tenant-1');
 
       const lastUsedDate = new Date('2026-02-01T10:00:00Z');
       // Query order in controller: lastUsed, agentRows, modelRows, recentMessages
@@ -341,7 +424,7 @@ describe('ProviderAnalyticsController', () => {
         connected_at: '2026-01-01',
         is_active: false,
       });
-      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+      tenantCache.resolve.mockResolvedValue('tenant-1');
 
       messageRepo.createQueryBuilder
         // last_used_at as a raw string (not a Date)
@@ -380,7 +463,7 @@ describe('ProviderAnalyticsController', () => {
         connected_at: '2026-01-01',
         is_active: true,
       });
-      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+      tenantCache.resolve.mockResolvedValue('tenant-1');
 
       const qbs = [
         makeQb({ rawOne: { last_used_at: null } }),
@@ -418,7 +501,7 @@ describe('ProviderAnalyticsController', () => {
         connected_at: '2026-01-01',
         is_active: true,
       });
-      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+      tenantCache.resolve.mockResolvedValue('tenant-1');
 
       const firstQb = makeQb({ rawOne: { last_used_at: null } });
       messageRepo.createQueryBuilder
@@ -446,7 +529,7 @@ describe('ProviderAnalyticsController', () => {
         connected_at: '2026-01-01',
         is_active: true,
       });
-      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+      tenantCache.resolve.mockResolvedValue('tenant-1');
 
       messageRepo.createQueryBuilder
         .mockReturnValueOnce(makeQb({ rawOne: { last_used_at: null } }))

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
@@ -90,6 +90,8 @@ describe('ProviderAnalyticsController', () => {
   describe('getAnalytics', () => {
     it('returns summary + timeseries for default range (24h, hourly)', async () => {
       const out = await controller.getAnalytics(user, 'subscription');
+      // Final `true` arg = excludeSystem: Playground usage must not pollute
+      // provider analytics aggregates.
       expect(aggregation.getSummaryMetrics).toHaveBeenCalledWith(
         '24h',
         'u1',
@@ -97,6 +99,7 @@ describe('ProviderAnalyticsController', () => {
         undefined,
         'subscription',
         undefined,
+        true,
       );
       expect(timeseries.getTimeseries).toHaveBeenCalledWith(
         '24h',
@@ -106,6 +109,7 @@ describe('ProviderAnalyticsController', () => {
         undefined,
         'subscription',
         undefined,
+        true,
       );
       expect(out.summary.messages).toEqual({ value: 5 });
       expect(out.token_usage).toEqual([{ hour: '01' }]);
@@ -121,6 +125,7 @@ describe('ProviderAnalyticsController', () => {
         'agent-x',
         'api_key',
         'openai',
+        true,
       );
     });
 
@@ -133,6 +138,7 @@ describe('ProviderAnalyticsController', () => {
         undefined,
         undefined,
         undefined,
+        true,
       );
     });
 
@@ -147,6 +153,7 @@ describe('ProviderAnalyticsController', () => {
         undefined,
         'subscription',
         undefined,
+        true,
       );
     });
   });
@@ -357,6 +364,75 @@ describe('ProviderAnalyticsController', () => {
       expect(out.agents[0].pct_of_total).toBe(0);
       expect(out.agents[0].last_used).toBeNull();
       expect(out.model_usage[0].pct_of_total).toBe(0);
+    });
+
+    it('filters every usage query by the connection label (case-insensitive, NULL->Default)', async () => {
+      // Two keys share provider+auth_type but differ by label. The detail for
+      // the "Work" connection must filter every usage query by that label so a
+      // sibling "Personal" key's usage never bleeds in.
+      providerRepo.findOne.mockResolvedValue({
+        id: 'c1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'Work',
+        cached_models: [],
+        key_prefix: 'sk',
+        connected_at: '2026-01-01',
+        is_active: true,
+      });
+      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+
+      const qbs = [
+        makeQb({ rawOne: { last_used_at: null } }),
+        makeQb({ rawMany: [] }),
+        makeQb({ rawMany: [] }),
+        makeQb({ rawMany: [] }),
+      ];
+      messageRepo.createQueryBuilder
+        .mockReturnValueOnce(qbs[0])
+        .mockReturnValueOnce(qbs[1])
+        .mockReturnValueOnce(qbs[2])
+        .mockReturnValueOnce(qbs[3]);
+
+      await controller.getConnectionDetail(user, 'c1');
+
+      // Every one of the four usage builders must carry the label predicate
+      // with the connection's label bound case-insensitively.
+      for (const qb of qbs) {
+        const labelCall = qb.andWhere.mock.calls.find((c) =>
+          String(c[0]).includes("LOWER(COALESCE(at.provider_key_label, 'Default'))"),
+        );
+        expect(labelCall).toBeDefined();
+        expect(labelCall![1]).toEqual({ keyLabel: 'Work' });
+      }
+    });
+
+    it('treats a legacy NULL connection label as Default in the usage filter', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'c1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: null,
+        cached_models: [],
+        key_prefix: 'sk',
+        connected_at: '2026-01-01',
+        is_active: true,
+      });
+      tenantRepo.findOne.mockResolvedValue({ id: 'tenant-1' });
+
+      const firstQb = makeQb({ rawOne: { last_used_at: null } });
+      messageRepo.createQueryBuilder
+        .mockReturnValueOnce(firstQb)
+        .mockReturnValueOnce(makeQb({ rawMany: [] }))
+        .mockReturnValueOnce(makeQb({ rawMany: [] }))
+        .mockReturnValueOnce(makeQb({ rawMany: [] }));
+
+      await controller.getConnectionDetail(user, 'c1');
+
+      const labelCall = firstQb.andWhere.mock.calls.find((c) =>
+        String(c[0]).includes("LOWER(COALESCE(at.provider_key_label, 'Default'))"),
+      );
+      expect(labelCall![1]).toEqual({ keyLabel: 'Default' });
     });
 
     it('returns null last_used_at when no rows have ever been recorded', async () => {

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
@@ -8,7 +8,6 @@ import { TimeseriesQueriesService } from '../services/timeseries-queries.service
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { AgentMessage } from '../../entities/agent-message.entity';
-import { Tenant } from '../../entities/tenant.entity';
 import {
   selectMessageRowColumns,
   filterByKeyLabel,
@@ -27,8 +26,6 @@ export class ProviderAnalyticsController {
     private readonly providerRepo: Repository<UserProvider>,
     @InjectRepository(AgentMessage)
     private readonly messageRepo: Repository<AgentMessage>,
-    @InjectRepository(Tenant)
-    private readonly tenantRepo: Repository<Tenant>,
   ) {}
 
   @Get()
@@ -38,6 +35,7 @@ export class ProviderAnalyticsController {
     @Query('range') range?: string,
     @Query('agent_name') agentName?: string,
     @Query('provider') provider?: string,
+    @Query('label') label?: string,
   ) {
     const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
     const hourly = validRange === '24h';
@@ -55,6 +53,7 @@ export class ProviderAnalyticsController {
         authType,
         provider,
         true,
+        label,
       ),
       this.timeseries.getTimeseries(
         validRange,
@@ -65,6 +64,7 @@ export class ProviderAnalyticsController {
         authType,
         provider,
         true,
+        label,
       ),
     ]);
 
@@ -84,6 +84,7 @@ export class ProviderAnalyticsController {
     @Query('auth_type') authType?: string,
     @Query('provider') provider?: string,
     @Query('range') range?: string,
+    @Query('label') label?: string,
   ) {
     const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
     const hourly = validRange === '24h';
@@ -96,6 +97,7 @@ export class ProviderAnalyticsController {
       tenantId,
       authType,
       provider,
+      label,
     );
   }
 
@@ -105,6 +107,7 @@ export class ProviderAnalyticsController {
     @Query('auth_type') authType?: string,
     @Query('provider') provider?: string,
     @Query('range') range?: string,
+    @Query('label') label?: string,
   ) {
     const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
     const hourly = validRange === '24h';
@@ -117,6 +120,7 @@ export class ProviderAnalyticsController {
       tenantId,
       authType,
       provider,
+      label,
     );
   }
 
@@ -126,6 +130,7 @@ export class ProviderAnalyticsController {
     @Query('auth_type') authType?: string,
     @Query('provider') provider?: string,
     @Query('range') range?: string,
+    @Query('label') label?: string,
   ) {
     const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
     const hourly = validRange === '24h';
@@ -138,6 +143,7 @@ export class ProviderAnalyticsController {
       tenantId,
       authType,
       provider,
+      label,
     );
   }
 
@@ -157,16 +163,21 @@ export class ProviderAnalyticsController {
     @CurrentUser() user: AuthUser,
     @Query('connection_id') connectionId?: string,
   ) {
-    if (!connectionId) return { connection: null, agents: [], recent_messages: [] };
+    // Every branch returns the same shape (incl. `model_usage`) so the client
+    // never has to special-case a missing field.
+    if (!connectionId)
+      return { connection: null, agents: [], model_usage: [], recent_messages: [] };
 
     // Look up the connection (security: must belong to the user)
     const conn = await this.providerRepo.findOne({
       where: { id: connectionId, user_id: user.id },
     });
-    if (!conn) return { connection: null, agents: [], recent_messages: [] };
+    if (!conn) return { connection: null, agents: [], model_usage: [], recent_messages: [] };
 
-    const tenant = await this.tenantRepo.findOne({ where: { name: user.id } });
-    if (!tenant) {
+    // Resolve the tenant via the shared cache like every other endpoint here,
+    // instead of re-querying the tenants table by name on every request.
+    const tenantId = await this.tenantCache.resolve(user.id);
+    if (!tenantId) {
       return {
         connection: {
           id: conn.id,
@@ -197,7 +208,7 @@ export class ProviderAnalyticsController {
       this.messageRepo
         .createQueryBuilder('at')
         .select('MAX(at.timestamp)', 'last_used_at')
-        .where('at.tenant_id = :tid', { tid: tenant.id })
+        .where('at.tenant_id = :tid', { tid: tenantId })
         .andWhere('at.provider = :provider', { provider: conn.provider })
         .andWhere('at.auth_type = :authType', { authType: conn.auth_type }),
       connLabel,
@@ -225,7 +236,7 @@ export class ProviderAnalyticsController {
       // NOT EXISTS semi-join in excludeSystemAgents (catches id- AND name-only
       // Playground rows without re-introducing duplication).
       .leftJoin('agents', 'a', 'a.id = at.agent_id')
-      .where('at.tenant_id = :tid', { tid: tenant.id })
+      .where('at.tenant_id = :tid', { tid: tenantId })
       .andWhere('at.provider = :provider', { provider: conn.provider })
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
       .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff30d })
@@ -242,7 +253,7 @@ export class ProviderAnalyticsController {
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .addSelect('COUNT(*)', 'messages')
-      .where('at.tenant_id = :tid', { tid: tenant.id })
+      .where('at.tenant_id = :tid', { tid: tenantId })
       .andWhere('at.provider = :provider', { provider: conn.provider })
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
       .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff30d })
@@ -260,7 +271,7 @@ export class ProviderAnalyticsController {
 
     // Recent messages (top 5)
     const msgQb = selectMessageRowColumns(this.messageRepo.createQueryBuilder('at'), costExpr)
-      .where('at.tenant_id = :tid', { tid: tenant.id })
+      .where('at.tenant_id = :tid', { tid: tenantId })
       .andWhere('at.provider = :provider', { provider: conn.provider })
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type });
     // Keep reserved Playground runs out of the recent-messages list too.

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
@@ -9,7 +9,7 @@ import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { Tenant } from '../../entities/tenant.entity';
-import { selectMessageRowColumns } from '../services/query-helpers';
+import { selectMessageRowColumns, filterByKeyLabel } from '../services/query-helpers';
 import { computeCutoff } from '../../common/utils/postgres-sql';
 import { sqlCastFloat, sqlSanitizeCost } from '../../common/utils/postgres-sql';
 
@@ -41,7 +41,17 @@ export class ProviderAnalyticsController {
     const agent = agentName || undefined;
 
     const [summary, ts] = await Promise.all([
-      this.aggregation.getSummaryMetrics(validRange, user.id, tenantId, agent, authType, provider),
+      // excludeSystem=true: Playground (is_system) usage must not pollute
+      // provider analytics aggregates.
+      this.aggregation.getSummaryMetrics(
+        validRange,
+        user.id,
+        tenantId,
+        agent,
+        authType,
+        provider,
+        true,
+      ),
       this.timeseries.getTimeseries(
         validRange,
         user.id,
@@ -50,6 +60,7 @@ export class ProviderAnalyticsController {
         agent,
         authType,
         provider,
+        true,
       ),
     ]);
 
@@ -171,14 +182,22 @@ export class ProviderAnalyticsController {
     const cutoff30d = computeCutoff('30 days');
     const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
 
+    // A connection is identified by (tenant, provider, auth_type, label). The
+    // label filter is mandatory: two keys sharing provider+auth_type but
+    // differing by label must not merge into one connection's detail. Legacy
+    // NULL provider_key_label collapses to 'Default'.
+    const connLabel = conn.label;
+
     // Global last_used_at for this connection (all time, not just 30d)
-    const lastUsedRow = await this.messageRepo
-      .createQueryBuilder('at')
-      .select('MAX(at.timestamp)', 'last_used_at')
-      .where('at.tenant_id = :tid', { tid: tenant.id })
-      .andWhere('at.provider = :provider', { provider: conn.provider })
-      .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
-      .getRawOne();
+    const lastUsedRow = await filterByKeyLabel(
+      this.messageRepo
+        .createQueryBuilder('at')
+        .select('MAX(at.timestamp)', 'last_used_at')
+        .where('at.tenant_id = :tid', { tid: tenant.id })
+        .andWhere('at.provider = :provider', { provider: conn.provider })
+        .andWhere('at.auth_type = :authType', { authType: conn.auth_type }),
+      connLabel,
+    ).getRawOne();
     const lastUsedAt =
       lastUsedRow?.last_used_at instanceof Date
         ? lastUsedRow.last_used_at.toISOString()
@@ -187,7 +206,7 @@ export class ProviderAnalyticsController {
           : null;
 
     // Agents using this provider (with platform from agents table)
-    const agentRows = await this.messageRepo
+    const agentQb = this.messageRepo
       .createQueryBuilder('at')
       .select('at.agent_name', 'agent_name')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
@@ -202,13 +221,12 @@ export class ProviderAnalyticsController {
       .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff30d })
       .andWhere('at.agent_name IS NOT NULL')
       // Exclude the reserved Playground (is_system) agent from the breakdown.
-      .andWhere('(a.is_system IS NULL OR a.is_system = false)')
-      .groupBy('at.agent_name')
-      .orderBy('tokens', 'DESC')
-      .getRawMany();
+      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+    filterByKeyLabel(agentQb, connLabel);
+    const agentRows = await agentQb.groupBy('at.agent_name').orderBy('tokens', 'DESC').getRawMany();
 
     // Model usage (30d)
-    const modelRows = await this.messageRepo
+    const modelQb = this.messageRepo
       .createQueryBuilder('at')
       .select('at.model', 'model')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
@@ -218,10 +236,9 @@ export class ProviderAnalyticsController {
       .andWhere('at.provider = :provider', { provider: conn.provider })
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
       .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff30d })
-      .andWhere('at.model IS NOT NULL')
-      .groupBy('at.model')
-      .orderBy('tokens', 'DESC')
-      .getRawMany();
+      .andWhere('at.model IS NOT NULL');
+    filterByKeyLabel(modelQb, connLabel);
+    const modelRows = await modelQb.groupBy('at.model').orderBy('tokens', 'DESC').getRawMany();
 
     const totalModelTokens = modelRows.reduce(
       (sum: number, r: Record<string, unknown>) => sum + Number(r['tokens'] ?? 0),
@@ -232,10 +249,9 @@ export class ProviderAnalyticsController {
     const msgQb = selectMessageRowColumns(this.messageRepo.createQueryBuilder('at'), costExpr)
       .where('at.tenant_id = :tid', { tid: tenant.id })
       .andWhere('at.provider = :provider', { provider: conn.provider })
-      .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
-      .orderBy('at.timestamp', 'DESC')
-      .limit(5);
-    const recentMessages = await msgQb.getRawMany();
+      .andWhere('at.auth_type = :authType', { authType: conn.auth_type });
+    filterByKeyLabel(msgQb, connLabel);
+    const recentMessages = await msgQb.orderBy('at.timestamp', 'DESC').limit(5).getRawMany();
 
     return {
       connection: {

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
@@ -9,7 +9,11 @@ import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { Tenant } from '../../entities/tenant.entity';
-import { selectMessageRowColumns, filterByKeyLabel } from '../services/query-helpers';
+import {
+  selectMessageRowColumns,
+  filterByKeyLabel,
+  excludeSystemAgents,
+} from '../services/query-helpers';
 import { computeCutoff } from '../../common/utils/postgres-sql';
 import { sqlCastFloat, sqlSanitizeCost } from '../../common/utils/postgres-sql';
 
@@ -216,15 +220,18 @@ export class ProviderAnalyticsController {
       .addSelect('MAX(a.agent_platform)', 'agent_platform')
       // Join on agent identity, not name: a soft-deleted agent sharing a slug
       // with a live one would otherwise match twice and double this breakdown's
-      // per-agent tokens/cost/message counts.
+      // per-agent tokens/cost/message counts. This one-to-(0/1) join is only for
+      // the `agent_platform` column; system-agent exclusion is handled by the
+      // NOT EXISTS semi-join in excludeSystemAgents (catches id- AND name-only
+      // Playground rows without re-introducing duplication).
       .leftJoin('agents', 'a', 'a.id = at.agent_id')
       .where('at.tenant_id = :tid', { tid: tenant.id })
       .andWhere('at.provider = :provider', { provider: conn.provider })
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
       .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff30d })
-      .andWhere('at.agent_name IS NOT NULL')
-      // Exclude the reserved Playground (is_system) agent from the breakdown.
-      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+      .andWhere('at.agent_name IS NOT NULL');
+    // Exclude the reserved Playground (is_system) agent from the breakdown.
+    excludeSystemAgents(agentQb);
     filterByKeyLabel(agentQb, connLabel);
     const agentRows = await agentQb.groupBy('at.agent_name').orderBy('tokens', 'DESC').getRawMany();
 
@@ -240,6 +247,9 @@ export class ProviderAnalyticsController {
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
       .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff30d })
       .andWhere('at.model IS NOT NULL');
+    // Same Playground exclusion as the agent breakdown, so the per-model token
+    // sum stays equal to the per-agent sum (both cover the same messages).
+    excludeSystemAgents(modelQb);
     filterByKeyLabel(modelQb, connLabel);
     const modelRows = await modelQb.groupBy('at.model').orderBy('tokens', 'DESC').getRawMany();
 
@@ -253,6 +263,8 @@ export class ProviderAnalyticsController {
       .where('at.tenant_id = :tid', { tid: tenant.id })
       .andWhere('at.provider = :provider', { provider: conn.provider })
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type });
+    // Keep reserved Playground runs out of the recent-messages list too.
+    excludeSystemAgents(msgQb);
     filterByKeyLabel(msgQb, connLabel);
     const recentMessages = await msgQb.orderBy('at.timestamp', 'DESC').limit(5).getRawMany();
 

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
@@ -214,7 +214,10 @@ export class ProviderAnalyticsController {
       .addSelect('COUNT(*)', 'messages')
       .addSelect('MAX(at.timestamp)', 'last_used')
       .addSelect('MAX(a.agent_platform)', 'agent_platform')
-      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
+      // Join on agent identity, not name: a soft-deleted agent sharing a slug
+      // with a live one would otherwise match twice and double this breakdown's
+      // per-agent tokens/cost/message counts.
+      .leftJoin('agents', 'a', 'a.id = at.agent_id')
       .where('at.tenant_id = :tid', { tid: tenant.id })
       .andWhere('at.provider = :provider', { provider: conn.provider })
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type })

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
@@ -1,0 +1,287 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CurrentUser } from '../../auth/current-user.decorator';
+import type { AuthUser } from '../../auth/auth.instance';
+import { AggregationService } from '../services/aggregation.service';
+import { TimeseriesQueriesService } from '../services/timeseries-queries.service';
+import { TenantCacheService } from '../../common/services/tenant-cache.service';
+import { UserProvider } from '../../entities/user-provider.entity';
+import { AgentMessage } from '../../entities/agent-message.entity';
+import { Tenant } from '../../entities/tenant.entity';
+import { selectMessageRowColumns } from '../services/query-helpers';
+import { computeCutoff } from '../../common/utils/postgres-sql';
+import { sqlCastFloat, sqlSanitizeCost } from '../../common/utils/postgres-sql';
+
+@Controller('api/v1/provider-analytics')
+export class ProviderAnalyticsController {
+  constructor(
+    private readonly aggregation: AggregationService,
+    private readonly timeseries: TimeseriesQueriesService,
+    private readonly tenantCache: TenantCacheService,
+    @InjectRepository(UserProvider)
+    private readonly providerRepo: Repository<UserProvider>,
+    @InjectRepository(AgentMessage)
+    private readonly messageRepo: Repository<AgentMessage>,
+    @InjectRepository(Tenant)
+    private readonly tenantRepo: Repository<Tenant>,
+  ) {}
+
+  @Get()
+  async getAnalytics(
+    @CurrentUser() user: AuthUser,
+    @Query('auth_type') authType?: string,
+    @Query('range') range?: string,
+    @Query('agent_name') agentName?: string,
+    @Query('provider') provider?: string,
+  ) {
+    const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
+    const hourly = validRange === '24h';
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const agent = agentName || undefined;
+
+    const [summary, ts] = await Promise.all([
+      this.aggregation.getSummaryMetrics(validRange, user.id, tenantId, agent, authType, provider),
+      this.timeseries.getTimeseries(
+        validRange,
+        user.id,
+        hourly,
+        tenantId,
+        agent,
+        authType,
+        provider,
+      ),
+    ]);
+
+    return {
+      summary: {
+        messages: summary.messages,
+        tokens: summary.tokens.tokens_today,
+      },
+      token_usage: ts.tokenUsage,
+      message_usage: ts.messageUsage,
+    };
+  }
+
+  @Get('per-agent-timeseries')
+  async getPerAgentTimeseries(
+    @CurrentUser() user: AuthUser,
+    @Query('auth_type') authType?: string,
+    @Query('provider') provider?: string,
+    @Query('range') range?: string,
+  ) {
+    const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
+    const hourly = validRange === '24h';
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+
+    return this.timeseries.getPerAgentTimeseries(
+      validRange,
+      user.id,
+      hourly,
+      tenantId,
+      authType,
+      provider,
+    );
+  }
+
+  @Get('per-agent-message-timeseries')
+  async getPerAgentMessageTimeseries(
+    @CurrentUser() user: AuthUser,
+    @Query('auth_type') authType?: string,
+    @Query('provider') provider?: string,
+    @Query('range') range?: string,
+  ) {
+    const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
+    const hourly = validRange === '24h';
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+
+    return this.timeseries.getPerAgentMessageTimeseries(
+      validRange,
+      user.id,
+      hourly,
+      tenantId,
+      authType,
+      provider,
+    );
+  }
+
+  @Get('per-agent-cost-timeseries')
+  async getPerAgentCostTimeseries(
+    @CurrentUser() user: AuthUser,
+    @Query('auth_type') authType?: string,
+    @Query('provider') provider?: string,
+    @Query('range') range?: string,
+  ) {
+    const validRange = range === '30d' ? '30d' : range === '7d' ? '7d' : '24h';
+    const hourly = validRange === '24h';
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+
+    return this.timeseries.getPerAgentCostTimeseries(
+      validRange,
+      user.id,
+      hourly,
+      tenantId,
+      authType,
+      provider,
+    );
+  }
+
+  @Get('agents')
+  async getAgents(@CurrentUser() user: AuthUser, @Query('auth_type') authType?: string) {
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const agents = await this.timeseries.getAgentNamesByAuthType(
+      authType ?? 'subscription',
+      user.id,
+      tenantId,
+    );
+    return { agents };
+  }
+
+  @Get('connection-detail')
+  async getConnectionDetail(
+    @CurrentUser() user: AuthUser,
+    @Query('connection_id') connectionId?: string,
+  ) {
+    if (!connectionId) return { connection: null, agents: [], recent_messages: [] };
+
+    // Look up the connection (security: must belong to the user)
+    const conn = await this.providerRepo.findOne({
+      where: { id: connectionId, user_id: user.id },
+    });
+    if (!conn) return { connection: null, agents: [], recent_messages: [] };
+
+    const tenant = await this.tenantRepo.findOne({ where: { name: user.id } });
+    if (!tenant) {
+      return {
+        connection: {
+          id: conn.id,
+          provider: conn.provider,
+          auth_type: conn.auth_type,
+          label: conn.label,
+          cached_model_count: Array.isArray(conn.cached_models) ? conn.cached_models.length : 0,
+          key_prefix: conn.key_prefix,
+          connected_at: conn.connected_at,
+        },
+        agents: [],
+        model_usage: [],
+        recent_messages: [],
+      };
+    }
+
+    const cutoff30d = computeCutoff('30 days');
+    const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
+
+    // Global last_used_at for this connection (all time, not just 30d)
+    const lastUsedRow = await this.messageRepo
+      .createQueryBuilder('at')
+      .select('MAX(at.timestamp)', 'last_used_at')
+      .where('at.tenant_id = :tid', { tid: tenant.id })
+      .andWhere('at.provider = :provider', { provider: conn.provider })
+      .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
+      .getRawOne();
+    const lastUsedAt =
+      lastUsedRow?.last_used_at instanceof Date
+        ? lastUsedRow.last_used_at.toISOString()
+        : lastUsedRow?.last_used_at
+          ? String(lastUsedRow.last_used_at)
+          : null;
+
+    // Agents using this provider (with platform from agents table)
+    const agentRows = await this.messageRepo
+      .createQueryBuilder('at')
+      .select('at.agent_name', 'agent_name')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
+      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
+      .addSelect('COUNT(*)', 'messages')
+      .addSelect('MAX(at.timestamp)', 'last_used')
+      .addSelect('MAX(a.agent_platform)', 'agent_platform')
+      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
+      .where('at.tenant_id = :tid', { tid: tenant.id })
+      .andWhere('at.provider = :provider', { provider: conn.provider })
+      .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
+      .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff30d })
+      .andWhere('at.agent_name IS NOT NULL')
+      // Exclude the reserved Playground (is_system) agent from the breakdown.
+      .andWhere('(a.is_system IS NULL OR a.is_system = false)')
+      .groupBy('at.agent_name')
+      .orderBy('tokens', 'DESC')
+      .getRawMany();
+
+    // Model usage (30d)
+    const modelRows = await this.messageRepo
+      .createQueryBuilder('at')
+      .select('at.model', 'model')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
+      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
+      .addSelect('COUNT(*)', 'messages')
+      .where('at.tenant_id = :tid', { tid: tenant.id })
+      .andWhere('at.provider = :provider', { provider: conn.provider })
+      .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
+      .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff30d })
+      .andWhere('at.model IS NOT NULL')
+      .groupBy('at.model')
+      .orderBy('tokens', 'DESC')
+      .getRawMany();
+
+    const totalModelTokens = modelRows.reduce(
+      (sum: number, r: Record<string, unknown>) => sum + Number(r['tokens'] ?? 0),
+      0,
+    );
+
+    // Recent messages (top 5)
+    const msgQb = selectMessageRowColumns(this.messageRepo.createQueryBuilder('at'), costExpr)
+      .where('at.tenant_id = :tid', { tid: tenant.id })
+      .andWhere('at.provider = :provider', { provider: conn.provider })
+      .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
+      .orderBy('at.timestamp', 'DESC')
+      .limit(5);
+    const recentMessages = await msgQb.getRawMany();
+
+    return {
+      connection: {
+        id: conn.id,
+        provider: conn.provider,
+        auth_type: conn.auth_type,
+        label: conn.label,
+        cached_model_count: Array.isArray(conn.cached_models) ? conn.cached_models.length : 0,
+        key_prefix: conn.key_prefix,
+        connected_at: conn.connected_at,
+        is_active: conn.is_active,
+        last_used_at: lastUsedAt,
+      },
+      agents: (() => {
+        const totalAgentTokens = agentRows.reduce(
+          (sum: number, r: Record<string, unknown>) => sum + Number(r['tokens'] ?? 0),
+          0,
+        );
+        return agentRows.map((r: Record<string, unknown>) => {
+          const tokens = Number(r['tokens'] ?? 0);
+          return {
+            agent_name: String(r['agent_name']),
+            agent_platform: r['agent_platform'] ? String(r['agent_platform']) : null,
+            tokens_30d: tokens,
+            cost_30d: Number(r['cost'] ?? 0),
+            messages_30d: Number(r['messages'] ?? 0),
+            pct_of_total: totalAgentTokens > 0 ? Math.round((tokens / totalAgentTokens) * 100) : 0,
+            last_used: r['last_used']
+              ? r['last_used'] instanceof Date
+                ? (r['last_used'] as Date).toISOString()
+                : String(r['last_used'])
+              : null,
+          };
+        });
+      })(),
+      model_usage: modelRows.map((r: Record<string, unknown>) => {
+        const tokens = Number(r['tokens'] ?? 0);
+        return {
+          model: String(r['model']),
+          tokens,
+          cost: Number(r['cost'] ?? 0),
+          messages: Number(r['messages'] ?? 0),
+          pct_of_total: totalModelTokens > 0 ? Math.round((tokens / totalModelTokens) * 100) : 0,
+        };
+      }),
+      recent_messages: recentMessages,
+    };
+  }
+}

--- a/packages/backend/src/analytics/controllers/rate-limits.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/rate-limits.controller.spec.ts
@@ -1,0 +1,73 @@
+import { RateLimitsController } from './rate-limits.controller';
+import type { RateLimitTrackerService } from '../../routing/proxy/rate-limit-tracker.service';
+import type { AuthUser } from '../../auth/auth.instance';
+
+describe('RateLimitsController', () => {
+  let tracker: { getRateLimits: jest.Mock };
+  let controller: RateLimitsController;
+  const user = { id: 'u1' } as AuthUser;
+
+  beforeEach(() => {
+    tracker = { getRateLimits: jest.fn() };
+    controller = new RateLimitsController(tracker as unknown as RateLimitTrackerService);
+  });
+
+  it('maps snapshots and computes utilization_pct', async () => {
+    tracker.getRateLimits.mockResolvedValue([
+      {
+        provider: 'openai',
+        authType: 'api_key',
+        keyLabel: 'k1',
+        limits: [
+          {
+            limitType: 'requests',
+            period: 'minute',
+            limitValue: 100,
+            usedValue: 33,
+            remainingValue: 67,
+            resetsAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      },
+    ]);
+
+    const out = await controller.getRateLimits(user);
+    expect(tracker.getRateLimits).toHaveBeenCalledWith('u1');
+    expect(out.providers[0].provider).toBe('openai');
+    expect(out.providers[0].key_label).toBe('k1');
+    expect(out.providers[0].limits[0].utilization_pct).toBe(33);
+  });
+
+  it('returns null utilization_pct when limit is zero/unknown and null key_label', async () => {
+    tracker.getRateLimits.mockResolvedValue([
+      {
+        provider: 'anthropic',
+        authType: 'subscription',
+        keyLabel: undefined,
+        limits: [
+          {
+            limitType: 'tokens',
+            period: 'minute',
+            limitValue: 0,
+            usedValue: 10,
+            remainingValue: null,
+            resetsAt: null,
+          },
+          {
+            limitType: 'requests',
+            period: 'minute',
+            limitValue: null,
+            usedValue: null,
+            remainingValue: null,
+            resetsAt: null,
+          },
+        ],
+      },
+    ]);
+
+    const out = await controller.getRateLimits(user);
+    expect(out.providers[0].key_label).toBeNull();
+    expect(out.providers[0].limits[0].utilization_pct).toBeNull();
+    expect(out.providers[0].limits[1].utilization_pct).toBeNull();
+  });
+});

--- a/packages/backend/src/analytics/controllers/rate-limits.controller.ts
+++ b/packages/backend/src/analytics/controllers/rate-limits.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get } from '@nestjs/common';
+import { CurrentUser } from '../../auth/current-user.decorator';
+import type { AuthUser } from '../../auth/auth.instance';
+import { RateLimitTrackerService } from '../../routing/proxy/rate-limit-tracker.service';
+
+@Controller('api/v1/rate-limits')
+export class RateLimitsController {
+  constructor(private readonly rateLimitTracker: RateLimitTrackerService) {}
+
+  @Get()
+  async getRateLimits(@CurrentUser() user: AuthUser) {
+    const snapshots = await this.rateLimitTracker.getRateLimits(user.id);
+    return {
+      providers: snapshots.map((s) => ({
+        provider: s.provider,
+        auth_type: s.authType,
+        key_label: s.keyLabel ?? null,
+        limits: s.limits.map((l) => ({
+          limit_type: l.limitType,
+          period: l.period,
+          limit_value: l.limitValue,
+          used_value: l.usedValue,
+          remaining_value: l.remainingValue,
+          resets_at: l.resetsAt,
+          utilization_pct:
+            l.limitValue != null && l.limitValue > 0 && l.usedValue != null
+              ? Math.round(((l.usedValue / l.limitValue) * 100 + Number.EPSILON) * 10) / 10
+              : null,
+        })),
+      })),
+    };
+  }
+}

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -30,6 +30,10 @@ describe('AggregationService', () => {
       getMany: jest.fn().mockResolvedValue([]),
       getOne: jest.fn().mockResolvedValue(null),
     };
+    // excludeSystemAgents() inspects existing joins via expressionMap.
+    (mockQb as unknown as { expressionMap: { joinAttributes: unknown[] } }).expressionMap = {
+      joinAttributes: [],
+    };
 
     const chainableMethods = [
       'select',
@@ -203,6 +207,43 @@ describe('AggregationService', () => {
       const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
       expect(clauses).toContain('at.auth_type = :authType');
       expect(clauses).toContain('at.provider = :provider');
+    });
+
+    it('excludes the system Playground agent from both windows when excludeSystem=true', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({ msg_count: 5, inp: 50, out: 25, cost: 0.5 })
+        .mockResolvedValueOnce({ msg_count: 4, tokens: 60, cost: 0.4 });
+
+      await service.getSummaryMetrics(
+        '24h',
+        'u1',
+        'tenant-123',
+        undefined,
+        undefined,
+        undefined,
+        true,
+      );
+
+      const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+      // Both the current and previous window builders add the guard, so it must
+      // appear (the join is also issued).
+      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
+      expect(mockQb.leftJoin).toHaveBeenCalledWith(
+        'agents',
+        'a',
+        'a.name = at.agent_name AND a.tenant_id = at.tenant_id',
+      );
+    });
+
+    it('does not exclude system agents by default (excludeSystem omitted)', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({ msg_count: 5, inp: 50, out: 25, cost: 0.5 })
+        .mockResolvedValueOnce({ msg_count: 4, tokens: 60, cost: 0.4 });
+
+      await service.getSummaryMetrics('24h', 'u1', 'tenant-123');
+
+      const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+      expect(clauses).not.toContain('(a.is_system IS NULL OR a.is_system = false)');
     });
   });
 });

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -259,7 +259,8 @@ describe('AggregationService', () => {
       const labelCalls = mockQb.andWhere.mock.calls.filter((c: unknown[]) => c[0] === labelClause);
       // Current + previous window builders each add the label predicate.
       expect(labelCalls).toHaveLength(2);
-      for (const call of labelCalls) expect(call[1]).toEqual({ keyLabel: 'Work' });
+      for (const call of labelCalls)
+        expect(call[1]).toEqual(expect.objectContaining({ keyLabel: 'Work' }));
     });
 
     it('does not add the label filter when no label is given', async () => {

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -228,11 +228,7 @@ describe('AggregationService', () => {
       // Both the current and previous window builders add the guard, so it must
       // appear (the join is also issued).
       expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
-      expect(mockQb.leftJoin).toHaveBeenCalledWith(
-        'agents',
-        'a',
-        'a.name = at.agent_name AND a.tenant_id = at.tenant_id',
-      );
+      expect(mockQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
     });
 
     it('does not exclude system agents by default (excludeSystem omitted)', async () => {

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -4,6 +4,7 @@ import { Brackets } from 'typeorm';
 import { AggregationService } from './aggregation.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
+import { EXCLUDE_SYSTEM_AGENTS_PREDICATE } from './query-helpers';
 
 describe('AggregationService', () => {
   let service: AggregationService;
@@ -30,11 +31,6 @@ describe('AggregationService', () => {
       getMany: jest.fn().mockResolvedValue([]),
       getOne: jest.fn().mockResolvedValue(null),
     };
-    // excludeSystemAgents() inspects existing joins via expressionMap.
-    (mockQb as unknown as { expressionMap: { joinAttributes: unknown[] } }).expressionMap = {
-      joinAttributes: [],
-    };
-
     const chainableMethods = [
       'select',
       'addSelect',
@@ -225,10 +221,10 @@ describe('AggregationService', () => {
       );
 
       const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
-      // Both the current and previous window builders add the guard, so it must
-      // appear (the join is also issued).
-      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
-      expect(mockQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
+      // Both the current and previous window builders add the semi-join guard.
+      // It adds no join of its own (pure NOT EXISTS existence test).
+      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(mockQb.leftJoin).not.toHaveBeenCalled();
     });
 
     it('does not exclude system agents by default (excludeSystem omitted)', async () => {
@@ -239,7 +235,7 @@ describe('AggregationService', () => {
       await service.getSummaryMetrics('24h', 'u1', 'tenant-123');
 
       const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
-      expect(clauses).not.toContain('(a.is_system IS NULL OR a.is_system = false)');
+      expect(clauses).not.toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
     });
   });
 });

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -8,11 +8,12 @@ import { TenantCacheService } from '../../common/services/tenant-cache.service';
 describe('AggregationService', () => {
   let service: AggregationService;
   let mockGetRawOne: jest.Mock;
+  let mockQb: Record<string, jest.Mock>;
 
   beforeEach(async () => {
     mockGetRawOne = jest.fn().mockResolvedValue({ total: 0 });
 
-    const mockQb: Record<string, jest.Mock> = {
+    mockQb = {
       select: jest.fn(),
       addSelect: jest.fn(),
       where: jest.fn(),
@@ -183,6 +184,25 @@ describe('AggregationService', () => {
       expect(result.tokens.tokens_today.trend_pct).toBe(0);
       expect(result.cost.trend_pct).toBe(0);
       expect(result.messages.trend_pct).toBe(0);
+    });
+
+    it('applies auth_type and provider filters to current + previous windows', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({ msg_count: 5, inp: 50, out: 25, cost: 0.5 })
+        .mockResolvedValueOnce({ msg_count: 4, tokens: 60, cost: 0.4 });
+
+      await service.getSummaryMetrics(
+        '24h',
+        'u1',
+        'tenant-123',
+        undefined,
+        'subscription',
+        'openai',
+      );
+
+      const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+      expect(clauses).toContain('at.auth_type = :authType');
+      expect(clauses).toContain('at.provider = :provider');
     });
   });
 });

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -237,5 +237,40 @@ describe('AggregationService', () => {
       const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
       expect(clauses).not.toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
     });
+
+    const labelClause = "LOWER(COALESCE(at.provider_key_label, 'Default')) = LOWER(:keyLabel)";
+
+    it('scopes both windows to a connection label when provided', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({ msg_count: 5, inp: 50, out: 25, cost: 0.5 })
+        .mockResolvedValueOnce({ msg_count: 4, tokens: 60, cost: 0.4 });
+
+      await service.getSummaryMetrics(
+        '24h',
+        'u1',
+        'tenant-123',
+        undefined,
+        'api_key',
+        'openai',
+        true,
+        'Work',
+      );
+
+      const labelCalls = mockQb.andWhere.mock.calls.filter((c: unknown[]) => c[0] === labelClause);
+      // Current + previous window builders each add the label predicate.
+      expect(labelCalls).toHaveLength(2);
+      for (const call of labelCalls) expect(call[1]).toEqual({ keyLabel: 'Work' });
+    });
+
+    it('does not add the label filter when no label is given', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({ msg_count: 5, inp: 50, out: 25, cost: 0.5 })
+        .mockResolvedValueOnce({ msg_count: 4, tokens: 60, cost: 0.4 });
+
+      await service.getSummaryMetrics('24h', 'u1', 'tenant-123');
+
+      const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+      expect(clauses).not.toContain(labelClause);
+    });
   });
 });

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -8,6 +8,7 @@ import {
   computeTrend,
   addTenantFilter,
   excludeSystemAgents,
+  filterByKeyLabel,
 } from './query-helpers';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { computeCutoff, sqlSanitizeCost } from '../../common/utils/postgres-sql';
@@ -62,6 +63,7 @@ export class AggregationService {
     authType?: string,
     provider?: string,
     excludeSystem = false,
+    label?: string,
   ) {
     const { cutoff, prevCutoff } = this.computeWindow(range);
     const safeCost = sqlSanitizeCost('at.cost_usd');
@@ -77,6 +79,10 @@ export class AggregationService {
     if (authType) currentQb.andWhere('at.auth_type = :authType', { authType });
     if (provider) currentQb.andWhere('at.provider = :provider', { provider });
     if (excludeSystem) excludeSystemAgents(currentQb);
+    // Connection-scoped label filter: keep two keys that share
+    // provider+auth_type but differ by label from merging into one connection's
+    // summary. Legacy NULL provider_key_label → 'Default'.
+    if (label !== undefined) filterByKeyLabel(currentQb, label);
 
     const prevQb = this.buildPreviousWindowQuery(
       userId,
@@ -87,6 +93,7 @@ export class AggregationService {
       authType,
       provider,
       excludeSystem,
+      label,
     )
       .select('COUNT(*)', 'msg_count')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
@@ -134,6 +141,7 @@ export class AggregationService {
     authType?: string,
     provider?: string,
     excludeSystem = false,
+    label?: string,
   ): SelectQueryBuilder<AgentMessage> {
     const qb = this.turnRepo
       .createQueryBuilder('at')
@@ -143,6 +151,8 @@ export class AggregationService {
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
     if (excludeSystem) excludeSystemAgents(qb);
+    // Connection-scoped label filter (see getSummaryMetrics).
+    if (label !== undefined) filterByKeyLabel(qb, label);
     return qb;
   }
 }

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -49,7 +49,14 @@ export class AggregationService {
     return Number(row?.total ?? 0);
   }
 
-  async getSummaryMetrics(range: string, userId: string, tenantId?: string, agentName?: string) {
+  async getSummaryMetrics(
+    range: string,
+    userId: string,
+    tenantId?: string,
+    agentName?: string,
+    authType?: string,
+    provider?: string,
+  ) {
     const { cutoff, prevCutoff } = this.computeWindow(range);
     const safeCost = sqlSanitizeCost('at.cost_usd');
 
@@ -61,8 +68,18 @@ export class AggregationService {
       .addSelect(`COALESCE(SUM(${safeCost}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff });
     addTenantFilter(currentQb, userId, agentName, tenantId);
+    if (authType) currentQb.andWhere('at.auth_type = :authType', { authType });
+    if (provider) currentQb.andWhere('at.provider = :provider', { provider });
 
-    const prevQb = this.buildPreviousWindowQuery(userId, agentName, tenantId, cutoff, prevCutoff)
+    const prevQb = this.buildPreviousWindowQuery(
+      userId,
+      agentName,
+      tenantId,
+      cutoff,
+      prevCutoff,
+      authType,
+      provider,
+    )
       .select('COUNT(*)', 'msg_count')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .addSelect(`COALESCE(SUM(${safeCost}), 0)`, 'cost');
@@ -106,12 +123,16 @@ export class AggregationService {
     tenantId: string | undefined,
     cutoff: string,
     prevCutoff: string,
+    authType?: string,
+    provider?: string,
   ): SelectQueryBuilder<AgentMessage> {
     const qb = this.turnRepo
       .createQueryBuilder('at')
       .where('at.timestamp >= :prevCutoff', { prevCutoff })
       .andWhere('at.timestamp < :cutoff', { cutoff });
     addTenantFilter(qb, userId, agentName, tenantId);
+    if (authType) qb.andWhere('at.auth_type = :authType', { authType });
+    if (provider) qb.andWhere('at.provider = :provider', { provider });
     return qb;
   }
 }

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -3,7 +3,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { rangeToInterval, rangeToPreviousInterval } from '../../common/utils/range.util';
-import { MetricWithTrend, computeTrend, addTenantFilter } from './query-helpers';
+import {
+  MetricWithTrend,
+  computeTrend,
+  addTenantFilter,
+  excludeSystemAgents,
+} from './query-helpers';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { computeCutoff, sqlSanitizeCost } from '../../common/utils/postgres-sql';
 
@@ -56,6 +61,7 @@ export class AggregationService {
     agentName?: string,
     authType?: string,
     provider?: string,
+    excludeSystem = false,
   ) {
     const { cutoff, prevCutoff } = this.computeWindow(range);
     const safeCost = sqlSanitizeCost('at.cost_usd');
@@ -70,6 +76,7 @@ export class AggregationService {
     addTenantFilter(currentQb, userId, agentName, tenantId);
     if (authType) currentQb.andWhere('at.auth_type = :authType', { authType });
     if (provider) currentQb.andWhere('at.provider = :provider', { provider });
+    if (excludeSystem) excludeSystemAgents(currentQb);
 
     const prevQb = this.buildPreviousWindowQuery(
       userId,
@@ -79,6 +86,7 @@ export class AggregationService {
       prevCutoff,
       authType,
       provider,
+      excludeSystem,
     )
       .select('COUNT(*)', 'msg_count')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
@@ -125,6 +133,7 @@ export class AggregationService {
     prevCutoff: string,
     authType?: string,
     provider?: string,
+    excludeSystem = false,
   ): SelectQueryBuilder<AgentMessage> {
     const qb = this.turnRepo
       .createQueryBuilder('at')
@@ -133,6 +142,7 @@ export class AggregationService {
     addTenantFilter(qb, userId, agentName, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
+    if (excludeSystem) excludeSystemAgents(qb);
     return qb;
   }
 }

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -200,11 +200,7 @@ describe('excludeSystemAgents', () => {
     const { qb, mockAndWhere, mockLeftJoin } = makeMockQb([]);
     excludeSystemAgents(qb);
 
-    expect(mockLeftJoin).toHaveBeenCalledWith(
-      'agents',
-      'a',
-      'a.name = at.agent_name AND a.tenant_id = at.tenant_id',
-    );
+    expect(mockLeftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
     expect(mockAndWhere).toHaveBeenCalledWith('(a.is_system IS NULL OR a.is_system = false)');
   });
 

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -7,6 +7,7 @@ import {
   excludeSystemAgents,
   EXCLUDE_SYSTEM_AGENTS_PREDICATE,
   filterByKeyLabel,
+  filterByLiveAgentName,
   MESSAGE_ROW_SELECT_ALIASES,
 } from './query-helpers';
 import { SelectQueryBuilder } from 'typeorm';
@@ -167,6 +168,19 @@ describe('addTenantFilter', () => {
     addTenantFilter(qb, 'user-123');
 
     expect(mockAndWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('filterByLiveAgentName constrains to the live agent id and returns the builder', () => {
+    const { qb, mockAndWhere } = makeMockQb();
+    const result = filterByLiveAgentName(qb, 'my-agent');
+
+    expect(result).toBe(qb);
+    expect(mockAndWhere).toHaveBeenCalledTimes(1);
+    const call = mockAndWhere.mock.calls[0];
+    expect(call[0]).toContain('at.agent_id = (');
+    expect(call[0]).toContain('FROM agents');
+    expect(call[0]).toContain('deleted_at IS NULL');
+    expect(call[1]).toEqual({ agentName: 'my-agent' });
   });
 
   it('returns the query builder for chaining', () => {

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -160,7 +160,11 @@ describe('addTenantFilter', () => {
     expect(secondCall[0]).toContain('at.agent_id = (');
     expect(secondCall[0]).toContain('FROM agents');
     expect(secondCall[0]).toContain('deleted_at IS NULL');
-    expect(secondCall[1]).toEqual({ agentName: 'my-agent' });
+    // No resolved tenant → the agent lookup is scoped via the user's tenant
+    // (tenant.name = userId), never `at.tenant_id` (which can be NULL here).
+    expect(secondCall[0]).toContain('FROM tenants');
+    expect(secondCall[0]).not.toContain('at.tenant_id');
+    expect(secondCall[1]).toEqual({ liveAgentName: 'my-agent', liveUserId: 'user-123' });
   });
 
   it('does not add agent_name filter when agentName is undefined', () => {
@@ -170,9 +174,9 @@ describe('addTenantFilter', () => {
     expect(mockAndWhere).toHaveBeenCalledTimes(1);
   });
 
-  it('filterByLiveAgentName constrains to the live agent id and returns the builder', () => {
+  it('filterByLiveAgentName scopes by the resolved tenant id when one is provided', () => {
     const { qb, mockAndWhere } = makeMockQb();
-    const result = filterByLiveAgentName(qb, 'my-agent');
+    const result = filterByLiveAgentName(qb, 'my-agent', 'user-123', 'tenant-456');
 
     expect(result).toBe(qb);
     expect(mockAndWhere).toHaveBeenCalledTimes(1);
@@ -180,7 +184,21 @@ describe('addTenantFilter', () => {
     expect(call[0]).toContain('at.agent_id = (');
     expect(call[0]).toContain('FROM agents');
     expect(call[0]).toContain('deleted_at IS NULL');
-    expect(call[1]).toEqual({ agentName: 'my-agent' });
+    expect(call[0]).toContain('a.tenant_id = :liveTenantId');
+    // Must never key the lookup off the (possibly NULL) message tenant_id.
+    expect(call[0]).not.toContain('at.tenant_id');
+    expect(call[1]).toEqual({ liveAgentName: 'my-agent', liveTenantId: 'tenant-456' });
+  });
+
+  it('filterByLiveAgentName resolves the tenant from the user on the fallback path (NULL tenant_id safe)', () => {
+    const { qb, mockAndWhere } = makeMockQb();
+    const result = filterByLiveAgentName(qb, 'my-agent', 'user-123');
+
+    expect(result).toBe(qb);
+    const call = mockAndWhere.mock.calls[0];
+    expect(call[0]).toContain('FROM tenants');
+    expect(call[0]).not.toContain('at.tenant_id');
+    expect(call[1]).toEqual({ liveAgentName: 'my-agent', liveUserId: 'user-123' });
   });
 
   it('returns the query builder for chaining', () => {

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -4,6 +4,8 @@ import {
   formatTimestamp,
   addTenantFilter,
   selectMessageRowColumns,
+  excludeSystemAgents,
+  filterByKeyLabel,
   MESSAGE_ROW_SELECT_ALIASES,
 } from './query-helpers';
 import { SelectQueryBuilder } from 'typeorm';
@@ -177,6 +179,86 @@ describe('addTenantFilter', () => {
     addTenantFilter(qb, 'user-123', 'my-agent', 'tenant-456');
 
     expect(mockAndWhere).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('excludeSystemAgents', () => {
+  function makeMockQb(existingJoinAliases: string[] = []) {
+    const mockAndWhere = jest.fn();
+    const mockLeftJoin = jest.fn();
+    const qb = {
+      expressionMap: {
+        joinAttributes: existingJoinAliases.map((name) => ({ alias: { name } })),
+      },
+      leftJoin: mockLeftJoin.mockImplementation(() => qb),
+      andWhere: mockAndWhere.mockImplementation(() => qb),
+    };
+    return { qb: qb as unknown as SelectQueryBuilder<never>, mockAndWhere, mockLeftJoin };
+  }
+
+  it('joins the agents table and excludes is_system rows when no agents join exists', () => {
+    const { qb, mockAndWhere, mockLeftJoin } = makeMockQb([]);
+    excludeSystemAgents(qb);
+
+    expect(mockLeftJoin).toHaveBeenCalledWith(
+      'agents',
+      'a',
+      'a.name = at.agent_name AND a.tenant_id = at.tenant_id',
+    );
+    expect(mockAndWhere).toHaveBeenCalledWith('(a.is_system IS NULL OR a.is_system = false)');
+  });
+
+  it('reuses an existing "a" join instead of joining agents twice', () => {
+    const { qb, mockAndWhere, mockLeftJoin } = makeMockQb(['a']);
+    excludeSystemAgents(qb);
+
+    expect(mockLeftJoin).not.toHaveBeenCalled();
+    expect(mockAndWhere).toHaveBeenCalledWith('(a.is_system IS NULL OR a.is_system = false)');
+  });
+
+  it('returns the query builder for chaining', () => {
+    const { qb } = makeMockQb([]);
+    expect(excludeSystemAgents(qb)).toBe(qb);
+  });
+});
+
+describe('filterByKeyLabel', () => {
+  function makeMockQb() {
+    const mockAndWhere = jest.fn();
+    const qb = { andWhere: mockAndWhere.mockImplementation(() => qb) };
+    return { qb: qb as unknown as SelectQueryBuilder<never>, mockAndWhere };
+  }
+
+  it('matches the label case-insensitively', () => {
+    const { qb, mockAndWhere } = makeMockQb();
+    filterByKeyLabel(qb, 'Work');
+    expect(mockAndWhere).toHaveBeenCalledWith(
+      "LOWER(COALESCE(at.provider_key_label, 'Default')) = LOWER(:keyLabel)",
+      { keyLabel: 'Work' },
+    );
+  });
+
+  it('collapses a null label to Default', () => {
+    const { qb, mockAndWhere } = makeMockQb();
+    filterByKeyLabel(qb, null);
+    expect(mockAndWhere.mock.calls[0][1]).toEqual({ keyLabel: 'Default' });
+  });
+
+  it('collapses an empty-string label to Default', () => {
+    const { qb, mockAndWhere } = makeMockQb();
+    filterByKeyLabel(qb, '');
+    expect(mockAndWhere.mock.calls[0][1]).toEqual({ keyLabel: 'Default' });
+  });
+
+  it('collapses an undefined label to Default', () => {
+    const { qb, mockAndWhere } = makeMockQb();
+    filterByKeyLabel(qb, undefined);
+    expect(mockAndWhere.mock.calls[0][1]).toEqual({ keyLabel: 'Default' });
+  });
+
+  it('returns the query builder for chaining', () => {
+    const { qb } = makeMockQb();
+    expect(filterByKeyLabel(qb, 'x')).toBe(qb);
   });
 });
 

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -5,6 +5,7 @@ import {
   addTenantFilter,
   selectMessageRowColumns,
   excludeSystemAgents,
+  EXCLUDE_SYSTEM_AGENTS_PREDICATE,
   filterByKeyLabel,
   MESSAGE_ROW_SELECT_ALIASES,
 } from './query-helpers';
@@ -183,37 +184,39 @@ describe('addTenantFilter', () => {
 });
 
 describe('excludeSystemAgents', () => {
-  function makeMockQb(existingJoinAliases: string[] = []) {
+  function makeMockQb() {
     const mockAndWhere = jest.fn();
     const mockLeftJoin = jest.fn();
     const qb = {
-      expressionMap: {
-        joinAttributes: existingJoinAliases.map((name) => ({ alias: { name } })),
-      },
       leftJoin: mockLeftJoin.mockImplementation(() => qb),
       andWhere: mockAndWhere.mockImplementation(() => qb),
     };
     return { qb: qb as unknown as SelectQueryBuilder<never>, mockAndWhere, mockLeftJoin };
   }
 
-  it('joins the agents table and excludes is_system rows when no agents join exists', () => {
-    const { qb, mockAndWhere, mockLeftJoin } = makeMockQb([]);
+  it('excludes system agents via a NOT EXISTS semi-join (no join added)', () => {
+    const { qb, mockAndWhere, mockLeftJoin } = makeMockQb();
     excludeSystemAgents(qb);
 
-    expect(mockLeftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
-    expect(mockAndWhere).toHaveBeenCalledWith('(a.is_system IS NULL OR a.is_system = false)');
+    // Semi-join only: never adds a LEFT JOIN of its own.
+    expect(mockLeftJoin).not.toHaveBeenCalled();
+    expect(mockAndWhere).toHaveBeenCalledWith(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
   });
 
-  it('reuses an existing "a" join instead of joining agents twice', () => {
-    const { qb, mockAndWhere, mockLeftJoin } = makeMockQb(['a']);
-    excludeSystemAgents(qb);
-
-    expect(mockLeftJoin).not.toHaveBeenCalled();
-    expect(mockAndWhere).toHaveBeenCalledWith('(a.is_system IS NULL OR a.is_system = false)');
+  it('matches the system agent by id OR name and never multiplies rows', () => {
+    // The predicate is a pure existence test (cannot duplicate fact rows) and
+    // matches on either agent_id OR agent_name (so a Playground row carrying
+    // only agent_name, NULL agent_id, is still excluded).
+    expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain('NOT EXISTS');
+    expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain('sysag.is_system = true');
+    expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain('sysag.tenant_id = at.tenant_id');
+    expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain(
+      'sysag.id = at.agent_id OR sysag.name = at.agent_name',
+    );
   });
 
   it('returns the query builder for chaining', () => {
-    const { qb } = makeMockQb([]);
+    const { qb } = makeMockQb();
     expect(excludeSystemAgents(qb)).toBe(qb);
   });
 });

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -70,6 +70,39 @@ export function addTenantFilter<T extends ObjectLiteral>(
 }
 
 /**
+ * Exclude the reserved Playground (`is_system`) agent from a message
+ * aggregate. Joins the `agents` table on (name, tenant_id) and keeps only
+ * rows whose agent is non-system (or has no matching agent row at all, e.g.
+ * legacy telemetry where the agent was deleted). Assumes the query builder
+ * aliases `agent_messages` as `at`. The join alias `a` is reused by callers
+ * that already reference `a.*`, so it must stay `a`.
+ */
+export function excludeSystemAgents<T extends ObjectLiteral>(
+  qb: SelectQueryBuilder<T>,
+): SelectQueryBuilder<T> {
+  if (!qb.expressionMap.joinAttributes.some((j) => j.alias.name === 'a')) {
+    qb.leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id');
+  }
+  return qb.andWhere('(a.is_system IS NULL OR a.is_system = false)');
+}
+
+/**
+ * Match a connection's key label case-insensitively, treating a legacy NULL
+ * `provider_key_label` as the canonical `'Default'`. A connection is identified
+ * by (tenant, provider, auth_type, label); without the label filter two keys
+ * that share provider+auth_type but differ by label merge into one. Assumes the
+ * query builder aliases `agent_messages` as `at`.
+ */
+export function filterByKeyLabel<T extends ObjectLiteral>(
+  qb: SelectQueryBuilder<T>,
+  label: string | null | undefined,
+): SelectQueryBuilder<T> {
+  return qb.andWhere("LOWER(COALESCE(at.provider_key_label, 'Default')) = LOWER(:keyLabel)", {
+    keyLabel: label && label.length > 0 ? label : 'Default',
+  });
+}
+
+/**
  * Single source of truth for the columns projected by any endpoint that
  * returns rows rendered by the frontend `MessageTable` / `ModelCell` component.
  * The frontend `MessageRow` type (packages/frontend/src/components/message-table-types.ts)

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -71,17 +71,25 @@ export function addTenantFilter<T extends ObjectLiteral>(
 
 /**
  * Exclude the reserved Playground (`is_system`) agent from a message
- * aggregate. Joins the `agents` table on (name, tenant_id) and keeps only
- * rows whose agent is non-system (or has no matching agent row at all, e.g.
- * legacy telemetry where the agent was deleted). Assumes the query builder
- * aliases `agent_messages` as `at`. The join alias `a` is reused by callers
- * that already reference `a.*`, so it must stay `a`.
+ * aggregate. Joins the `agents` table on **agent identity** (`a.id =
+ * at.agent_id`) and keeps only rows whose agent is non-system (or has no
+ * matching agent row at all, e.g. legacy telemetry where the agent was
+ * deleted → `is_system` is NULL → included).
+ *
+ * The join is on `agent_id`, not `(name, tenant_id)`, on purpose: a soft-
+ * deleted agent and a live agent can share a slug, so a name-based join is
+ * one-to-many and multiplies fact rows, inflating any SUM/COUNT downstream.
+ * Joining on the immutable id is one-to-(zero-or-one), so no duplication.
+ *
+ * Assumes the query builder aliases `agent_messages` as `at` (so `at.agent_id`
+ * is the fact-table column). The join alias `a` is reused by callers that
+ * already reference `a.*`, so it must stay `a`.
  */
 export function excludeSystemAgents<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,
 ): SelectQueryBuilder<T> {
   if (!qb.expressionMap.joinAttributes.some((j) => j.alias.name === 'a')) {
-    qb.leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id');
+    qb.leftJoin('agents', 'a', 'a.id = at.agent_id');
   }
   return qb.andWhere('(a.is_system IS NULL OR a.is_system = false)');
 }

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -51,16 +51,29 @@ export function downsample(data: number[], targetLen: number): number[] {
 export function filterByLiveAgentName<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,
   agentName: string,
+  userId: string,
+  tenantId?: string,
 ): SelectQueryBuilder<T> {
+  // Scope the live-agent lookup to the SAME tenant the outer query resolves to,
+  // NOT `at.tenant_id`: on the user_id fallback path (no resolved tenant)
+  // message rows can carry a NULL tenant_id, which would make the subquery match
+  // nothing and blank the chart. When a tenant is resolved, match it directly;
+  // otherwise resolve the tenant from the user (tenant.name = userId).
+  const tenantScope = tenantId
+    ? 'a.tenant_id = :liveTenantId'
+    : 'a.tenant_id = (SELECT t.id FROM tenants t WHERE t.name = :liveUserId LIMIT 1)';
+  const params: ObjectLiteral = { liveAgentName: agentName };
+  if (tenantId) params.liveTenantId = tenantId;
+  else params.liveUserId = userId;
   return qb.andWhere(
     `at.agent_id = (
-        SELECT id FROM agents
-        WHERE tenant_id = at.tenant_id
-          AND name = :agentName
-          AND deleted_at IS NULL
+        SELECT a.id FROM agents a
+        WHERE ${tenantScope}
+          AND a.name = :liveAgentName
+          AND a.deleted_at IS NULL
         LIMIT 1
       )`,
-    { agentName },
+    params,
   );
 }
 
@@ -76,7 +89,7 @@ export function addTenantFilter<T extends ObjectLiteral>(
     qb.andWhere('at.user_id = :userId', { userId });
   }
   if (agentName) {
-    filterByLiveAgentName(qb, agentName);
+    filterByLiveAgentName(qb, agentName, userId, tenantId);
   }
   return qb;
 }

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -71,27 +71,38 @@ export function addTenantFilter<T extends ObjectLiteral>(
 
 /**
  * Exclude the reserved Playground (`is_system`) agent from a message
- * aggregate. Joins the `agents` table on **agent identity** (`a.id =
- * at.agent_id`) and keeps only rows whose agent is non-system (or has no
- * matching agent row at all, e.g. legacy telemetry where the agent was
- * deleted → `is_system` is NULL → included).
+ * aggregate. A row is dropped iff it belongs to a system agent of the same
+ * tenant by EITHER `agent_id` OR `agent_name`; every other row (including
+ * orphan telemetry with a NULL/unmatched `agent_id` and a non-system name)
+ * stays included.
  *
- * The join is on `agent_id`, not `(name, tenant_id)`, on purpose: a soft-
- * deleted agent and a live agent can share a slug, so a name-based join is
- * one-to-many and multiplies fact rows, inflating any SUM/COUNT downstream.
- * Joining on the immutable id is one-to-(zero-or-one), so no duplication.
+ * Implemented as a `NOT EXISTS` semi-join rather than a LEFT JOIN. Two
+ * properties matter and only the semi-join satisfies both:
  *
- * Assumes the query builder aliases `agent_messages` as `at` (so `at.agent_id`
- * is the fact-table column). The join alias `a` is reused by callers that
- * already reference `a.*`, so it must stay `a`.
+ *  1. No duplication — a semi-join is a pure existence test, so it can never
+ *     multiply fact rows even when a soft-deleted agent and a live agent share
+ *     a slug (which a name-based LEFT JOIN would, inflating any SUM/COUNT).
+ *  2. No leak — matching on `id` OR `name` means a Playground message that
+ *     carries only `agent_name = 'Playground'` (NULL or unmatched `agent_id`)
+ *     is still excluded. An id-only LEFT JOIN left those rows with a NULL
+ *     `is_system` and wrongly counted them.
+ *
+ * Assumes the query builder aliases `agent_messages` as `at`. This helper adds
+ * no join, so callers that need agent columns must add their own `agents` join
+ * (one-to-(0/1) on `a.id = at.agent_id`) independently.
  */
+/**
+ * The exact `NOT EXISTS` predicate `excludeSystemAgents` appends. Exported so
+ * call sites and tests reference one string instead of duplicating (and
+ * drifting on) the SQL.
+ */
+export const EXCLUDE_SYSTEM_AGENTS_PREDICATE =
+  'NOT EXISTS (SELECT 1 FROM agents sysag WHERE sysag.tenant_id = at.tenant_id AND sysag.is_system = true AND (sysag.id = at.agent_id OR sysag.name = at.agent_name))';
+
 export function excludeSystemAgents<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,
 ): SelectQueryBuilder<T> {
-  if (!qb.expressionMap.joinAttributes.some((j) => j.alias.name === 'a')) {
-    qb.leftJoin('agents', 'a', 'a.id = at.agent_id');
-  }
-  return qb.andWhere('(a.is_system IS NULL OR a.is_system = false)');
+  return qb.andWhere(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
 }
 
 /**

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -39,6 +39,31 @@ export function downsample(data: number[], targetLen: number): number[] {
   return result;
 }
 
+/**
+ * Constrain a message aggregate to the LIVE agent currently owning a slug.
+ *
+ * `agent_messages` stores `agent_id` alongside `agent_name`, so filtering by
+ * name alone would pull in rows from a soft-deleted agent that shares the slug
+ * with a live one (slug reuse). Resolving to the live agent's id keeps a
+ * recreated agent's chart free of its dead namesake's history. Assumes the
+ * query builder aliases `agent_messages` as `at`.
+ */
+export function filterByLiveAgentName<T extends ObjectLiteral>(
+  qb: SelectQueryBuilder<T>,
+  agentName: string,
+): SelectQueryBuilder<T> {
+  return qb.andWhere(
+    `at.agent_id = (
+        SELECT id FROM agents
+        WHERE tenant_id = at.tenant_id
+          AND name = :agentName
+          AND deleted_at IS NULL
+        LIMIT 1
+      )`,
+    { agentName },
+  );
+}
+
 export function addTenantFilter<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,
   userId: string,
@@ -51,20 +76,7 @@ export function addTenantFilter<T extends ObjectLiteral>(
     qb.andWhere('at.user_id = :userId', { userId });
   }
   if (agentName) {
-    // Resolve to the live agent's id so soft-deleted agents that share the
-    // same slug as the current agent don't leak old rows. agent_messages
-    // stores agent_id alongside agent_name; we filter on the id of whatever
-    // live agent currently owns the slug.
-    qb.andWhere(
-      `at.agent_id = (
-        SELECT id FROM agents
-        WHERE tenant_id = at.tenant_id
-          AND name = :agentName
-          AND deleted_at IS NULL
-        LIMIT 1
-      )`,
-      { agentName },
-    );
+    filterByLiveAgentName(qb, agentName);
   }
   return qb;
 }

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -469,11 +469,7 @@ describe('TimeseriesQueriesService', () => {
       );
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
       expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
-      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith(
-        'agents',
-        'a',
-        'a.name = at.agent_name AND a.tenant_id = at.tenant_id',
-      );
+      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
     });
 
     it('does not exclude system agents by default', async () => {
@@ -510,6 +506,15 @@ describe('TimeseriesQueriesService', () => {
       expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
       expect(clauses).toContain('at.auth_type = :authType');
       expect(clauses).toContain('at.provider = :provider');
+      // Identity-based join (a.id = at.agent_id) — a soft-deleted agent that
+      // shares a slug with a live one must NOT match multiple `a` rows and
+      // double-count the per-agent SUM.
+      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
+      expect(mockTurnQb.leftJoin).not.toHaveBeenCalledWith(
+        'agents',
+        'a',
+        'a.name = at.agent_name AND a.tenant_id = at.tenant_id',
+      );
     });
 
     it('getPerAgentMessageTimeseries pivots message counts', async () => {
@@ -535,9 +540,12 @@ describe('TimeseriesQueriesService', () => {
       const out = await service.getPerProviderTimeseries('24h', 'u1', true, 'tenant-1', 'agent-x');
       expect(out.agents).toEqual(['anthropic', 'openai']);
       expect(out.timeseries[0]).toEqual({ hour: '01', anthropic: 3, openai: 7 });
-      expect(mockTurnQb.andWhere.mock.calls.map((c) => c[0])).toContain(
-        'at.agent_name = :agentName',
-      );
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
+      expect(clauses).toContain('at.agent_name = :agentName');
+      // Playground (is_system) usage must be excluded from per-provider totals,
+      // via the same identity-based agents join as the per-agent endpoints.
+      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
+      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
     });
 
     it('getPerProviderMessageTimeseries pivots message counts', async () => {
@@ -557,6 +565,10 @@ describe('TimeseriesQueriesService', () => {
       const out = await service.getPerModelTimeseries('24h', 'u1', true, 'tenant-1', 'agent-x');
       expect(out.agents).toEqual(['gpt-4o']);
       expect(out.timeseries).toEqual([{ hour: '01', 'gpt-4o': 9 }]);
+      // Playground (is_system) usage must be excluded from per-model totals.
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
+      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
+      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
     });
 
     it('getPerModelMessageTimeseries pivots message counts', async () => {

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -475,6 +475,25 @@ describe('TimeseriesQueriesService', () => {
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
       expect(clauses).not.toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
     });
+
+    it('scopes the aggregate timeseries to a connection label when provided', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getTimeseries(
+        '24h',
+        'u1',
+        true,
+        'tenant-1',
+        undefined,
+        'api_key',
+        'openai',
+        true,
+        'Work',
+      );
+      const labelCall = mockTurnQb.andWhere.mock.calls.find(
+        (c) => c[0] === "LOWER(COALESCE(at.provider_key_label, 'Default')) = LOWER(:keyLabel)",
+      );
+      expect(labelCall![1]).toEqual({ keyLabel: 'Work' });
+    });
   });
 
   describe('per-agent pivoted timeseries (hourly)', () => {
@@ -526,6 +545,39 @@ describe('TimeseriesQueriesService', () => {
       expect(out.agents).toEqual(['alpha']);
       expect(out.timeseries).toEqual([{ date: '2026-01-01', alpha: 2.5 }]);
     });
+
+    const labelClause = "LOWER(COALESCE(at.provider_key_label, 'Default')) = LOWER(:keyLabel)";
+
+    it('scopes each per-agent timeseries to a connection label when provided', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getPerAgentTimeseries('24h', 'u1', true, 't1', 'api_key', 'openai', 'Work');
+      await service.getPerAgentMessageTimeseries(
+        '24h',
+        'u1',
+        true,
+        't1',
+        'api_key',
+        'openai',
+        'Work',
+      );
+      await service.getPerAgentCostTimeseries('24h', 'u1', true, 't1', 'api_key', 'openai', 'Work');
+      const labelCalls = mockTurnQb.andWhere.mock.calls.filter((c) => c[0] === labelClause);
+      expect(labelCalls).toHaveLength(3);
+      for (const call of labelCalls) expect(call[1]).toEqual({ keyLabel: 'Work' });
+    });
+
+    it('treats a legacy empty connection label as Default in the per-agent filter', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getPerAgentTimeseries('24h', 'u1', true, 't1', 'api_key', 'openai', '');
+      const labelCall = mockTurnQb.andWhere.mock.calls.find((c) => c[0] === labelClause);
+      expect(labelCall![1]).toEqual({ keyLabel: 'Default' });
+    });
+
+    it('omits the label filter when no label is given', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getPerAgentTimeseries('24h', 'u1', true, 't1', 'api_key', 'openai');
+      expect(mockTurnQb.andWhere.mock.calls.some((c) => c[0] === labelClause)).toBe(false);
+    });
   });
 
   describe('per-provider / per-model pivoted timeseries', () => {
@@ -538,11 +590,47 @@ describe('TimeseriesQueriesService', () => {
       expect(out.agents).toEqual(['anthropic', 'openai']);
       expect(out.timeseries[0]).toEqual({ hour: '01', anthropic: 3, openai: 7 });
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
-      expect(clauses).toContain('at.agent_name = :agentName');
+      // Scope to the LIVE agent owning the slug (agent_id subquery), not a raw
+      // name match — a soft-deleted agent sharing the slug must not leak rows.
+      const liveAgentClause = clauses.find(
+        (c) =>
+          typeof c === 'string' &&
+          c.includes('at.agent_id = (') &&
+          c.includes('deleted_at IS NULL'),
+      );
+      expect(liveAgentClause).toBeDefined();
+      expect(clauses).not.toContain('at.agent_name = :agentName');
+      const liveAgentCall = mockTurnQb.andWhere.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('at.agent_id = ('),
+      );
+      expect(liveAgentCall![1]).toEqual({ agentName: 'agent-x' });
       // Playground (is_system) usage must be excluded from per-provider totals,
       // via the same NOT EXISTS semi-join as the per-agent endpoints (no join).
       expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
       expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
+    });
+
+    it('getPerModelTimeseries scopes to the live agent id when an agent is given', async () => {
+      mockGetRawMany.mockResolvedValue([{ hour: '01', model: 'gpt-4o', tokens: 9 }]);
+      await service.getPerModelTimeseries('24h', 'u1', true, 'tenant-1', 'agent-x');
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
+      const liveAgentClause = clauses.find(
+        (c) =>
+          typeof c === 'string' &&
+          c.includes('at.agent_id = (') &&
+          c.includes('deleted_at IS NULL'),
+      );
+      expect(liveAgentClause).toBeDefined();
+      expect(clauses).not.toContain('at.agent_name = :agentName');
+    });
+
+    it('omits the agent filter entirely when no agent is given', async () => {
+      mockGetRawMany.mockResolvedValue([{ hour: '01', provider: 'openai', tokens: 1 }]);
+      await service.getPerProviderTimeseries('24h', 'u1', true, 'tenant-1');
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
+      expect(clauses.some((c) => typeof c === 'string' && c.includes('at.agent_id = ('))).toBe(
+        false,
+      );
     });
 
     it('getPerProviderMessageTimeseries pivots message counts', async () => {

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -61,6 +61,10 @@ describe('TimeseriesQueriesService', () => {
       getRawOne: jest.fn().mockResolvedValue({}),
       getMany: mockGetMany,
     };
+    // excludeSystemAgents() inspects existing joins via expressionMap.
+    (mockTurnQb as unknown as { expressionMap: { joinAttributes: unknown[] } }).expressionMap = {
+      joinAttributes: [],
+    };
 
     mockAgentQb = {
       select: jest.fn().mockReturnThis(),
@@ -449,6 +453,34 @@ describe('TimeseriesQueriesService', () => {
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
       expect(clauses).toContain('at.auth_type = :authType');
       expect(clauses).toContain('at.provider = :provider');
+    });
+
+    it('excludes the system Playground agent when excludeSystem=true', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getTimeseries(
+        '24h',
+        'u1',
+        true,
+        'tenant-1',
+        undefined,
+        undefined,
+        undefined,
+        true,
+      );
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
+      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
+      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith(
+        'agents',
+        'a',
+        'a.name = at.agent_name AND a.tenant_id = at.tenant_id',
+      );
+    });
+
+    it('does not exclude system agents by default', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getTimeseries('24h', 'u1', true, 'tenant-1');
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
+      expect(clauses).not.toContain('(a.is_system IS NULL OR a.is_system = false)');
     });
   });
 

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -603,7 +603,7 @@ describe('TimeseriesQueriesService', () => {
       const liveAgentCall = mockTurnQb.andWhere.mock.calls.find(
         (c) => typeof c[0] === 'string' && c[0].includes('at.agent_id = ('),
       );
-      expect(liveAgentCall![1]).toEqual({ agentName: 'agent-x' });
+      expect(liveAgentCall![1]).toEqual({ liveAgentName: 'agent-x', liveTenantId: 'tenant-1' });
       // Playground (is_system) usage must be excluded from per-provider totals,
       // via the same NOT EXISTS semi-join as the per-agent endpoints (no join).
       expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -4,7 +4,7 @@ import { TimeseriesQueriesService } from './timeseries-queries.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { Agent } from '../../entities/agent.entity';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
-import { MESSAGE_ROW_SELECT_ALIASES } from './query-helpers';
+import { MESSAGE_ROW_SELECT_ALIASES, EXCLUDE_SYSTEM_AGENTS_PREDICATE } from './query-helpers';
 
 describe('TimeseriesQueriesService', () => {
   let service: TimeseriesQueriesService;
@@ -60,10 +60,6 @@ describe('TimeseriesQueriesService', () => {
       getRawMany: mockGetRawMany,
       getRawOne: jest.fn().mockResolvedValue({}),
       getMany: mockGetMany,
-    };
-    // excludeSystemAgents() inspects existing joins via expressionMap.
-    (mockTurnQb as unknown as { expressionMap: { joinAttributes: unknown[] } }).expressionMap = {
-      joinAttributes: [],
     };
 
     mockAgentQb = {
@@ -468,15 +464,16 @@ describe('TimeseriesQueriesService', () => {
         true,
       );
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
-      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
-      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
+      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      // Semi-join exclusion adds no LEFT JOIN of its own.
+      expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
     });
 
     it('does not exclude system agents by default', async () => {
       mockGetRawMany.mockResolvedValue([]);
       await service.getTimeseries('24h', 'u1', true, 'tenant-1');
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
-      expect(clauses).not.toContain('(a.is_system IS NULL OR a.is_system = false)');
+      expect(clauses).not.toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
     });
   });
 
@@ -503,17 +500,17 @@ describe('TimeseriesQueriesService', () => {
         { hour: '02', alpha: 3, bravo: 0 },
       ]);
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
-      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
+      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
       expect(clauses).toContain('at.auth_type = :authType');
       expect(clauses).toContain('at.provider = :provider');
-      // Identity-based join (a.id = at.agent_id) — a soft-deleted agent that
-      // shares a slug with a live one must NOT match multiple `a` rows and
-      // double-count the per-agent SUM.
-      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
-      expect(mockTurnQb.leftJoin).not.toHaveBeenCalledWith(
-        'agents',
-        'a',
-        'a.name = at.agent_name AND a.tenant_id = at.tenant_id',
+      // The NOT EXISTS semi-join matches a system agent by id OR name and is a
+      // pure existence test, so a soft-deleted agent sharing a slug with a live
+      // one can never multiply the per-agent SUM. It adds no LEFT JOIN.
+      expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
+      // Matching by name (not just id) means a Playground row carrying only
+      // agent_name (NULL agent_id) is excluded too — no leak.
+      expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain(
+        'sysag.id = at.agent_id OR sysag.name = at.agent_name',
       );
     });
 
@@ -543,9 +540,9 @@ describe('TimeseriesQueriesService', () => {
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
       expect(clauses).toContain('at.agent_name = :agentName');
       // Playground (is_system) usage must be excluded from per-provider totals,
-      // via the same identity-based agents join as the per-agent endpoints.
-      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
-      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
+      // via the same NOT EXISTS semi-join as the per-agent endpoints (no join).
+      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
     });
 
     it('getPerProviderMessageTimeseries pivots message counts', async () => {
@@ -567,8 +564,8 @@ describe('TimeseriesQueriesService', () => {
       expect(out.timeseries).toEqual([{ hour: '01', 'gpt-4o': 9 }]);
       // Playground (is_system) usage must be excluded from per-model totals.
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
-      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
-      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith('agents', 'a', 'a.id = at.agent_id');
+      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
     });
 
     it('getPerModelMessageTimeseries pivots message counts', async () => {
@@ -596,8 +593,10 @@ describe('TimeseriesQueriesService', () => {
       const out = await service.getAgentNamesByAuthType('subscription', 'u1', 'tenant-1');
       expect(out).toEqual(['a', 'b']);
       expect(mockTurnQb.andWhere.mock.calls.map((c) => c[0])).toContain(
-        '(a.is_system IS NULL OR a.is_system = false)',
+        EXCLUDE_SYSTEM_AGENTS_PREDICATE,
       );
+      // No LEFT JOIN on agents anymore — exclusion is a pure semi-join.
+      expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -433,4 +433,127 @@ describe('TimeseriesQueriesService', () => {
       expect(result[0].sparkline).toEqual([]);
     });
   });
+
+  describe('getTimeseries with authType/provider filters', () => {
+    it('applies auth_type and provider andWhere clauses', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getTimeseries(
+        '24h',
+        'u1',
+        true,
+        'tenant-1',
+        'agent-x',
+        'subscription',
+        'openai',
+      );
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
+      expect(clauses).toContain('at.auth_type = :authType');
+      expect(clauses).toContain('at.provider = :provider');
+    });
+  });
+
+  describe('per-agent pivoted timeseries (hourly)', () => {
+    const rows = [
+      { hour: '01', agent_name: 'bravo', tokens: 5, messages: 2, cost: 0.5 },
+      { hour: '01', agent_name: 'alpha', tokens: 10, messages: 1, cost: 1.0 },
+      { hour: '02', agent_name: 'alpha', tokens: 3, messages: 4, cost: 0.3 },
+    ];
+
+    it('getPerAgentTimeseries pivots tokens with sorted agents and zero-fill', async () => {
+      mockGetRawMany.mockResolvedValue(rows);
+      const out = await service.getPerAgentTimeseries(
+        '24h',
+        'u1',
+        true,
+        'tenant-1',
+        'subscription',
+        'openai',
+      );
+      expect(out.agents).toEqual(['alpha', 'bravo']);
+      expect(out.timeseries).toEqual([
+        { hour: '01', alpha: 10, bravo: 5 },
+        { hour: '02', alpha: 3, bravo: 0 },
+      ]);
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
+      expect(clauses).toContain('(a.is_system IS NULL OR a.is_system = false)');
+      expect(clauses).toContain('at.auth_type = :authType');
+      expect(clauses).toContain('at.provider = :provider');
+    });
+
+    it('getPerAgentMessageTimeseries pivots message counts', async () => {
+      mockGetRawMany.mockResolvedValue(rows);
+      const out = await service.getPerAgentMessageTimeseries('24h', 'u1', true);
+      expect(out.timeseries[0]).toEqual({ hour: '01', alpha: 1, bravo: 2 });
+    });
+
+    it('getPerAgentCostTimeseries pivots cost (non-hourly date bucket)', async () => {
+      mockGetRawMany.mockResolvedValue([{ date: '2026-01-01', agent_name: 'alpha', cost: 2.5 }]);
+      const out = await service.getPerAgentCostTimeseries('7d', 'u1', false);
+      expect(out.agents).toEqual(['alpha']);
+      expect(out.timeseries).toEqual([{ date: '2026-01-01', alpha: 2.5 }]);
+    });
+  });
+
+  describe('per-provider / per-model pivoted timeseries', () => {
+    it('getPerProviderTimeseries filters by agentName and pivots tokens', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { hour: '01', provider: 'openai', tokens: 7 },
+        { hour: '01', provider: 'anthropic', tokens: 3 },
+      ]);
+      const out = await service.getPerProviderTimeseries('24h', 'u1', true, 'tenant-1', 'agent-x');
+      expect(out.agents).toEqual(['anthropic', 'openai']);
+      expect(out.timeseries[0]).toEqual({ hour: '01', anthropic: 3, openai: 7 });
+      expect(mockTurnQb.andWhere.mock.calls.map((c) => c[0])).toContain(
+        'at.agent_name = :agentName',
+      );
+    });
+
+    it('getPerProviderMessageTimeseries pivots message counts', async () => {
+      mockGetRawMany.mockResolvedValue([{ hour: '01', provider: 'openai', messages: 4 }]);
+      const out = await service.getPerProviderMessageTimeseries('24h', 'u1', true);
+      expect(out.timeseries).toEqual([{ hour: '01', openai: 4 }]);
+    });
+
+    it('getPerProviderCostTimeseries pivots cost', async () => {
+      mockGetRawMany.mockResolvedValue([{ hour: '01', provider: 'openai', cost: 1.25 }]);
+      const out = await service.getPerProviderCostTimeseries('24h', 'u1', true);
+      expect(out.timeseries).toEqual([{ hour: '01', openai: 1.25 }]);
+    });
+
+    it('getPerModelTimeseries pivots tokens', async () => {
+      mockGetRawMany.mockResolvedValue([{ hour: '01', model: 'gpt-4o', tokens: 9 }]);
+      const out = await service.getPerModelTimeseries('24h', 'u1', true, 'tenant-1', 'agent-x');
+      expect(out.agents).toEqual(['gpt-4o']);
+      expect(out.timeseries).toEqual([{ hour: '01', 'gpt-4o': 9 }]);
+    });
+
+    it('getPerModelMessageTimeseries pivots message counts', async () => {
+      mockGetRawMany.mockResolvedValue([{ hour: '01', model: 'gpt-4o', messages: 2 }]);
+      const out = await service.getPerModelMessageTimeseries('24h', 'u1', true);
+      expect(out.timeseries).toEqual([{ hour: '01', 'gpt-4o': 2 }]);
+    });
+
+    it('getPerModelCostTimeseries pivots cost', async () => {
+      mockGetRawMany.mockResolvedValue([{ hour: '01', model: 'gpt-4o', cost: 0.9 }]);
+      const out = await service.getPerModelCostTimeseries('24h', 'u1', true);
+      expect(out.timeseries).toEqual([{ hour: '01', 'gpt-4o': 0.9 }]);
+    });
+
+    it('zero-fills missing values from null', async () => {
+      mockGetRawMany.mockResolvedValue([{ hour: '01', provider: 'openai', tokens: null }]);
+      const out = await service.getPerProviderTimeseries('24h', 'u1', true);
+      expect(out.timeseries).toEqual([{ hour: '01', openai: 0 }]);
+    });
+  });
+
+  describe('getAgentNamesByAuthType', () => {
+    it('returns distinct agent names excluding system agents', async () => {
+      mockGetRawMany.mockResolvedValue([{ agent_name: 'a' }, { agent_name: 'b' }]);
+      const out = await service.getAgentNamesByAuthType('subscription', 'u1', 'tenant-1');
+      expect(out).toEqual(['a', 'b']);
+      expect(mockTurnQb.andWhere.mock.calls.map((c) => c[0])).toContain(
+        '(a.is_system IS NULL OR a.is_system = false)',
+      );
+    });
+  });
 });

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -4,7 +4,13 @@ import { Repository } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { Agent } from '../../entities/agent.entity';
 import { rangeToInterval } from '../../common/utils/range.util';
-import { addTenantFilter, selectMessageRowColumns, excludeSystemAgents } from './query-helpers';
+import {
+  addTenantFilter,
+  selectMessageRowColumns,
+  excludeSystemAgents,
+  filterByKeyLabel,
+  filterByLiveAgentName,
+} from './query-helpers';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import {
   computeCutoff,
@@ -42,6 +48,7 @@ export class TimeseriesQueriesService {
     authType?: string,
     provider?: string,
     excludeSystem = false,
+    label?: string,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -60,6 +67,9 @@ export class TimeseriesQueriesService {
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
     if (excludeSystem) excludeSystemAgents(qb);
+    // Connection-scoped label filter: keep sibling keys (same provider+auth_type,
+    // different label) out of this connection's aggregate chart. NULL → 'Default'.
+    if (label !== undefined) filterByKeyLabel(qb, label);
     const rows = await qb.groupBy(bucketAlias).orderBy(bucketAlias, 'ASC').getRawMany();
 
     const tokenUsage: {
@@ -288,6 +298,7 @@ export class TimeseriesQueriesService {
     tenantId?: string,
     authType?: string,
     provider?: string,
+    label?: string,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -308,6 +319,10 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
+    // Scope to a single connection (provider+auth_type+label). Without the label
+    // filter two keys that share provider+auth_type but differ by label merge
+    // into one connection's chart. Legacy NULL provider_key_label → 'Default'.
+    if (label !== undefined) filterByKeyLabel(qb, label);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -325,6 +340,7 @@ export class TimeseriesQueriesService {
     tenantId?: string,
     authType?: string,
     provider?: string,
+    label?: string,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -343,6 +359,8 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
+    // Connection-scoped label filter (see getPerAgentTimeseries).
+    if (label !== undefined) filterByKeyLabel(qb, label);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -360,6 +378,7 @@ export class TimeseriesQueriesService {
     tenantId?: string,
     authType?: string,
     provider?: string,
+    label?: string,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -379,6 +398,8 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
+    // Connection-scoped label filter (see getPerAgentTimeseries).
+    if (label !== undefined) filterByKeyLabel(qb, label);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -412,7 +433,9 @@ export class TimeseriesQueriesService {
     // stay consistent with the per-agent / summary endpoints (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
-    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+    // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
+    // agent sharing the name doesn't leak its old rows into this chart.
+    if (agentName) filterByLiveAgentName(qb, agentName);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -445,7 +468,9 @@ export class TimeseriesQueriesService {
     // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
-    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+    // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
+    // agent sharing the name doesn't leak its old rows into this chart.
+    if (agentName) filterByLiveAgentName(qb, agentName);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -479,7 +504,9 @@ export class TimeseriesQueriesService {
     // consistent with the per-agent / summary endpoints (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
-    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+    // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
+    // agent sharing the name doesn't leak its old rows into this chart.
+    if (agentName) filterByLiveAgentName(qb, agentName);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -512,7 +539,9 @@ export class TimeseriesQueriesService {
     // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
-    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+    // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
+    // agent sharing the name doesn't leak its old rows into this chart.
+    if (agentName) filterByLiveAgentName(qb, agentName);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -545,7 +574,9 @@ export class TimeseriesQueriesService {
     // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
-    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+    // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
+    // agent sharing the name doesn't leak its old rows into this chart.
+    if (agentName) filterByLiveAgentName(qb, agentName);
     const rows = await qb
       .groupBy(bucketAlias)
       .addGroupBy('at.provider')
@@ -576,7 +607,9 @@ export class TimeseriesQueriesService {
     // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
-    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+    // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
+    // agent sharing the name doesn't leak its old rows into this chart.
+    if (agentName) filterByLiveAgentName(qb, agentName);
     const rows = await qb
       .groupBy(bucketAlias)
       .addGroupBy('at.model')

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -299,10 +299,12 @@ export class TimeseriesQueriesService {
       .select(bucketExpr, bucketAlias)
       .addSelect('at.agent_name', 'agent_name')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
-      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
       .where('at.timestamp >= :cutoff', { cutoff })
-      .andWhere('at.agent_name IS NOT NULL')
-      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+      .andWhere('at.agent_name IS NOT NULL');
+    // Join on agent identity (a.id = at.agent_id), not name+tenant: a soft-
+    // deleted agent sharing a slug with a live one would otherwise match
+    // multiple `a` rows and multiply the per-agent SUM.
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
@@ -334,10 +336,10 @@ export class TimeseriesQueriesService {
       .select(bucketExpr, bucketAlias)
       .addSelect('at.agent_name', 'agent_name')
       .addSelect('COUNT(*)', 'messages')
-      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
       .where('at.timestamp >= :cutoff', { cutoff })
-      .andWhere('at.agent_name IS NOT NULL')
-      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+      .andWhere('at.agent_name IS NOT NULL');
+    // Identity-based join (see getPerAgentTimeseries) to avoid double-counting.
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
@@ -370,10 +372,10 @@ export class TimeseriesQueriesService {
       .select(bucketExpr, bucketAlias)
       .addSelect('at.agent_name', 'agent_name')
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
-      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
       .where('at.timestamp >= :cutoff', { cutoff })
-      .andWhere('at.agent_name IS NOT NULL')
-      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+      .andWhere('at.agent_name IS NOT NULL');
+    // Identity-based join (see getPerAgentTimeseries) to avoid double-counting.
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
@@ -406,6 +408,9 @@ export class TimeseriesQueriesService {
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
+    // Exclude the reserved Playground (is_system) agent so per-provider totals
+    // stay consistent with the per-agent / summary endpoints (identity join).
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
 
@@ -437,6 +442,8 @@ export class TimeseriesQueriesService {
       .addSelect('COUNT(*)', 'messages')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
+    // Exclude the reserved Playground (is_system) agent (identity join).
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
 
@@ -468,6 +475,9 @@ export class TimeseriesQueriesService {
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL');
+    // Exclude the reserved Playground (is_system) agent so per-model totals stay
+    // consistent with the per-agent / summary endpoints (identity join).
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
 
@@ -499,6 +509,8 @@ export class TimeseriesQueriesService {
       .addSelect('COUNT(*)', 'messages')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL');
+    // Exclude the reserved Playground (is_system) agent (identity join).
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
 
@@ -530,6 +542,8 @@ export class TimeseriesQueriesService {
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
+    // Exclude the reserved Playground (is_system) agent (identity join).
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
     const rows = await qb
@@ -559,6 +573,8 @@ export class TimeseriesQueriesService {
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL');
+    // Exclude the reserved Playground (is_system) agent (identity join).
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
     const rows = await qb
@@ -577,7 +593,11 @@ export class TimeseriesQueriesService {
     const qb = this.turnRepo
       .createQueryBuilder('at')
       .select('DISTINCT at.agent_name', 'agent_name')
-      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
+      // Identity-based join (a.id = at.agent_id) so a soft-deleted agent that
+      // shares a slug with a live one can't match multiple `a` rows. DISTINCT
+      // already collapses duplicates here, but keeping the join consistent with
+      // excludeSystemAgents avoids a future SUM/COUNT inheriting the bug.
+      .leftJoin('agents', 'a', 'a.id = at.agent_id')
       .where('at.auth_type = :authType', { authType })
       .andWhere('at.agent_name IS NOT NULL')
       // Exclude the reserved Playground (is_system) agent.

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -39,6 +39,8 @@ export class TimeseriesQueriesService {
     hourly: boolean,
     tenantId?: string,
     agentName?: string,
+    authType?: string,
+    provider?: string,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -54,6 +56,8 @@ export class TimeseriesQueriesService {
       .addSelect('COUNT(*)', 'count')
       .where('at.timestamp >= :cutoff', { cutoff });
     addTenantFilter(qb, userId, agentName, tenantId);
+    if (authType) qb.andWhere('at.auth_type = :authType', { authType });
+    if (provider) qb.andWhere('at.provider = :provider', { provider });
     const rows = await qb.groupBy(bucketAlias).orderBy(bucketAlias, 'ASC').getRawMany();
 
     const tokenUsage: {
@@ -275,6 +279,312 @@ export class TimeseriesQueriesService {
     });
   }
 
+  async getPerAgentTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    authType?: string,
+    provider?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.agent_name', 'agent_name')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
+      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.agent_name IS NOT NULL')
+      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    if (authType) qb.andWhere('at.auth_type = :authType', { authType });
+    if (provider) qb.andWhere('at.provider = :provider', { provider });
+
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.agent_name')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+
+    return pivotByKey(rows, bucketAlias, 'agent_name', 'tokens');
+  }
+
+  async getPerAgentMessageTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    authType?: string,
+    provider?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.agent_name', 'agent_name')
+      .addSelect('COUNT(*)', 'messages')
+      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.agent_name IS NOT NULL')
+      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    if (authType) qb.andWhere('at.auth_type = :authType', { authType });
+    if (provider) qb.andWhere('at.provider = :provider', { provider });
+
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.agent_name')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+
+    return pivotByKey(rows, bucketAlias, 'agent_name', 'messages');
+  }
+
+  async getPerAgentCostTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    authType?: string,
+    provider?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+    const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
+
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.agent_name', 'agent_name')
+      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
+      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.agent_name IS NOT NULL')
+      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    if (authType) qb.andWhere('at.auth_type = :authType', { authType });
+    if (provider) qb.andWhere('at.provider = :provider', { provider });
+
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.agent_name')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+
+    return pivotByKey(rows, bucketAlias, 'agent_name', 'cost');
+  }
+
+  async getPerProviderTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    agentName?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.provider', 'provider')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.provider IS NOT NULL');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.provider')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+
+    return pivotByKey(rows, bucketAlias, 'provider', 'tokens');
+  }
+
+  async getPerProviderMessageTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    agentName?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.provider', 'provider')
+      .addSelect('COUNT(*)', 'messages')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.provider IS NOT NULL');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.provider')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+
+    return pivotByKey(rows, bucketAlias, 'provider', 'messages');
+  }
+
+  async getPerModelTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    agentName?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.model', 'model')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.model IS NOT NULL');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.model')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+
+    return pivotByKey(rows, bucketAlias, 'model', 'tokens');
+  }
+
+  async getPerModelMessageTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    agentName?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.model', 'model')
+      .addSelect('COUNT(*)', 'messages')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.model IS NOT NULL');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.model')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+
+    return pivotByKey(rows, bucketAlias, 'model', 'messages');
+  }
+
+  async getPerProviderCostTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    agentName?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+    const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.provider', 'provider')
+      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.provider IS NOT NULL');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.provider')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+    return pivotByKey(rows, bucketAlias, 'provider', 'cost');
+  }
+
+  async getPerModelCostTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    agentName?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+    const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.model', 'model')
+      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.model IS NOT NULL');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.model')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+    return pivotByKey(rows, bucketAlias, 'model', 'cost');
+  }
+
+  async getAgentNamesByAuthType(
+    authType: string,
+    userId: string,
+    tenantId?: string,
+  ): Promise<string[]> {
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select('DISTINCT at.agent_name', 'agent_name')
+      .leftJoin('agents', 'a', 'a.name = at.agent_name AND a.tenant_id = at.tenant_id')
+      .where('at.auth_type = :authType', { authType })
+      .andWhere('at.agent_name IS NOT NULL')
+      // Exclude the reserved Playground (is_system) agent.
+      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+    addTenantFilter(qb, userId, undefined, tenantId);
+    const rows = await qb.orderBy('at.agent_name', 'ASC').getRawMany();
+    return rows.map((r: Record<string, unknown>) => String(r['agent_name']));
+  }
+
   private parseBucketRow(
     r: Record<string, unknown>,
     bucketAlias: 'hour' | 'date',
@@ -288,4 +598,36 @@ export class TimeseriesQueriesService {
     row[bucketAlias] = String(r[bucketAlias]);
     return row;
   }
+}
+
+/**
+ * Pivot grouped rows into a per-bucket timeseries with one numeric column per
+ * distinct series key. Series keys are sorted alphabetically and every bucket
+ * row carries every series (zero-filled), so the frontend can render a stable
+ * multi-series chart without re-deriving the column set.
+ */
+function pivotByKey(
+  rows: Array<Record<string, unknown>>,
+  bucketAlias: string,
+  keyField: string,
+  valueField: string,
+): { agents: string[]; timeseries: Array<Record<string, number | string>> } {
+  const keySet = new Set<string>();
+  for (const r of rows) keySet.add(String(r[keyField]));
+  const keys = [...keySet].sort();
+
+  const byBucket = new Map<string, Record<string, number>>();
+  for (const r of rows) {
+    const bucket = String(r[bucketAlias]);
+    if (!byBucket.has(bucket)) byBucket.set(bucket, {});
+    byBucket.get(bucket)![String(r[keyField])] = Number(r[valueField] ?? 0);
+  }
+
+  const timeseries = [...byBucket.entries()].map(([bucket, map]) => {
+    const row: Record<string, number | string> = { [bucketAlias]: bucket };
+    for (const k of keys) row[k] = map[k] ?? 0;
+    return row;
+  });
+
+  return { agents: keys, timeseries };
 }

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { Agent } from '../../entities/agent.entity';
 import { rangeToInterval } from '../../common/utils/range.util';
-import { addTenantFilter, selectMessageRowColumns } from './query-helpers';
+import { addTenantFilter, selectMessageRowColumns, excludeSystemAgents } from './query-helpers';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import {
   computeCutoff,
@@ -41,6 +41,7 @@ export class TimeseriesQueriesService {
     agentName?: string,
     authType?: string,
     provider?: string,
+    excludeSystem = false,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -58,6 +59,7 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, agentName, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
+    if (excludeSystem) excludeSystemAgents(qb);
     const rows = await qb.groupBy(bucketAlias).orderBy(bucketAlias, 'ASC').getRawMany();
 
     const tokenUsage: {

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -301,9 +301,9 @@ export class TimeseriesQueriesService {
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.agent_name IS NOT NULL');
-    // Join on agent identity (a.id = at.agent_id), not name+tenant: a soft-
-    // deleted agent sharing a slug with a live one would otherwise match
-    // multiple `a` rows and multiply the per-agent SUM.
+    // Drop the reserved Playground (is_system) agent. The NOT EXISTS semi-join
+    // matches by id OR name (so name-only Playground rows are excluded too) and
+    // can't multiply the per-agent SUM the way a name-based LEFT JOIN would.
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
@@ -338,7 +338,7 @@ export class TimeseriesQueriesService {
       .addSelect('COUNT(*)', 'messages')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.agent_name IS NOT NULL');
-    // Identity-based join (see getPerAgentTimeseries) to avoid double-counting.
+    // Semi-join exclusion (see getPerAgentTimeseries): no double-count, no leak.
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
@@ -374,7 +374,7 @@ export class TimeseriesQueriesService {
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.agent_name IS NOT NULL');
-    // Identity-based join (see getPerAgentTimeseries) to avoid double-counting.
+    // Semi-join exclusion (see getPerAgentTimeseries): no double-count, no leak.
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
@@ -409,7 +409,7 @@ export class TimeseriesQueriesService {
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
     // Exclude the reserved Playground (is_system) agent so per-provider totals
-    // stay consistent with the per-agent / summary endpoints (identity join).
+    // stay consistent with the per-agent / summary endpoints (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
@@ -442,7 +442,7 @@ export class TimeseriesQueriesService {
       .addSelect('COUNT(*)', 'messages')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent (identity join).
+    // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
@@ -476,7 +476,7 @@ export class TimeseriesQueriesService {
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL');
     // Exclude the reserved Playground (is_system) agent so per-model totals stay
-    // consistent with the per-agent / summary endpoints (identity join).
+    // consistent with the per-agent / summary endpoints (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
@@ -509,7 +509,7 @@ export class TimeseriesQueriesService {
       .addSelect('COUNT(*)', 'messages')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent (identity join).
+    // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
@@ -542,7 +542,7 @@ export class TimeseriesQueriesService {
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent (identity join).
+    // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
@@ -573,7 +573,7 @@ export class TimeseriesQueriesService {
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent (identity join).
+    // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
     excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (agentName) qb.andWhere('at.agent_name = :agentName', { agentName });
@@ -593,15 +593,12 @@ export class TimeseriesQueriesService {
     const qb = this.turnRepo
       .createQueryBuilder('at')
       .select('DISTINCT at.agent_name', 'agent_name')
-      // Identity-based join (a.id = at.agent_id) so a soft-deleted agent that
-      // shares a slug with a live one can't match multiple `a` rows. DISTINCT
-      // already collapses duplicates here, but keeping the join consistent with
-      // excludeSystemAgents avoids a future SUM/COUNT inheriting the bug.
-      .leftJoin('agents', 'a', 'a.id = at.agent_id')
       .where('at.auth_type = :authType', { authType })
-      .andWhere('at.agent_name IS NOT NULL')
-      // Exclude the reserved Playground (is_system) agent.
-      .andWhere('(a.is_system IS NULL OR a.is_system = false)');
+      .andWhere('at.agent_name IS NOT NULL');
+    // Exclude the reserved Playground (is_system) agent. The NOT EXISTS semi-join
+    // matches by id OR name, so a Playground row carrying only agent_name (NULL
+    // agent_id) is still dropped, and it can't multiply rows.
+    excludeSystemAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     const rows = await qb.orderBy('at.agent_name', 'ASC').getRawMany();
     return rows.map((r: Record<string, unknown>) => String(r['agent_name']));

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -435,7 +435,7 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
-    if (agentName) filterByLiveAgentName(qb, agentName);
+    if (agentName) filterByLiveAgentName(qb, agentName, userId, tenantId);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -470,7 +470,7 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
-    if (agentName) filterByLiveAgentName(qb, agentName);
+    if (agentName) filterByLiveAgentName(qb, agentName, userId, tenantId);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -506,7 +506,7 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
-    if (agentName) filterByLiveAgentName(qb, agentName);
+    if (agentName) filterByLiveAgentName(qb, agentName, userId, tenantId);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -541,7 +541,7 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
-    if (agentName) filterByLiveAgentName(qb, agentName);
+    if (agentName) filterByLiveAgentName(qb, agentName, userId, tenantId);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -576,7 +576,7 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
-    if (agentName) filterByLiveAgentName(qb, agentName);
+    if (agentName) filterByLiveAgentName(qb, agentName, userId, tenantId);
     const rows = await qb
       .groupBy(bucketAlias)
       .addGroupBy('at.provider')
@@ -609,7 +609,7 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
-    if (agentName) filterByLiveAgentName(qb, agentName);
+    if (agentName) filterByLiveAgentName(qb, agentName, userId, tenantId);
     const rows = await qb
       .groupBy(bucketAlias)
       .addGroupBy('at.model')

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -25,6 +25,7 @@ import { PlaygroundRun } from '../entities/playground-run.entity';
 import { PlaygroundColumn } from '../entities/playground-column.entity';
 import { ReasoningContentCacheEntry } from '../entities/reasoning-content-cache-entry.entity';
 import { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import { ProviderRateLimit } from '../entities/provider-rate-limit.entity';
 import { DatabaseSeederService } from './database-seeder.service';
 import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
@@ -116,6 +117,7 @@ import { DropRedundantAgentApiKeyPrefixIndex1790400000000 } from './migrations/1
 import { LiftProvidersToUserLevel1791000000000 } from './migrations/1791000000000-LiftProvidersToUserLevel';
 import { LiftCustomProvidersToUserLevel1791200000000 } from './migrations/1791200000000-LiftCustomProvidersToUserLevel';
 import { SeedPlaygroundAgents1791400000000 } from './migrations/1791400000000-SeedPlaygroundAgents';
+import { AddProviderRateLimits1791500000000 } from './migrations/1791500000000-AddProviderRateLimits';
 
 const entities = [
   AgentMessage,
@@ -141,6 +143,7 @@ const entities = [
   PlaygroundColumn,
   ReasoningContentCacheEntry,
   AgentProviderAccess,
+  ProviderRateLimit,
 ];
 
 const migrations = [
@@ -233,6 +236,7 @@ const migrations = [
   LiftProvidersToUserLevel1791000000000,
   LiftCustomProvidersToUserLevel1791200000000,
   SeedPlaygroundAgents1791400000000,
+  AddProviderRateLimits1791500000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1791500000000-AddProviderRateLimits.ts
+++ b/packages/backend/src/database/migrations/1791500000000-AddProviderRateLimits.ts
@@ -22,13 +22,17 @@ export class AddProviderRateLimits1791500000000 implements MigrationInterface {
         CONSTRAINT "PK_provider_rate_limits" PRIMARY KEY ("id")
       )
     `);
+    // The "latest snapshot" lookup keys on the full connection identity
+    // (user, provider, auth_type, key_label, limit_type) ordered by capture
+    // time, so the index must carry that whole tuple — keying on
+    // (user, provider) alone collapsed distinct auth types / labels.
     await queryRunner.query(
-      `CREATE INDEX "IDX_rate_limits_user_provider" ON "provider_rate_limits" ("user_id", "provider", "captured_at" DESC)`,
+      `CREATE INDEX "IDX_rate_limits_connection_latest" ON "provider_rate_limits" ("user_id", "provider", "auth_type", "key_label", "limit_type", "captured_at" DESC)`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_rate_limits_user_provider"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_rate_limits_connection_latest"`);
     await queryRunner.query(`DROP TABLE IF EXISTS "provider_rate_limits"`);
   }
 }

--- a/packages/backend/src/database/migrations/1791500000000-AddProviderRateLimits.ts
+++ b/packages/backend/src/database/migrations/1791500000000-AddProviderRateLimits.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProviderRateLimits1791500000000 implements MigrationInterface {
+  name = 'AddProviderRateLimits1791500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "provider_rate_limits" (
+        "id" varchar NOT NULL,
+        "user_id" varchar NOT NULL,
+        "provider" varchar NOT NULL,
+        "auth_type" varchar NOT NULL,
+        "key_label" varchar,
+        "limit_type" varchar NOT NULL,
+        "period" varchar NOT NULL,
+        "limit_value" bigint,
+        "used_value" bigint NOT NULL DEFAULT 0,
+        "remaining_value" bigint,
+        "resets_at" TIMESTAMP,
+        "source" varchar NOT NULL DEFAULT 'header',
+        "captured_at" TIMESTAMP NOT NULL DEFAULT NOW(),
+        CONSTRAINT "PK_provider_rate_limits" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_rate_limits_user_provider" ON "provider_rate_limits" ("user_id", "provider", "captured_at" DESC)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_rate_limits_user_provider"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "provider_rate_limits"`);
+  }
+}

--- a/packages/backend/src/entities/provider-rate-limit.entity.ts
+++ b/packages/backend/src/entities/provider-rate-limit.entity.ts
@@ -1,0 +1,51 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
+
+@Entity('provider_rate_limits')
+export class ProviderRateLimit {
+  @PrimaryColumn('varchar')
+  id!: string;
+
+  @Column('varchar')
+  user_id!: string;
+
+  @Column('varchar')
+  provider!: string;
+
+  @Column('varchar')
+  auth_type!: string;
+
+  @Column('varchar', { nullable: true, default: null })
+  key_label!: string | null;
+
+  /** 'requests' | 'tokens' | 'input_tokens' | 'output_tokens' */
+  @Column('varchar')
+  limit_type!: string;
+
+  /** 'minute' | 'hour' | 'day' | 'week' | 'month' */
+  @Column('varchar')
+  period!: string;
+
+  /** Max allowed for this period (null = unknown). */
+  @Column('bigint', { nullable: true, default: null })
+  limit_value!: string | null;
+
+  /** Current consumption in this period. */
+  @Column('bigint')
+  used_value!: string;
+
+  /** Remaining (from headers, null if computed). */
+  @Column('bigint', { nullable: true, default: null })
+  remaining_value!: string | null;
+
+  /** When this period resets. */
+  @Column(timestampType(), { nullable: true, default: null })
+  resets_at!: string | null;
+
+  /** 'header' | 'hardcoded' | 'computed' */
+  @Column('varchar', { default: 'header' })
+  source!: string;
+
+  @Column(timestampType(), { default: timestampDefault() })
+  captured_at!: string;
+}

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -24,6 +24,7 @@ import type { ThinkingBlockCache } from '../thinking-block-cache';
 import type { ReasoningContentCache } from '../reasoning-content-cache';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
 import type { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
+import type { RateLimitTrackerService } from '../rate-limit-tracker.service';
 
 /**
  * Stream-warmup helper is mocked because the real implementation depends on
@@ -92,6 +93,7 @@ describe('ProxyService — orchestration', () => {
   let reasoningCache: ReasoningContentCache;
   let modelParamsService: { get: jest.Mock; list: jest.Mock; set: jest.Mock; delete: jest.Mock };
   let providerParamSpecs: { getSpecs: jest.Mock; list: jest.Mock };
+  let rateLimitTracker: { captureFromResponse: jest.Mock };
   let svc: ProxyService;
 
   beforeEach(() => {
@@ -144,6 +146,7 @@ describe('ProxyService — orchestration', () => {
       ),
       list: jest.fn().mockResolvedValue(specCatalog),
     };
+    rateLimitTracker = { captureFromResponse: jest.fn() };
 
     svc = new ProxyService(
       resolveService as unknown as ResolveService,
@@ -164,6 +167,7 @@ describe('ProxyService — orchestration', () => {
       reasoningCache,
       modelParamsService as unknown as AgentModelParamsService,
       providerParamSpecs as unknown as ProviderParamSpecService,
+      rateLimitTracker as unknown as RateLimitTrackerService,
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -315,6 +315,59 @@ describe('ProxyService — orchestration', () => {
       expect(momentum.recordTier).toHaveBeenCalledWith('sess-1', 'standard');
     });
 
+    it('captures primary rate-limit headers under the canonical Default label for an unlabeled key', async () => {
+      // The resolved route carries no keyLabel (unlabeled key). The capture must
+      // attribute the headers to the canonical 'Default' connection, not a NULL
+      // that could collide with a real 'Default' connection on read.
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      const primaryOk = okResponse(200);
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: primaryOk,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await svc.proxyRequest(baseOpts());
+
+      const primaryCapture = rateLimitTracker.captureFromResponse.mock.calls.find(
+        (c) => c[0] === primaryOk,
+      );
+      expect(primaryCapture).toEqual([primaryOk, 'user-1', 'openai', 'api_key', 'Default']);
+    });
+
+    it('captures primary rate-limit headers under the pinned key label', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: { ...route('openai', 'api_key', 'gpt-4o'), keyLabel: 'Work' },
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      const primaryOk = okResponse(200);
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: primaryOk,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await svc.proxyRequest(baseOpts());
+
+      const primaryCapture = rateLimitTracker.captureFromResponse.mock.calls.find(
+        (c) => c[0] === primaryOk,
+      );
+      expect(primaryCapture).toEqual([primaryOk, 'user-1', 'openai', 'api_key', 'Work']);
+    });
+
     it('passes the raw stored OpenAI OAuth blob alongside the unwrapped access token', async () => {
       const rawBlob = JSON.stringify({
         t: 'cached-access',
@@ -713,7 +766,7 @@ describe('ProxyService — orchestration', () => {
       expect(fallbackCapture).toEqual([fallbackOk, 'user-1', 'anthropic', 'subscription', 'Work']);
     });
 
-    it('passes empty auth_type to the fallback capture when the success has no authType', async () => {
+    it('records the fallback capture under the canonical Default label when the success has no keyLabel', async () => {
       const fallbackOk = okResponse();
       fallbackService.tryForwardToProvider.mockResolvedValue({
         response: new Response('upstream broken', { status: 502 }),
@@ -733,10 +786,12 @@ describe('ProxyService — orchestration', () => {
 
       await svc.proxyRequest(baseOpts());
 
+      // No explicit keyLabel on the fallback success → canonical 'Default'
+      // (mirrors the primary path), never NULL/undefined.
       const fallbackCapture = rateLimitTracker.captureFromResponse.mock.calls.find(
         (c) => c[0] === fallbackOk,
       );
-      expect(fallbackCapture).toEqual([fallbackOk, 'user-1', 'anthropic', '', undefined]);
+      expect(fallbackCapture).toEqual([fallbackOk, 'user-1', 'anthropic', '', 'Default']);
     });
 
     it('returns the successful fallback auth_type, not the primary auth_type (#1173)', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -680,6 +680,65 @@ describe('ProxyService — orchestration', () => {
       expect(result.meta.primaryProvider).toBe('openai');
     });
 
+    it("captures the fallback success response's rate-limit headers", async () => {
+      // The failed primary still gets a capture call; this proves the WINNING
+      // fallback connection's limits are also captured (provider/auth/label
+      // matching the fallback, not the primary).
+      const fallbackOk = okResponse();
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: new Response('upstream broken', { status: 502 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      fallbackService.tryFallbacks.mockResolvedValue({
+        success: {
+          forward: { response: fallbackOk, isGoogle: false, isAnthropic: true, isChatGpt: false },
+          model: 'claude',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+          authType: 'subscription',
+          keyLabel: 'Work',
+        },
+        failures: [],
+      } as never);
+
+      await svc.proxyRequest(baseOpts());
+
+      // One capture for the failed primary, one for the fallback success.
+      const fallbackCapture = rateLimitTracker.captureFromResponse.mock.calls.find(
+        (c) => c[0] === fallbackOk,
+      );
+      expect(fallbackCapture).toBeDefined();
+      expect(fallbackCapture).toEqual([fallbackOk, 'user-1', 'anthropic', 'subscription', 'Work']);
+    });
+
+    it('passes empty auth_type to the fallback capture when the success has no authType', async () => {
+      const fallbackOk = okResponse();
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: new Response('upstream broken', { status: 502 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      fallbackService.tryFallbacks.mockResolvedValue({
+        success: {
+          forward: { response: fallbackOk, isGoogle: false, isAnthropic: true, isChatGpt: false },
+          model: 'claude',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+        },
+        failures: [],
+      } as never);
+
+      await svc.proxyRequest(baseOpts());
+
+      const fallbackCapture = rateLimitTracker.captureFromResponse.mock.calls.find(
+        (c) => c[0] === fallbackOk,
+      );
+      expect(fallbackCapture).toEqual([fallbackOk, 'user-1', 'anthropic', '', undefined]);
+    });
+
     it('returns the successful fallback auth_type, not the primary auth_type (#1173)', async () => {
       // Mixed-auth chain: primary openai/api_key fails, fallback
       // anthropic/subscription succeeds. The recorder reads meta.auth_type to

--- a/packages/backend/src/routing/proxy/__tests__/rate-limit-tracker.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/rate-limit-tracker.service.spec.ts
@@ -1,0 +1,329 @@
+import { RateLimitTrackerService } from '../rate-limit-tracker.service';
+import { ProviderRateLimit } from '../../../entities/provider-rate-limit.entity';
+
+interface FakeRow {
+  provider: string;
+  auth_type: string;
+  key_label: string | null;
+  limit_type: string;
+  period: string;
+  limit_value: string | null;
+  remaining_value: string | null;
+  used_value: string;
+  resets_at: string | null;
+}
+
+function makeHeaders(entries: Record<string, string>): Headers {
+  return new Headers(entries);
+}
+
+describe('RateLimitTrackerService', () => {
+  let repo: {
+    save: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let qb: Record<string, jest.Mock>;
+  let getManyRows: ProviderRateLimit[];
+  let service: RateLimitTrackerService;
+
+  beforeEach(() => {
+    getManyRows = [];
+    qb = {
+      where: jest.fn(),
+      andWhere: jest.fn(),
+      getMany: jest.fn(async () => getManyRows),
+    };
+    qb.where.mockReturnValue(qb);
+    qb.andWhere.mockReturnValue(qb);
+
+    repo = {
+      save: jest.fn().mockResolvedValue(undefined),
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    };
+
+    service = new RateLimitTrackerService(
+      repo as unknown as ConstructorParameters<typeof RateLimitTrackerService>[0],
+    );
+  });
+
+  // Flush in-memory cache between tests by using unique userIds.
+  let userCounter = 0;
+  const nextUser = () => `user-${userCounter++}`;
+
+  describe('captureFromResponse — OpenAI headers', () => {
+    it('parses request + token limits and persists rows', async () => {
+      const userId = nextUser();
+      const res = new Response(null, {
+        headers: makeHeaders({
+          'x-ratelimit-limit-requests': '100',
+          'x-ratelimit-remaining-requests': '60',
+          'x-ratelimit-reset-requests': '6m32.512s',
+          'x-ratelimit-limit-tokens': '1000',
+          'x-ratelimit-remaining-tokens': '750',
+          'x-ratelimit-reset-tokens': '30s',
+        }),
+      });
+
+      service.captureFromResponse(res, userId, 'openai', 'api_key', 'k1');
+      // allow fire-and-forget persistence microtask to settle
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(repo.save).toHaveBeenCalledTimes(2);
+      const saved = repo.save.mock.calls.map((c) => c[0]);
+      const requests = saved.find((s) => s.limit_type === 'requests');
+      expect(requests.used_value).toBe('40');
+      expect(requests.limit_value).toBe('100');
+      expect(requests.remaining_value).toBe('60');
+      expect(requests.resets_at).toContain('T'); // ISO timestamp
+      const tokens = saved.find((s) => s.limit_type === 'tokens');
+      expect(tokens.used_value).toBe('250');
+    });
+
+    it('treats chatgpt as openai', async () => {
+      const userId = nextUser();
+      const res = new Response(null, {
+        headers: makeHeaders({ 'x-ratelimit-limit-requests': '10' }),
+      });
+      service.captureFromResponse(res, userId, 'chatgpt', 'subscription');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(repo.save).toHaveBeenCalled();
+    });
+
+    it('computes null used_value when remaining missing', async () => {
+      const userId = nextUser();
+      const res = new Response(null, {
+        headers: makeHeaders({ 'x-ratelimit-limit-requests': '10' }),
+      });
+      service.captureFromResponse(res, userId, 'openai', 'api_key');
+      await Promise.resolve();
+      await Promise.resolve();
+      const saved = repo.save.mock.calls[0][0];
+      expect(saved.used_value).toBe('0'); // null used -> '0'
+      expect(saved.remaining_value).toBeNull();
+    });
+  });
+
+  describe('captureFromResponse — Anthropic headers', () => {
+    it('parses anthropic request + token limits with ISO reset passthrough', async () => {
+      const userId = nextUser();
+      const iso = '2026-01-01T00:00:00Z';
+      const res = new Response(null, {
+        headers: makeHeaders({
+          'anthropic-ratelimit-requests-limit': '50',
+          'anthropic-ratelimit-requests-remaining': '20',
+          'anthropic-ratelimit-requests-reset': iso,
+          'anthropic-ratelimit-tokens-limit': '5000',
+          'anthropic-ratelimit-tokens-remaining': '4000',
+          'anthropic-ratelimit-tokens-reset': iso,
+        }),
+      });
+      service.captureFromResponse(res, userId, 'anthropic', 'subscription');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(repo.save).toHaveBeenCalledTimes(2);
+      const saved = repo.save.mock.calls.map((c) => c[0]);
+      expect(saved.find((s) => s.limit_type === 'requests').resets_at).toBe(iso);
+      expect(saved.find((s) => s.limit_type === 'tokens').used_value).toBe('1000');
+    });
+
+    it('handles anthropic headers with no reset value', async () => {
+      const userId = nextUser();
+      const res = new Response(null, {
+        headers: makeHeaders({ 'anthropic-ratelimit-tokens-remaining': '100' }),
+      });
+      service.captureFromResponse(res, userId, 'anthropic', 'api_key');
+      await Promise.resolve();
+      await Promise.resolve();
+      const saved = repo.save.mock.calls[0][0];
+      expect(saved.limit_type).toBe('tokens');
+      expect(saved.resets_at).toBeNull();
+    });
+  });
+
+  describe('captureFromResponse — no-op paths', () => {
+    it('does nothing for providers without rate-limit headers', () => {
+      const userId = nextUser();
+      const res = new Response(null, { headers: makeHeaders({}) });
+      service.captureFromResponse(res, userId, 'gemini', 'api_key');
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('does nothing for a known provider that emits no recognized headers', () => {
+      const userId = nextUser();
+      const res = new Response(null, { headers: makeHeaders({ 'x-other': '1' }) });
+      service.captureFromResponse(res, userId, 'openai', 'api_key');
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('swallows persistence errors (fire-and-forget)', async () => {
+      const userId = nextUser();
+      repo.save.mockRejectedValueOnce(new Error('db down'));
+      const res = new Response(null, {
+        headers: makeHeaders({ 'x-ratelimit-limit-requests': '10' }),
+      });
+      expect(() => service.captureFromResponse(res, userId, 'openai', 'api_key')).not.toThrow();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    it('never throws when header access blows up', () => {
+      const userId = nextUser();
+      const badResponse = {
+        get headers(): Headers {
+          throw new Error('boom');
+        },
+      } as unknown as Response;
+      expect(() =>
+        service.captureFromResponse(badResponse, userId, 'openai', 'api_key'),
+      ).not.toThrow();
+    });
+  });
+
+  describe('parseResetDuration branches', () => {
+    it('parses combined h/m/s/ms durations', async () => {
+      const userId = nextUser();
+      const res = new Response(null, {
+        headers: makeHeaders({
+          'x-ratelimit-limit-requests': '10',
+          'x-ratelimit-remaining-requests': '5',
+          'x-ratelimit-reset-requests': '1h2m3s500ms',
+        }),
+      });
+      service.captureFromResponse(res, userId, 'openai', 'api_key');
+      await Promise.resolve();
+      await Promise.resolve();
+      const saved = repo.save.mock.calls[0][0];
+      expect(saved.resets_at).toContain('T');
+    });
+
+    it('returns null for an unparseable duration (no time units)', async () => {
+      const userId = nextUser();
+      const res = new Response(null, {
+        headers: makeHeaders({
+          'x-ratelimit-limit-requests': '10',
+          'x-ratelimit-remaining-requests': '5',
+          'x-ratelimit-reset-requests': 'soon',
+        }),
+      });
+      service.captureFromResponse(res, userId, 'openai', 'api_key');
+      await Promise.resolve();
+      await Promise.resolve();
+      const saved = repo.save.mock.calls[0][0];
+      expect(saved.resets_at).toBeNull();
+    });
+  });
+
+  describe('cache eviction', () => {
+    it('evicts the oldest entry once the cache is full', async () => {
+      // Use a single OpenAI provider but rotate the userId so each capture
+      // writes a distinct cache key (userId:provider). MAX_CACHE is 2000, so
+      // 2001 distinct keys forces one eviction of the oldest entry.
+      const res = new Response(null, {
+        headers: makeHeaders({ 'x-ratelimit-limit-requests': '1' }),
+      });
+      for (let i = 0; i < 2001; i++) {
+        service.captureFromResponse(res.clone(), `evict-${i}`, 'openai', 'api_key');
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+      // The very first user's entry should have been evicted.
+      const out = await service.getRateLimits('evict-0');
+      // DB returns nothing for that user, so the evicted in-memory entry is gone.
+      expect(out).toEqual([]);
+    });
+  });
+
+  describe('getRateLimits', () => {
+    it('returns cached snapshot without hitting DB grouping for that provider', async () => {
+      const userId = nextUser();
+      const res = new Response(null, {
+        headers: makeHeaders({
+          'x-ratelimit-limit-requests': '100',
+          'x-ratelimit-remaining-requests': '90',
+        }),
+      });
+      service.captureFromResponse(res, userId, 'openai', 'api_key', 'lbl');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const out = await service.getRateLimits(userId);
+      expect(out).toHaveLength(1);
+      expect(out[0].provider).toBe('openai');
+      expect(out[0].keyLabel).toBe('lbl');
+      expect(out[0].limits[0].usedValue).toBe(10);
+    });
+
+    it('reads from DB when nothing cached and populates cache', async () => {
+      const userId = nextUser();
+      const row: FakeRow = {
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        key_label: null,
+        limit_type: 'tokens',
+        period: 'minute',
+        limit_value: '1000',
+        remaining_value: '400',
+        used_value: '600',
+        resets_at: '2026-01-01T00:00:00Z',
+      };
+      getManyRows = [row as unknown as ProviderRateLimit];
+
+      const out = await service.getRateLimits(userId);
+      expect(out).toHaveLength(1);
+      expect(out[0].provider).toBe('anthropic');
+      expect(out[0].keyLabel).toBeUndefined();
+      expect(out[0].limits[0].limitValue).toBe(1000);
+      expect(out[0].limits[0].remainingValue).toBe(400);
+      expect(out[0].limits[0].usedValue).toBe(600);
+
+      // Second call should serve from the cache populated above.
+      repo.createQueryBuilder.mockClear();
+      const out2 = await service.getRateLimits(userId);
+      expect(out2).toHaveLength(1);
+    });
+
+    it('handles DB rows with null numeric fields', async () => {
+      const userId = nextUser();
+      const row: FakeRow = {
+        provider: 'anthropic',
+        auth_type: 'api_key',
+        key_label: 'k',
+        limit_type: 'requests',
+        period: 'minute',
+        limit_value: null,
+        remaining_value: null,
+        used_value: '0',
+        resets_at: null,
+      };
+      getManyRows = [row as unknown as ProviderRateLimit];
+      const out = await service.getRateLimits(userId);
+      expect(out[0].limits[0].limitValue).toBeNull();
+      expect(out[0].limits[0].remainingValue).toBeNull();
+      // '0' is falsy as a value but a truthy string, so it parses to 0.
+      expect(out[0].limits[0].usedValue).toBe(0);
+      expect(out[0].keyLabel).toBe('k');
+    });
+
+    it('expires stale cache entries and falls back to DB', async () => {
+      const userId = nextUser();
+      const realNow = Date.now;
+      // Seed cache at t=0
+      const res = new Response(null, {
+        headers: makeHeaders({ 'x-ratelimit-limit-requests': '10' }),
+      });
+      service.captureFromResponse(res, userId, 'openai', 'api_key');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Jump forward beyond TTL so the cached entry is expired.
+      jest.spyOn(Date, 'now').mockReturnValue(realNow() + 120_000);
+      getManyRows = [];
+      const out = await service.getRateLimits(userId);
+      // expired openai entry deleted; DB returns nothing -> empty
+      expect(out).toEqual([]);
+      (Date.now as jest.Mock).mockRestore();
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/rate-limit-tracker.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/rate-limit-tracker.service.spec.ts
@@ -306,6 +306,81 @@ describe('RateLimitTrackerService', () => {
       expect(out[0].keyLabel).toBe('k');
     });
 
+    it('keeps same-provider connections separate by auth_type and label (cache)', async () => {
+      const userId = nextUser();
+      const res = () =>
+        new Response(null, {
+          headers: makeHeaders({
+            'x-ratelimit-limit-requests': '100',
+            'x-ratelimit-remaining-requests': '90',
+          }),
+        });
+
+      // Same provider, three distinct connections: differing auth_type and label.
+      service.captureFromResponse(res(), userId, 'openai', 'api_key', 'work');
+      service.captureFromResponse(res(), userId, 'openai', 'api_key', 'personal');
+      service.captureFromResponse(res(), userId, 'openai', 'subscription', 'work');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const out = await service.getRateLimits(userId);
+      expect(out).toHaveLength(3);
+      const ids = out.map((s) => `${s.provider}|${s.authType}|${s.keyLabel}`).sort();
+      expect(ids).toEqual([
+        'openai|api_key|personal',
+        'openai|api_key|work',
+        'openai|subscription|work',
+      ]);
+    });
+
+    it('groups DB rows by full connection tuple, not just provider', async () => {
+      const userId = nextUser();
+      const mk = (auth: string, label: string | null, limitType: string): FakeRow => ({
+        provider: 'openai',
+        auth_type: auth,
+        key_label: label,
+        limit_type: limitType,
+        period: 'minute',
+        limit_value: '100',
+        remaining_value: '50',
+        used_value: '50',
+        resets_at: null,
+      });
+      // Two distinct connections for the same provider plus a second limit_type
+      // on the first connection. Must yield two snapshots; the first carries
+      // both its limit rows.
+      getManyRows = [
+        mk('api_key', 'work', 'requests'),
+        mk('api_key', 'work', 'tokens'),
+        mk('subscription', 'personal', 'requests'),
+      ] as unknown as ProviderRateLimit[];
+
+      const out = await service.getRateLimits(userId);
+      expect(out).toHaveLength(2);
+      const work = out.find((s) => s.authType === 'api_key' && s.keyLabel === 'work');
+      const personal = out.find((s) => s.authType === 'subscription' && s.keyLabel === 'personal');
+      expect(work?.limits).toHaveLength(2);
+      expect(personal?.limits).toHaveLength(1);
+    });
+
+    it('matches the latest-snapshot subquery on the full connection identity', async () => {
+      const userId = nextUser();
+      getManyRows = [];
+      await service.getRateLimits(userId);
+      // The correlated subquery must constrain auth_type, key_label and
+      // limit_type (collapsing NULL labels to 'Default'), not just provider.
+      const subqueryCall = qb.andWhere.mock.calls.find((c) =>
+        String(c[0]).includes('MAX(rl2.captured_at)'),
+      );
+      expect(subqueryCall).toBeDefined();
+      const sql = String(subqueryCall![0]);
+      expect(sql).toContain('rl2.auth_type = rl.auth_type');
+      expect(sql).toContain(
+        "COALESCE(rl2.key_label, 'Default') = COALESCE(rl.key_label, 'Default')",
+      );
+      expect(sql).toContain('rl2.limit_type = rl.limit_type');
+    });
+
     it('expires stale cache entries and falls back to DB', async () => {
       const userId = nextUser();
       const realNow = Date.now;

--- a/packages/backend/src/routing/proxy/__tests__/rate-limit-tracker.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/rate-limit-tracker.service.spec.ts
@@ -261,6 +261,31 @@ describe('RateLimitTrackerService', () => {
       expect(out).toEqual([]);
     });
 
+    it('reclaims expired entries before evicting a live one when full', async () => {
+      const res = new Response(null, {
+        headers: makeHeaders({ 'x-ratelimit-limit-requests': '1' }),
+      });
+      const t0 = 1_000_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(t0);
+      // Fill the cache to capacity; every entry expires at t0 + TTL.
+      for (let i = 0; i < 2000; i++) {
+        service.captureFromResponse(res.clone(), `stale-${i}`, 'openai', 'api_key');
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+      // Advance past the TTL so all 2000 entries are now expired, then insert a
+      // fresh one: setCapped must sweep the expired entries (freeing capacity)
+      // rather than evicting a live entry.
+      nowSpy.mockReturnValue(t0 + 60_001);
+      service.captureFromResponse(res.clone(), 'fresh-user', 'openai', 'api_key');
+      await Promise.resolve();
+      await Promise.resolve();
+      // The fresh entry is live and served straight from the in-memory cache.
+      const fresh = await service.getRateLimits('fresh-user');
+      expect(fresh.length).toBeGreaterThan(0);
+      nowSpy.mockRestore();
+    });
+
     it('enforces MAX_CACHE on the DB-repopulation path', async () => {
       // Fill the cache to exactly MAX_CACHE via captures.
       const res = new Response(null, {

--- a/packages/backend/src/routing/proxy/__tests__/rate-limit-tracker.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/rate-limit-tracker.service.spec.ts
@@ -103,6 +103,33 @@ describe('RateLimitTrackerService', () => {
       expect(saved.used_value).toBe('0'); // null used -> '0'
       expect(saved.remaining_value).toBeNull();
     });
+
+    it('persists an unlabeled key under the canonical Default connection label', async () => {
+      const userId = nextUser();
+      const res = new Response(null, {
+        headers: makeHeaders({ 'x-ratelimit-limit-requests': '10' }),
+      });
+      // No keyLabel passed: the row must store an explicit 'Default', not NULL,
+      // so it matches the analytics layer's NULL→'Default' connection keying.
+      service.captureFromResponse(res, userId, 'openai', 'api_key');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(repo.save.mock.calls[0][0].key_label).toBe('Default');
+
+      const out = await service.getRateLimits(userId);
+      expect(out[0].keyLabel).toBe('Default');
+    });
+
+    it('persists an empty-string key label under the canonical Default connection', async () => {
+      const userId = nextUser();
+      const res = new Response(null, {
+        headers: makeHeaders({ 'x-ratelimit-limit-requests': '10' }),
+      });
+      service.captureFromResponse(res, userId, 'openai', 'api_key', '');
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(repo.save.mock.calls[0][0].key_label).toBe('Default');
+    });
   });
 
   describe('captureFromResponse — Anthropic headers', () => {
@@ -232,6 +259,43 @@ describe('RateLimitTrackerService', () => {
       const out = await service.getRateLimits('evict-0');
       // DB returns nothing for that user, so the evicted in-memory entry is gone.
       expect(out).toEqual([]);
+    });
+
+    it('enforces MAX_CACHE on the DB-repopulation path', async () => {
+      // Fill the cache to exactly MAX_CACHE via captures.
+      const res = new Response(null, {
+        headers: makeHeaders({ 'x-ratelimit-limit-requests': '1' }),
+      });
+      for (let i = 0; i < 2000; i++) {
+        service.captureFromResponse(res.clone(), `repop-${i}`, 'openai', 'api_key');
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // A getRateLimits for a brand-new user whose DB returns a fresh
+      // connection forces a repopulation cache.set. With the cache already at
+      // capacity, the repopulation must evict the oldest entry (repop-0)
+      // instead of growing past MAX_CACHE.
+      const row: FakeRow = {
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        key_label: 'team',
+        limit_type: 'tokens',
+        period: 'minute',
+        limit_value: '1000',
+        remaining_value: '400',
+        used_value: '600',
+        resets_at: null,
+      };
+      getManyRows = [row as unknown as ProviderRateLimit];
+      const fresh = await service.getRateLimits('repop-new');
+      expect(fresh).toHaveLength(1);
+
+      // The oldest captured connection was evicted by the capped repopulation;
+      // its in-memory entry is gone and its DB lookup returns nothing.
+      getManyRows = [];
+      const evicted = await service.getRateLimits('repop-0');
+      expect(evicted).toEqual([]);
     });
   });
 

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -165,6 +165,7 @@ export class ProxyFallbackService {
       provider: string;
       fallbackIndex: number;
       authType?: AuthType;
+      keyLabel?: string;
     } | null;
     failures: FailedFallback[];
   }> {
@@ -315,7 +316,14 @@ export class ProxyFallbackService {
 
       if (forward.response.ok) {
         return {
-          success: { forward, model, provider, fallbackIndex: i, authType },
+          success: {
+            forward,
+            model,
+            provider,
+            fallbackIndex: i,
+            authType,
+            keyLabel: providerKeyLabel,
+          },
           failures,
         };
       }

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -4,6 +4,7 @@ import { AgentMessage } from '../../entities/agent-message.entity';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { MessageRecording } from '../../entities/message-recording.entity';
 import { ReasoningContentCacheEntry } from '../../entities/reasoning-content-cache-entry.entity';
+import { ProviderRateLimit } from '../../entities/provider-rate-limit.entity';
 import { RoutingCoreModule } from '../routing-core/routing-core.module';
 import { ModelPricesModule } from '../../model-prices/model-prices.module';
 import { ModelDiscoveryModule } from '../../model-discovery/model-discovery.module';
@@ -27,6 +28,7 @@ import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { ReasoningContentCache } from './reasoning-content-cache';
 import { ProxyExceptionFilter } from './proxy-exception.filter';
+import { RateLimitTrackerService } from './rate-limit-tracker.service';
 
 @Module({
   imports: [
@@ -35,6 +37,7 @@ import { ProxyExceptionFilter } from './proxy-exception.filter';
       CustomProvider,
       MessageRecording,
       ReasoningContentCacheEntry,
+      ProviderRateLimit,
     ]),
     RoutingCoreModule,
     ModelPricesModule,
@@ -61,7 +64,8 @@ import { ProxyExceptionFilter } from './proxy-exception.filter';
     ReasoningContentCache,
     ProxyExceptionFilter,
     MessageRecordingService,
+    RateLimitTrackerService,
   ],
-  exports: [ProviderClient],
+  exports: [ProviderClient, RateLimitTrackerService],
 })
 export class ProxyModule {}

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -13,6 +13,7 @@ import { ForwardResult } from './provider-client';
 import { SessionMomentumService } from './session-momentum.service';
 import { LimitCheckService } from '../../notifications/services/limit-check.service';
 import { shouldTriggerFallback } from './fallback-status-codes';
+import { RateLimitTrackerService } from './rate-limit-tracker.service';
 import { Tier, TIERS, ScorerMessage } from '../../scoring/types';
 import type {
   AuthType,
@@ -142,6 +143,7 @@ export class ProxyService {
     private readonly reasoningCache: ReasoningContentCache,
     private readonly modelParamsService: AgentModelParamsService,
     private readonly providerParamSpecs: ProviderParamSpecService,
+    private readonly rateLimitTracker: RateLimitTrackerService,
   ) {}
 
   async proxyRequest(opts: ProxyRequestOptions): Promise<ProxyResult> {
@@ -266,6 +268,15 @@ export class ProxyService {
       reasoningContentLookup,
       paramMergeContext,
     });
+
+    // Capture rate limit headers (fire-and-forget, never blocks proxy)
+    this.rateLimitTracker.captureFromResponse(
+      forward.response,
+      userId,
+      route.provider,
+      route.authType,
+      route.keyLabel ?? undefined,
+    );
 
     if (!forward.response.ok && shouldTriggerFallback(forward.response.status)) {
       const fallbackResult = await this.tryFallbackChain({

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -595,6 +595,17 @@ export class ProxyService {
         modelParams: fallbackModelParams,
         specs: fallbackSpecs,
       });
+      // Capture the fallback provider's rate-limit headers too — only the
+      // failed primary was tracked before, so a fallback-served request left
+      // the winning connection's limits unrecorded. Fire-and-forget: the
+      // tracker swallows its own errors and never throws into the proxy path.
+      this.rateLimitTracker.captureFromResponse(
+        success.forward.response,
+        userId,
+        success.provider,
+        success.authType ?? '',
+        success.keyLabel,
+      );
       return {
         forward: success.forward,
         meta: this.buildBaseMeta(resolved, success.model, {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -13,7 +13,7 @@ import { ForwardResult } from './provider-client';
 import { SessionMomentumService } from './session-momentum.service';
 import { LimitCheckService } from '../../notifications/services/limit-check.service';
 import { shouldTriggerFallback } from './fallback-status-codes';
-import { RateLimitTrackerService } from './rate-limit-tracker.service';
+import { RateLimitTrackerService, canonicalConnectionLabel } from './rate-limit-tracker.service';
 import { Tier, TIERS, ScorerMessage } from '../../scoring/types';
 import type {
   AuthType,
@@ -269,13 +269,16 @@ export class ProxyService {
       paramMergeContext,
     });
 
-    // Capture rate limit headers (fire-and-forget, never blocks proxy)
+    // Capture rate limit headers (fire-and-forget, never blocks proxy).
+    // Attribute to the canonical connection label so an unlabeled key is
+    // recorded under the stored 'Default' connection rather than a NULL that
+    // could collide with a real 'Default' connection on read.
     this.rateLimitTracker.captureFromResponse(
       forward.response,
       userId,
       route.provider,
       route.authType,
-      route.keyLabel ?? undefined,
+      canonicalConnectionLabel(route.keyLabel),
     );
 
     if (!forward.response.ok && shouldTriggerFallback(forward.response.status)) {
@@ -604,7 +607,9 @@ export class ProxyService {
         userId,
         success.provider,
         success.authType ?? '',
-        success.keyLabel,
+        // Mirror the primary path: a fallback success with no explicit keyLabel
+        // is recorded under the canonical 'Default' connection, not NULL.
+        canonicalConnectionLabel(success.keyLabel),
       );
       return {
         forward: success.forward,

--- a/packages/backend/src/routing/proxy/rate-limit-tracker.service.ts
+++ b/packages/backend/src/routing/proxy/rate-limit-tracker.service.ts
@@ -1,0 +1,276 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
+import { ProviderRateLimit } from '../../entities/provider-rate-limit.entity';
+
+/**
+ * Parsed rate limit snapshot from a single provider response.
+ */
+export interface RateLimitSnapshot {
+  userId: string;
+  provider: string;
+  authType: string;
+  keyLabel?: string;
+  limits: RateLimitEntry[];
+}
+
+export interface RateLimitEntry {
+  limitType: string; // 'requests' | 'tokens' | 'input_tokens' | 'output_tokens'
+  period: string; // 'minute' | 'hour' | 'day'
+  limitValue: number | null;
+  remainingValue: number | null;
+  usedValue: number | null;
+  resetsAt: string | null; // ISO timestamp
+}
+
+// In-memory cache: userId:provider -> latest snapshot
+const TTL_MS = 60_000;
+const MAX_CACHE = 2_000;
+
+interface CachedSnapshot {
+  data: RateLimitSnapshot;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CachedSnapshot>();
+
+/**
+ * Extract rate-limit headers from OpenAI and Anthropic responses.
+ * Returns parsed entries or null if no rate-limit headers found.
+ */
+function extractRateLimitHeaders(headers: Headers, provider: string): RateLimitEntry[] | null {
+  const entries: RateLimitEntry[] = [];
+  const lower = provider.toLowerCase();
+
+  if (lower === 'openai' || lower === 'chatgpt') {
+    // OpenAI: x-ratelimit-limit-requests, x-ratelimit-remaining-requests, etc.
+    const reqLimit = headers.get('x-ratelimit-limit-requests');
+    const reqRemaining = headers.get('x-ratelimit-remaining-requests');
+    const reqReset = headers.get('x-ratelimit-reset-requests');
+    if (reqLimit || reqRemaining) {
+      const limit = reqLimit ? parseInt(reqLimit, 10) : null;
+      const remaining = reqRemaining ? parseInt(reqRemaining, 10) : null;
+      entries.push({
+        limitType: 'requests',
+        period: 'minute',
+        limitValue: limit,
+        remainingValue: remaining,
+        usedValue: limit != null && remaining != null ? limit - remaining : null,
+        resetsAt: reqReset ? parseResetDuration(reqReset) : null,
+      });
+    }
+
+    const tokLimit = headers.get('x-ratelimit-limit-tokens');
+    const tokRemaining = headers.get('x-ratelimit-remaining-tokens');
+    const tokReset = headers.get('x-ratelimit-reset-tokens');
+    if (tokLimit || tokRemaining) {
+      const limit = tokLimit ? parseInt(tokLimit, 10) : null;
+      const remaining = tokRemaining ? parseInt(tokRemaining, 10) : null;
+      entries.push({
+        limitType: 'tokens',
+        period: 'minute',
+        limitValue: limit,
+        remainingValue: remaining,
+        usedValue: limit != null && remaining != null ? limit - remaining : null,
+        resetsAt: tokReset ? parseResetDuration(tokReset) : null,
+      });
+    }
+  }
+
+  if (lower === 'anthropic') {
+    // Anthropic: anthropic-ratelimit-requests-limit, etc.
+    const reqLimit = headers.get('anthropic-ratelimit-requests-limit');
+    const reqRemaining = headers.get('anthropic-ratelimit-requests-remaining');
+    const reqReset = headers.get('anthropic-ratelimit-requests-reset');
+    if (reqLimit || reqRemaining) {
+      const limit = reqLimit ? parseInt(reqLimit, 10) : null;
+      const remaining = reqRemaining ? parseInt(reqRemaining, 10) : null;
+      entries.push({
+        limitType: 'requests',
+        period: 'minute',
+        limitValue: limit,
+        remainingValue: remaining,
+        usedValue: limit != null && remaining != null ? limit - remaining : null,
+        resetsAt: reqReset ?? null,
+      });
+    }
+
+    const tokLimit = headers.get('anthropic-ratelimit-tokens-limit');
+    const tokRemaining = headers.get('anthropic-ratelimit-tokens-remaining');
+    const tokReset = headers.get('anthropic-ratelimit-tokens-reset');
+    if (tokLimit || tokRemaining) {
+      const limit = tokLimit ? parseInt(tokLimit, 10) : null;
+      const remaining = tokRemaining ? parseInt(tokRemaining, 10) : null;
+      entries.push({
+        limitType: 'tokens',
+        period: 'minute',
+        limitValue: limit,
+        remainingValue: remaining,
+        usedValue: limit != null && remaining != null ? limit - remaining : null,
+        resetsAt: tokReset ?? null,
+      });
+    }
+  }
+
+  return entries.length > 0 ? entries : null;
+}
+
+/**
+ * Parse OpenAI reset duration strings like "6m32.512s" or "1h2m3s" to ISO timestamp.
+ */
+function parseResetDuration(raw: string): string | null {
+  // Already an ISO timestamp
+  if (raw.includes('T') || raw.includes('-')) return raw;
+
+  let ms = 0;
+  const hMatch = raw.match(/(\d+)h/);
+  const mMatch = raw.match(/(\d+(?:\.\d+)?)m(?!s)/);
+  const sMatch = raw.match(/(\d+(?:\.\d+)?)s/);
+  const msMatch = raw.match(/(\d+)ms/);
+
+  if (hMatch) ms += parseFloat(hMatch[1]) * 3600_000;
+  if (mMatch) ms += parseFloat(mMatch[1]) * 60_000;
+  if (sMatch) ms += parseFloat(sMatch[1]) * 1000;
+  if (msMatch) ms += parseInt(msMatch[1], 10);
+
+  if (ms === 0) return null;
+  return new Date(Date.now() + ms).toISOString();
+}
+
+@Injectable()
+export class RateLimitTrackerService {
+  private readonly logger = new Logger(RateLimitTrackerService.name);
+
+  constructor(
+    @InjectRepository(ProviderRateLimit)
+    private readonly rateLimitRepo: Repository<ProviderRateLimit>,
+  ) {}
+
+  /**
+   * Fire-and-forget: extract rate limit headers from a provider response
+   * and persist them. Errors never propagate to the proxy response path.
+   */
+  captureFromResponse(
+    response: Response,
+    userId: string,
+    provider: string,
+    authType: string,
+    keyLabel?: string,
+  ): void {
+    try {
+      const entries = extractRateLimitHeaders(response.headers, provider);
+      if (!entries) return;
+
+      const snapshot: RateLimitSnapshot = {
+        userId,
+        provider,
+        authType,
+        keyLabel,
+        limits: entries,
+      };
+
+      // Update in-memory cache immediately
+      const cacheKey = `${userId}:${provider}`;
+      if (cache.size >= MAX_CACHE && !cache.has(cacheKey)) {
+        const firstKey = cache.keys().next().value;
+        if (firstKey !== undefined) cache.delete(firstKey);
+      }
+      cache.set(cacheKey, { data: snapshot, expiresAt: Date.now() + TTL_MS });
+
+      // Persist async (fire-and-forget)
+      this.persistSnapshot(snapshot).catch(() => {
+        // Silently ignore persistence errors
+      });
+    } catch {
+      // Never propagate to proxy
+    }
+  }
+
+  /**
+   * Get the latest rate limit state for all providers of a user.
+   */
+  async getRateLimits(userId: string): Promise<RateLimitSnapshot[]> {
+    // Check in-memory cache first
+    const snapshots: RateLimitSnapshot[] = [];
+    const uncachedProviders = new Set<string>();
+
+    // Collect cached entries
+    for (const [key, entry] of cache) {
+      if (!key.startsWith(`${userId}:`)) continue;
+      if (entry.expiresAt > Date.now()) {
+        snapshots.push(entry.data);
+      } else {
+        cache.delete(key);
+        uncachedProviders.add(key.split(':')[1]);
+      }
+    }
+
+    // Fetch from DB for any that weren't cached
+    const dbRows = await this.rateLimitRepo
+      .createQueryBuilder('rl')
+      .where('rl.user_id = :userId', { userId })
+      .andWhere(
+        'rl.captured_at = (SELECT MAX(rl2.captured_at) FROM provider_rate_limits rl2 WHERE rl2.user_id = rl.user_id AND rl2.provider = rl.provider AND rl2.limit_type = rl.limit_type)',
+      )
+      .getMany();
+
+    // Group DB rows by provider
+    const byProvider = new Map<string, ProviderRateLimit[]>();
+    for (const row of dbRows) {
+      const existing = byProvider.get(row.provider) ?? [];
+      existing.push(row);
+      byProvider.set(row.provider, existing);
+    }
+
+    // Build snapshots for uncached providers
+    for (const [provider, rows] of byProvider) {
+      const cacheKey = `${userId}:${provider}`;
+      if (cache.has(cacheKey) && cache.get(cacheKey)!.expiresAt > Date.now()) continue;
+
+      const snapshot: RateLimitSnapshot = {
+        userId,
+        provider,
+        authType: rows[0].auth_type,
+        keyLabel: rows[0].key_label ?? undefined,
+        limits: rows.map((r) => ({
+          limitType: r.limit_type,
+          period: r.period,
+          limitValue: r.limit_value ? parseInt(r.limit_value, 10) : null,
+          remainingValue: r.remaining_value ? parseInt(r.remaining_value, 10) : null,
+          usedValue: r.used_value ? parseInt(r.used_value, 10) : null,
+          resetsAt: r.resets_at,
+        })),
+      };
+      snapshots.push(snapshot);
+
+      // Populate cache
+      cache.set(cacheKey, { data: snapshot, expiresAt: Date.now() + TTL_MS });
+    }
+
+    return snapshots;
+  }
+
+  private async persistSnapshot(snapshot: RateLimitSnapshot): Promise<void> {
+    const now = new Date().toISOString();
+    for (const entry of snapshot.limits) {
+      const record = Object.assign(new ProviderRateLimit(), {
+        id: randomUUID(),
+        user_id: snapshot.userId,
+        provider: snapshot.provider,
+        auth_type: snapshot.authType,
+        key_label: snapshot.keyLabel ?? null,
+        limit_type: entry.limitType,
+        period: entry.period,
+        limit_value: entry.limitValue?.toString() ?? null,
+        used_value: entry.usedValue?.toString() ?? '0',
+        remaining_value: entry.remainingValue?.toString() ?? null,
+        resets_at: entry.resetsAt,
+        source: 'header',
+        captured_at: now,
+      });
+
+      await this.rateLimitRepo.save(record);
+    }
+  }
+}

--- a/packages/backend/src/routing/proxy/rate-limit-tracker.service.ts
+++ b/packages/backend/src/routing/proxy/rate-limit-tracker.service.ts
@@ -81,8 +81,17 @@ function userCachePrefix(userId: string): string {
  */
 function setCapped(cacheKey: string, snapshot: RateLimitSnapshot): void {
   if (cache.size >= MAX_CACHE && !cache.has(cacheKey)) {
-    const firstKey = cache.keys().next().value;
-    if (firstKey !== undefined) cache.delete(firstKey);
+    // Reclaim expired entries first: stale snapshots shouldn't consume capacity
+    // and force premature eviction of a still-live entry.
+    const now = Date.now();
+    for (const [key, entry] of cache) {
+      if (entry.expiresAt <= now) cache.delete(key);
+    }
+    // Still at capacity (everything live) → evict the oldest as a last resort.
+    if (cache.size >= MAX_CACHE) {
+      const firstKey = cache.keys().next().value;
+      if (firstKey !== undefined) cache.delete(firstKey);
+    }
   }
   cache.set(cacheKey, { data: snapshot, expiresAt: Date.now() + TTL_MS });
 }

--- a/packages/backend/src/routing/proxy/rate-limit-tracker.service.ts
+++ b/packages/backend/src/routing/proxy/rate-limit-tracker.service.ts
@@ -24,7 +24,9 @@ export interface RateLimitEntry {
   resetsAt: string | null; // ISO timestamp
 }
 
-// In-memory cache: userId:provider -> latest snapshot
+// In-memory cache keyed by connection identity (user, provider, auth_type,
+// key_label) -> latest snapshot. Keying on userId:provider alone collapsed
+// distinct auth types / labels for the same provider into one entry.
 const TTL_MS = 60_000;
 const MAX_CACHE = 2_000;
 
@@ -34,6 +36,34 @@ interface CachedSnapshot {
 }
 
 const cache = new Map<string, CachedSnapshot>();
+
+// Delimiter for the composite cache key. userId is a UUID, so a space can't
+// alias one tuple onto another.
+const KEY_SEP = ' ';
+
+/** Canonical label for a connection — a legacy missing label collapses to 'Default'. */
+function canonicalLabel(keyLabel?: string | null): string {
+  return keyLabel && keyLabel.length > 0 ? keyLabel : 'Default';
+}
+
+/**
+ * Composite cache key identifying a connection by
+ * (user, provider, auth_type, key_label). Keying on userId:provider alone
+ * collapsed distinct auth types / labels for one provider into a single entry.
+ */
+function connectionCacheKey(
+  userId: string,
+  provider: string,
+  authType: string,
+  keyLabel?: string | null,
+): string {
+  return [userId, provider, authType, canonicalLabel(keyLabel)].join(KEY_SEP);
+}
+
+/** Per-user prefix used to scan the cache for one user's connections. */
+function userCachePrefix(userId: string): string {
+  return `${userId}${KEY_SEP}`;
+}
 
 /**
  * Extract rate-limit headers from OpenAI and Anthropic responses.
@@ -170,8 +200,9 @@ export class RateLimitTrackerService {
         limits: entries,
       };
 
-      // Update in-memory cache immediately
-      const cacheKey = `${userId}:${provider}`;
+      // Update in-memory cache immediately. Keyed by the full connection tuple
+      // so distinct auth types / labels for one provider stay separate.
+      const cacheKey = connectionCacheKey(userId, provider, authType, keyLabel);
       if (cache.size >= MAX_CACHE && !cache.has(cacheKey)) {
         const firstKey = cache.keys().next().value;
         if (firstKey !== undefined) cache.delete(firstKey);
@@ -188,49 +219,57 @@ export class RateLimitTrackerService {
   }
 
   /**
-   * Get the latest rate limit state for all providers of a user.
+   * Get the latest rate limit state for all of a user's provider connections.
    */
   async getRateLimits(userId: string): Promise<RateLimitSnapshot[]> {
     // Check in-memory cache first
     const snapshots: RateLimitSnapshot[] = [];
-    const uncachedProviders = new Set<string>();
+    const prefix = userCachePrefix(userId);
 
-    // Collect cached entries
+    // Collect live cached entries; drop expired ones.
     for (const [key, entry] of cache) {
-      if (!key.startsWith(`${userId}:`)) continue;
+      if (!key.startsWith(prefix)) continue;
       if (entry.expiresAt > Date.now()) {
         snapshots.push(entry.data);
       } else {
         cache.delete(key);
-        uncachedProviders.add(key.split(':')[1]);
       }
     }
 
-    // Fetch from DB for any that weren't cached
+    // Fetch the latest row per (provider, auth_type, key_label, limit_type)
+    // tuple from the DB — the lookup must key on the full connection identity,
+    // not just provider, or distinct labels/auth types would collapse.
     const dbRows = await this.rateLimitRepo
       .createQueryBuilder('rl')
       .where('rl.user_id = :userId', { userId })
       .andWhere(
-        'rl.captured_at = (SELECT MAX(rl2.captured_at) FROM provider_rate_limits rl2 WHERE rl2.user_id = rl.user_id AND rl2.provider = rl.provider AND rl2.limit_type = rl.limit_type)',
+        `rl.captured_at = (
+          SELECT MAX(rl2.captured_at) FROM provider_rate_limits rl2
+          WHERE rl2.user_id = rl.user_id
+            AND rl2.provider = rl.provider
+            AND rl2.auth_type = rl.auth_type
+            AND COALESCE(rl2.key_label, 'Default') = COALESCE(rl.key_label, 'Default')
+            AND rl2.limit_type = rl.limit_type
+        )`,
       )
       .getMany();
 
-    // Group DB rows by provider
-    const byProvider = new Map<string, ProviderRateLimit[]>();
+    // Group DB rows by connection identity (provider, auth_type, key_label).
+    const byConnection = new Map<string, ProviderRateLimit[]>();
     for (const row of dbRows) {
-      const existing = byProvider.get(row.provider) ?? [];
+      const key = connectionCacheKey(userId, row.provider, row.auth_type, row.key_label);
+      const existing = byConnection.get(key) ?? [];
       existing.push(row);
-      byProvider.set(row.provider, existing);
+      byConnection.set(key, existing);
     }
 
-    // Build snapshots for uncached providers
-    for (const [provider, rows] of byProvider) {
-      const cacheKey = `${userId}:${provider}`;
+    // Build snapshots for connections not already served from the cache.
+    for (const [cacheKey, rows] of byConnection) {
       if (cache.has(cacheKey) && cache.get(cacheKey)!.expiresAt > Date.now()) continue;
 
       const snapshot: RateLimitSnapshot = {
         userId,
-        provider,
+        provider: rows[0].provider,
         authType: rows[0].auth_type,
         keyLabel: rows[0].key_label ?? undefined,
         limits: rows.map((r) => ({

--- a/packages/backend/src/routing/proxy/rate-limit-tracker.service.ts
+++ b/packages/backend/src/routing/proxy/rate-limit-tracker.service.ts
@@ -41,8 +41,16 @@ const cache = new Map<string, CachedSnapshot>();
 // alias one tuple onto another.
 const KEY_SEP = ' ';
 
-/** Canonical label for a connection — a legacy missing label collapses to 'Default'. */
-function canonicalLabel(keyLabel?: string | null): string {
+/**
+ * Canonical label for a connection — a legacy missing label collapses to the
+ * stored `'Default'` connection (the value `provider.service` persists for an
+ * unlabeled key, and the value the analytics layer's `filterByKeyLabel`
+ * collapses NULL/empty to). Exported so the proxy capture path attributes a
+ * response to the SAME label the connection is keyed under, instead of leaving
+ * it NULL and relying on read-time coercion (which fabricated a 'Default' that
+ * could collide with a real 'Default' connection).
+ */
+export function canonicalConnectionLabel(keyLabel?: string | null): string {
   return keyLabel && keyLabel.length > 0 ? keyLabel : 'Default';
 }
 
@@ -57,12 +65,26 @@ function connectionCacheKey(
   authType: string,
   keyLabel?: string | null,
 ): string {
-  return [userId, provider, authType, canonicalLabel(keyLabel)].join(KEY_SEP);
+  return [userId, provider, authType, canonicalConnectionLabel(keyLabel)].join(KEY_SEP);
 }
 
 /** Per-user prefix used to scan the cache for one user's connections. */
 function userCachePrefix(userId: string): string {
   return `${userId}${KEY_SEP}`;
+}
+
+/**
+ * Insert/refresh a cache entry while enforcing MAX_CACHE. When the cache is at
+ * capacity and the key is new, evict the oldest (insertion-ordered) entry first
+ * so the in-memory cache can never grow unbounded — applies to BOTH the
+ * header-capture and the DB-repopulation paths.
+ */
+function setCapped(cacheKey: string, snapshot: RateLimitSnapshot): void {
+  if (cache.size >= MAX_CACHE && !cache.has(cacheKey)) {
+    const firstKey = cache.keys().next().value;
+    if (firstKey !== undefined) cache.delete(firstKey);
+  }
+  cache.set(cacheKey, { data: snapshot, expiresAt: Date.now() + TTL_MS });
 }
 
 /**
@@ -192,22 +214,26 @@ export class RateLimitTrackerService {
       const entries = extractRateLimitHeaders(response.headers, provider);
       if (!entries) return;
 
+      // Attribute the headers to the canonical connection label. An unlabeled
+      // key (NULL/empty) maps to the stored 'Default' connection rather than
+      // being persisted as NULL and relying on read-time coercion — that kept
+      // the cache key and the persisted row consistent with how the analytics
+      // layer keys connections, and stops a fabricated NULL→'Default' from
+      // ambiguously merging with a real 'Default' connection.
+      const label = canonicalConnectionLabel(keyLabel);
+
       const snapshot: RateLimitSnapshot = {
         userId,
         provider,
         authType,
-        keyLabel,
+        keyLabel: label,
         limits: entries,
       };
 
       // Update in-memory cache immediately. Keyed by the full connection tuple
       // so distinct auth types / labels for one provider stay separate.
-      const cacheKey = connectionCacheKey(userId, provider, authType, keyLabel);
-      if (cache.size >= MAX_CACHE && !cache.has(cacheKey)) {
-        const firstKey = cache.keys().next().value;
-        if (firstKey !== undefined) cache.delete(firstKey);
-      }
-      cache.set(cacheKey, { data: snapshot, expiresAt: Date.now() + TTL_MS });
+      const cacheKey = connectionCacheKey(userId, provider, authType, label);
+      setCapped(cacheKey, snapshot);
 
       // Persist async (fire-and-forget)
       this.persistSnapshot(snapshot).catch(() => {
@@ -283,8 +309,9 @@ export class RateLimitTrackerService {
       };
       snapshots.push(snapshot);
 
-      // Populate cache
-      cache.set(cacheKey, { data: snapshot, expiresAt: Date.now() + TTL_MS });
+      // Populate cache — capped like the header-capture path so DB
+      // repopulation can't grow the in-memory cache past MAX_CACHE.
+      setCapped(cacheKey, snapshot);
     }
 
     return snapshots;

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -39,6 +39,7 @@ import { PlaygroundRun } from '../src/entities/playground-run.entity';
 import { PlaygroundColumn } from '../src/entities/playground-column.entity';
 import { ReasoningContentCacheEntry } from '../src/entities/reasoning-content-cache-entry.entity';
 import { AgentProviderAccess } from '../src/entities/agent-provider-access.entity';
+import { ProviderRateLimit } from '../src/entities/provider-rate-limit.entity';
 import { HealthModule } from '../src/health/health.module';
 import { AnalyticsModule } from '../src/analytics/analytics.module';
 import { OtlpModule } from '../src/otlp/otlp.module';
@@ -81,6 +82,7 @@ const entities = [
   PlaygroundColumn,
   ReasoningContentCacheEntry,
   AgentProviderAccess,
+  ProviderRateLimit,
 ];
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 const OPENROUTER_MODELS_FIXTURE = {

--- a/packages/backend/test/provider-analytics.e2e-spec.ts
+++ b/packages/backend/test/provider-analytics.e2e-spec.ts
@@ -12,6 +12,8 @@ import {
 
 let app: INestApplication;
 let connectionId: string;
+let workConnectionId: string;
+let personalConnectionId: string;
 
 beforeAll(async () => {
   app = await createTestApp();
@@ -35,15 +37,59 @@ beforeAll(async () => {
     ],
   );
 
-  // Subscription-auth messages on openai for the test agent.
+  // Subscription-auth messages on openai for the test agent, tagged with the
+  // connection's label so they belong to the 'My OpenAI' connection detail.
   for (const [model, inTok, outTok] of [
     ['gpt-4o', 1000, 500],
     ['gpt-4o-mini', 200, 100],
   ] as Array<[string, number, number]>) {
     await ds.query(
-      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
-       VALUES ($1,$2,$3,$4,'ok',$5,'openai','subscription',$6,$7,0,0,$8,'msg','agent','test-agent',$9)`,
+      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, provider_key_label, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+       VALUES ($1,$2,$3,$4,'ok',$5,'openai','subscription','My OpenAI',$6,$7,0,0,$8,'msg','agent','test-agent',$9)`,
       [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, model, inTok, outTok, 0.01, TEST_USER_ID],
+    );
+  }
+
+  // Finding 1: a reserved Playground (is_system) agent whose usage must NOT
+  // pollute provider analytics aggregates or the connection breakdown.
+  const playgroundAgentId = uuid();
+  await ds.query(
+    `INSERT INTO agents (id, name, display_name, description, is_active, is_system, complexity_routing_enabled, tenant_id, created_at, updated_at)
+     VALUES ($1,'Playground','Playground','reserved',true,true,true,$2,$3,$3)`,
+    [playgroundAgentId, TEST_TENANT_ID, now],
+  );
+  await ds.query(
+    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+     VALUES ($1,$2,$3,$4,'ok','gpt-4o','openai','subscription',9000,9000,0,0,0.99,'msg','agent','Playground',$5)`,
+    [uuid(), TEST_TENANT_ID, playgroundAgentId, now, TEST_USER_ID],
+  );
+
+  // Finding 2: two connections sharing provider+auth_type but differing by
+  // label. Each has one message tagged with its provider_key_label; the
+  // connection-detail endpoint must keep their usage separate.
+  workConnectionId = uuid();
+  personalConnectionId = uuid();
+  for (const [id, label] of [
+    [workConnectionId, 'Work'],
+    [personalConnectionId, 'Personal'],
+  ] as Array<[string, string]>) {
+    await ds.query(
+      `INSERT INTO user_providers (id, user_id, agent_id, provider, key_prefix, auth_type, label, is_active, connected_at, updated_at, cached_models)
+       VALUES ($1,$2,NULL,'anthropic',$3,'api_key',$4,true,$5,$5,$6)`,
+      [id, TEST_USER_ID, `sk-${label}`, label, now, JSON.stringify([{ id: 'claude' }])],
+    );
+    await ds.query(
+      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, provider_key_label, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+       VALUES ($1,$2,$3,$4,'ok','claude','anthropic','api_key',$5,$6,$6,0,0,0.02,'msg','agent','test-agent',$7)`,
+      [
+        uuid(),
+        TEST_TENANT_ID,
+        TEST_AGENT_ID,
+        now,
+        label,
+        label === 'Work' ? 111 : 222,
+        TEST_USER_ID,
+      ],
     );
   }
 });
@@ -62,6 +108,18 @@ describe('GET /api/v1/provider-analytics', () => {
     expect(res.body).toHaveProperty('token_usage');
     expect(res.body).toHaveProperty('message_usage');
     expect(res.body.summary.messages.value).toBeGreaterThan(0);
+  });
+
+  it('excludes the reserved Playground (is_system) agent from summary aggregates', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/provider-analytics?auth_type=subscription&provider=openai&range=24h')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    // Real openai subscription usage is 2 messages / 1800 tokens. The
+    // Playground message (18000 tokens, 2 messages-worth of pollution) must be
+    // excluded, so the summary reflects only the non-system rows.
+    expect(res.body.summary.messages.value).toBe(2);
+    expect(res.body.summary.tokens.value).toBe(1800);
   });
 
   it('supports the agents endpoint', async () => {
@@ -116,6 +174,36 @@ describe('GET /api/v1/provider-analytics', () => {
     expect(Array.isArray(res.body.model_usage)).toBe(true);
     expect(res.body.model_usage.length).toBeGreaterThan(0);
     expect(Array.isArray(res.body.recent_messages)).toBe(true);
+  });
+
+  it('keeps same-provider/auth connections separate by label in connection-detail', async () => {
+    // Work key: one message, 222 tokens (111 in + 111 out). Personal key: one
+    // message, 444 tokens. They share provider=anthropic, auth_type=api_key, so
+    // without the label filter each detail would report the other's usage too.
+    const work = await request(app.getHttpServer())
+      .get(`/api/v1/provider-analytics/connection-detail?connection_id=${workConnectionId}`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    const personal = await request(app.getHttpServer())
+      .get(`/api/v1/provider-analytics/connection-detail?connection_id=${personalConnectionId}`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    const workTokens = work.body.model_usage.reduce(
+      (s: number, m: { tokens: number }) => s + m.tokens,
+      0,
+    );
+    const personalTokens = personal.body.model_usage.reduce(
+      (s: number, m: { tokens: number }) => s + m.tokens,
+      0,
+    );
+    expect(work.body.connection.label).toBe('Work');
+    expect(personal.body.connection.label).toBe('Personal');
+    // Each connection sees only its own usage (222 vs 444), not the merged 666.
+    expect(workTokens).toBe(222);
+    expect(personalTokens).toBe(444);
+    expect(work.body.recent_messages).toHaveLength(1);
+    expect(personal.body.recent_messages).toHaveLength(1);
   });
 
   it('returns an empty shape for a missing connection_id', async () => {

--- a/packages/backend/test/provider-analytics.e2e-spec.ts
+++ b/packages/backend/test/provider-analytics.e2e-spec.ts
@@ -50,6 +50,18 @@ beforeAll(async () => {
     );
   }
 
+  // Finding 1 (join duplication): a SOFT-DELETED agent that reuses the live
+  // agent's slug `test-agent` in the same tenant. A name-based agents join
+  // (a.name = at.agent_name) would match BOTH this row and the live agent for
+  // every `test-agent` message, doubling every per-agent SUM. The id-based
+  // join (a.id = at.agent_id) matches only the live agent, so totals stay exact.
+  const ghostAgentId = uuid();
+  await ds.query(
+    `INSERT INTO agents (id, name, display_name, description, is_active, complexity_routing_enabled, tenant_id, created_at, updated_at, deleted_at)
+     VALUES ($1,'test-agent','Old Test Agent','recreated slug',false,true,$2,$3,$3,$3)`,
+    [ghostAgentId, TEST_TENANT_ID, now],
+  );
+
   // Finding 1: a reserved Playground (is_system) agent whose usage must NOT
   // pollute provider analytics aggregates or the connection breakdown.
   const playgroundAgentId = uuid();
@@ -139,6 +151,21 @@ describe('GET /api/v1/provider-analytics', () => {
     expect(res.body).toHaveProperty('agents');
     expect(res.body).toHaveProperty('timeseries');
     expect(res.body.agents).toContain('test-agent');
+  });
+
+  it('does not double-count when a soft-deleted agent shares a slug (Finding 1)', async () => {
+    // Real openai subscription usage for `test-agent` is exactly 1800 tokens
+    // (1500 + 300). A soft-deleted agent reuses the same slug+tenant, so a
+    // name-based join would report 3600. The id-based join keeps it at 1800.
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/provider-analytics/per-agent-timeseries?auth_type=subscription&provider=openai')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    const total = res.body.timeseries.reduce(
+      (sum: number, row: Record<string, number>) => sum + (row['test-agent'] ?? 0),
+      0,
+    );
+    expect(total).toBe(1800);
   });
 
   it('returns per-agent message + cost timeseries', async () => {
@@ -244,6 +271,27 @@ describe('GET /api/v1/overview/per-* timeseries', () => {
       expect(res.body).toHaveProperty('agents');
       expect(res.body).toHaveProperty('timeseries');
     }
+  });
+
+  it('excludes the Playground (is_system) agent from per-provider and per-model timeseries (Finding 2)', async () => {
+    // The Playground agent logged 18000 openai/gpt-4o tokens. Real openai usage
+    // is 1800 tokens (gpt-4o 1500 + gpt-4o-mini 300). Before the fix these
+    // endpoints had no is_system filter, so openai would have read 19800 and
+    // gpt-4o 19500. After the fix the Playground rows are excluded.
+    const sumKey = (rows: Array<Record<string, number>>, key: string): number =>
+      rows.reduce((sum, row) => sum + (row[key] ?? 0), 0);
+
+    const provider = await request(app.getHttpServer())
+      .get('/api/v1/overview/per-provider-timeseries?range=24h')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(sumKey(provider.body.timeseries, 'openai')).toBe(1800);
+
+    const model = await request(app.getHttpServer())
+      .get('/api/v1/overview/per-model-timeseries?range=24h')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(sumKey(model.body.timeseries, 'gpt-4o')).toBe(1500);
   });
 });
 

--- a/packages/backend/test/provider-analytics.e2e-spec.ts
+++ b/packages/backend/test/provider-analytics.e2e-spec.ts
@@ -1,0 +1,171 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { v4 as uuid } from 'uuid';
+import request from 'supertest';
+import {
+  createTestApp,
+  TEST_API_KEY,
+  TEST_TENANT_ID,
+  TEST_AGENT_ID,
+  TEST_USER_ID,
+} from './helpers';
+
+let app: INestApplication;
+let connectionId: string;
+
+beforeAll(async () => {
+  app = await createTestApp();
+  const ds = app.get(DataSource);
+  const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+
+  // A user-global OpenAI connection (agent_id NULL = global under the new schema).
+  connectionId = uuid();
+  await ds.query(
+    `INSERT INTO user_providers (id, user_id, agent_id, provider, key_prefix, auth_type, label, is_active, connected_at, updated_at, cached_models)
+     VALUES ($1,$2,NULL,$3,$4,$5,$6,true,$7,$7,$8)`,
+    [
+      connectionId,
+      TEST_USER_ID,
+      'openai',
+      'sk-abc',
+      'subscription',
+      'My OpenAI',
+      now,
+      JSON.stringify([{ id: 'gpt-4o' }, { id: 'gpt-4o-mini' }]),
+    ],
+  );
+
+  // Subscription-auth messages on openai for the test agent.
+  for (const [model, inTok, outTok] of [
+    ['gpt-4o', 1000, 500],
+    ['gpt-4o-mini', 200, 100],
+  ] as Array<[string, number, number]>) {
+    await ds.query(
+      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+       VALUES ($1,$2,$3,$4,'ok',$5,'openai','subscription',$6,$7,0,0,$8,'msg','agent','test-agent',$9)`,
+      [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, model, inTok, outTok, 0.01, TEST_USER_ID],
+    );
+  }
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('GET /api/v1/provider-analytics', () => {
+  it('returns summary + token/message usage for subscription auth', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/provider-analytics?auth_type=subscription&range=24h')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(res.body).toHaveProperty('summary');
+    expect(res.body).toHaveProperty('token_usage');
+    expect(res.body).toHaveProperty('message_usage');
+    expect(res.body.summary.messages.value).toBeGreaterThan(0);
+  });
+
+  it('supports the agents endpoint', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/provider-analytics/agents?auth_type=subscription')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(Array.isArray(res.body.agents)).toBe(true);
+    expect(res.body.agents).toContain('test-agent');
+  });
+
+  it('returns per-agent token timeseries pivots', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/provider-analytics/per-agent-timeseries?auth_type=subscription&provider=openai')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(res.body).toHaveProperty('agents');
+    expect(res.body).toHaveProperty('timeseries');
+    expect(res.body.agents).toContain('test-agent');
+  });
+
+  it('returns per-agent message + cost timeseries', async () => {
+    await request(app.getHttpServer())
+      .get(
+        '/api/v1/provider-analytics/per-agent-message-timeseries?auth_type=subscription&provider=openai',
+      )
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    await request(app.getHttpServer())
+      .get(
+        '/api/v1/provider-analytics/per-agent-cost-timeseries?auth_type=subscription&provider=openai&range=7d',
+      )
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+  });
+
+  it('returns connection detail for an owned connection', async () => {
+    const res = await request(app.getHttpServer())
+      .get(`/api/v1/provider-analytics/connection-detail?connection_id=${connectionId}`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(res.body.connection).toMatchObject({
+      id: connectionId,
+      provider: 'openai',
+      auth_type: 'subscription',
+      cached_model_count: 2,
+    });
+    expect(Array.isArray(res.body.agents)).toBe(true);
+    expect(res.body.agents.some((a: { agent_name: string }) => a.agent_name === 'test-agent')).toBe(
+      true,
+    );
+    expect(Array.isArray(res.body.model_usage)).toBe(true);
+    expect(res.body.model_usage.length).toBeGreaterThan(0);
+    expect(Array.isArray(res.body.recent_messages)).toBe(true);
+  });
+
+  it('returns an empty shape for a missing connection_id', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/provider-analytics/connection-detail')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(res.body).toEqual({ connection: null, agents: [], recent_messages: [] });
+  });
+
+  it('returns an empty shape for a connection that does not belong to the user', async () => {
+    const res = await request(app.getHttpServer())
+      .get(`/api/v1/provider-analytics/connection-detail?connection_id=${uuid()}`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(res.body.connection).toBeNull();
+  });
+});
+
+describe('GET /api/v1/overview/per-* timeseries', () => {
+  it('exposes per-agent, per-provider and per-model overview timeseries', async () => {
+    const paths = [
+      'per-agent-timeseries',
+      'per-agent-message-timeseries',
+      'per-agent-cost-timeseries',
+      'per-provider-timeseries',
+      'per-provider-message-timeseries',
+      'per-provider-cost-timeseries',
+      'per-model-timeseries',
+      'per-model-message-timeseries',
+      'per-model-cost-timeseries',
+    ];
+    for (const p of paths) {
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/overview/${p}?range=24h`)
+        .set('x-api-key', TEST_API_KEY)
+        .expect(200);
+      expect(res.body).toHaveProperty('agents');
+      expect(res.body).toHaveProperty('timeseries');
+    }
+  });
+});
+
+describe('GET /api/v1/rate-limits', () => {
+  it('returns an empty providers list when nothing has been captured', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/rate-limits')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(res.body).toHaveProperty('providers');
+    expect(Array.isArray(res.body.providers)).toBe(true);
+  });
+});

--- a/packages/backend/test/provider-analytics.e2e-spec.ts
+++ b/packages/backend/test/provider-analytics.e2e-spec.ts
@@ -62,6 +62,16 @@ beforeAll(async () => {
     [ghostAgentId, TEST_TENANT_ID, now],
   );
 
+  // Finding 4: a message owned by the SOFT-DELETED `test-agent` (ghost id) on a
+  // distinct provider/model. A per-provider/per-model timeseries scoped to the
+  // live `test-agent` must NOT include this dead namesake's row — the agent
+  // filter has to resolve to the live agent's id, not match by slug.
+  await ds.query(
+    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+     VALUES ($1,$2,$3,$4,'ok','ghost-model','ghostprovider','api_key',5000,5000,0,0,0.5,'msg','agent','test-agent',$5)`,
+    [uuid(), TEST_TENANT_ID, ghostAgentId, now, TEST_USER_ID],
+  );
+
   // Finding 1: a reserved Playground (is_system) agent whose usage must NOT
   // pollute provider analytics aggregates or the connection breakdown.
   const playgroundAgentId = uuid();
@@ -212,6 +222,63 @@ describe('GET /api/v1/provider-analytics', () => {
       .expect(200);
   });
 
+  it('scopes per-agent timeseries to a single connection label (P2)', async () => {
+    // Work and Personal share provider=anthropic, auth_type=api_key. Without the
+    // label filter the per-agent chart for either connection would merge both
+    // (666 tokens). With it, Work sees only its 222 tokens.
+    const merged = await request(app.getHttpServer())
+      .get('/api/v1/provider-analytics/per-agent-timeseries?auth_type=api_key&provider=anthropic')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    const mergedTotal = merged.body.timeseries.reduce(
+      (sum: number, row: Record<string, number>) => sum + (row['test-agent'] ?? 0),
+      0,
+    );
+    expect(mergedTotal).toBe(666);
+
+    const work = await request(app.getHttpServer())
+      .get(
+        '/api/v1/provider-analytics/per-agent-timeseries?auth_type=api_key&provider=anthropic&label=Work',
+      )
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    const workTotal = work.body.timeseries.reduce(
+      (sum: number, row: Record<string, number>) => sum + (row['test-agent'] ?? 0),
+      0,
+    );
+    expect(workTotal).toBe(222);
+  });
+
+  it('scopes the summary + message timeseries to a connection label (P2)', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/provider-analytics?auth_type=api_key&provider=anthropic&label=Personal&range=24h')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    // Personal key: one message, 444 tokens — Work's 222 must not leak in.
+    expect(res.body.summary.messages.value).toBe(1);
+    expect(res.body.summary.tokens.value).toBe(444);
+
+    const msg = await request(app.getHttpServer())
+      .get(
+        '/api/v1/provider-analytics/per-agent-message-timeseries?auth_type=api_key&provider=anthropic&label=Personal',
+      )
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    const personalMessages = msg.body.timeseries.reduce(
+      (sum: number, row: Record<string, number>) => sum + (row['test-agent'] ?? 0),
+      0,
+    );
+    expect(personalMessages).toBe(1);
+
+    const cost = await request(app.getHttpServer())
+      .get(
+        '/api/v1/provider-analytics/per-agent-cost-timeseries?auth_type=api_key&provider=anthropic&label=Work',
+      )
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(cost.body.agents).toContain('test-agent');
+  });
+
   it('returns connection detail for an owned connection', async () => {
     const res = await request(app.getHttpServer())
       .get(`/api/v1/provider-analytics/connection-detail?connection_id=${connectionId}`)
@@ -295,7 +362,8 @@ describe('GET /api/v1/provider-analytics', () => {
       .get('/api/v1/provider-analytics/connection-detail')
       .set('x-api-key', TEST_API_KEY)
       .expect(200);
-    expect(res.body).toEqual({ connection: null, agents: [], recent_messages: [] });
+    // Every branch returns the same shape, including model_usage.
+    expect(res.body).toEqual({ connection: null, agents: [], model_usage: [], recent_messages: [] });
   });
 
   it('returns an empty shape for a connection that does not belong to the user', async () => {
@@ -351,6 +419,24 @@ describe('GET /api/v1/overview/per-* timeseries', () => {
       .set('x-api-key', TEST_API_KEY)
       .expect(200);
     expect(sumKey(model.body.timeseries, 'gpt-4o')).toBe(1500);
+  });
+
+  it('scopes per-provider/per-model timeseries to the LIVE agent, excluding a soft-deleted namesake (Finding 4)', async () => {
+    // A soft-deleted `test-agent` logged 10000 ghostprovider/ghost-model tokens.
+    // Scoping the per-provider/per-model timeseries to the live `test-agent`
+    // must resolve to the live agent's id, so the dead namesake's rows never
+    // appear in the agent-scoped chart.
+    const provider = await request(app.getHttpServer())
+      .get('/api/v1/overview/per-provider-timeseries?range=24h&agent_name=test-agent')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(provider.body.agents).not.toContain('ghostprovider');
+
+    const model = await request(app.getHttpServer())
+      .get('/api/v1/overview/per-model-timeseries?range=24h&agent_name=test-agent')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(model.body.agents).not.toContain('ghost-model');
   });
 });
 

--- a/packages/backend/test/provider-analytics.e2e-spec.ts
+++ b/packages/backend/test/provider-analytics.e2e-spec.ts
@@ -76,6 +76,17 @@ beforeAll(async () => {
     [uuid(), TEST_TENANT_ID, playgroundAgentId, now, TEST_USER_ID],
   );
 
+  // P2 leak case: an ORPHAN Playground message with a NULL agent_id but
+  // agent_name = 'Playground'. The previous id-only exclusion join left this
+  // row's `is_system` NULL and wrongly INCLUDED it. The NOT EXISTS semi-join
+  // matches the reserved Playground agent by NAME too, so this row is excluded
+  // from every aggregate, timeseries and the connection breakdown.
+  await ds.query(
+    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, provider, auth_type, provider_key_label, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, description, service_type, agent_name, user_id)
+     VALUES ($1,$2,NULL,$3,'ok','gpt-4o','openai','subscription','My OpenAI',7000,7000,0,0,0.77,'msg','agent','Playground',$4)`,
+    [uuid(), TEST_TENANT_ID, now, TEST_USER_ID],
+  );
+
   // Finding 2: two connections sharing provider+auth_type but differing by
   // label. Each has one message tagged with its provider_key_label; the
   // connection-detail endpoint must keep their usage separate.
@@ -127,11 +138,29 @@ describe('GET /api/v1/provider-analytics', () => {
       .get('/api/v1/provider-analytics?auth_type=subscription&provider=openai&range=24h')
       .set('x-api-key', TEST_API_KEY)
       .expect(200);
-    // Real openai subscription usage is 2 messages / 1800 tokens. The
-    // Playground message (18000 tokens, 2 messages-worth of pollution) must be
-    // excluded, so the summary reflects only the non-system rows.
+    // Real openai subscription usage is 2 messages / 1800 tokens. Both the
+    // Playground message with a matching agent_id (18000 tokens) AND the orphan
+    // Playground message with a NULL agent_id but agent_name 'Playground'
+    // (14000 tokens) must be excluded, so the summary reflects only the
+    // non-system rows. The orphan is the P2 leak case the name-based NOT EXISTS
+    // exclusion fixes — an id-only join would have counted it.
     expect(res.body.summary.messages.value).toBe(2);
     expect(res.body.summary.tokens.value).toBe(1800);
+  });
+
+  it('excludes an orphan Playground row (NULL agent_id, name only) from per-agent timeseries (P2)', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/provider-analytics/per-agent-timeseries?auth_type=subscription&provider=openai')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    // The orphan carries agent_name 'Playground'; the id-or-name semi-join drops
+    // it, so no 'Playground' column appears and test-agent stays at 1800.
+    expect(res.body.agents).not.toContain('Playground');
+    const total = res.body.timeseries.reduce(
+      (sum: number, row: Record<string, number>) => sum + (row['test-agent'] ?? 0),
+      0,
+    );
+    expect(total).toBe(1800);
   });
 
   it('supports the agents endpoint', async () => {
@@ -214,6 +243,21 @@ describe('GET /api/v1/provider-analytics', () => {
       0,
     );
     expect(agentTokens).toBe(modelTokens);
+    // P2 leak guard: the orphan Playground row (NULL agent_id, name 'Playground',
+    // label 'My OpenAI') also carries this connection's label, so without the
+    // name-based exclusion it would inflate both breakdowns by 14000 tokens and
+    // push a 'Playground' agent row into the list. Real usage is 1800 tokens.
+    expect(agentTokens).toBe(1800);
+    expect(modelTokens).toBe(1800);
+    expect(
+      res.body.agents.some((a: { agent_name: string }) => a.agent_name === 'Playground'),
+    ).toBe(false);
+    // The orphan also must not surface in recent messages.
+    expect(
+      res.body.recent_messages.some(
+        (m: { agent_name: string }) => m.agent_name === 'Playground',
+      ),
+    ).toBe(false);
   });
 
   it('keeps same-provider/auth connections separate by label in connection-detail', async () => {
@@ -287,10 +331,12 @@ describe('GET /api/v1/overview/per-* timeseries', () => {
   });
 
   it('excludes the Playground (is_system) agent from per-provider and per-model timeseries (Finding 2)', async () => {
-    // The Playground agent logged 18000 openai/gpt-4o tokens. Real openai usage
-    // is 1800 tokens (gpt-4o 1500 + gpt-4o-mini 300). Before the fix these
-    // endpoints had no is_system filter, so openai would have read 19800 and
-    // gpt-4o 19500. After the fix the Playground rows are excluded.
+    // The Playground agent logged 18000 openai/gpt-4o tokens (agent_id set), and
+    // an orphan Playground row logged 14000 more (NULL agent_id, name only).
+    // Real openai usage is 1800 tokens (gpt-4o 1500 + gpt-4o-mini 300). Before
+    // the fix these endpoints either had no is_system filter or used an id-only
+    // join that missed the orphan. After the name-based NOT EXISTS exclusion
+    // BOTH Playground rows are dropped from every per-* timeseries.
     const sumKey = (rows: Array<Record<string, number>>, key: string): number =>
       rows.reduce((sum, row) => sum + (row[key] ?? 0), 0);
 

--- a/packages/backend/test/provider-analytics.e2e-spec.ts
+++ b/packages/backend/test/provider-analytics.e2e-spec.ts
@@ -201,6 +201,19 @@ describe('GET /api/v1/provider-analytics', () => {
     expect(Array.isArray(res.body.model_usage)).toBe(true);
     expect(res.body.model_usage.length).toBeGreaterThan(0);
     expect(Array.isArray(res.body.recent_messages)).toBe(true);
+    // The agent breakdown joins agents by id, not name, so the soft-deleted
+    // agent reusing the 'test-agent' slug cannot double-count it. Both the agent
+    // and model breakdowns cover the same messages, so their token sums must be
+    // equal; a name-based join would inflate the agent side to twice the model side.
+    const agentTokens = res.body.agents.reduce(
+      (s: number, a: { tokens_30d: number }) => s + Number(a.tokens_30d),
+      0,
+    );
+    const modelTokens = res.body.model_usage.reduce(
+      (s: number, m: { tokens: number }) => s + Number(m.tokens),
+      0,
+    );
+    expect(agentTokens).toBe(modelTokens);
   });
 
   it('keeps same-provider/auth connections separate by label in connection-detail', async () => {

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -130,13 +130,9 @@ const Limits: Component = () => {
       />
 
       <div class="page-header">
-        <div>
-          <h1>Limits</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Get notified or block requests when token
-            or cost thresholds are exceeded
-          </span>
-        </div>
+        <span class="breadcrumb">
+          Get notified or block requests when token or cost thresholds are exceeded
+        </span>
         <button
           class="btn btn--primary btn--sm"
           onClick={() => {

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -435,13 +435,7 @@ const Routing: Component = () => {
       />
 
       <div class="page-header routing-page-header">
-        <div>
-          <h1>Routing</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Pick which model handles each type of
-            request
-          </span>
-        </div>
+        <span class="breadcrumb">Pick which model handles each type of request</span>
         <Show when={!connectedProviders.loading}>
           <div style="display: flex; gap: 8px;">
             <Show when={isEnabled()}>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -182,15 +182,9 @@ const Settings: Component = () => {
         name="description"
         content={`Configure settings for ${agentDisplayName() ?? agentName()}.`}
       />
-      <div class="page-header">
-        <div>
-          <h1>Settings</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Rename your agent, manage API keys, and
-            view setup instructions
-          </span>
-        </div>
-      </div>
+      <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); margin: 0 0 var(--gap-lg);">
+        Rename your agent, manage API keys, and view setup instructions
+      </p>
 
       {/* -- Agent Name ------------------------------ */}
       <div class="settings-card">

--- a/packages/frontend/src/services/api/analytics.ts
+++ b/packages/frontend/src/services/api/analytics.ts
@@ -1,4 +1,126 @@
-import { fetchJson, fetchMutate } from './core.js';
+import { fetchJson } from './core.js';
+
+export type PivotedTimeseries = Promise<{
+  agents: string[];
+  timeseries: Array<Record<string, number | string>>;
+}>;
+
+export function getProviderAnalytics(
+  authType: string,
+  range = '24h',
+  agentName?: string,
+  provider?: string,
+) {
+  return fetchJson('/provider-analytics', {
+    auth_type: authType,
+    range,
+    ...(agentName ? { agent_name: agentName } : {}),
+    ...(provider ? { provider } : {}),
+  });
+}
+
+export function getProviderAnalyticsAgents(authType: string): Promise<{ agents: string[] }> {
+  return fetchJson('/provider-analytics/agents', { auth_type: authType }) as Promise<{
+    agents: string[];
+  }>;
+}
+
+export function getPerAgentTimeseries(
+  authType: string,
+  provider: string,
+  range = '24h',
+): PivotedTimeseries {
+  return fetchJson('/provider-analytics/per-agent-timeseries', {
+    auth_type: authType,
+    provider,
+    range,
+  }) as PivotedTimeseries;
+}
+
+export function getPerAgentMessageTimeseries(
+  authType: string,
+  provider: string,
+  range = '24h',
+): PivotedTimeseries {
+  return fetchJson('/provider-analytics/per-agent-message-timeseries', {
+    auth_type: authType,
+    provider,
+    range,
+  }) as PivotedTimeseries;
+}
+
+export function getPerAgentCostTimeseries(
+  authType: string,
+  provider: string,
+  range = '24h',
+): PivotedTimeseries {
+  return fetchJson('/provider-analytics/per-agent-cost-timeseries', {
+    auth_type: authType,
+    provider,
+    range,
+  }) as PivotedTimeseries;
+}
+
+export function getConnectionDetail(connectionId: string) {
+  return fetchJson('/provider-analytics/connection-detail', { connection_id: connectionId });
+}
+
+export function getGlobalPerAgentTimeseries(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-agent-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getGlobalPerAgentMessageTimeseries(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-agent-message-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getGlobalPerAgentCostTimeseries(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-agent-cost-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getGlobalPerProviderTimeseries(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-provider-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getGlobalPerProviderMessageTimeseries(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-provider-message-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getGlobalPerProviderCostTimeseries(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-provider-cost-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getGlobalPerModelTimeseries(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-model-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getGlobalPerModelMessageTimeseries(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-model-message-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getGlobalPerModelCostTimeseries(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-model-cost-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getPerProviderTimeseries(agentName: string, range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-provider-timeseries', {
+    agent_name: agentName,
+    range,
+  }) as PivotedTimeseries;
+}
+
+export function getPerProviderMessageTimeseries(
+  agentName: string,
+  range = '24h',
+): PivotedTimeseries {
+  return fetchJson('/overview/per-provider-message-timeseries', {
+    agent_name: agentName,
+    range,
+  }) as PivotedTimeseries;
+}
+
+export function getRateLimits() {
+  return fetchJson('/rate-limits');
+}
 
 export function getOverview(range = '24h', agentName?: string) {
   return fetchJson('/overview', { range, ...(agentName ? { agent_name: agentName } : {}) });

--- a/packages/frontend/src/services/connection-breadcrumb-store.ts
+++ b/packages/frontend/src/services/connection-breadcrumb-store.ts
@@ -1,0 +1,17 @@
+import { createSignal } from 'solid-js';
+
+const [connName, setConnName] = createSignal<string | null>(null);
+const [connBackLink, setConnBackLink] = createSignal<string>('/providers/subscriptions');
+
+export function connectionBreadcrumbName(): string | null {
+  return connName();
+}
+
+export function connectionBreadcrumbBackLink(): string {
+  return connBackLink();
+}
+
+export function setConnectionBreadcrumb(name: string | null, backLink?: string): void {
+  setConnName(name);
+  if (backLink) setConnBackLink(backLink);
+}

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -61,14 +61,13 @@ describe("Limits page", () => {
     mockRoutingStatus = { enabled: false };
   });
 
-  it("renders page title", () => {
-    render(() => <Limits />);
-    expect(screen.getByText("Limits")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Limits />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
-  it("renders breadcrumb with agent name", () => {
+  it("renders page description without duplicating the agent heading", () => {
     const { container } = render(() => <Limits />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Get notified or block requests when token or cost thresholds are exceeded");
   });
 

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -617,12 +617,12 @@ beforeEach(() => {
 });
 
 describe('Routing page', () => {
-  it('renders the page header with the agent display name', async () => {
-    render(() => <Routing />);
+  it('renders routing description without a duplicate page heading', async () => {
+    const { container } = render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText('Routing')).toBeDefined();
+      expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
     });
-    expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
+    expect(container.querySelector('h1')).toBeNull();
   });
 
   it('renders the empty providers state when no providers are connected', async () => {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -138,9 +138,9 @@ describe("Settings", () => {
     mockUpdateAgent.mockResolvedValue({});
   });
 
-  it("renders Settings heading", () => {
-    render(() => <Settings />);
-    expect(screen.getByText("Settings")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Settings />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
   it("renders agent name input with value", () => {
@@ -330,9 +330,8 @@ describe("Settings", () => {
     });
   });
 
-  it("shows breadcrumb with agent name", () => {
+  it("shows settings description without duplicating the agent heading", () => {
     const { container } = render(() => <Settings />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Rename your agent");
   });
 

--- a/packages/frontend/tests/services/api/analytics.test.ts
+++ b/packages/frontend/tests/services/api/analytics.test.ts
@@ -89,4 +89,101 @@ describe('analytics API client', () => {
     expect(url).toContain('range=30d');
     expect(url).toContain('agent_name=demo');
   });
+
+  it('getProviderAnalytics forwards auth_type, range and optional filters', async () => {
+    const fetchMock = setupFetch({});
+    await analytics.getProviderAnalytics('subscription', '7d', 'demo', 'openai');
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/provider-analytics');
+    expect(url).toContain('auth_type=subscription');
+    expect(url).toContain('range=7d');
+    expect(url).toContain('agent_name=demo');
+    expect(url).toContain('provider=openai');
+  });
+
+  it('getProviderAnalytics omits agent_name and provider when absent', async () => {
+    const fetchMock = setupFetch({});
+    await analytics.getProviderAnalytics('api_key');
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('auth_type=api_key');
+    expect(url).toContain('range=24h');
+    expect(url).not.toContain('agent_name=');
+    expect(url).not.toContain('provider=');
+  });
+
+  it('getProviderAnalyticsAgents forwards auth_type', async () => {
+    const fetchMock = setupFetch({ agents: [] });
+    await analytics.getProviderAnalyticsAgents('subscription');
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/provider-analytics/agents');
+    expect(url).toContain('auth_type=subscription');
+  });
+
+  it('per-agent timeseries endpoints forward auth_type + provider + range', async () => {
+    const fns: Array<[(a: string, p: string, r?: string) => unknown, string]> = [
+      [analytics.getPerAgentTimeseries, 'per-agent-timeseries'],
+      [analytics.getPerAgentMessageTimeseries, 'per-agent-message-timeseries'],
+      [analytics.getPerAgentCostTimeseries, 'per-agent-cost-timeseries'],
+    ];
+    for (const [fn, path] of fns) {
+      const fetchMock = setupFetch({ agents: [], timeseries: [] });
+      await fn('subscription', 'openai', '30d');
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain(`/api/v1/provider-analytics/${path}`);
+      expect(url).toContain('auth_type=subscription');
+      expect(url).toContain('provider=openai');
+      expect(url).toContain('range=30d');
+    }
+  });
+
+  it('getConnectionDetail forwards connection_id', async () => {
+    const fetchMock = setupFetch({});
+    await analytics.getConnectionDetail('conn-1');
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/provider-analytics/connection-detail');
+    expect(url).toContain('connection_id=conn-1');
+  });
+
+  it('global per-* timeseries endpoints forward range', async () => {
+    const fns: Array<[(r?: string) => unknown, string]> = [
+      [analytics.getGlobalPerAgentTimeseries, 'per-agent-timeseries'],
+      [analytics.getGlobalPerAgentMessageTimeseries, 'per-agent-message-timeseries'],
+      [analytics.getGlobalPerAgentCostTimeseries, 'per-agent-cost-timeseries'],
+      [analytics.getGlobalPerProviderTimeseries, 'per-provider-timeseries'],
+      [analytics.getGlobalPerProviderMessageTimeseries, 'per-provider-message-timeseries'],
+      [analytics.getGlobalPerProviderCostTimeseries, 'per-provider-cost-timeseries'],
+      [analytics.getGlobalPerModelTimeseries, 'per-model-timeseries'],
+      [analytics.getGlobalPerModelMessageTimeseries, 'per-model-message-timeseries'],
+      [analytics.getGlobalPerModelCostTimeseries, 'per-model-cost-timeseries'],
+    ];
+    for (const [fn, path] of fns) {
+      const fetchMock = setupFetch({ agents: [], timeseries: [] });
+      await fn('7d');
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain(`/api/v1/overview/${path}`);
+      expect(url).toContain('range=7d');
+    }
+  });
+
+  it('agent-scoped per-provider timeseries endpoints forward agent_name + range', async () => {
+    const fns: Array<[(a: string, r?: string) => unknown, string]> = [
+      [analytics.getPerProviderTimeseries, 'per-provider-timeseries'],
+      [analytics.getPerProviderMessageTimeseries, 'per-provider-message-timeseries'],
+    ];
+    for (const [fn, path] of fns) {
+      const fetchMock = setupFetch({ agents: [], timeseries: [] });
+      await fn('demo', '30d');
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain(`/api/v1/overview/${path}`);
+      expect(url).toContain('agent_name=demo');
+      expect(url).toContain('range=30d');
+    }
+  });
+
+  it('getRateLimits hits the rate-limits endpoint', async () => {
+    const fetchMock = setupFetch({ providers: [] });
+    await analytics.getRateLimits();
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/rate-limits');
+  });
 });

--- a/packages/frontend/tests/services/connection-breadcrumb-store.test.ts
+++ b/packages/frontend/tests/services/connection-breadcrumb-store.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import {
+  connectionBreadcrumbBackLink,
+  connectionBreadcrumbName,
+  setConnectionBreadcrumb,
+} from '../../src/services/connection-breadcrumb-store';
+
+describe('connection breadcrumb store', () => {
+  it('stores the connection label and optional return link', () => {
+    expect(connectionBreadcrumbName()).toBeNull();
+    expect(connectionBreadcrumbBackLink()).toBe('/providers/subscriptions');
+
+    setConnectionBreadcrumb('OpenAI Default', '/providers/byok');
+    expect(connectionBreadcrumbName()).toBe('OpenAI Default');
+    expect(connectionBreadcrumbBackLink()).toBe('/providers/byok');
+
+    setConnectionBreadcrumb(null);
+    expect(connectionBreadcrumbName()).toBeNull();
+    expect(connectionBreadcrumbBackLink()).toBe('/providers/byok');
+  });
+});


### PR DESCRIPTION
## ✨ What changed
- Added a `provider_rate_limits` table and a `RateLimitTrackerService` that records rate-limit headers from proxy responses (primary and fallback paths).
- Added `provider-analytics` and `rate-limits` endpoints, plus additive per-agent / per-provider / per-model timeseries on the overview endpoint.
- Added the frontend API client and a connection breadcrumb store that the upcoming analytics views will consume.

## 💭 Why
Operators need per-connection usage and rate-limit visibility. This lands the data layer so the analytics UI (a follow-up that stacks on the harness rebrand) can render it without further backend work.

## 👤 For users
No visible change yet. This is the backend and data layer; the charts and connection pages ship in the follow-up PR.

## 🔧 For operators
- New migration `1791500000000-AddProviderRateLimits` (auto-runs on boot): one table plus a lookup index. No env changes.
- The proxy hot path is unaffected. Rate-limit capture is fire-and-forget and never throws into the request.

## 📝 Notes
- Aggregates exclude the reserved Playground (`is_system`) agent. Analytics are scoped per connection (provider + auth_type + label) so distinct keys stay separate.
- Deliberately omits #2061's base-divergent proxy/overview deltas that would regress PR1 to PR5.
- Stacked on PR5 (#2165); base `feat/playground`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backend provider analytics and rate‑limit tracking, capturing headers from primary and fallback proxy responses and exposing per‑connection usage and limits. Also fixes rate‑limit cache eviction to sweep expired snapshots first so live entries aren’t evicted, and removes duplicate page headings in agent child views.

- **New Features**
  - `RateLimitTrackerService`: parses provider headers, caches latest snapshots (60s TTL), persists to DB; keyed by (user, provider, `auth_type`, label, limit type); caps DB repopulation; fire‑and‑forget.
  - Endpoints:
    - `GET /api/v1/rate-limits` — latest per‑connection limits with utilization.
    - `GET /api/v1/provider-analytics` — summary, agents by `auth_type`, per‑agent/provider/model token/message/cost timeseries, and connection detail (filterable by `auth_type`/provider/label/agent).
    - `GET /api/v1/overview/*` — additive per‑agent/per‑provider/per‑model timeseries.
  - Aggregations exclude the reserved Playground agent via a NOT EXISTS semi‑join; analytics and rate‑limit capture use the canonical connection label so distinct keys never merge.
  - Frontend: API client for new endpoints and a small `connection-breadcrumb` store for analytics views.
  - Migration: `1791500000000-AddProviderRateLimits` adds `provider_rate_limits` and an index for latest‑snapshot lookups. Auto‑runs; no env changes.

- **Bug Fixes**
  - Stopped double‑counting by joining agents on id in per‑agent timeseries and connection‑detail agent breakdowns; agent‑scoped provider/model timeseries constrain to the live agent id; live‑agent lookup is scoped by the resolved tenant (or `tenant.name = userId` fallback) to avoid empty timeseries when message rows have NULL `tenant_id`.
  - Fixed system‑agent leakage across summaries and timeseries by excluding Playground rows via a NOT EXISTS semi‑join that matches by id or name.
  - Label‑scoped queries across summaries and aggregates so keys sharing provider+`auth_type` don’t merge; connection‑detail returns a consistent shape (`model_usage` in all branches).
  - Also capture rate‑limit headers from successful fallback responses; rate‑limit cache sweeps expired entries before enforcing max size.
  - Frontend: removed duplicate child headings on Limits, Routing, and Settings pages; tests updated.

<sup>Written for commit feabc59ad1e05d68e84d71f57dfe5664d273f695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

