### PR TITLE
feat: rebrand to Harnesses with in-sidebar harness list

### DIFF
--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -246,10 +246,10 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ renamed: true, name: 'bot-renamed', display_name: 'Bot Renamed' });
     expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'bot-renamed', 'Bot Renamed');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
-    // The Messages-filter variant (?includeSystem=true) is a distinct cache
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
+    // The Messages-filter variant (system agents included) is a distinct cache
     // entry and must also be cleared so it never goes stale after a rename.
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents?includeSystem=true');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
   });
 
   it('rejects rename with empty slug', async () => {
@@ -280,7 +280,10 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ deleted: true });
     expect(mockDeleteAgent).toHaveBeenCalledWith('u1', 'bot-1');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+    // Both canonical variants are cleared so neither the Workspace list nor the
+    // Messages filter (system agents included) goes stale after a delete.
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
   });
 
   it('passes agent_category and agent_platform to onboardAgent', async () => {
@@ -505,7 +508,7 @@ describe('AgentsController', () => {
     const result = await ctrl.createAgent(user as never, { name: 'My Agent' } as never);
 
     expect(result.agent.name).toBe('my-agent');
-    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=false');
   });
 
   it('rejects createAgent with empty slug', async () => {
@@ -627,7 +630,7 @@ describe('AgentsController', () => {
       name: 'bot-copy',
       displayName: 'Bot Copy',
     });
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
   });
 
   it('rejects duplicateAgent with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -508,7 +508,10 @@ describe('AgentsController', () => {
     const result = await ctrl.createAgent(user as never, { name: 'My Agent' } as never);
 
     expect(result.agent.name).toBe('my-agent');
+    // Both canonical variants are cleared so neither the Workspace list nor the
+    // Messages filter (system agents included) goes stale after a create.
     expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=false');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=true');
   });
 
   it('rejects createAgent with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -26,8 +26,8 @@ import { AuthUser } from '../../auth/auth.instance';
 import { CreateAgentDto } from '../../common/dto/create-agent.dto';
 import { DuplicateAgentDto } from '../../common/dto/duplicate-agent.dto';
 import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
-import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
-import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { AgentListCacheInterceptor } from '../../common/interceptors/agent-list-cache.interceptor';
+import { AGENT_LIST_CACHE_TTL_MS, agentListCacheKey } from '../../common/constants/cache.constants';
 import { slugify } from '../../common/utils/slugify';
 import { PLAYGROUND_AGENT_SLUG } from '../../common/constants/playground.constants';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
@@ -49,17 +49,17 @@ export class AgentsController {
   ) {}
 
   private async invalidateAgentListCache(userId: string): Promise<void> {
-    // GET /agents is cached per (user, originalUrl). The Messages filter hits the
-    // ?includeSystem=true variant, which is a distinct cache entry, so a single
-    // del() would leave it stale after a create/rename/delete. Clear both.
+    // GET /agents has exactly two canonical cache entries per user (system agents
+    // included or not — see AgentListCacheInterceptor). Clear both so neither the
+    // Workspace list nor the Messages filter goes stale after a mutation.
     await Promise.all([
-      this.cacheManager.del(`${userId}:/api/v1/agents`),
-      this.cacheManager.del(`${userId}:/api/v1/agents?includeSystem=true`),
+      this.cacheManager.del(agentListCacheKey(userId, false)),
+      this.cacheManager.del(agentListCacheKey(userId, true)),
     ]);
   }
 
   @Get('agents')
-  @UseInterceptors(UserCacheInterceptor)
+  @UseInterceptors(AgentListCacheInterceptor)
   @CacheTTL(AGENT_LIST_CACHE_TTL_MS)
   async getAgents(@CurrentUser() user: AuthUser, @Query('includeSystem') includeSystem?: string) {
     const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;

--- a/packages/backend/src/common/constants/cache.constants.ts
+++ b/packages/backend/src/common/constants/cache.constants.ts
@@ -3,3 +3,14 @@ export const AGENT_LIST_CACHE_TTL_MS = 60_000;
 export const MODEL_PRICES_CACHE_TTL_MS = 300_000;
 export const PUBLIC_STATS_CACHE_TTL_MS = 86_400_000;
 export const FREE_MODELS_CACHE_TTL_MS = 3_600_000;
+
+/**
+ * Canonical cache key for the GET /agents list. The route varies only by whether
+ * the reserved system (Playground) agent is included, so every query-string
+ * variant collapses to one of two keys keyed on that boolean — never the raw
+ * URL. This keeps the key set bounded (exactly two per user) so invalidation can
+ * enumerate it exhaustively and no variant is ever left stale.
+ */
+export function agentListCacheKey(userId: string, includeSystem: boolean): string {
+  return `${userId}:/api/v1/agents:system=${includeSystem}`;
+}

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
@@ -1,0 +1,75 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AgentListCacheInterceptor } from './agent-list-cache.interceptor';
+
+function createMockContext(
+  user: { id?: string } | undefined,
+  query: Record<string, string> | undefined,
+  method = 'GET',
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user, query, method, originalUrl: '/api/v1/agents' }),
+      getResponse: () => ({}),
+    }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    getArgs: () => [],
+    getArgByIndex: () => ({}),
+    switchToRpc: () => ({}) as never,
+    switchToWs: () => ({}) as never,
+    getType: () => 'http',
+  } as unknown as ExecutionContext;
+}
+
+describe('AgentListCacheInterceptor', () => {
+  let interceptor: AgentListCacheInterceptor;
+
+  beforeEach(() => {
+    const mockCacheManager = {} as never;
+    interceptor = new AgentListCacheInterceptor(mockCacheManager, new Reflector());
+  });
+
+  describe('trackBy', () => {
+    it('keys on the system=true canonical variant for ?includeSystem=true', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'true' }),
+      );
+      expect(key).toBe('u1:/api/v1/agents:system=true');
+    });
+
+    it('keys on the system=false canonical variant when no query param is present', () => {
+      const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, undefined));
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('collapses ?includeSystem=false onto the same system=false key (no stranded variant)', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'false' }),
+      );
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('collapses any non-"true" value onto the system=false key', () => {
+      const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, { includeSystem: '1' }));
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('returns undefined for non-GET requests', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'true' }, 'POST'),
+      );
+      expect(key).toBeUndefined();
+    });
+
+    it('returns undefined when user is not present', () => {
+      const key = interceptor['trackBy'](createMockContext(undefined, undefined));
+      expect(key).toBeUndefined();
+    });
+
+    it('returns undefined when user has no id', () => {
+      const key = interceptor['trackBy'](createMockContext({}, undefined));
+      expect(key).toBeUndefined();
+    });
+  });
+});

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
@@ -1,0 +1,29 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+import { UserCacheInterceptor } from './user-cache.interceptor';
+import { agentListCacheKey } from '../constants/cache.constants';
+
+/**
+ * Cache interceptor for GET /agents. Unlike the generic URL-keyed
+ * UserCacheInterceptor, it collapses every query-string variant (no param,
+ * ?includeSystem=true, ?includeSystem=false, anything else) onto one of two
+ * canonical keys based on the normalized `includeSystem` boolean. That keeps the
+ * cached key set bounded to exactly two entries per user, so mutation handlers
+ * can invalidate it exhaustively (see agentListCacheKey) without a stray URL
+ * variant being left stale.
+ */
+@Injectable()
+export class AgentListCacheInterceptor extends UserCacheInterceptor {
+  protected trackBy(context: ExecutionContext): string | undefined {
+    const request = context.switchToHttp().getRequest<Request>();
+    if (request.method !== 'GET') return undefined;
+    const user = (request as unknown as Record<string, unknown>).user as
+      | { id?: string }
+      | undefined;
+    if (!user?.id) return undefined;
+
+    const includeSystem =
+      (request.query as { includeSystem?: string } | undefined)?.includeSystem === 'true';
+    return agentListCacheKey(user.id, includeSystem);
+  }
+}

--- a/packages/frontend/src/components/AddAgentModal.tsx
+++ b/packages/frontend/src/components/AddAgentModal.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from '@solidjs/router';
 import AgentTypeSelect from './AgentTypeSelect.jsx';
 import { createAgent, getGlobalProviders } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
-import { markAgentCreated } from '../services/recent-agents.js';
+import { markAgentCreated, markSetupPending } from '../services/recent-agents.js';
 import { type AgentCategory, type AgentPlatform, PLATFORMS_BY_CATEGORY } from 'manifest-shared';
 
 /**
@@ -67,6 +67,10 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
       resetForm();
       const slug = result?.agent?.name ?? agentName;
       markAgentCreated(slug);
+      // Persistent flag so the setup modal reopens after a page refresh until
+      // the user dismisses or completes it (the in-memory mark above is dropped
+      // on reload / cleared by AgentGuard once the agent appears in the list).
+      markSetupPending(slug);
 
       // Decide whether to nudge the user into connecting a provider. A brand-new
       // tenant has nothing routed yet, so we open the provider flow on landing.

--- a/packages/frontend/src/components/AddAgentModal.tsx
+++ b/packages/frontend/src/components/AddAgentModal.tsx
@@ -7,7 +7,7 @@ import { markAgentCreated } from '../services/recent-agents.js';
 import { type AgentCategory, type AgentPlatform, PLATFORMS_BY_CATEGORY } from 'manifest-shared';
 
 /**
- * "Connect Agent" modal extracted from Workspace so it can be reused by other
+ * "Connect Harness" modal extracted from Workspace so it can be reused by other
  * onboarding surfaces (e.g. an empty-state CTA or a deep-link).
  *
  * Onboarding navigation: a freshly created agent inherits every connected
@@ -62,7 +62,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
       // The user dismissed the modal while the request was in flight — honour
       // that dismissal and skip every success side effect + the navigation.
       if (cancelled) return;
-      toast.success(`Agent "${agentName}" connected`);
+      toast.success(`Harness "${agentName}" connected`);
       props.onClose();
       resetForm();
       const slug = result?.agent?.name ?? agentName;
@@ -84,7 +84,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
       if (cancelled) return;
 
       // Land on Routing either way; the new agent's API key is surfaced there.
-      navigate(`/agents/${encodeURIComponent(slug)}/routing`, {
+      navigate(`/harnesses/${encodeURIComponent(slug)}/routing`, {
         state: {
           newApiKey: result?.apiKey,
           ...(hasProviders ? {} : { openProviders: true }),
@@ -121,10 +121,10 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
           onKeyDown={handleKeyDown}
         >
           <h2 class="modal-card__title" id="add-agent-title">
-            Connect Agent
+            Connect Harness
           </h2>
           <p class="modal-card__desc">
-            Name your agent to start tracking its LLM usage, costs, and messages in real time.
+            Name your harness to start tracking its LLM usage, costs, and messages in real time.
           </p>
 
           <div class="agent-type-select-row">
@@ -140,14 +140,14 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
             </div>
             <div style="flex: 1;">
               <label class="modal-card__field-label" for="agent-name-input">
-                Agent name
+                Harness name
               </label>
               <input
                 ref={(el) => requestAnimationFrame(() => el.focus())}
                 id="agent-name-input"
                 class="modal-card__input modal-card__input--lg"
                 type="text"
-                placeholder="e.g. My Cool Agent"
+                placeholder="e.g. My Cool Harness"
                 value={name()}
                 onInput={(e) => setName(e.currentTarget.value)}
                 disabled={creating()}

--- a/packages/frontend/src/components/AgentTypeSelect.tsx
+++ b/packages/frontend/src/components/AgentTypeSelect.tsx
@@ -66,7 +66,7 @@ const AgentTypeSelect: Component<Props> = (props) => {
         disabled={props.disabled}
         aria-haspopup="listbox"
         aria-expanded={open()}
-        aria-label={`Agent type: ${props.platform ? PLATFORM_LABELS[props.platform] : 'Select'}`}
+        aria-label={`Harness type: ${props.platform ? PLATFORM_LABELS[props.platform] : 'Select'}`}
       >
         <Show when={selectedIcon()}>
           <img

--- a/packages/frontend/src/components/DuplicateAgentModal.tsx
+++ b/packages/frontend/src/components/DuplicateAgentModal.tsx
@@ -84,7 +84,7 @@ const DuplicateAgentModal: Component<Props> = (props) => {
       toast.success(`Duplicated "${props.sourceName}" to "${slug}"`);
       props.onClose();
       props.onDuplicated?.();
-      navigate(`/agents/${encodeURIComponent(slug)}`, {
+      navigate(`/harnesses/${encodeURIComponent(slug)}`, {
         state: { newApiKey: result.apiKey },
       });
     } catch {
@@ -120,12 +120,12 @@ const DuplicateAgentModal: Component<Props> = (props) => {
             Duplicate "{props.sourceName}"
           </h2>
           <p class="modal-card__desc">
-            Creates a new agent with the same providers, routing, and tier configuration. A fresh
+            Creates a new harness with the same providers, routing, and tier configuration. A fresh
             API key is generated — telemetry and message history stay with the original.
           </p>
 
           <label class="modal-card__field-label" for="duplicate-agent-name">
-            New agent name
+            New harness name
           </label>
           <input
             ref={(el) =>
@@ -191,7 +191,7 @@ const DuplicateAgentModal: Component<Props> = (props) => {
               disabled={!name().trim() || submitting()}
               type="button"
             >
-              {submitting() ? <span class="spinner" /> : 'Duplicate agent'}
+              {submitting() ? <span class="spinner" /> : 'Duplicate harness'}
             </button>
           </div>
         </div>

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -134,7 +134,7 @@ const Header: Component<HeaderProps> = (props) => {
         )}
         <Show when={getAgentName()}>
           <span class="header__separator">/</span>
-          <A href="/agents" class="header__breadcrumb-link">
+          <A href="/harnesses" class="header__breadcrumb-link">
             Workspace
           </A>
           <span class="header__separator">/</span>
@@ -153,7 +153,7 @@ const Header: Component<HeaderProps> = (props) => {
               <button
                 class="header__gear-btn"
                 onClick={() => setGearOpen(!gearOpen())}
-                aria-label="Agent actions"
+                aria-label="Harness actions"
                 aria-haspopup="menu"
                 aria-expanded={gearOpen()}
               >
@@ -172,7 +172,7 @@ const Header: Component<HeaderProps> = (props) => {
               <Show when={gearOpen()}>
                 <div class="header__dropdown" role="menu" style="left: 0; right: auto;">
                   <A
-                    href={`/agents/${encodeURIComponent(getAgentName()!)}/settings`}
+                    href={`/harnesses/${encodeURIComponent(getAgentName()!)}/settings`}
                     class="header__dropdown-item"
                     role="menuitem"
                     onClick={() => setGearOpen(false)}
@@ -211,7 +211,7 @@ const Header: Component<HeaderProps> = (props) => {
                       <path d="M20 2H10c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m0 12H10V4h10z" />
                       <path d="M4 22h10c1.1 0 2-.9 2-2v-2h-2v2H4V10h2V8H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2m10-10h2v-2h2V8h-2V6h-2v2h-2v2h2z" />
                     </svg>
-                    Duplicate agent
+                    Duplicate harness
                   </button>
                 </div>
               </Show>

--- a/packages/frontend/src/components/MessageDetails.tsx
+++ b/packages/frontend/src/components/MessageDetails.tsx
@@ -133,7 +133,7 @@ function MiscategorizeControl(props: {
       class="msg-detail__miscat-btn"
       onClick={toggle}
       disabled={busy()}
-      title="Flag this message's routing category as wrong. Repeated flags reduce this category's routing score for this agent."
+      title="Flag this message's routing category as wrong. Repeated flags reduce this category's routing score for this harness."
       aria-pressed={flagged()}
     >
       {flagged() ? 'Flagged as miscategorized — undo' : 'Wrong category?'}
@@ -285,7 +285,7 @@ export default function MessageDetails(props: MessageDetailsProps): JSX.Element 
               <Show when={d.agent_logs.length > 0}>
                 <div class="msg-detail__section">
                   <div class="msg-detail__section-title">
-                    Agent Logs
+                    Harness Logs
                     <span class="msg-detail__count">{d.agent_logs.length}</span>
                   </div>
                   <div class="data-table-scroll">

--- a/packages/frontend/src/components/RoutingInstructionModal.tsx
+++ b/packages/frontend/src/components/RoutingInstructionModal.tsx
@@ -70,7 +70,7 @@ const RoutingInstructionModal: Component<Props> = (props) => {
                 </Show>
               </Show>
               <Show when={isEnable()} fallback={<>Deactivate routing</>}>
-                Set up agent: <em>{props.agentName}</em>
+                Set up harness: <em>{props.agentName}</em>
               </Show>
             </div>
             <button class="modal__close" onClick={() => props.onClose()} aria-label="Close">
@@ -92,7 +92,7 @@ const RoutingInstructionModal: Component<Props> = (props) => {
           </div>
           <Show when={isEnable()}>
             <p class="modal-card__desc">
-              Connect your agent to Manifest to start routing requests.
+              Connect your harness to Manifest to start routing requests.
             </p>
           </Show>
 
@@ -102,17 +102,17 @@ const RoutingInstructionModal: Component<Props> = (props) => {
               <>
                 <p style="margin: 0 0 14px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
                   This will stop routing requests through Manifest and restore direct model access
-                  in your OpenClaw agent.
+                  in your OpenClaw harness.
                 </p>
 
                 <p style="margin: 0 0 8px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-                  1. Pick the model your agent should use directly:
+                  1. Pick the model your harness should use directly:
                 </p>
 
                 <ModelSelectDropdown selectedValue={selectedModel()} onSelect={handleModelSelect} />
 
                 <p style="margin: 14px 0; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-                  2. Run these commands in your agent's terminal to restore direct model access:
+                  2. Run these commands in your harness's terminal to restore direct model access:
                 </p>
 
                 <div class="modal-terminal">

--- a/packages/frontend/src/components/SetupModal.tsx
+++ b/packages/frontend/src/components/SetupModal.tsx
@@ -61,7 +61,7 @@ const SetupModal: Component<{
                 />
               </Show>
               <span class="setup-modal__title-text">
-                Set up agent: <em>{props.agentName}</em>
+                Set up harness: <em>{props.agentName}</em>
               </span>
             </div>
             <button class="modal__close" onClick={() => props.onClose()} aria-label="Close">
@@ -81,7 +81,9 @@ const SetupModal: Component<{
               </svg>
             </button>
           </div>
-          <p class="modal-card__desc">Connect your agent to Manifest to start routing requests.</p>
+          <p class="modal-card__desc">
+            Connect your harness to Manifest to start routing requests.
+          </p>
 
           <Show
             when={!apiKeyData.error || !!props.apiKey}
@@ -89,7 +91,7 @@ const SetupModal: Component<{
               <ErrorState
                 error={apiKeyData.error}
                 title="Could not load API key"
-                message="Failed to fetch your agent's API key. Please try again."
+                message="Failed to fetch your harness's API key. Please try again."
                 onRetry={refetchKey}
               />
             }

--- a/packages/frontend/src/components/SetupStepAddProvider.tsx
+++ b/packages/frontend/src/components/SetupStepAddProvider.tsx
@@ -44,18 +44,18 @@ const SetupStepAddProvider: Component<Props> = (props) => {
     <div>
       <h3 class="setup-step__heading">
         {props.platform === 'hermes'
-          ? 'Connect your Hermes agent to Manifest'
+          ? 'Connect your Hermes harness to Manifest'
           : props.platform === 'openclaw'
-            ? 'Connect your OpenClaw agent to Manifest'
+            ? 'Connect your OpenClaw harness to Manifest'
             : props.platform === 'nanobot'
-              ? 'Connect your Nanobot agent to Manifest'
+              ? 'Connect your Nanobot harness to Manifest'
               : props.platform === 'craft'
-                ? 'Connect your Craft agent to Manifest'
+                ? 'Connect your Craft harness to Manifest'
                 : props.platform === 'claude-code'
                   ? 'Connect Claude Code to Manifest'
                   : props.platform === 'opencode'
                     ? 'Connect OpenCode to Manifest'
-                    : 'Connect your agent to Manifest'}
+                    : 'Connect your harness to Manifest'}
       </h3>
 
       {/* Platform-filtered mode: show only relevant content */}
@@ -99,7 +99,7 @@ const SetupStepAddProvider: Component<Props> = (props) => {
       {/* Default / "other": show full tabbed UI */}
       <Show when={!isFiltered()}>
         <p class="setup-step__desc">
-          Point your agent at the Manifest endpoint using the model{' '}
+          Point your harness at the Manifest endpoint using the model{' '}
           <code class="setup-model-hint__code">auto</code>
         </p>
 

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -1,9 +1,21 @@
 import { A, useLocation } from '@solidjs/router';
-import type { Component } from 'solid-js';
+import { Show, For, createSignal, createResource, type Component } from 'solid-js';
+import { useAgentName } from '../services/routing.js';
+import { getAgents } from '../services/api.js';
+import { agentPing } from '../services/sse.js';
+import { platformIcon } from 'manifest-shared';
+import AddAgentModal from './AddAgentModal.jsx';
 
 interface SidebarProps {
   mobileOpen?: boolean;
   onNavigate?: () => void;
+}
+
+interface HarnessItem {
+  agent_name: string;
+  display_name?: string;
+  agent_platform?: string | null;
+  agent_category?: string | null;
 }
 
 /**
@@ -20,6 +32,32 @@ function makeIsGlobalActive(pathname: () => string) {
 const Sidebar: Component<SidebarProps> = (props) => {
   const location = useLocation();
   const isGlobalActive = makeIsGlobalActive(() => location.pathname);
+  const getAgentName = useAgentName();
+  const [agentsCollapsed, setAgentsCollapsed] = createSignal(false);
+  const [addModalOpen, setAddModalOpen] = createSignal(false);
+
+  // Harness list for the in-nav switcher. Refetches whenever the agent SSE ping
+  // fires (create/delete/rename). Uses the DEFAULT getAgents() — system agents
+  // (the reserved Playground) are excluded so they never leak into the switcher.
+  const [agents] = createResource(
+    () => agentPing(),
+    async (): Promise<HarnessItem[]> => {
+      try {
+        const data = (await getAgents()) as { agents?: HarnessItem[] } | HarnessItem[] | null;
+        if (Array.isArray(data)) return data;
+        return data?.agents ?? [];
+      } catch {
+        return [];
+      }
+    },
+  );
+
+  const currentAgent = () => getAgentName();
+
+  const handleNav = () => {
+    props.onNavigate?.();
+    window.dispatchEvent(new CustomEvent('sidebar-navigate'));
+  };
 
   return (
     <nav
@@ -29,8 +67,7 @@ const Sidebar: Component<SidebarProps> = (props) => {
       aria-label="Navigation"
       onClick={(event) => {
         if ((event.target as HTMLElement).closest('a.sidebar__link')) {
-          props.onNavigate?.();
-          window.dispatchEvent(new CustomEvent('sidebar-navigate'));
+          handleNav();
         }
       }}
     >
@@ -75,15 +112,91 @@ const Sidebar: Component<SidebarProps> = (props) => {
       >
         Local
       </A>
-      <div class="sidebar__section-label">HARNESSES</div>
-      <A
-        href="/harnesses"
-        class="sidebar__link"
-        classList={{ active: isGlobalActive('/harnesses') }}
-        aria-current={isGlobalActive('/harnesses') ? 'page' : undefined}
+
+      {/* Harnesses — collapsible section with a + create button */}
+      <div
+        class="sidebar__section-label sidebar__section-label--interactive"
+        onClick={() => setAgentsCollapsed(!agentsCollapsed())}
       >
-        Harnesses
-      </A>
+        <div class="sidebar__section-label-left">
+          <span>HARNESSES</span>
+          <button
+            type="button"
+            class="sidebar__section-add"
+            title="Create new harness"
+            aria-label="Create new harness"
+            onClick={(e) => {
+              e.stopPropagation();
+              setAddModalOpen(true);
+            }}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6z" />
+            </svg>
+          </button>
+        </div>
+        <button
+          type="button"
+          class="sidebar__section-caret"
+          onClick={(e) => {
+            e.stopPropagation();
+            setAgentsCollapsed(!agentsCollapsed());
+          }}
+          aria-expanded={!agentsCollapsed()}
+          aria-label={agentsCollapsed() ? 'Expand harnesses' : 'Collapse harnesses'}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            style={{
+              transition: 'transform 150ms',
+              transform: agentsCollapsed() ? 'rotate(-90deg)' : 'rotate(0deg)',
+            }}
+          >
+            <path d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z" />
+          </svg>
+        </button>
+      </div>
+
+      <Show when={!agentsCollapsed()}>
+        <div class="sidebar__agents-list">
+          <For
+            each={agents() ?? []}
+            fallback={<div class="sidebar__agents-empty">No harnesses yet</div>}
+          >
+            {(agent) => {
+              const name = () => agent.agent_name;
+              const display = () => agent.display_name || agent.agent_name;
+              const icon = () => platformIcon(agent.agent_platform, agent.agent_category);
+              const isSelected = () => currentAgent() === name();
+              return (
+                <A
+                  href={`/harnesses/${name()}`}
+                  class="sidebar__agent-item"
+                  classList={{ 'sidebar__agent-item--active': isSelected() }}
+                  aria-current={isSelected() ? 'page' : undefined}
+                  onClick={handleNav}
+                >
+                  <Show when={icon()}>
+                    <img src={icon()} alt="" class="sidebar__agent-icon" />
+                  </Show>
+                  <span class="sidebar__agent-item-name">{display()}</span>
+                </A>
+              );
+            }}
+          </For>
+        </div>
+      </Show>
 
       <div class="sidebar__section-label">TOOLS</div>
       <A
@@ -109,6 +222,9 @@ const Sidebar: Component<SidebarProps> = (props) => {
         </span>
         <p class="sidebar__feedback-hint">Share ideas or report bugs.</p>
       </a>
+
+      {/* Create-harness modal, opened by the HARNESSES section + button */}
+      <AddAgentModal open={addModalOpen()} onClose={() => setAddModalOpen(false)} />
     </nav>
   );
 };

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -8,7 +8,7 @@ interface SidebarProps {
 
 /**
  * Returns true when the given route matches the current location either
- * exactly or as a path prefix (so `/agents` stays active on `/agents/:name/*`).
+ * exactly or as a path prefix (so `/harnesses` stays active on `/harnesses/:name/*`).
  */
 function makeIsGlobalActive(pathname: () => string) {
   return (route: string): boolean => {
@@ -26,7 +26,7 @@ const Sidebar: Component<SidebarProps> = (props) => {
       id="agent-navigation"
       class="sidebar"
       classList={{ 'sidebar--mobile-open': props.mobileOpen === true }}
-      aria-label="Agent navigation"
+      aria-label="Navigation"
       onClick={(event) => {
         if ((event.target as HTMLElement).closest('a.sidebar__link')) {
           props.onNavigate?.();
@@ -75,14 +75,14 @@ const Sidebar: Component<SidebarProps> = (props) => {
       >
         Local
       </A>
-      <div class="sidebar__section-label">AGENTS</div>
+      <div class="sidebar__section-label">HARNESSES</div>
       <A
-        href="/agents"
+        href="/harnesses"
         class="sidebar__link"
-        classList={{ active: isGlobalActive('/agents') }}
-        aria-current={isGlobalActive('/agents') ? 'page' : undefined}
+        classList={{ active: isGlobalActive('/harnesses') }}
+        aria-current={isGlobalActive('/harnesses') ? 'page' : undefined}
       >
-        Agents
+        Harnesses
       </A>
 
       <div class="sidebar__section-label">TOOLS</div>

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -181,7 +181,7 @@ const Sidebar: Component<SidebarProps> = (props) => {
               const isSelected = () => currentAgent() === name();
               return (
                 <A
-                  href={`/harnesses/${name()}`}
+                  href={`/harnesses/${encodeURIComponent(name())}`}
                   class="sidebar__agent-item"
                   classList={{ 'sidebar__agent-item--active': isSelected() }}
                   aria-current={isSelected() ? 'page' : undefined}

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -113,51 +113,24 @@ const Sidebar: Component<SidebarProps> = (props) => {
         Local
       </A>
 
-      {/* Harnesses — collapsible section with a + create button */}
-      <div
-        class="sidebar__section-label sidebar__section-label--interactive"
-        onClick={() => setAgentsCollapsed(!agentsCollapsed())}
-      >
-        <div class="sidebar__section-label-left">
-          <span>HARNESSES</span>
-          <button
-            type="button"
-            class="sidebar__section-add"
-            title="Create new harness"
-            aria-label="Create new harness"
-            onClick={(e) => {
-              e.stopPropagation();
-              setAddModalOpen(true);
-            }}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="14"
-              height="14"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6z" />
-            </svg>
-          </button>
-        </div>
+      {/* Harnesses — collapsible section with a + create button.
+          The collapse toggle and the create button are sibling buttons (never
+          nested) so both are independently keyboard-operable. */}
+      <div class="sidebar__section-header">
         <button
           type="button"
           class="sidebar__section-caret"
-          onClick={(e) => {
-            e.stopPropagation();
-            setAgentsCollapsed(!agentsCollapsed());
-          }}
+          onClick={() => setAgentsCollapsed(!agentsCollapsed())}
           aria-expanded={!agentsCollapsed()}
-          aria-label={agentsCollapsed() ? 'Expand harnesses' : 'Collapse harnesses'}
         >
+          <span>HARNESSES</span>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="12"
             height="12"
             fill="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
             style={{
               transition: 'transform 150ms',
               transform: agentsCollapsed() ? 'rotate(-90deg)' : 'rotate(0deg)',
@@ -166,13 +139,35 @@ const Sidebar: Component<SidebarProps> = (props) => {
             <path d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z" />
           </svg>
         </button>
+        <button
+          type="button"
+          class="sidebar__section-add"
+          title="Create new harness"
+          aria-label="Create new harness"
+          onClick={() => setAddModalOpen(true)}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6z" />
+          </svg>
+        </button>
       </div>
 
       <Show when={!agentsCollapsed()}>
         <div class="sidebar__agents-list">
           <For
             each={agents() ?? []}
-            fallback={<div class="sidebar__agents-empty">No harnesses yet</div>}
+            fallback={
+              <Show when={!agents.loading}>
+                <div class="sidebar__agents-empty">No harnesses yet</div>
+              </Show>
+            }
           >
             {(agent) => {
               const name = () => agent.agent_name;

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -132,7 +132,7 @@ const HEADER_LABELS: Record<MessageColumnKey, string> = {
   duration: 'Latency',
   status: 'Status',
   feedback: '',
-  agent: 'Agent',
+  agent: 'Harness',
 };
 
 const TOOLTIP_TEXT: Partial<Record<MessageColumnKey, string>> = {
@@ -364,7 +364,7 @@ export function StatusCell(
             {item.status === 'fallback_error' && <FallbackIcon />}
             {item.status === 'rate_limited' ? (
               agentName ? (
-                <A href={`/agents/${encodeURIComponent(agentName)}/limits`}>
+                <A href={`/harnesses/${encodeURIComponent(agentName)}/limits`}>
                   {formatStatus(item.status)}
                 </A>
               ) : (

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -103,16 +103,10 @@ render(
               return <Navigate href={`/harnesses${search}${hash}`} />;
             }}
           />
+          {/* The *rest splat matches zero trailing segments too, so this single
+              route also covers the bare /agents/:agentName path. */}
           <Route
             path="/agents/:agentName/*rest"
-            component={() => {
-              const { pathname, search, hash } = window.location;
-              const target = pathname.replace(/^\/agents/, '/harnesses');
-              return <Navigate href={`${target}${search}${hash}`} />;
-            }}
-          />
-          <Route
-            path="/agents/:agentName"
             component={() => {
               const { pathname, search, hash } = window.location;
               const target = pathname.replace(/^\/agents/, '/harnesses');

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -1,6 +1,6 @@
 /* @refresh reload */
 import { render } from 'solid-js/web';
-import { Router, Route } from '@solidjs/router';
+import { Router, Route, Navigate } from '@solidjs/router';
 import { MetaProvider, Title } from '@solidjs/meta';
 import App from './App.jsx';
 import AuthLayout from './layouts/AuthLayout.jsx';
@@ -69,12 +69,12 @@ render(
           <Route path="/" component={RootRedirect} />
           <Route path="/overview" component={GlobalOverview} />
           <Route path="/messages" component={MessageLog} />
-          <Route path="/agents" component={Workspace} />
+          <Route path="/harnesses" component={Workspace} />
           <Route path="/playground" component={Playground} />
           <Route path="/providers/subscriptions" component={Subscriptions} />
           <Route path="/providers/byok" component={Byok} />
           <Route path="/providers/local" component={LocalProviders} />
-          <Route path="/agents/:agentName" component={AgentGuard}>
+          <Route path="/harnesses/:agentName" component={AgentGuard}>
             {/* Redirects: /limits → /guardrails, /messages → global /messages */}
             <Route path="/limits" component={AgentLimitsRedirect} />
             <Route path="/messages" component={AgentMessagesRedirect} />
@@ -94,6 +94,26 @@ render(
             <Route path="/free-models" component={FreeModels} />
             <Route path="/help" component={Help} />
           </Route>
+
+          {/* Legacy /agents redirects → /harnesses (keep bookmarks alive) */}
+          <Route path="/agents" component={() => <Navigate href="/harnesses" />} />
+          <Route
+            path="/agents/:agentName/*rest"
+            component={() => {
+              const { pathname, search, hash } = window.location;
+              const target = pathname.replace(/^\/agents/, '/harnesses');
+              return <Navigate href={`${target}${search}${hash}`} />;
+            }}
+          />
+          <Route
+            path="/agents/:agentName"
+            component={() => {
+              const { pathname, search, hash } = window.location;
+              const target = pathname.replace(/^\/agents/, '/harnesses');
+              return <Navigate href={`${target}${search}${hash}`} />;
+            }}
+          />
+
           <Route path="/connect-provider" component={ConnectProvider} />
           <Route path="/account" component={Account} />
         </Route>

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -96,7 +96,13 @@ render(
           </Route>
 
           {/* Legacy /agents redirects → /harnesses (keep bookmarks alive) */}
-          <Route path="/agents" component={() => <Navigate href="/harnesses" />} />
+          <Route
+            path="/agents"
+            component={() => {
+              const { search, hash } = window.location;
+              return <Navigate href={`/harnesses${search}${hash}`} />;
+            }}
+          />
           <Route
             path="/agents/:agentName/*rest"
             component={() => {

--- a/packages/frontend/src/pages/AgentDetail.tsx
+++ b/packages/frontend/src/pages/AgentDetail.tsx
@@ -8,7 +8,7 @@ import { agentPlatformIcon } from '../services/agent-platform-store.js';
 /**
  * AgentDetail — horizontal-tabbed shell for the agent detail view.
  *
- * Renders a header (back-link to /agents + platform icon + agent display name)
+ * Renders a header (back-link to /harnesses + platform icon + agent display name)
  * and a horizontal tab bar (Overview / Routing / Providers / Limits / Settings).
  * Child routes render in the body via props.children (SolidJS nested <Route>).
  */
@@ -36,10 +36,10 @@ const AgentDetail: ParentComponent = (props) => {
 
       <div style="margin-bottom: 8px;">
         <A
-          href="/agents"
+          href="/harnesses"
           style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); text-decoration: none;"
         >
-          ← Agents
+          ← Harnesses
         </A>
       </div>
 

--- a/packages/frontend/src/pages/AgentLimitsRedirect.tsx
+++ b/packages/frontend/src/pages/AgentLimitsRedirect.tsx
@@ -3,7 +3,7 @@ import type { Component } from 'solid-js';
 import { agentPath } from '../services/routing.js';
 
 /**
- * Redirects /agents/:agentName/limits → /agents/:agentName/guardrails.
+ * Redirects /harnesses/:agentName/limits → /harnesses/:agentName/guardrails.
  * Keeps backward-compat for any bookmarks or links using the old path.
  */
 const AgentLimitsRedirect: Component = () => {

--- a/packages/frontend/src/pages/AgentMessagesRedirect.tsx
+++ b/packages/frontend/src/pages/AgentMessagesRedirect.tsx
@@ -2,7 +2,7 @@ import { Navigate } from '@solidjs/router';
 import type { Component } from 'solid-js';
 
 /**
- * Redirects /agents/:agentName/messages → /messages (global message log).
+ * Redirects /harnesses/:agentName/messages → /messages (global message log).
  * Keeps backward-compat now that messages has a global home from PR1.
  */
 const AgentMessagesRedirect: Component = () => <Navigate href="/messages" />;

--- a/packages/frontend/src/pages/AgentProviders.tsx
+++ b/packages/frontend/src/pages/AgentProviders.tsx
@@ -137,7 +137,7 @@ const AgentProviders: Component = () => {
   return (
     <div>
       <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); margin-bottom: 16px;">
-        Enable the global provider connections this agent may use. Turning a provider off removes
+        Enable the global provider connections this harness may use. Turning a provider off removes
         routing assignments that depend on its models.
       </p>
 
@@ -261,7 +261,7 @@ const AgentProviders: Component = () => {
             >
               <h2 class="modal-card__title">Disable provider</h2>
               <p class="modal-card__desc">
-                This agent will no longer route requests through{' '}
+                This harness will no longer route requests through{' '}
                 <strong style="color: hsl(var(--foreground));">
                   {providerName(target().provider)}
                 </strong>

--- a/packages/frontend/src/pages/ConnectProvider.tsx
+++ b/packages/frontend/src/pages/ConnectProvider.tsx
@@ -32,7 +32,7 @@ const ConnectProvider: Component = () => {
     if (baseUrl) qp.set('baseUrl', baseUrl);
     if (apiKey) qp.set('apiKey', apiKey);
     if (models) qp.set('models', models);
-    return `/agents/${encodeURIComponent(agentName)}/routing?${qp.toString()}`;
+    return `/harnesses/${encodeURIComponent(agentName)}/routing?${qp.toString()}`;
   };
 
   const autoCreate = async () => {
@@ -68,9 +68,9 @@ const ConnectProvider: Component = () => {
     <div class="container--sm" style="padding-top: 80px;">
       <Show when={!data.loading && (data()?.length ?? 0) > 1}>
         <div class="panel" style="max-width: 440px; margin: 0 auto; padding: 32px;">
-          <h2 style="margin: 0 0 8px;">Select an agent</h2>
+          <h2 style="margin: 0 0 8px;">Select a harness</h2>
           <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); margin: 0 0 24px;">
-            Which agent should this provider be added to?
+            Which harness should this provider be added to?
           </p>
           <div style="display: flex; flex-direction: column; gap: 8px;">
             <For each={data()}>

--- a/packages/frontend/src/pages/FreeModels.tsx
+++ b/packages/frontend/src/pages/FreeModels.tsx
@@ -104,9 +104,9 @@ const ConnectButton: Component<{ provider: FreeProviderDto }> = (props) => {
   const href = () => {
     const b = builtin();
     if (b) {
-      return `/agents/${encodeURIComponent(agentName())}/routing?provider=${b.id}`;
+      return `/harnesses/${encodeURIComponent(agentName())}/routing?provider=${b.id}`;
     }
-    const base = `/agents/${encodeURIComponent(agentName())}/routing?provider=custom&name=${encodeURIComponent(props.provider.name)}&baseUrl=${encodeURIComponent(props.provider.base_url!)}`;
+    const base = `/harnesses/${encodeURIComponent(agentName())}/routing?provider=custom&name=${encodeURIComponent(props.provider.name)}&baseUrl=${encodeURIComponent(props.provider.base_url!)}`;
     const m = models();
     return m ? `${base}&models=${encodeURIComponent(m)}` : base;
   };
@@ -150,7 +150,7 @@ const FreeModels: Component = () => {
         <div>
           <h1>Free Models</h1>
           <span class="breadcrumb">
-            Cloud providers offering free API access for {agentDisplayName() ?? 'your agent'}
+            Cloud providers offering free API access for {agentDisplayName() ?? 'your harness'}
           </span>
         </div>
       </div>

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -108,9 +108,13 @@ const GlobalOverview: Component = () => {
           <Show when={showEmptyState()}>
             <div class="empty-state">
               <div class="empty-state__title">No activity yet</div>
-              <p>Create an agent and send a message. Usage data shows up here.</p>
-              <A href="/agents" class="btn btn--primary btn--sm" style="margin-top: var(--gap-md);">
-                Go to Agents
+              <p>Create a harness and send a message. Usage data shows up here.</p>
+              <A
+                href="/harnesses"
+                class="btn btn--primary btn--sm"
+                style="margin-top: var(--gap-md);"
+              >
+                Go to Harnesses
               </A>
               <div class="empty-state__img-wrapper">
                 <img

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -130,13 +130,9 @@ const Limits: Component = () => {
       />
 
       <div class="page-header">
-        <div>
-          <h1>Limits</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Get notified or block requests when token
-            or cost thresholds are exceeded
-          </span>
-        </div>
+        <span class="breadcrumb">
+          Get notified or block requests when token or cost thresholds are exceeded
+        </span>
         <button
           class="btn btn--primary btn--sm"
           onClick={() => {

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -179,7 +179,7 @@ const Limits: Component = () => {
             <line x1="12" y1="17" x2="12.01" y2="17" />
           </svg>
           <span>
-            One or more hard limits triggered. New proxy requests for this agent will be blocked
+            One or more hard limits triggered. New proxy requests for this harness will be blocked
             until the usage resets in the next period.
           </span>
         </div>

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -101,10 +101,10 @@ const Login: Component = () => {
   return (
     <>
       <Title>Sign In - Manifest</Title>
-      <Meta name="description" content="Sign in to Manifest to monitor your AI agents." />
+      <Meta name="description" content="Sign in to Manifest to monitor your AI harnesses." />
       <div class="auth-header">
         <h1 class="auth-header__title">Welcome back</h1>
-        <p class="auth-header__subtitle">Take control of your AI agent costs</p>
+        <p class="auth-header__subtitle">Take control of your AI harness costs</p>
       </div>
 
       <SocialButtons enabledProviders={socialProviders()} lastUsed={lastAuthMethod()} />

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -71,7 +71,7 @@ const MessageLog: Component = () => {
       ? DETAILED_COLUMNS.filter((c) => c !== 'feedback')
       : DETAILED_COLUMNS;
     if (params.agentName) return base;
-    // Global Messages spans every agent, so show which agent each row belongs to.
+    // Global Messages spans every harness, so show which harness each row belongs to.
     const at = base.indexOf('model');
     return [...base.slice(0, at), 'agent' as const, ...base.slice(at)];
   };
@@ -92,7 +92,7 @@ const MessageLog: Component = () => {
     },
   );
   const agentFilterOptions = createMemo(() => [
-    { label: 'All agents', value: '' },
+    { label: 'All harnesses', value: '' },
     ...(agentList() ?? []).map((a) => ({ label: a, value: a })),
   ]);
   const [providerFilter, setProviderFilter] = createSignal('');
@@ -344,7 +344,7 @@ const MessageLog: Component = () => {
         content={
           params.agentName
             ? `Browse all messages sent and received by ${agentDisplayName() ?? decodeURIComponent(params.agentName)}. Filter by provider or cost.`
-            : 'Browse all messages across all agents. Filter by provider or cost.'
+            : 'Browse all messages across all harnesses. Filter by provider or cost.'
         }
       />
       <div class="page-header">
@@ -393,7 +393,7 @@ const MessageLog: Component = () => {
           </Show>
           <Show when={showEmptyState() && !!params.agentName && !setupCompleted()}>
             <button class="btn btn--primary btn--sm" onClick={() => setSetupOpen(true)}>
-              Set up agent
+              Set up harness
             </button>
           </Show>
         </div>
@@ -477,24 +477,24 @@ const MessageLog: Component = () => {
                     when={params.agentName}
                     fallback={
                       <>
-                        <p>Create an agent and send a message. Every LLM call shows up here.</p>
+                        <p>Create a harness and send a message. Every LLM call shows up here.</p>
                         <A
-                          href="/agents"
+                          href="/harnesses"
                           class="btn btn--primary btn--sm"
                           style="margin-top: var(--gap-md);"
                         >
-                          Go to Agents
+                          Go to Harnesses
                         </A>
                       </>
                     }
                   >
-                    <p>Set up your agent and send a message. Every LLM call shows up here.</p>
+                    <p>Set up your harness and send a message. Every LLM call shows up here.</p>
                     <button
                       class="btn btn--primary btn--sm"
                       style="margin-top: var(--gap-md);"
                       onClick={() => setSetupOpen(true)}
                     >
-                      Set up agent
+                      Set up harness
                     </button>
                   </Show>
                   <div class="empty-state__img-wrapper">
@@ -515,7 +515,7 @@ const MessageLog: Component = () => {
                   class="btn btn--primary btn--sm"
                   style="margin-top: var(--gap-md);"
                   onClick={() =>
-                    navigate(`/agents/${encodeURIComponent(params.agentName)}/routing`, {
+                    navigate(`/harnesses/${encodeURIComponent(params.agentName)}/routing`, {
                       state: { openProviders: true },
                     })
                   }

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -28,7 +28,7 @@ import {
   type CustomProviderData,
 } from '../services/api.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
-import { isRecentlyCreated } from '../services/recent-agents.js';
+import { isRecentlyCreated, isSetupPending, clearSetupPending } from '../services/recent-agents.js';
 import { messagePing } from '../services/sse.js';
 import {
   RANGE_STORAGE_KEY,
@@ -104,8 +104,15 @@ const Overview: Component = () => {
   const [savingsTimeseries, setSavingsTimeseries] = createSignal<
     Array<{ date?: string; hour?: string; actual_cost: number; baseline_cost: number }>
   >([]);
+  // Open gate keys off a persistent "setup pending" flag (localStorage) so the
+  // modal reliably reopens after a page refresh until the user dismisses or
+  // completes it; `isRecentlyCreated` is an in-session OR that need not survive
+  // reloads. The completed/dismissed flags are the backstop against re-opening.
   const [setupOpen, setSetupOpen] = createSignal(
-    isRecentlyCreated(decodeURIComponent(params.agentName)),
+    (isSetupPending(decodeURIComponent(params.agentName)) ||
+      isRecentlyCreated(decodeURIComponent(params.agentName))) &&
+      !localStorage.getItem(`setup_completed_${params.agentName}`) &&
+      !localStorage.getItem(`setup_dismissed_${params.agentName}`),
   );
   const [setupCompleted, setSetupCompleted] = createSignal(
     !!localStorage.getItem(`setup_completed_${params.agentName}`),
@@ -408,10 +415,12 @@ const Overview: Component = () => {
           agentCategory={agentCategory()}
           onClose={() => {
             localStorage.setItem(`setup_dismissed_${params.agentName}`, '1');
+            clearSetupPending(decodeURIComponent(params.agentName));
             setSetupOpen(false);
           }}
           onDone={() => {
             localStorage.setItem(`setup_completed_${params.agentName}`, '1');
+            clearSetupPending(decodeURIComponent(params.agentName));
             setSetupCompleted(true);
           }}
           onGoToRouting={() => {

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -259,7 +259,7 @@ const Overview: Component = () => {
             </Show>
             <Show when={showEmptyState() && !setupCompleted()}>
               <button class="btn btn--primary btn--sm" onClick={() => setSetupOpen(true)}>
-                Set up agent
+                Set up harness
               </button>
             </Show>
           </div>
@@ -273,13 +273,13 @@ const Overview: Component = () => {
                 fallback={
                   <div class="empty-state">
                     <div class="empty-state__title">No activity yet</div>
-                    <p>Set up your agent and send a message. Usage data shows up here.</p>
+                    <p>Set up your harness and send a message. Usage data shows up here.</p>
                     <button
                       class="btn btn--primary btn--sm"
                       style="margin-top: var(--gap-md);"
                       onClick={() => setSetupOpen(true)}
                     >
-                      Set up agent
+                      Set up harness
                     </button>
                     <div class="empty-state__img-wrapper">
                       <img
@@ -299,7 +299,7 @@ const Overview: Component = () => {
                     class="btn btn--primary btn--sm"
                     style="margin-top: var(--gap-md);"
                     onClick={() =>
-                      navigate(`/agents/${encodeURIComponent(params.agentName)}/routing`, {
+                      navigate(`/harnesses/${encodeURIComponent(params.agentName)}/routing`, {
                         state: { openProviders: true },
                       })
                     }
@@ -370,7 +370,7 @@ const Overview: Component = () => {
                         style="display: flex; justify-content: space-between; align-items: center;"
                       >
                         Recent Messages
-                        <A href={`/agents/${params.agentName}/messages`} class="view-more-link">
+                        <A href={`/harnesses/${params.agentName}/messages`} class="view-more-link">
                           View more
                         </A>
                       </div>
@@ -415,7 +415,7 @@ const Overview: Component = () => {
             setSetupCompleted(true);
           }}
           onGoToRouting={() => {
-            navigate(`/agents/${encodeURIComponent(params.agentName)}/routing`, {
+            navigate(`/harnesses/${encodeURIComponent(params.agentName)}/routing`, {
               state: { openProviders: true },
             });
           }}

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -102,7 +102,7 @@ const Register: Component = () => {
       <Title>Sign Up - Manifest</Title>
       <Meta
         name="description"
-        content="Create a Manifest account to start monitoring your AI agents."
+        content="Create a Manifest account to start monitoring your AI harnesses."
       />
       <Show
         when={emailSent()}
@@ -110,7 +110,7 @@ const Register: Component = () => {
           <>
             <div class="auth-header">
               <h1 class="auth-header__title">Create an account</h1>
-              <p class="auth-header__subtitle">Monitor your AI agents' costs and usage</p>
+              <p class="auth-header__subtitle">Monitor your AI harnesses' costs and usage</p>
             </div>
 
             <SocialButtons enabledProviders={socialProviders()} lastUsed={lastAuthMethod()} />

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -435,13 +435,7 @@ const Routing: Component = () => {
       />
 
       <div class="page-header routing-page-header">
-        <div>
-          <h1>Routing</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Pick which model handles each type of
-            request
-          </span>
-        </div>
+        <span class="breadcrumb">Pick which model handles each type of request</span>
         <Show when={!connectedProviders.loading}>
           <div style="display: flex; gap: 8px;">
             <Show when={isEnabled()}>

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -15,7 +15,7 @@ import ResponseModeModal from '../components/ResponseModeModal.js';
 import { toast } from '../services/toast-store.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import SetupModal from '../components/SetupModal.jsx';
-import { isRecentlyCreated } from '../services/recent-agents.js';
+import { isRecentlyCreated, isSetupPending, clearSetupPending } from '../services/recent-agents.js';
 import { agentPlatform, agentCategory } from '../services/agent-platform-store.js';
 import RoutingDefaultTierSection from './RoutingDefaultTierSection.js';
 import RoutingSpecificitySection from './RoutingSpecificitySection.js';
@@ -60,10 +60,13 @@ const Routing: Component = () => {
   const agentName = () => decodeURIComponent(params.agentName);
 
   // Newly created agents land on this tab; show the setup modal here too (it
-  // used to live only on Overview). Opens for a freshly-created agent unless
-  // already completed/dismissed.
+  // used to live only on Overview). The open gate keys off a persistent
+  // "setup pending" flag (localStorage) so the modal reliably reopens after a
+  // page refresh until the user dismisses or completes it. The in-memory
+  // `isRecentlyCreated` is kept as an in-session OR but is not required to
+  // survive reloads.
   const [setupOpen, setSetupOpen] = createSignal(
-    isRecentlyCreated(agentName()) &&
+    (isSetupPending(agentName()) || isRecentlyCreated(agentName())) &&
       !localStorage.getItem(`setup_completed_${params.agentName}`) &&
       !localStorage.getItem(`setup_dismissed_${params.agentName}`),
   );
@@ -774,10 +777,12 @@ const Routing: Component = () => {
         agentCategory={agentCategory()}
         onClose={() => {
           localStorage.setItem(`setup_dismissed_${params.agentName}`, '1');
+          clearSetupPending(agentName());
           setSetupOpen(false);
         }}
         onDone={() => {
           localStorage.setItem(`setup_completed_${params.agentName}`, '1');
+          clearSetupPending(agentName());
           setSetupOpen(false);
         }}
       />

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -182,15 +182,9 @@ const Settings: Component = () => {
         name="description"
         content={`Configure settings for ${agentDisplayName() ?? agentName()}.`}
       />
-      <div class="page-header">
-        <div>
-          <h1>Settings</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Rename your agent, manage API keys, and
-            view setup instructions
-          </span>
-        </div>
-      </div>
+      <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); margin: 0 0 var(--gap-lg);">
+        Rename your agent, manage API keys, and view setup instructions
+      </p>
 
       {/* -- Agent Name ------------------------------ */}
       <div class="settings-card">

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -136,8 +136,8 @@ const Settings: Component = () => {
     setDeleting(true);
     try {
       await deleteAgent(agentName());
-      toast.success(`Agent "${agentName()}" deleted`);
-      navigate('/agents', { replace: true });
+      toast.success(`Harness "${agentName()}" deleted`);
+      navigate('/harnesses', { replace: true });
     } catch {
       setDeleting(false);
     }
@@ -152,7 +152,7 @@ const Settings: Component = () => {
       const result = await renameAgent(agentName(), name().trim());
       const slug = (result?.name as string) ?? name().trim();
       markAgentCreated(slug);
-      window.location.replace(`/agents/${encodeURIComponent(slug)}/settings`);
+      window.location.replace(`/harnesses/${encodeURIComponent(slug)}/settings`);
     } catch {
       setName(agentName());
     } finally {
@@ -191,20 +191,20 @@ const Settings: Component = () => {
         </div>
       </div>
 
-      {/* -- Agent Name ------------------------------ */}
+      {/* -- Harness Name ------------------------------ */}
       <div class="settings-card">
         <div class="settings-card__row">
           <div class="settings-card__label">
-            <span class="settings-card__label-title">Agent name</span>
+            <span class="settings-card__label-title">Harness name</span>
             <span class="settings-card__label-desc">
-              The display name for this agent across the dashboard.
+              The display name for this harness across the dashboard.
             </span>
           </div>
           <div class="settings-card__control">
             <input
               class="settings-card__input"
               type="text"
-              aria-label="Agent name"
+              aria-label="Harness name"
               value={name()}
               onInput={(e) => setName(e.currentTarget.value)}
             />
@@ -228,8 +228,8 @@ const Settings: Component = () => {
         </div>
       </div>
 
-      {/* -- Agent Type (read-only + change modal) --- */}
-      <h2 class="settings-section__title">Agent type</h2>
+      {/* -- Harness Type (read-only + change modal) --- */}
+      <h2 class="settings-section__title">Harness type</h2>
       <div class="settings-card">
         <div class="settings-card__row">
           <div class="settings-card__label">
@@ -279,10 +279,10 @@ const Settings: Component = () => {
         <h2 class="settings-section__title">API Key</h2>
         <div class="settings-card">
           <div class="settings-card__body">
-            <span class="settings-card__label-title">Agent API key</span>
+            <span class="settings-card__label-title">Harness API key</span>
             <span class="settings-card__label-desc" style="font-size: 14px;">
-              This key authenticates your agent's requests to Manifest. Rotating it generates a new
-              key and immediately invalidates the current one.
+              This key authenticates your harness's requests to Manifest. Rotating it generates a
+              new key and immediately invalidates the current one.
             </span>
             <div class="settings-card__key-row">
               <code class="settings-card__key-value">{displayedKey()}</code>
@@ -377,7 +377,7 @@ const Settings: Component = () => {
                 <>
                   <span class="settings-card__label-title">Enable message logs</span>
                   <span class="settings-card__label-desc">
-                    Capture every request and response to get full visibility on your agent's
+                    Capture every request and response to get full visibility on your harness's
                     conversations, model choices, and performance.
                   </span>
                 </>
@@ -415,9 +415,9 @@ const Settings: Component = () => {
         </div>
         <div class="settings-card__row">
           <div class="settings-card__label">
-            <span class="settings-card__label-title">Delete this agent</span>
+            <span class="settings-card__label-title">Delete this harness</span>
             <span class="settings-card__label-desc">
-              Permanently delete this agent, its API key, and all messages and analytics. This
+              Permanently delete this harness, its API key, and all messages and analytics. This
               action cannot be undone.
             </span>
           </div>
@@ -429,7 +429,7 @@ const Settings: Component = () => {
                 setDeleteConfirmName('');
               }}
             >
-              Delete agent
+              Delete harness
             </button>
           </div>
         </div>
@@ -486,7 +486,7 @@ const Settings: Component = () => {
             </div>
             <p style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); margin-bottom: var(--gap-md);">
               This will permanently delete the{' '}
-              <strong style="color: hsl(var(--foreground));">{agentName()}</strong> agent and all
+              <strong style="color: hsl(var(--foreground));">{agentName()}</strong> harness and all
               its data. This action cannot be undone.
             </p>
             <label
@@ -517,7 +517,7 @@ const Settings: Component = () => {
                   <span class="sr-only">Deleting...</span>
                 </>
               ) : (
-                'Delete this agent'
+                'Delete this harness'
               )}
             </button>
           </div>
@@ -573,7 +573,7 @@ const Settings: Component = () => {
             <ul style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); margin: 0 0 var(--gap-md) 0; padding-left: 20px; line-height: 1.7;">
               <li>
                 <strong style="color: hsl(var(--foreground));">Conversation context:</strong> no way
-                to review what your agent sent or received
+                to review what your harness sent or received
               </li>
               <li>
                 <strong style="color: hsl(var(--foreground));">Troubleshooting:</strong> no data to
@@ -618,9 +618,9 @@ const Settings: Component = () => {
             onClick={(e) => e.stopPropagation()}
           >
             <h2 class="modal-card__title" id="change-type-modal-title">
-              Change agent type
+              Change harness type
             </h2>
-            <p class="modal-card__desc">Select the new type and platform for this agent.</p>
+            <p class="modal-card__desc">Select the new type and platform for this harness.</p>
 
             <AgentTypeGrid
               category={modalCategory()}

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -69,12 +69,12 @@ const Workspace: Component = () => {
     () => getAgents() as Promise<AgentsData>,
   );
   const [modalOpen, setModalOpen] = createSignal(false);
-  // Deep-link support: visiting /agents?add=true auto-opens the connect modal so
+  // Deep-link support: visiting /harnesses?add=true auto-opens the connect modal so
   // onboarding surfaces can route a user straight into creating an agent. We
   // clear the param so a refresh or back-navigation doesn't re-trigger it.
   const [searchParams, setSearchParams] = useSearchParams();
   // React to the deep-link on every navigation, not just initial mount: opening
-  // /agents?add=true while Workspace is already mounted still opens the modal. We
+  // /harnesses?add=true while Workspace is already mounted still opens the modal. We
   // clear the param (replace) so a refresh or back-nav doesn't re-trigger it.
   createEffect(() => {
     if (searchParams.add === 'true') {
@@ -98,7 +98,7 @@ const Workspace: Component = () => {
     setDeleting(true);
     try {
       await deleteAgent(target);
-      toast.success(`Agent "${target}" deleted`);
+      toast.success(`Harness "${target}" deleted`);
       closeDeleteModal();
       await refetch();
     } catch {
@@ -110,15 +110,15 @@ const Workspace: Component = () => {
 
   return (
     <div class="container--md">
-      <Title>My Agents - Manifest</Title>
+      <Title>My Harnesses - Manifest</Title>
       <Meta
         name="description"
-        content="View and manage all your AI agents. Monitor usage, messages, and costs."
+        content="View and manage all your harnesses. Monitor usage, messages, and costs."
       />
       <div class="page-header">
         <div>
-          <h1>My Agents</h1>
-          <span class="breadcrumb">View and manage all your connected AI agents</span>
+          <h1>My Harnesses</h1>
+          <span class="breadcrumb">View and manage all your connected harnesses</span>
         </div>
         <button class="btn btn--primary btn--sm" onClick={() => setModalOpen(true)}>
           <svg
@@ -135,7 +135,7 @@ const Workspace: Component = () => {
             <line x1="12" y1="5" x2="12" y2="19" />
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
-          Connect Agent
+          Connect Harness
         </button>
       </div>
 
@@ -166,14 +166,16 @@ const Workspace: Component = () => {
             when={data()?.agents?.length}
             fallback={
               <div class="empty-state">
-                <div class="empty-state__title">No agents yet</div>
-                <p>Connect an agent or an AI app to take control of your routing and your costs.</p>
+                <div class="empty-state__title">No harnesses yet</div>
+                <p>
+                  Connect a harness or an AI app to take control of your routing and your costs.
+                </p>
                 <button
                   class="btn btn--primary btn--sm"
                   style="margin-top: var(--gap-md);"
                   onClick={() => setModalOpen(true)}
                 >
-                  Connect your first agent
+                  Connect your first harness
                 </button>
               </div>
             }
@@ -182,7 +184,10 @@ const Workspace: Component = () => {
               <For each={data()!.agents}>
                 {(agent) => (
                   <div class="agent-card-wrap">
-                    <A href={`/agents/${encodeURIComponent(agent.agent_name)}`} class="agent-card">
+                    <A
+                      href={`/harnesses/${encodeURIComponent(agent.agent_name)}`}
+                      class="agent-card"
+                    >
                       <div class="agent-card__top">
                         <Show when={platformIcon(agent.agent_platform, agent.agent_category)}>
                           <img
@@ -275,8 +280,8 @@ const Workspace: Component = () => {
             </h3>
             <p style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); margin-bottom: var(--gap-md);">
               This will permanently delete the{' '}
-              <strong style="color: hsl(var(--foreground));">{deleteTarget()}</strong> agent and all
-              its data. This action cannot be undone.
+              <strong style="color: hsl(var(--foreground));">{deleteTarget()}</strong> harness and
+              all its data. This action cannot be undone.
             </p>
             <label
               for="workspace-delete-confirm"
@@ -308,7 +313,7 @@ const Workspace: Component = () => {
                 onClick={handleDelete}
                 disabled={deleteConfirmName() !== deleteTarget() || deleting()}
               >
-                {deleting() ? <span class="spinner" /> : 'Delete agent'}
+                {deleting() ? <span class="spinner" /> : 'Delete harness'}
               </button>
             </div>
           </div>

--- a/packages/frontend/src/services/recent-agents.ts
+++ b/packages/frontend/src/services/recent-agents.ts
@@ -11,3 +11,36 @@ export function isRecentlyCreated(slug: string): boolean {
 export function clearRecentAgent(slug: string): void {
   recentlyCreated.delete(slug);
 }
+
+/**
+ * Persistent "setup pending" flag (localStorage-backed) so the setup modal
+ * reliably reopens after a page refresh until the user dismisses or completes
+ * it. Unlike the in-memory `recentlyCreated` Set above (which AgentGuard clears
+ * and a refresh drops), this survives reloads. All accessors wrap localStorage
+ * in try/catch so SSR / denied-storage environments degrade gracefully.
+ */
+const SETUP_PENDING_PREFIX = 'setup_pending_';
+
+export function markSetupPending(slug: string): void {
+  try {
+    localStorage.setItem(SETUP_PENDING_PREFIX + slug, '1');
+  } catch {
+    // Storage unavailable (SSR / privacy mode) — pending state is best-effort.
+  }
+}
+
+export function isSetupPending(slug: string): boolean {
+  try {
+    return localStorage.getItem(SETUP_PENDING_PREFIX + slug) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function clearSetupPending(slug: string): void {
+  try {
+    localStorage.removeItem(SETUP_PENDING_PREFIX + slug);
+  } catch {
+    // Storage unavailable — nothing to clear.
+  }
+}

--- a/packages/frontend/src/services/routing.ts
+++ b/packages/frontend/src/services/routing.ts
@@ -1,13 +1,13 @@
-import { useLocation } from "@solidjs/router";
+import { useLocation } from '@solidjs/router';
 
 export function useAgentName(): () => string | null {
   const location = useLocation();
   return () => {
-    const match = location.pathname.match(/^\/agents\/([^/]+)/);
+    const match = location.pathname.match(/^\/harnesses\/([^/]+)/);
     return match?.[1] ? decodeURIComponent(match[1]) : null;
   };
 }
 
 export function agentPath(agentName: string | null, sub: string): string {
-  return agentName ? `/agents/${encodeURIComponent(agentName)}${sub}` : "/";
+  return agentName ? `/harnesses/${encodeURIComponent(agentName)}${sub}` : '/';
 }

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -836,6 +836,126 @@ h6 {
   font-weight: 500;
 }
 
+/* Interactive section label (HARNESSES) — same base as .sidebar__section-label */
+.sidebar__section-label--interactive {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px var(--gap-lg) 6px var(--gap-md);
+  margin: var(--gap-md) 0.5rem 1px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.sidebar__section-label--interactive:hover {
+  background: hsl(var(--sidebar-accent));
+}
+
+.sidebar__section-label-left {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sidebar__section-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  background: hsl(var(--muted));
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.sidebar__section-label--interactive:hover .sidebar__section-add {
+  opacity: 1;
+}
+
+.sidebar__section-add:hover {
+  color: hsl(var(--sidebar-foreground));
+  background: hsl(var(--border));
+}
+
+.sidebar__section-caret {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.sidebar__section-caret:hover {
+  color: hsl(var(--sidebar-foreground));
+}
+
+/* Harness list items */
+.sidebar__agents-list {
+  padding: 0;
+}
+
+.sidebar__agent-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px var(--gap-lg);
+  margin: 1px 0.5rem;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: hsl(var(--sidebar-foreground));
+  text-decoration: none;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  border-radius: var(--radius);
+}
+
+.sidebar__agent-item:hover {
+  background: hsl(var(--sidebar-accent));
+  color: hsl(var(--sidebar-accent-foreground));
+}
+
+.sidebar__agent-item--active {
+  background: hsl(var(--sidebar-accent));
+  color: hsl(var(--sidebar-primary));
+  font-weight: 600;
+}
+
+.sidebar__agent-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.dark .sidebar__agent-icon {
+  filter: invert(1);
+}
+
+.sidebar__agent-item-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar__agents-empty {
+  padding: 6px var(--gap-lg);
+  margin: 1px 0.5rem;
+  font-size: var(--font-size-sm);
+  color: hsl(var(--muted-foreground));
+}
+
 .sidebar__spacer {
   flex: 1;
 }

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -812,7 +812,9 @@ h6 {
   letter-spacing: 0.05em;
 }
 
-.sidebar__link {
+/* Base styling shared by global nav links and harness switcher items. */
+.sidebar__link,
+.sidebar__agent-item {
   display: flex;
   align-items: center;
   gap: var(--gap-xs);
@@ -825,7 +827,8 @@ h6 {
   transition: all var(--transition-fast);
 }
 
-.sidebar__link:hover {
+.sidebar__link:hover,
+.sidebar__agent-item:hover {
   background: hsl(var(--sidebar-accent));
   color: hsl(var(--sidebar-accent-foreground));
 }
@@ -836,26 +839,40 @@ h6 {
   font-weight: 500;
 }
 
-/* Interactive section label (HARNESSES) — same base as .sidebar__section-label */
-.sidebar__section-label--interactive {
+/* HARNESSES section header — a row holding the collapse toggle and + button. */
+.sidebar__section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px var(--gap-lg) 6px var(--gap-md);
   margin: var(--gap-md) 0.5rem 1px;
+}
+
+/* Collapse toggle: carries the uppercased section label styling so it reads as
+   a section heading, with the caret icon trailing the text. */
+.sidebar__section-caret {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+  padding: 6px var(--gap-md);
+  background: none;
+  border: none;
   border-radius: var(--radius);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: left;
   cursor: pointer;
   transition: background var(--transition-fast);
 }
 
-.sidebar__section-label--interactive:hover {
+.sidebar__section-caret:hover,
+.sidebar__section-caret:focus-visible {
   background: hsl(var(--sidebar-accent));
-}
-
-.sidebar__section-label-left {
-  display: flex;
-  align-items: center;
-  gap: 4px;
+  color: hsl(var(--sidebar-foreground));
 }
 
 .sidebar__section-add {
@@ -870,61 +887,26 @@ h6 {
   padding: 0;
   color: hsl(var(--muted-foreground));
   cursor: pointer;
-  opacity: 0;
   transition:
-    opacity var(--transition-fast),
     color var(--transition-fast),
     background var(--transition-fast);
 }
 
-.sidebar__section-label--interactive:hover .sidebar__section-add {
-  opacity: 1;
-}
-
-.sidebar__section-add:hover {
+.sidebar__section-add:hover,
+.sidebar__section-add:focus-visible {
   color: hsl(var(--sidebar-foreground));
   background: hsl(var(--border));
 }
 
-.sidebar__section-caret {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  padding: 0;
-  color: hsl(var(--muted-foreground));
-  cursor: pointer;
-  transition: color var(--transition-fast);
-}
-
-.sidebar__section-caret:hover {
-  color: hsl(var(--sidebar-foreground));
-}
-
-/* Harness list items */
+/* Harness list items reuse the shared link base (above); these are the only
+   harness-specific overrides — a wider icon gap and a bolder label. */
 .sidebar__agents-list {
   padding: 0;
 }
 
 .sidebar__agent-item {
-  display: flex;
-  align-items: center;
   gap: 8px;
-  padding: 6px var(--gap-lg);
-  margin: 1px 0.5rem;
-  font-size: var(--font-size-sm);
   font-weight: 500;
-  color: hsl(var(--sidebar-foreground));
-  text-decoration: none;
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  border-radius: var(--radius);
-}
-
-.sidebar__agent-item:hover {
-  background: hsl(var(--sidebar-accent));
-  color: hsl(var(--sidebar-accent-foreground));
 }
 
 .sidebar__agent-item--active {

--- a/packages/frontend/src/styles/wizard.css
+++ b/packages/frontend/src/styles/wizard.css
@@ -383,6 +383,14 @@
 .setup-method-tabs .panel__tabs {
   width: 100%;
   margin-bottom: 12px;
+  /* The framework tabs don't shrink (flex-shrink: 0), so a full row can exceed
+     the modal width. Scroll within the modal instead of overflowing past its
+     edge (the mobile media query already does this; desktop needs it too). */
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.setup-method-tabs .panel__tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .setup-method-tabs .panel__tab {

--- a/packages/frontend/tests/components/AddAgentModal.test.tsx
+++ b/packages/frontend/tests/components/AddAgentModal.test.tsx
@@ -18,8 +18,10 @@ vi.mock("../../src/services/toast-store.js", () => ({
 }));
 
 const mockMarkAgentCreated = vi.fn();
+const mockMarkSetupPending = vi.fn();
 vi.mock("../../src/services/recent-agents.js", () => ({
   markAgentCreated: (...args: unknown[]) => mockMarkAgentCreated(...args),
+  markSetupPending: (...args: unknown[]) => mockMarkSetupPending(...args),
 }));
 
 vi.mock("../../src/components/AgentTypeSelect.jsx", () => ({
@@ -99,6 +101,8 @@ describe("AddAgentModal", () => {
       });
     });
     expect(mockMarkAgentCreated).toHaveBeenCalledWith("new-agent");
+    // Persistent flag set so the setup modal survives a refresh on landing.
+    expect(mockMarkSetupPending).toHaveBeenCalledWith("new-agent");
     expect(onClose).toHaveBeenCalled();
   });
 
@@ -145,6 +149,7 @@ describe("AddAgentModal", () => {
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
       expect(mockMarkAgentCreated).toHaveBeenCalledWith("Typed Name");
+      expect(mockMarkSetupPending).toHaveBeenCalledWith("Typed Name");
       expect(mockNavigate).toHaveBeenCalledWith(
         `/harnesses/${encodeURIComponent("Typed Name")}/routing`,
         expect.anything(),
@@ -208,6 +213,7 @@ describe("AddAgentModal", () => {
 
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(mockMarkAgentCreated).not.toHaveBeenCalled();
+    expect(mockMarkSetupPending).not.toHaveBeenCalled();
     expect(mockGetGlobalProviders).not.toHaveBeenCalled();
   });
 
@@ -228,6 +234,7 @@ describe("AddAgentModal", () => {
 
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(mockMarkAgentCreated).not.toHaveBeenCalled();
+    expect(mockMarkSetupPending).not.toHaveBeenCalled();
   });
 
   it("does not navigate if dismissed during the providers lookup", async () => {
@@ -275,6 +282,7 @@ describe("AddAgentModal", () => {
       expect(mockCreateAgent).toHaveBeenCalled();
     });
     expect(mockMarkAgentCreated).not.toHaveBeenCalled();
+    expect(mockMarkSetupPending).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 

--- a/packages/frontend/tests/components/AddAgentModal.test.tsx
+++ b/packages/frontend/tests/components/AddAgentModal.test.tsx
@@ -68,8 +68,8 @@ describe("AddAgentModal", () => {
 
   it("renders the dialog title and description when open", () => {
     const { container } = renderOpen();
-    expect(container.textContent).toContain("Connect Agent");
-    expect(container.textContent).toContain("Name your agent to start tracking");
+    expect(container.textContent).toContain("Connect Harness");
+    expect(container.textContent).toContain("Name your harness to start tracking");
   });
 
   it("keeps Create disabled until a non-blank name is entered", () => {
@@ -94,7 +94,7 @@ describe("AddAgentModal", () => {
     fireEvent.input(input, { target: { value: "agent-a" } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/new-agent/routing", {
+      expect(mockNavigate).toHaveBeenCalledWith("/harnesses/new-agent/routing", {
         state: { newApiKey: "key-1" },
       });
     });
@@ -108,7 +108,7 @@ describe("AddAgentModal", () => {
     fireEvent.input(input, { target: { value: "agent-b" } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/new-agent/routing", {
+      expect(mockNavigate).toHaveBeenCalledWith("/harnesses/new-agent/routing", {
         state: { newApiKey: "key-1", openProviders: true },
       });
     });
@@ -120,7 +120,7 @@ describe("AddAgentModal", () => {
     fireEvent.input(input, { target: { value: "agent-c" } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/new-agent/routing", {
+      expect(mockNavigate).toHaveBeenCalledWith("/harnesses/new-agent/routing", {
         state: { newApiKey: "key-1", openProviders: true },
       });
     });
@@ -132,7 +132,7 @@ describe("AddAgentModal", () => {
     fireEvent.input(input, { target: { value: "agent-d" } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/new-agent/routing", {
+      expect(mockNavigate).toHaveBeenCalledWith("/harnesses/new-agent/routing", {
         state: { newApiKey: "key-1", openProviders: true },
       });
     });
@@ -146,7 +146,7 @@ describe("AddAgentModal", () => {
     await vi.waitFor(() => {
       expect(mockMarkAgentCreated).toHaveBeenCalledWith("Typed Name");
       expect(mockNavigate).toHaveBeenCalledWith(
-        `/agents/${encodeURIComponent("Typed Name")}/routing`,
+        `/harnesses/${encodeURIComponent("Typed Name")}/routing`,
         expect.anything(),
       );
     });

--- a/packages/frontend/tests/components/AddAgentModal.test.tsx
+++ b/packages/frontend/tests/components/AddAgentModal.test.tsx
@@ -260,7 +260,7 @@ describe("AddAgentModal", () => {
     fireEvent.input(input, { target: { value: "clean" } });
     fireEvent.click(screen.getByText("Create"));
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/new-agent/routing", {
+      expect(mockNavigate).toHaveBeenCalledWith("/harnesses/new-agent/routing", {
         state: { newApiKey: "key-1" },
       });
     });

--- a/packages/frontend/tests/components/AgentTypeSelect.test.tsx
+++ b/packages/frontend/tests/components/AgentTypeSelect.test.tsx
@@ -359,13 +359,13 @@ describe("AgentTypeSelect", () => {
     ));
     expect(
       blankContainer.querySelector(".agent-type-select__trigger")!.getAttribute("aria-label"),
-    ).toBe("Agent type: Select");
+    ).toBe("Harness type: Select");
 
     const { container: pickedContainer } = render(() => (
       <AgentTypeSelect {...defaultProps} category="coding" platform="claude-code" />
     ));
     expect(
       pickedContainer.querySelector(".agent-type-select__trigger")!.getAttribute("aria-label"),
-    ).toBe("Agent type: Claude Code");
+    ).toBe("Harness type: Claude Code");
   });
 });

--- a/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
+++ b/packages/frontend/tests/components/DuplicateAgentModal.test.tsx
@@ -117,7 +117,7 @@ describe('DuplicateAgentModal', () => {
     });
 
     const btn = Array.from(document.querySelectorAll('button')).find(
-      (b) => b.textContent?.trim() === 'Duplicate agent',
+      (b) => b.textContent?.trim() === 'Duplicate harness',
     ) as HTMLButtonElement;
     fireEvent.click(btn);
 
@@ -127,7 +127,7 @@ describe('DuplicateAgentModal', () => {
     await waitFor(() => {
       expect(mockToastSuccess).toHaveBeenCalled();
       expect(mockMarkAgentCreated).toHaveBeenCalledWith('my-agent-copy');
-      expect(mockNavigate).toHaveBeenCalledWith('/agents/my-agent-copy', {
+      expect(mockNavigate).toHaveBeenCalledWith('/harnesses/my-agent-copy', {
         state: { newApiKey: 'mnfst_xyz' },
       });
       expect(onClose).toHaveBeenCalled();
@@ -145,7 +145,7 @@ describe('DuplicateAgentModal', () => {
 
     await waitFor(() => {
       const btn = Array.from(document.querySelectorAll('button')).find(
-        (b) => b.textContent?.trim() === 'Duplicate agent',
+        (b) => b.textContent?.trim() === 'Duplicate harness',
       ) as HTMLButtonElement;
       expect(btn.hasAttribute('disabled')).toBe(true);
     });
@@ -209,7 +209,7 @@ describe('DuplicateAgentModal', () => {
     });
 
     const btn = Array.from(document.querySelectorAll('button')).find(
-      (b) => b.textContent?.trim() === 'Duplicate agent',
+      (b) => b.textContent?.trim() === 'Duplicate harness',
     ) as HTMLButtonElement;
     fireEvent.click(btn);
 
@@ -286,7 +286,7 @@ describe('DuplicateAgentModal', () => {
     });
 
     const duplicateBtn = Array.from(document.querySelectorAll('button')).find(
-      (b) => b.textContent?.trim() === 'Duplicate agent',
+      (b) => b.textContent?.trim() === 'Duplicate harness',
     ) as HTMLButtonElement;
     fireEvent.click(duplicateBtn);
 

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -307,38 +307,38 @@ describe("Header - gear dropdown", () => {
   it("shows gear button when on an agent page", () => {
     mockAgentName = "my-agent";
     render(() => <Header />);
-    expect(screen.getByLabelText("Agent actions")).toBeDefined();
+    expect(screen.getByLabelText("Harness actions")).toBeDefined();
   });
 
   it("does not show gear button when not on an agent page", () => {
     mockAgentName = null;
     render(() => <Header />);
-    expect(screen.queryByLabelText("Agent actions")).toBeNull();
+    expect(screen.queryByLabelText("Harness actions")).toBeNull();
   });
 
   it("opens dropdown with Settings and Duplicate items", async () => {
     mockAgentName = "my-agent";
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("Agent actions"));
+    await fireEvent.click(screen.getByLabelText("Harness actions"));
     expect(screen.getByText("Settings")).toBeDefined();
-    expect(screen.getByText("Duplicate agent")).toBeDefined();
+    expect(screen.getByText("Duplicate harness")).toBeDefined();
   });
 
   it("Settings links to the agent settings page", async () => {
     mockAgentName = "my-agent";
     const { container } = render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("Agent actions"));
-    const settingsLink = container.querySelector('a[href="/agents/my-agent/settings"]');
+    await fireEvent.click(screen.getByLabelText("Harness actions"));
+    const settingsLink = container.querySelector('a[href="/harnesses/my-agent/settings"]');
     expect(settingsLink).not.toBeNull();
   });
 
   it("closes gear dropdown when clicking outside", async () => {
     mockAgentName = "my-agent";
     render(() => <Header />);
-    await fireEvent.click(screen.getByLabelText("Agent actions"));
+    await fireEvent.click(screen.getByLabelText("Harness actions"));
     expect(screen.getByText("Settings")).toBeDefined();
     await fireEvent.click(document.body);
-    expect(screen.queryByText("Duplicate agent")).toBeNull();
+    expect(screen.queryByText("Duplicate harness")).toBeNull();
   });
 });
 

--- a/packages/frontend/tests/components/MessageDetails.test.tsx
+++ b/packages/frontend/tests/components/MessageDetails.test.tsx
@@ -137,7 +137,7 @@ describe('MessageDetails', () => {
     mockGetMessageDetails.mockResolvedValue(detailsResponse);
     const { container } = render(() => <MessageDetails messageId="msg-1" />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Agent Logs');
+      expect(container.textContent).toContain('Harness Logs');
       expect(container.textContent).toContain('Agent started processing');
       expect(container.textContent).toContain('info');
     });
@@ -306,7 +306,7 @@ describe('MessageDetails', () => {
     await vi.waitFor(() => {
       expect(container.textContent).toContain('LLM Calls');
       expect(container.textContent).not.toContain('Tool Executions');
-      expect(container.textContent).not.toContain('Agent Logs');
+      expect(container.textContent).not.toContain('Harness Logs');
     });
   });
 
@@ -473,7 +473,7 @@ describe('MessageDetails', () => {
     // Table body is not rendered while collapsed.
     expect(container.textContent).not.toContain('curl/8.14.1');
     expect(container.textContent).not.toContain('x-custom-foo');
-    // There should be 3 tables visible (LLM Calls, Tool Executions, Agent Logs), not 4.
+    // There should be 3 tables visible (LLM Calls, Tool Executions, Harness Logs), not 4.
     const tables = container.querySelectorAll('table.msg-detail__table');
     expect(tables.length).toBe(3);
   });
@@ -1018,7 +1018,7 @@ describe('MessageDetails', () => {
       expect(titleButton.textContent).toContain('3');
       titleButton.click();
       // Scope the key-extraction to the Model Parameters table specifically;
-      // the LLM Calls / Tool Executions / Agent Logs sections also use
+      // the LLM Calls / Tool Executions / Harness Logs sections also use
       // `.msg-detail__table` and would dilute a global selector. The
       // wrapper id starts with `msg-detail-model-params-` for exactly this
       // kind of disambiguation.

--- a/packages/frontend/tests/components/MessageTable.test.tsx
+++ b/packages/frontend/tests/components/MessageTable.test.tsx
@@ -515,7 +515,7 @@ describe('MessageTable', () => {
       ));
       const link = container.querySelector('a');
       expect(link).not.toBeNull();
-      expect(link!.getAttribute('href')).toContain('/agents/my-agent/limits');
+      expect(link!.getAttribute('href')).toContain('/harnesses/my-agent/limits');
     });
 
     it('renders error tooltip for error messages', () => {
@@ -994,7 +994,7 @@ describe('MessageTable', () => {
         />
       ));
       const headers = container.querySelectorAll('th');
-      expect(headers[0]!.textContent).toContain('Agent');
+      expect(headers[0]!.textContent).toContain('Harness');
       expect(headers[1]!.textContent).toContain('Date');
     });
 

--- a/packages/frontend/tests/components/RecordedMessageModal.test.tsx
+++ b/packages/frontend/tests/components/RecordedMessageModal.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@solidjs/testing-library";
 
 const mockNavigate = vi.fn();
-let mockPathname = "/agents/test-agent/messages";
+let mockPathname = "/harnesses/test-agent/messages";
 vi.mock("@solidjs/router", () => ({
   useNavigate: () => mockNavigate,
   useLocation: () => ({ pathname: mockPathname }),
@@ -95,7 +95,7 @@ function baseDetails(overrides: Record<string, unknown> = {}) {
 describe("RecordedMessageModal (drawer)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPathname = "/agents/test-agent/messages";
+    mockPathname = "/harnesses/test-agent/messages";
     mockGetMessageDetails.mockResolvedValue(baseDetails());
     mockDeleteMessageRecording.mockResolvedValue(undefined);
     // jsdom doesn't implement scrollIntoView; the drawer's jumpTo() calls

--- a/packages/frontend/tests/components/SetupModal.test.tsx
+++ b/packages/frontend/tests/components/SetupModal.test.tsx
@@ -50,7 +50,7 @@ describe("SetupModal", () => {
     const { container } = render(() => (
       <SetupModal open={true} agentName="my-agent" onClose={onClose} />
     ));
-    expect(container.textContent).toContain("Set up agent:");
+    expect(container.textContent).toContain("Set up harness:");
     expect(container.textContent).toContain("my-agent");
   });
 
@@ -105,7 +105,7 @@ describe("SetupModal", () => {
     const { container } = render(() => (
       <SetupModal open={true} agentName="test-agent" onClose={onClose} />
     ));
-    expect(container.textContent).toContain("Connect your agent to Manifest");
+    expect(container.textContent).toContain("Connect your harness to Manifest");
   });
 
   it("closes on overlay click", () => {

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -20,13 +20,13 @@ describe("SetupStepAddProvider", () => {
 
   it("renders heading", () => {
     render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(screen.getByText("Connect your agent to Manifest")).toBeDefined();
+    expect(screen.getByText("Connect your harness to Manifest")).toBeDefined();
   });
 
   it("shows description with auto model", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
     expect(container.textContent).toContain("auto");
-    expect(container.textContent).toContain("Point your agent");
+    expect(container.textContent).toContain("Point your harness");
   });
 
   it("renders Agents and Toolkits segmented tabs", () => {
@@ -286,7 +286,7 @@ describe("SetupStepAddProvider", () => {
       render(() => (
         <SetupStepAddProvider {...defaultProps} platform="openclaw" />
       ));
-      expect(screen.getByText("Connect your OpenClaw agent to Manifest")).toBeDefined();
+      expect(screen.getByText("Connect your OpenClaw harness to Manifest")).toBeDefined();
     });
 
     it("shows HermesSetup directly when platform is hermes", () => {
@@ -301,7 +301,7 @@ describe("SetupStepAddProvider", () => {
       render(() => (
         <SetupStepAddProvider {...defaultProps} platform="hermes" />
       ));
-      expect(screen.getByText("Connect your Hermes agent to Manifest")).toBeDefined();
+      expect(screen.getByText("Connect your Hermes harness to Manifest")).toBeDefined();
     });
 
     it("shows NanobotSetup directly when platform is nanobot", () => {
@@ -318,7 +318,7 @@ describe("SetupStepAddProvider", () => {
       render(() => (
         <SetupStepAddProvider {...defaultProps} platform="nanobot" />
       ));
-      expect(screen.getByText("Connect your Nanobot agent to Manifest")).toBeDefined();
+      expect(screen.getByText("Connect your Nanobot harness to Manifest")).toBeDefined();
     });
 
     it("shows CraftAgentSetup directly when platform is craft", () => {
@@ -335,7 +335,7 @@ describe("SetupStepAddProvider", () => {
       render(() => (
         <SetupStepAddProvider {...defaultProps} platform="craft" />
       ));
-      expect(screen.getByText("Connect your Craft agent to Manifest")).toBeDefined();
+      expect(screen.getByText("Connect your Craft harness to Manifest")).toBeDefined();
     });
 
     it("shows ClaudeCodeSetup directly when platform is claude-code", () => {
@@ -439,14 +439,14 @@ describe("SetupStepAddProvider", () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="openclaw" />
       ));
-      expect(container.textContent).toContain("Connect your OpenClaw agent to Manifest");
+      expect(container.textContent).toContain("Connect your OpenClaw harness to Manifest");
     });
 
     it("does not show description text in filtered mode", () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="openclaw" />
       ));
-      expect(container.textContent).not.toContain("Point your agent at the Manifest endpoint");
+      expect(container.textContent).not.toContain("Point your harness at the Manifest endpoint");
     });
   });
 });

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 
 let mockPathname = "/overview";
 
@@ -14,7 +14,12 @@ vi.mock("@solidjs/router", () => ({
       }
     }
     return (
-      <a href={props.href} class={classes.join(" ").trim()} aria-current={props["aria-current"]}>
+      <a
+        href={props.href}
+        class={classes.join(" ").trim()}
+        aria-current={props["aria-current"]}
+        onClick={props.onClick}
+      >
         {props.children}
       </a>
     );
@@ -22,17 +27,63 @@ vi.mock("@solidjs/router", () => ({
   useLocation: () => ({ get pathname() { return mockPathname; } }),
 }));
 
-import Sidebar from "../../src/components/Sidebar";
+// getAgents returns the harness list rendered in the in-nav switcher. Each test
+// can override the resolved value via mockGetAgents.
+const mockGetAgents = vi.fn();
+vi.mock("../../src/services/api.js", () => ({
+  getAgents: (...args: unknown[]) => mockGetAgents(...args),
+}));
 
-beforeEach(() => {
-  mockPathname = "/overview";
+// The SSE ping signal drives the agents resource refetch — a stable 0 is fine.
+vi.mock("../../src/services/sse.js", () => ({
+  agentPing: () => 0,
+}));
+
+// Stub the create-harness modal so the Sidebar test stays isolated from the
+// modal's own dependency tree; we only assert that the + button opens it.
+const mockAddModal = vi.fn();
+vi.mock("../../src/components/AddAgentModal.jsx", async () => {
+  const { Show } = await import("solid-js");
+  return {
+    default: (props: any) => (
+      // Read props.open reactively (Show tracks the `when` accessor) so the stub
+      // re-renders when the Sidebar toggles addModalOpen.
+      <Show
+        when={(() => {
+          mockAddModal(props.open);
+          return props.open;
+        })()}
+      >
+        <div data-testid="add-agent-modal" />
+      </Show>
+    ),
+  };
 });
 
-describe("Sidebar — global nav (agent route)", () => {
-  beforeEach(() => {
-    mockPathname = "/harnesses/test-agent";
-  });
+import Sidebar from "../../src/components/Sidebar";
 
+const SAMPLE_AGENTS = [
+  {
+    agent_name: "alpha",
+    display_name: "Alpha Harness",
+    agent_platform: "openclaw",
+    agent_category: "personal",
+  },
+  {
+    // No display_name → falls back to agent_name. No platform → no icon.
+    agent_name: "beta",
+    agent_platform: null,
+    agent_category: null,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPathname = "/overview";
+  mockGetAgents.mockResolvedValue({ agents: SAMPLE_AGENTS });
+});
+
+describe("Sidebar — global nav links", () => {
   it("renders Overview link", () => {
     render(() => <Sidebar />);
     expect(screen.getByText("Overview")).toBeDefined();
@@ -43,11 +94,6 @@ describe("Sidebar — global nav (agent route)", () => {
     expect(screen.getByText("Messages")).toBeDefined();
   });
 
-  it("renders Harnesses link", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Harnesses")).toBeDefined();
-  });
-
   it("renders provider section links", () => {
     render(() => <Sidebar />);
     expect(screen.getByText("PROVIDERS")).toBeDefined();
@@ -56,127 +102,257 @@ describe("Sidebar — global nav (agent route)", () => {
     expect(screen.getByText("Local")).toBeDefined();
   });
 
-  it("does not render MONITORING section on agent route", () => {
+  it("renders the HARNESSES section label", () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText("HARNESSES")).toBeDefined();
+  });
+
+  it("renders the TOOLS section with Playground link", () => {
+    const { container } = render(() => <Sidebar />);
+    expect(screen.getByText("TOOLS")).toBeDefined();
+    expect(container.querySelector('a[href="/playground"]')).not.toBeNull();
+  });
+
+  it("does not render legacy MONITORING/MANAGE/RESOURCES sections", () => {
     const { container } = render(() => <Sidebar />);
     expect(container.textContent).not.toContain("MONITORING");
-  });
-
-  it("does not render MANAGE section on agent route", () => {
-    const { container } = render(() => <Sidebar />);
     expect(container.textContent).not.toContain("MANAGE");
-  });
-
-  it("does not render RESOURCES section on agent route", () => {
-    const { container } = render(() => <Sidebar />);
     expect(container.textContent).not.toContain("RESOURCES");
   });
 
-  it("links point to global routes, not agent-scoped routes", () => {
+  it("global links point to global routes", () => {
     const { container } = render(() => <Sidebar />);
     expect(container.querySelector('a[href="/overview"]')).not.toBeNull();
     expect(container.querySelector('a[href="/messages"]')).not.toBeNull();
     expect(container.querySelector('a[href="/providers/subscriptions"]')).not.toBeNull();
     expect(container.querySelector('a[href="/providers/byok"]')).not.toBeNull();
     expect(container.querySelector('a[href="/providers/local"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/harnesses"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/playground"]')).not.toBeNull();
   });
 
-  it("marks Harnesses link active on /harnesses/:name path", () => {
+  it("keeps exactly the expected sidebar__link set (no static Harnesses link)", () => {
     const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/harnesses"]');
-    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks Harnesses link active on /harnesses/:name/routing sub-path", () => {
-    mockPathname = "/harnesses/test-agent/routing";
-    const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/harnesses"]');
-    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
-  });
-});
-
-describe("Sidebar — global nav (global route)", () => {
-  it("renders Overview link in global mode", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Overview")).toBeDefined();
-  });
-
-  it("renders Messages link in global mode", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Messages")).toBeDefined();
-  });
-
-  it("renders Harnesses link pointing to /harnesses", () => {
-    const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/harnesses"]');
-    expect(agentsLink).not.toBeNull();
-    expect(agentsLink?.textContent).toContain("Harnesses");
-  });
-
-  it("marks provider links active on provider pages", () => {
-    mockPathname = "/providers/byok";
-    const { container } = render(() => <Sidebar />);
-    const byokLink = container.querySelector('a[href="/providers/byok"]');
-    expect(byokLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("does not render MONITORING section in global mode", () => {
-    const { container } = render(() => <Sidebar />);
-    expect(container.textContent).not.toContain("MONITORING");
-  });
-
-  it("marks Overview link active on /overview path", () => {
-    const { container } = render(() => <Sidebar />);
-    const overviewLink = container.querySelector('a[href="/overview"]');
-    expect(overviewLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks Messages link active on /messages path", () => {
-    mockPathname = "/messages";
-    const { container } = render(() => <Sidebar />);
-    const messagesLink = container.querySelector('a[href="/messages"]');
-    expect(messagesLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks Harnesses link active on /harnesses path", () => {
-    mockPathname = "/harnesses";
-    const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/harnesses"]');
-    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("does not mark Overview active when on /messages", () => {
-    mockPathname = "/messages";
-    const { container } = render(() => <Sidebar />);
-    const overviewLink = container.querySelector('a[href="/overview"]');
-    expect(overviewLink?.getAttribute("aria-current")).not.toBe("page");
-  });
-});
-
-describe("Sidebar — identical in agent and global mode", () => {
-  it("renders the same links on /overview and /harnesses/:name", () => {
-    mockPathname = "/overview";
-    const { container: globalContainer } = render(() => <Sidebar />);
-    const globalLinks = Array.from(globalContainer.querySelectorAll("a.sidebar__link")).map(
-      (a) => a.getAttribute("href"),
+    const links = Array.from(container.querySelectorAll("a.sidebar__link")).map((a) =>
+      a.getAttribute("href"),
     );
-
-    mockPathname = "/harnesses/test-agent";
-    const { container: agentContainer } = render(() => <Sidebar />);
-    const agentLinks = Array.from(agentContainer.querySelectorAll("a.sidebar__link")).map(
-      (a) => a.getAttribute("href"),
-    );
-
-    expect(agentLinks).toEqual(globalLinks);
-    expect(globalLinks).toEqual([
+    expect(links).toEqual([
       "/overview",
       "/messages",
       "/providers/subscriptions",
       "/providers/byok",
       "/providers/local",
-      "/harnesses",
       "/playground",
     ]);
+    // The collapsible section replaces the old static link — there is no
+    // sidebar__link pointing at /harnesses anymore.
+    expect(container.querySelector('a.sidebar__link[href="/harnesses"]')).toBeNull();
+  });
+});
+
+describe("Sidebar — global nav active state", () => {
+  it("marks Overview active only on exact /overview path", () => {
+    const { container } = render(() => <Sidebar />);
+    const link = container.querySelector('a[href="/overview"]');
+    expect(link?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("marks Messages active on /messages", () => {
+    mockPathname = "/messages";
+    const { container } = render(() => <Sidebar />);
+    const link = container.querySelector('a[href="/messages"]');
+    expect(link?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("marks provider links active on provider pages (prefix match)", () => {
+    mockPathname = "/providers/byok";
+    const { container } = render(() => <Sidebar />);
+    const link = container.querySelector('a[href="/providers/byok"]');
+    expect(link?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("marks Subscriptions active on /providers/subscriptions", () => {
+    mockPathname = "/providers/subscriptions";
+    const { container } = render(() => <Sidebar />);
+    const link = container.querySelector('a[href="/providers/subscriptions"]');
+    expect(link?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("marks Local active on /providers/local", () => {
+    mockPathname = "/providers/local";
+    const { container } = render(() => <Sidebar />);
+    const link = container.querySelector('a[href="/providers/local"]');
+    expect(link?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("marks Playground active on /playground", () => {
+    mockPathname = "/playground";
+    const { container } = render(() => <Sidebar />);
+    const link = container.querySelector('a[href="/playground"]');
+    expect(link?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("does not mark Overview active when on /messages", () => {
+    mockPathname = "/messages";
+    const { container } = render(() => <Sidebar />);
+    const link = container.querySelector('a[href="/overview"]');
+    expect(link?.getAttribute("aria-current")).not.toBe("page");
+  });
+});
+
+describe("Sidebar — harness switcher list", () => {
+  it("renders one harness item per agent", async () => {
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(2);
+    });
+    expect(mockGetAgents).toHaveBeenCalledWith();
+  });
+
+  it("links each item to /harnesses/:name and shows the display name", async () => {
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector('a[href="/harnesses/alpha"]')).not.toBeNull();
+    });
+    const alpha = container.querySelector('a[href="/harnesses/alpha"]');
+    expect(alpha?.textContent).toContain("Alpha Harness");
+  });
+
+  it("falls back to agent_name when display_name is missing", async () => {
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector('a[href="/harnesses/beta"]')).not.toBeNull();
+    });
+    const beta = container.querySelector('a[href="/harnesses/beta"]');
+    expect(beta?.textContent).toContain("beta");
+  });
+
+  it("renders a platform icon for agents that have one and omits it otherwise", async () => {
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(2);
+    });
+    const alpha = container.querySelector('a[href="/harnesses/alpha"]');
+    const beta = container.querySelector('a[href="/harnesses/beta"]');
+    // alpha has a known platform → icon present; beta has no platform → no icon.
+    expect(alpha?.querySelector("img.sidebar__agent-icon")).not.toBeNull();
+    expect(beta?.querySelector("img.sidebar__agent-icon")).toBeNull();
+  });
+
+  it("marks the current /harnesses/:name route active", async () => {
+    mockPathname = "/harnesses/alpha";
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector('a[href="/harnesses/alpha"]')).not.toBeNull();
+    });
+    const alpha = container.querySelector('a[href="/harnesses/alpha"]');
+    const beta = container.querySelector('a[href="/harnesses/beta"]');
+    expect(alpha?.getAttribute("aria-current")).toBe("page");
+    expect(alpha?.classList.contains("sidebar__agent-item--active")).toBe(true);
+    expect(beta?.getAttribute("aria-current")).not.toBe("page");
+  });
+
+  it("excludes system/Playground agents by calling getAgents() with the default (no includeSystem)", async () => {
+    render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(mockGetAgents).toHaveBeenCalled();
+    });
+    // Default invocation = system agents excluded (getAgents(false)).
+    expect(mockGetAgents).toHaveBeenCalledWith();
+  });
+
+  it("resolves a bare array response (no { agents } wrapper)", async () => {
+    mockGetAgents.mockResolvedValue(SAMPLE_AGENTS);
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(2);
+    });
+  });
+
+  it("renders the empty state when there are no harnesses", async () => {
+    mockGetAgents.mockResolvedValue({ agents: [] });
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector(".sidebar__agents-empty")).not.toBeNull();
+    });
+    expect(container.querySelector(".sidebar__agents-empty")?.textContent).toContain(
+      "No harnesses yet",
+    );
+    expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(0);
+  });
+
+  it("falls back to an empty list (and empty state) when getAgents rejects", async () => {
+    mockGetAgents.mockRejectedValue(new Error("boom"));
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector(".sidebar__agents-empty")).not.toBeNull();
+    });
+  });
+
+  it("falls back to an empty list when getAgents resolves to null", async () => {
+    mockGetAgents.mockResolvedValue(null);
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector(".sidebar__agents-empty")).not.toBeNull();
+    });
+    expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(0);
+  });
+});
+
+describe("Sidebar — collapse toggle", () => {
+  it("hides the harness list when the caret is clicked, and re-shows on toggle back", async () => {
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
+    });
+
+    const caret = container.querySelector(".sidebar__section-caret") as HTMLButtonElement;
+    expect(caret.getAttribute("aria-expanded")).toBe("true");
+
+    await fireEvent.click(caret);
+    expect(container.querySelector(".sidebar__agents-list")).toBeNull();
+    expect(caret.getAttribute("aria-expanded")).toBe("false");
+    expect(caret.getAttribute("aria-label")).toBe("Expand harnesses");
+
+    await fireEvent.click(caret);
+    expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
+    expect(caret.getAttribute("aria-expanded")).toBe("true");
+    expect(caret.getAttribute("aria-label")).toBe("Collapse harnesses");
+  });
+
+  it("toggles collapse when the section label itself is clicked", async () => {
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
+    });
+    const label = container.querySelector(".sidebar__section-label--interactive") as HTMLElement;
+    await fireEvent.click(label);
+    expect(container.querySelector(".sidebar__agents-list")).toBeNull();
+  });
+});
+
+describe("Sidebar — create-harness modal", () => {
+  it("opens the AddAgentModal when the + button is clicked", async () => {
+    const { container } = render(() => <Sidebar />);
+    expect(container.querySelector('[data-testid="add-agent-modal"]')).toBeNull();
+
+    const addBtn = container.querySelector(".sidebar__section-add") as HTMLButtonElement;
+    await fireEvent.click(addBtn);
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="add-agent-modal"]')).not.toBeNull();
+    });
+    expect(mockAddModal).toHaveBeenCalledWith(true);
+  });
+
+  it("clicking + does not also toggle the section collapse", async () => {
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
+    });
+    const addBtn = container.querySelector(".sidebar__section-add") as HTMLButtonElement;
+    await fireEvent.click(addBtn);
+    // List stays visible — the + click stopped propagation to the label toggle.
+    expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
   });
 });
 
@@ -207,51 +383,25 @@ describe("Sidebar — structure and interaction", () => {
     expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 
-  it("renders Feedback section", () => {
-    render(() => <Sidebar />);
+  it("calls onNavigate when a harness item is clicked", async () => {
+    const onNavigate = vi.fn();
+    const { container } = render(() => <Sidebar onNavigate={onNavigate} />);
+    await waitFor(() => {
+      expect(container.querySelector('a[href="/harnesses/alpha"]')).not.toBeNull();
+    });
+    const item = container.querySelector('a[href="/harnesses/alpha"]') as HTMLAnchorElement;
+    item.addEventListener("click", (event) => event.preventDefault(), { once: true });
+    await fireEvent.click(item);
+    expect(onNavigate).toHaveBeenCalled();
+  });
+
+  it("renders Feedback section with hint and external attributes", () => {
+    const { container } = render(() => <Sidebar />);
     expect(screen.getByText("Feedback")).toBeDefined();
-  });
-
-  it("shows feedback hint text", () => {
-    const { container } = render(() => <Sidebar />);
     expect(container.textContent).toContain("Share ideas or report bugs");
-  });
-
-  it("feedback link is external with correct attributes", () => {
-    const { container } = render(() => <Sidebar />);
     const feedbackLink = container.querySelector("a.sidebar__feedback") as HTMLAnchorElement;
     expect(feedbackLink).not.toBeNull();
     expect(feedbackLink.target).toBe("_blank");
     expect(feedbackLink.rel).toContain("noopener");
-  });
-});
-
-describe("Sidebar — active state via isGlobalActive prefix matching", () => {
-  it("marks /harnesses active on /harnesses sub-path /harnesses/foo/routing", () => {
-    mockPathname = "/harnesses/foo/routing";
-    const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/harnesses"]');
-    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks /harnesses active on /harnesses/foo (no trailing slash)", () => {
-    mockPathname = "/harnesses/foo";
-    const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/harnesses"]');
-    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("does not mark /overview active when on /harnesses", () => {
-    mockPathname = "/harnesses";
-    const { container } = render(() => <Sidebar />);
-    const overviewLink = container.querySelector('a[href="/overview"]');
-    expect(overviewLink?.getAttribute("aria-current")).not.toBe("page");
-  });
-
-  it("marks /overview active only on exact /overview path", () => {
-    mockPathname = "/overview";
-    const { container } = render(() => <Sidebar />);
-    const overviewLink = container.querySelector('a[href="/overview"]');
-    expect(overviewLink?.getAttribute("aria-current")).toBe("page");
   });
 });

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -278,9 +278,21 @@ describe("Sidebar — harness switcher list", () => {
     });
   });
 
-  it("renders the empty state when there are no harnesses", async () => {
-    mockGetAgents.mockResolvedValue({ agents: [] });
+  it("renders the empty state only once the resource resolves empty (not while loading)", async () => {
+    // Hold the resource in its loading state with a promise we resolve manually.
+    let resolveAgents!: (v: unknown) => void;
+    mockGetAgents.mockReturnValue(
+      new Promise((res) => {
+        resolveAgents = res;
+      }),
+    );
     const { container } = render(() => <Sidebar />);
+    // The section is expanded, but while loading the empty state must NOT flash.
+    expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
+    expect(container.querySelector(".sidebar__agents-empty")).toBeNull();
+
+    // Resolve to an empty list → empty state appears now that loading is done.
+    resolveAgents({ agents: [] });
     await waitFor(() => {
       expect(container.querySelector(".sidebar__agents-empty")).not.toBeNull();
     });
@@ -309,7 +321,17 @@ describe("Sidebar — harness switcher list", () => {
 });
 
 describe("Sidebar — collapse toggle", () => {
-  it("hides the harness list when the caret is clicked, and re-shows on toggle back", async () => {
+  it("the collapse toggle is a real button labelled HARNESSES with aria-expanded", async () => {
+    const { container } = render(() => <Sidebar />);
+    const caret = container.querySelector(".sidebar__section-caret");
+    // Keyboard-operable: it is a <button> (native keyboard semantics), not a div.
+    expect(caret?.tagName).toBe("BUTTON");
+    expect((caret as HTMLButtonElement).type).toBe("button");
+    expect(caret?.textContent).toContain("HARNESSES");
+    expect(caret?.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("hides the harness list when the toggle is clicked, and re-shows on toggle back", async () => {
     const { container } = render(() => <Sidebar />);
     await waitFor(() => {
       expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
@@ -321,26 +343,43 @@ describe("Sidebar — collapse toggle", () => {
     await fireEvent.click(caret);
     expect(container.querySelector(".sidebar__agents-list")).toBeNull();
     expect(caret.getAttribute("aria-expanded")).toBe("false");
-    expect(caret.getAttribute("aria-label")).toBe("Expand harnesses");
 
     await fireEvent.click(caret);
     expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
     expect(caret.getAttribute("aria-expanded")).toBe("true");
-    expect(caret.getAttribute("aria-label")).toBe("Collapse harnesses");
   });
 
-  it("toggles collapse when the section label itself is clicked", async () => {
+  it("the section toggle and the + create button are sibling buttons (not nested)", () => {
     const { container } = render(() => <Sidebar />);
-    await waitFor(() => {
-      expect(container.querySelector(".sidebar__agents-list")).not.toBeNull();
-    });
-    const label = container.querySelector(".sidebar__section-label--interactive") as HTMLElement;
-    await fireEvent.click(label);
-    expect(container.querySelector(".sidebar__agents-list")).toBeNull();
+    const caret = container.querySelector(".sidebar__section-caret");
+    const add = container.querySelector(".sidebar__section-add");
+    expect(caret?.tagName).toBe("BUTTON");
+    expect(add?.tagName).toBe("BUTTON");
+    // A button must never contain another button.
+    expect(caret?.querySelector("button")).toBeNull();
+    expect(add?.querySelector("button")).toBeNull();
+    // They share the same parent — true siblings.
+    expect(add?.parentElement).toBe(caret?.parentElement);
+    // No interactive <div> remains for the section header.
+    expect(container.querySelector("div.sidebar__section-label--interactive")).toBeNull();
   });
 });
 
 describe("Sidebar — create-harness modal", () => {
+  it("the + create button is always in the DOM and focusable (not hover-gated)", () => {
+    const { container } = render(() => <Sidebar />);
+    const addBtn = container.querySelector(".sidebar__section-add") as HTMLButtonElement;
+    // Always rendered (not conditionally mounted on hover) and a real button,
+    // so it is reachable by keyboard focus and touch.
+    expect(addBtn).not.toBeNull();
+    expect(addBtn.tagName).toBe("BUTTON");
+    expect(addBtn.type).toBe("button");
+    expect(addBtn.getAttribute("aria-label")).toBe("Create new harness");
+    // It is focusable: focusing it makes it the active element.
+    addBtn.focus();
+    expect(document.activeElement).toBe(addBtn);
+  });
+
   it("opens the AddAgentModal when the + button is clicked", async () => {
     const { container } = render(() => <Sidebar />);
     expect(container.querySelector('[data-testid="add-agent-modal"]')).toBeNull();

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -217,6 +217,16 @@ describe("Sidebar — harness switcher list", () => {
     expect(alpha?.textContent).toContain("Alpha Harness");
   });
 
+  it("URL-encodes harness names with special characters in the item href", async () => {
+    mockGetAgents.mockResolvedValueOnce({ agents: [{ agent_name: "a/b c", display_name: "A B" }] });
+    const { container } = render(() => <Sidebar />);
+    await waitFor(() => {
+      expect(container.querySelector("a.sidebar__agent-item")).not.toBeNull();
+    });
+    const item = container.querySelector("a.sidebar__agent-item");
+    expect(item?.getAttribute("href")).toBe("/harnesses/a%2Fb%20c");
+  });
+
   it("falls back to agent_name when display_name is missing", async () => {
     const { container } = render(() => <Sidebar />);
     await waitFor(() => {

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
 
 describe("Sidebar — global nav (agent route)", () => {
   beforeEach(() => {
-    mockPathname = "/agents/test-agent";
+    mockPathname = "/harnesses/test-agent";
   });
 
   it("renders Overview link", () => {
@@ -43,9 +43,9 @@ describe("Sidebar — global nav (agent route)", () => {
     expect(screen.getByText("Messages")).toBeDefined();
   });
 
-  it("renders Agents link", () => {
+  it("renders Harnesses link", () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Agents")).toBeDefined();
+    expect(screen.getByText("Harnesses")).toBeDefined();
   });
 
   it("renders provider section links", () => {
@@ -78,19 +78,19 @@ describe("Sidebar — global nav (agent route)", () => {
     expect(container.querySelector('a[href="/providers/subscriptions"]')).not.toBeNull();
     expect(container.querySelector('a[href="/providers/byok"]')).not.toBeNull();
     expect(container.querySelector('a[href="/providers/local"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/agents"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/harnesses"]')).not.toBeNull();
   });
 
-  it("marks Agents link active on /agents/:name path", () => {
+  it("marks Harnesses link active on /harnesses/:name path", () => {
     const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/agents"]');
+    const agentsLink = container.querySelector('a[href="/harnesses"]');
     expect(agentsLink?.getAttribute("aria-current")).toBe("page");
   });
 
-  it("marks Agents link active on /agents/:name/routing sub-path", () => {
-    mockPathname = "/agents/test-agent/routing";
+  it("marks Harnesses link active on /harnesses/:name/routing sub-path", () => {
+    mockPathname = "/harnesses/test-agent/routing";
     const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/agents"]');
+    const agentsLink = container.querySelector('a[href="/harnesses"]');
     expect(agentsLink?.getAttribute("aria-current")).toBe("page");
   });
 });
@@ -106,11 +106,11 @@ describe("Sidebar — global nav (global route)", () => {
     expect(screen.getByText("Messages")).toBeDefined();
   });
 
-  it("renders Agents link pointing to /agents", () => {
+  it("renders Harnesses link pointing to /harnesses", () => {
     const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/agents"]');
+    const agentsLink = container.querySelector('a[href="/harnesses"]');
     expect(agentsLink).not.toBeNull();
-    expect(agentsLink?.textContent).toContain("Agents");
+    expect(agentsLink?.textContent).toContain("Harnesses");
   });
 
   it("marks provider links active on provider pages", () => {
@@ -138,10 +138,10 @@ describe("Sidebar — global nav (global route)", () => {
     expect(messagesLink?.getAttribute("aria-current")).toBe("page");
   });
 
-  it("marks Agents link active on /agents path", () => {
-    mockPathname = "/agents";
+  it("marks Harnesses link active on /harnesses path", () => {
+    mockPathname = "/harnesses";
     const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/agents"]');
+    const agentsLink = container.querySelector('a[href="/harnesses"]');
     expect(agentsLink?.getAttribute("aria-current")).toBe("page");
   });
 
@@ -154,14 +154,14 @@ describe("Sidebar — global nav (global route)", () => {
 });
 
 describe("Sidebar — identical in agent and global mode", () => {
-  it("renders the same links on /overview and /agents/:name", () => {
+  it("renders the same links on /overview and /harnesses/:name", () => {
     mockPathname = "/overview";
     const { container: globalContainer } = render(() => <Sidebar />);
     const globalLinks = Array.from(globalContainer.querySelectorAll("a.sidebar__link")).map(
       (a) => a.getAttribute("href"),
     );
 
-    mockPathname = "/agents/test-agent";
+    mockPathname = "/harnesses/test-agent";
     const { container: agentContainer } = render(() => <Sidebar />);
     const agentLinks = Array.from(agentContainer.querySelectorAll("a.sidebar__link")).map(
       (a) => a.getAttribute("href"),
@@ -174,7 +174,7 @@ describe("Sidebar — identical in agent and global mode", () => {
       "/providers/subscriptions",
       "/providers/byok",
       "/providers/local",
-      "/agents",
+      "/harnesses",
       "/playground",
     ]);
   });
@@ -185,7 +185,7 @@ describe("Sidebar — structure and interaction", () => {
     const { container } = render(() => <Sidebar />);
     const nav = container.querySelector("nav.sidebar");
     expect(nav).not.toBeNull();
-    expect(nav?.getAttribute("aria-label")).toBe("Agent navigation");
+    expect(nav?.getAttribute("aria-label")).toBe("Navigation");
   });
 
   it("applies the mobile open class", () => {
@@ -227,22 +227,22 @@ describe("Sidebar — structure and interaction", () => {
 });
 
 describe("Sidebar — active state via isGlobalActive prefix matching", () => {
-  it("marks /agents active on /agents sub-path /agents/foo/routing", () => {
-    mockPathname = "/agents/foo/routing";
+  it("marks /harnesses active on /harnesses sub-path /harnesses/foo/routing", () => {
+    mockPathname = "/harnesses/foo/routing";
     const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/agents"]');
+    const agentsLink = container.querySelector('a[href="/harnesses"]');
     expect(agentsLink?.getAttribute("aria-current")).toBe("page");
   });
 
-  it("marks /agents active on /agents/foo (no trailing slash)", () => {
-    mockPathname = "/agents/foo";
+  it("marks /harnesses active on /harnesses/foo (no trailing slash)", () => {
+    mockPathname = "/harnesses/foo";
     const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/agents"]');
+    const agentsLink = container.querySelector('a[href="/harnesses"]');
     expect(agentsLink?.getAttribute("aria-current")).toBe("page");
   });
 
-  it("does not mark /overview active when on /agents", () => {
-    mockPathname = "/agents";
+  it("does not mark /overview active when on /harnesses", () => {
+    mockPathname = "/harnesses";
     const { container } = render(() => <Sidebar />);
     const overviewLink = container.querySelector('a[href="/overview"]');
     expect(overviewLink?.getAttribute("aria-current")).not.toBe("page");

--- a/packages/frontend/tests/components/message-table-cells.test.tsx
+++ b/packages/frontend/tests/components/message-table-cells.test.tsx
@@ -113,7 +113,7 @@ describe('StatusCell without agentName (global mode)', () => {
     const { container } = render(() => <table><tbody><tr>{StatusCell(row, 'my-agent')}</tr></tbody></table>);
     const link = container.querySelector('a');
     expect(link).not.toBeNull();
-    expect(link!.getAttribute('href')).toContain('/agents/my-agent/limits');
+    expect(link!.getAttribute('href')).toContain('/harnesses/my-agent/limits');
   });
 });
 

--- a/packages/frontend/tests/pages/AgentDetail.test.tsx
+++ b/packages/frontend/tests/pages/AgentDetail.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@solidjs/testing-library";
 
 // Hoisted mutable state so individual tests can override pathname
-let mockPathname = "/agents/my-agent";
+let mockPathname = "/harnesses/my-agent";
 const mockParams = { agentName: "my-agent" };
 
 vi.mock("@solidjs/router", () => ({
@@ -40,7 +40,7 @@ import AgentDetail from "../../src/pages/AgentDetail";
 
 describe("AgentDetail", () => {
   beforeEach(() => {
-    mockPathname = "/agents/my-agent";
+    mockPathname = "/harnesses/my-agent";
     mockParams.agentName = "my-agent";
     mockAgentDisplayName = null;
   });
@@ -50,11 +50,11 @@ describe("AgentDetail", () => {
     expect(container.querySelector("title")?.textContent).toBe("my-agent | Manifest");
   });
 
-  it("renders a back-link to /agents", () => {
+  it("renders a back-link to /harnesses", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
-    const backLink = container.querySelector('a[href="/agents"]') as HTMLAnchorElement;
+    const backLink = container.querySelector('a[href="/harnesses"]') as HTMLAnchorElement;
     expect(backLink).not.toBeNull();
-    expect(backLink.textContent).toContain("Agents");
+    expect(backLink.textContent).toContain("Harnesses");
   });
 
   it("renders an H1 with the agent name", () => {
@@ -80,35 +80,35 @@ describe("AgentDetail", () => {
   it("Overview tab links to the agent root path", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
-    expect(tabs[0].getAttribute("href")).toBe("/agents/my-agent");
+    expect(tabs[0].getAttribute("href")).toBe("/harnesses/my-agent");
   });
 
-  it("Routing tab links to /agents/:name/routing", () => {
+  it("Routing tab links to /harnesses/:name/routing", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
-    expect(tabs[1].getAttribute("href")).toBe("/agents/my-agent/routing");
+    expect(tabs[1].getAttribute("href")).toBe("/harnesses/my-agent/routing");
   });
 
-  it("Providers tab links to /agents/:name/providers", () => {
+  it("Providers tab links to /harnesses/:name/providers", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
-    expect(tabs[2].getAttribute("href")).toBe("/agents/my-agent/providers");
+    expect(tabs[2].getAttribute("href")).toBe("/harnesses/my-agent/providers");
   });
 
-  it("Limits tab links to /agents/:name/guardrails", () => {
+  it("Limits tab links to /harnesses/:name/guardrails", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
-    expect(tabs[3].getAttribute("href")).toBe("/agents/my-agent/guardrails");
+    expect(tabs[3].getAttribute("href")).toBe("/harnesses/my-agent/guardrails");
   });
 
-  it("Settings tab links to /agents/:name/settings", () => {
+  it("Settings tab links to /harnesses/:name/settings", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
-    expect(tabs[4].getAttribute("href")).toBe("/agents/my-agent/settings");
+    expect(tabs[4].getAttribute("href")).toBe("/harnesses/my-agent/settings");
   });
 
   it("marks Overview tab active when pathname is the agent root", () => {
-    mockPathname = "/agents/my-agent";
+    mockPathname = "/harnesses/my-agent";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
     expect(tabs[0].getAttribute("aria-selected")).toBe("true");
@@ -119,14 +119,14 @@ describe("AgentDetail", () => {
   });
 
   it("marks Overview tab active when pathname is /overview", () => {
-    mockPathname = "/agents/my-agent/overview";
+    mockPathname = "/harnesses/my-agent/overview";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]');
     expect(tabs[0].getAttribute("aria-selected")).toBe("true");
   });
 
   it("marks Routing tab active when pathname is /routing", () => {
-    mockPathname = "/agents/my-agent/routing";
+    mockPathname = "/harnesses/my-agent/routing";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]');
     expect(tabs[0].getAttribute("aria-selected")).toBe("false");
@@ -134,21 +134,21 @@ describe("AgentDetail", () => {
   });
 
   it("marks Limits tab active when pathname is /guardrails", () => {
-    mockPathname = "/agents/my-agent/guardrails";
+    mockPathname = "/harnesses/my-agent/guardrails";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]');
     expect(tabs[3].getAttribute("aria-selected")).toBe("true");
   });
 
   it("marks Providers tab active when pathname is /providers", () => {
-    mockPathname = "/agents/my-agent/providers";
+    mockPathname = "/harnesses/my-agent/providers";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]');
     expect(tabs[2].getAttribute("aria-selected")).toBe("true");
   });
 
   it("marks Settings tab active when pathname starts with /settings", () => {
-    mockPathname = "/agents/my-agent/settings/advanced";
+    mockPathname = "/harnesses/my-agent/settings/advanced";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]');
     expect(tabs[4].getAttribute("aria-selected")).toBe("true");
@@ -165,7 +165,7 @@ describe("AgentDetail", () => {
 
   it("decodes URL-encoded agent names in title", () => {
     mockParams.agentName = "my%20agent";
-    mockPathname = "/agents/my%20agent";
+    mockPathname = "/harnesses/my%20agent";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     expect(container.querySelector("title")?.textContent).toBe("my agent | Manifest");
     expect(container.querySelector("h1")?.textContent?.trim()).toBe("my agent");
@@ -177,7 +177,7 @@ describe("AgentDetail", () => {
   });
 
   it("applies panel__tab--active class to the active tab", () => {
-    mockPathname = "/agents/my-agent/routing";
+    mockPathname = "/harnesses/my-agent/routing";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]');
     expect(tabs[1].className).toContain("panel__tab--active");
@@ -223,7 +223,7 @@ describe("AgentDetail with platform icon", () => {
     }));
     vi.doMock("@solidjs/router", () => ({
       useParams: () => ({ agentName: "my-agent" }),
-      useLocation: () => ({ pathname: "/agents/my-agent" }),
+      useLocation: () => ({ pathname: "/harnesses/my-agent" }),
       A: (props: any) => <a href={props.href} role={props.role}>{props.children}</a>,
     }));
     vi.doMock("@solidjs/meta", () => ({

--- a/packages/frontend/tests/pages/AgentOverview.test.tsx
+++ b/packages/frontend/tests/pages/AgentOverview.test.tsx
@@ -8,7 +8,7 @@ import { render } from "@solidjs/testing-library";
 
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: "test-agent" }),
-  useLocation: () => ({ pathname: "/agents/test-agent", state: null }),
+  useLocation: () => ({ pathname: "/harnesses/test-agent", state: null }),
   useNavigate: () => vi.fn(),
   A: (props: any) => <a href={props.href}>{props.children}</a>,
 }));

--- a/packages/frontend/tests/pages/AgentRedirects.test.tsx
+++ b/packages/frontend/tests/pages/AgentRedirects.test.tsx
@@ -21,19 +21,19 @@ describe("AgentLimitsRedirect", () => {
     const { container } = render(() => <AgentLimitsRedirect />);
     const navigate = container.querySelector('[data-testid="navigate"]');
     expect(navigate).not.toBeNull();
-    expect(navigate?.getAttribute("data-href")).toBe("/agents/demo-agent/guardrails");
+    expect(navigate?.getAttribute("data-href")).toBe("/harnesses/demo-agent/guardrails");
   });
 
   it("encodes agent names with special characters correctly", () => {
     mockParams.agentName = "my agent";
     const { container } = render(() => <AgentLimitsRedirect />);
     const navigate = container.querySelector('[data-testid="navigate"]');
-    expect(navigate?.getAttribute("data-href")).toBe("/agents/my%20agent/guardrails");
+    expect(navigate?.getAttribute("data-href")).toBe("/harnesses/my%20agent/guardrails");
   });
 });
 
 describe("AgentMessagesRedirect", () => {
-  it("redirects /agents/:name/messages to global /messages", () => {
+  it("redirects /harnesses/:name/messages to global /messages", () => {
     const { container } = render(() => <AgentMessagesRedirect />);
     const navigate = container.querySelector('[data-testid="navigate"]');
     expect(navigate).not.toBeNull();

--- a/packages/frontend/tests/pages/ConnectProvider.test.tsx
+++ b/packages/frontend/tests/pages/ConnectProvider.test.tsx
@@ -34,7 +34,7 @@ describe('ConnectProvider', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        expect.stringContaining('/agents/my-agent/routing?'),
+        expect.stringContaining('/harnesses/my-agent/routing?'),
         { replace: true },
       );
     });
@@ -59,7 +59,7 @@ describe('ConnectProvider', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        expect.stringContaining('/agents/my-agent/routing?'),
+        expect.stringContaining('/harnesses/my-agent/routing?'),
         { replace: true },
       );
     });
@@ -76,7 +76,7 @@ describe('ConnectProvider', () => {
     render(() => <ConnectProvider />);
 
     await waitFor(() => {
-      expect(screen.getByText('Select an agent')).toBeDefined();
+      expect(screen.getByText('Select a harness')).toBeDefined();
     });
 
     expect(screen.getByText('Agent One')).toBeDefined();
@@ -100,7 +100,7 @@ describe('ConnectProvider', () => {
     fireEvent.click(screen.getByText('Agent Two'));
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      expect.stringContaining('/agents/agent-2/routing?'),
+      expect.stringContaining('/harnesses/agent-2/routing?'),
       { replace: true },
     );
   });
@@ -157,7 +157,7 @@ describe('ConnectProvider', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        expect.stringContaining('/agents/my-agent/routing?'),
+        expect.stringContaining('/harnesses/my-agent/routing?'),
         { replace: true },
       );
     });
@@ -191,7 +191,7 @@ describe('ConnectProvider with provider deep-link', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        expect.stringContaining('/agents/my-agent/routing?'),
+        expect.stringContaining('/harnesses/my-agent/routing?'),
         { replace: true },
       );
     });
@@ -219,11 +219,11 @@ describe('ConnectProvider agent name URL encoding', () => {
 
     const url = mockNavigate.mock.calls[0][0] as string;
     // Verify each unsafe character is percent-encoded in the path segment
-    expect(url).toContain('/agents/test%2Fagent%3Fid%3D1%26x%3D2%23frag/routing?');
+    expect(url).toContain('/harnesses/test%2Fagent%3Fid%3D1%26x%3D2%23frag/routing?');
     // Raw unsafe characters must NOT appear in the path segment
-    expect(url).not.toContain('/agents/test/agent');
-    expect(url).not.toMatch(/\/agents\/[^/?]*\?id=1/);
-    expect(url).not.toMatch(/\/agents\/[^/?]*#frag/);
+    expect(url).not.toContain('/harnesses/test/agent');
+    expect(url).not.toMatch(/\/harnesses\/[^/?]*\?id=1/);
+    expect(url).not.toMatch(/\/harnesses\/[^/?]*#frag/);
   });
 
   it('URL-encodes unsafe characters in agent name when clicking picker button', async () => {
@@ -244,8 +244,8 @@ describe('ConnectProvider agent name URL encoding', () => {
     fireEvent.click(screen.getByText('Tricky'));
 
     const url = mockNavigate.mock.calls[0][0] as string;
-    expect(url).toContain('/agents/test%2Fagent%3Fid%3D1/routing?');
-    expect(url).not.toContain('/agents/test/agent');
+    expect(url).toContain('/harnesses/test%2Fagent%3Fid%3D1/routing?');
+    expect(url).not.toContain('/harnesses/test/agent');
   });
 
   it('URL-encodes unicode (emoji + non-Latin) agent names', async () => {
@@ -260,7 +260,7 @@ describe('ConnectProvider agent name URL encoding', () => {
 
     const url = mockNavigate.mock.calls[0][0] as string;
     // encodeURIComponent of '🤖' is '%F0%9F%A4%96', cyrillic 'а' is '%D0%B0'
-    expect(url).toContain('/agents/test-%F0%9F%A4%96-%D0%B0%D0%B3%D0%B5%D0%BD%D1%82/routing?');
+    expect(url).toContain('/harnesses/test-%F0%9F%A4%96-%D0%B0%D0%B3%D0%B5%D0%BD%D1%82/routing?');
     // Raw unicode should not appear in the encoded URL
     expect(url).not.toContain('🤖');
     expect(url).not.toContain('агент');
@@ -279,7 +279,7 @@ describe('ConnectProvider agent name URL encoding', () => {
     const url = mockNavigate.mock.calls[0][0] as string;
     // Parsing must recover the original agent name from the path segment
     const parsed = new URL(url, 'http://example.com');
-    const match = parsed.pathname.match(/^\/agents\/([^/]+)\/routing$/);
+    const match = parsed.pathname.match(/^\/harnesses\/([^/]+)\/routing$/);
     expect(match).not.toBeNull();
     expect(decodeURIComponent(match![1])).toBe(unsafeName);
   });

--- a/packages/frontend/tests/pages/FreeModels.test.tsx
+++ b/packages/frontend/tests/pages/FreeModels.test.tsx
@@ -168,7 +168,7 @@ describe('FreeModels', () => {
       const connectBtn = screen.getByText('Connect Cohere');
       expect(connectBtn.tagName).toBe('A');
       const href = connectBtn.getAttribute('href')!;
-      expect(href).toContain('/agents/test-agent/routing?');
+      expect(href).toContain('/harnesses/test-agent/routing?');
       expect(href).toContain('provider=custom');
       expect(href).toContain('name=Cohere');
       expect(href).toContain('command-a-03-2025');

--- a/packages/frontend/tests/pages/GlobalOverview.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverview.test.tsx
@@ -218,7 +218,7 @@ describe("GlobalOverview", () => {
     const { container } = render(() => <GlobalOverview />);
     await vi.waitFor(() => {
       expect(container.querySelector("[data-testid='setup-modal']")).toBeNull();
-      expect(container.textContent).not.toContain("Set up agent");
+      expect(container.textContent).not.toContain("Set up harness");
     });
   });
 
@@ -239,11 +239,11 @@ describe("GlobalOverview", () => {
       });
     });
 
-    it("shows CTA link to /agents in empty state", async () => {
+    it("shows CTA link to /harnesses in empty state", async () => {
       mockGetOverview.mockResolvedValue(emptyOverviewData);
       const { container } = render(() => <GlobalOverview />);
       await vi.waitFor(() => {
-        const agentsLink = container.querySelector('a[href="/agents"]');
+        const agentsLink = container.querySelector('a[href="/harnesses"]');
         expect(agentsLink).not.toBeNull();
       });
     });

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -61,14 +61,13 @@ describe("Limits page", () => {
     mockRoutingStatus = { enabled: false };
   });
 
-  it("renders page title", () => {
-    render(() => <Limits />);
-    expect(screen.getByText("Limits")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Limits />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
-  it("renders breadcrumb with agent name", () => {
+  it("renders page description without duplicating the agent heading", () => {
     const { container } = render(() => <Limits />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Get notified or block requests when token or cost thresholds are exceeded");
   });
 

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -575,7 +575,7 @@ describe("MessageLog", () => {
     const btn = container.querySelector('.empty-state button.btn--primary') as HTMLButtonElement;
     fireEvent.click(btn);
     expect(mockNavigate).toHaveBeenCalledWith(
-      "/agents/test-agent/routing",
+      "/harnesses/test-agent/routing",
       { state: { openProviders: true } },
     );
   });
@@ -591,11 +591,11 @@ describe("MessageLog", () => {
     });
   });
 
-  it("shows Set up agent when no setupCompleted and no providers", async () => {
+  it("shows Set up harness when no setupCompleted and no providers", async () => {
     mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Set up agent");
+      expect(container.textContent).toContain("Set up harness");
       expect(container.textContent).not.toContain("Enable routing");
       expect(container.textContent).not.toContain("Connect provider");
     });
@@ -1291,7 +1291,7 @@ describe("MessageLog", () => {
         const selects = container.querySelectorAll('[data-testid="select"]');
         // agent filter is the first select in global mode
         expect(selects.length).toBeGreaterThanOrEqual(1);
-        expect(selects[0].textContent).toContain("All agents");
+        expect(selects[0].textContent).toContain("All harnesses");
       });
     });
 
@@ -1321,8 +1321,8 @@ describe("MessageLog", () => {
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         const selects = container.querySelectorAll('[data-testid="select"]');
-        // In agent mode, first select is provider filter (no "All agents" option)
-        expect(selects[0].textContent).not.toContain("All agents");
+        // In agent mode, first select is provider filter (no "All harnesses" option)
+        expect(selects[0].textContent).not.toContain("All harnesses");
         expect(selects[0].textContent).toContain("All providers");
       });
     });
@@ -1346,7 +1346,7 @@ describe("MessageLog", () => {
       });
     });
 
-    it("omits agent_name query param when 'All agents' is selected", async () => {
+    it("omits agent_name query param when 'All harnesses' is selected", async () => {
       mockAgentName = "";
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
@@ -1363,7 +1363,7 @@ describe("MessageLog", () => {
         expect(calls.some((c: any[]) => c[0]?.agent_name === "agent-alpha")).toBe(true);
       });
       mockGetMessages.mockClear();
-      // Then go back to "All agents"
+      // Then go back to "All harnesses"
       fireEvent.change(agentSelect, { target: { value: "" } });
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
@@ -1430,7 +1430,7 @@ describe("MessageLog", () => {
         expect(mockGetAgents).toHaveBeenCalled();
         const selects = container.querySelectorAll('[data-testid="select"]');
         // Agent filter still renders gracefully (agentList() ?? [] = [])
-        expect(selects[0].textContent).toContain("All agents");
+        expect(selects[0].textContent).toContain("All harnesses");
         expect(selects[0].textContent).not.toContain("agent-alpha");
       });
       // Unmount and reset before the rejection can leak into the next test.
@@ -1465,9 +1465,9 @@ describe("MessageLog", () => {
       });
     });
 
-    it("renders 'Agent' column header in the message table when in global mode", async () => {
+    it("renders 'Harness' column header in the message table when in global mode", async () => {
       // Fix: columns() now inserts 'agent' before 'model' when !params.agentName.
-      // This test asserts the Agent column header actually appears in the DOM,
+      // This test asserts the Harness column header actually appears in the DOM,
       // not just that the component receives the columns array.
       mockAgentName = "";
       mockGetMessages.mockResolvedValue(messagesData);
@@ -1477,10 +1477,10 @@ describe("MessageLog", () => {
       });
       const headers = Array.from(container.querySelectorAll("thead th"));
       const headerTexts = headers.map((th) => th.textContent?.trim());
-      expect(headerTexts).toContain("Agent");
+      expect(headerTexts).toContain("Harness");
     });
 
-    it("does NOT render 'Agent' column header in agent-scoped mode", async () => {
+    it("does NOT render 'Harness' column header in agent-scoped mode", async () => {
       // mockAgentName is "test-agent" from beforeEach — agent-scoped mode.
       // columns() returns DETAILED_COLUMNS unchanged (no 'agent' key).
       mockGetMessages.mockResolvedValue(messagesData);
@@ -1490,7 +1490,7 @@ describe("MessageLog", () => {
       });
       const headers = Array.from(container.querySelectorAll("thead th"));
       const headerTexts = headers.map((th) => th.textContent?.trim());
-      expect(headerTexts).not.toContain("Agent");
+      expect(headerTexts).not.toContain("Harness");
     });
 
     it("renders agent_name values in the Agent column cells in global mode", async () => {
@@ -1549,30 +1549,30 @@ describe("MessageLog", () => {
       });
     });
 
-    it("shows 'Go to Agents' link (not SetupModal CTA) in the empty state in global mode", async () => {
+    it("shows 'Go to Harnesses' link (not SetupModal CTA) in the empty state in global mode", async () => {
       mockAgentName = "";
       mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         expect(container.textContent).toContain("No messages yet");
-        // Global empty state guides to /agents, not set-up-agent modal
-        const link = container.querySelector('a[href="/agents"]') as HTMLAnchorElement;
+        // Global empty state guides to /harnesses, not set-up-agent modal
+        const link = container.querySelector('a[href="/harnesses"]') as HTMLAnchorElement;
         expect(link).not.toBeNull();
-        expect(link.textContent).toContain("Go to Agents");
-        // No "Set up agent" button in global mode
-        expect(container.textContent).not.toContain("Set up agent");
+        expect(link.textContent).toContain("Go to Harnesses");
+        // No "Set up harness" button in global mode
+        expect(container.textContent).not.toContain("Set up harness");
       });
     });
 
-    it("does not navigate to /agents/undefined/routing in global mode", async () => {
+    it("does not navigate to /harnesses/undefined/routing in global mode", async () => {
       mockAgentName = "";
       mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         expect(container.textContent).toContain("No messages yet");
       });
-      // Clicking the "Go to Agents" link should use the href attribute, not navigate()
-      // Verify no button triggers mockNavigate with "/agents/undefined/routing"
+      // Clicking the "Go to Harnesses" link should use the href attribute, not navigate()
+      // Verify no button triggers mockNavigate with "/harnesses/undefined/routing"
       expect(mockNavigate).not.toHaveBeenCalledWith(
         expect.stringContaining("undefined"),
         expect.anything(),

--- a/packages/frontend/tests/pages/Overview-limits.test.tsx
+++ b/packages/frontend/tests/pages/Overview-limits.test.tsx
@@ -72,6 +72,8 @@ vi.mock("../../src/components/Select.jsx", () => ({
 
 vi.mock("../../src/services/recent-agents.js", () => ({
   isRecentlyCreated: () => false,
+  isSetupPending: () => false,
+  clearSetupPending: vi.fn(),
 }));
 
 import Overview from "../../src/pages/Overview";

--- a/packages/frontend/tests/pages/Overview-limits.test.tsx
+++ b/packages/frontend/tests/pages/Overview-limits.test.tsx
@@ -4,7 +4,7 @@ import { render } from "@solidjs/testing-library";
 let mockAgentName = "test-agent";
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: mockAgentName }),
-  useLocation: () => ({ pathname: `/agents/${mockAgentName}`, state: null }),
+  useLocation: () => ({ pathname: `/harnesses/${mockAgentName}`, state: null }),
   useNavigate: () => vi.fn(),
   A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
 }));

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -6,7 +6,7 @@ let mockLocationState: any = null;
 const mockNavigate = vi.fn();
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: mockAgentName }),
-  useLocation: () => ({ pathname: `/agents/${mockAgentName}`, state: mockLocationState }),
+  useLocation: () => ({ pathname: `/harnesses/${mockAgentName}`, state: mockLocationState }),
   useNavigate: () => mockNavigate,
   A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
 }));
@@ -368,7 +368,7 @@ describe("Overview", () => {
     await vi.waitFor(() => {
       const link = container.querySelector('a.view-more-link') as HTMLAnchorElement;
       expect(link).not.toBeNull();
-      expect(link.getAttribute("href")).toBe("/agents/test-agent/messages");
+      expect(link.getAttribute("href")).toBe("/harnesses/test-agent/messages");
     });
   });
 
@@ -564,16 +564,16 @@ describe("Overview", () => {
     const btn = container.querySelector('.empty-state button.btn--primary') as HTMLButtonElement;
     fireEvent.click(btn);
     expect(mockNavigate).toHaveBeenCalledWith(
-      "/agents/test-agent/routing",
+      "/harnesses/test-agent/routing",
       { state: { openProviders: true } },
     );
   });
 
-  it("shows Set up agent button when not setupCompleted and no providers", async () => {
+  it("shows Set up harness button when not setupCompleted and no providers", async () => {
     mockGetOverview.mockResolvedValue(emptyOverviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Set up agent");
+      expect(container.textContent).toContain("Set up harness");
       expect(container.textContent).not.toContain("Enable routing");
       expect(container.textContent).not.toContain("Connect provider");
     });
@@ -610,7 +610,7 @@ describe("Overview", () => {
       });
       fireEvent.click(screen.getByTestId("setup-go-routing"));
       expect(mockNavigate).toHaveBeenCalledWith(
-        "/agents/test-agent/routing",
+        "/harnesses/test-agent/routing",
         { state: { openProviders: true } },
       );
     });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -90,7 +90,14 @@ vi.mock("../../src/components/FeedbackModal.jsx", () => ({
 
 vi.mock("../../src/components/SetupModal.jsx", () => ({
   default: (props: any) => (
-    <div data-testid="setup-modal" data-open={props.open ? "true" : "false"} data-agent={props.agentName ?? ""} data-api-key={props.apiKey ?? ""}>
+    <div
+      data-testid="setup-modal"
+      data-open={props.open ? "true" : "false"}
+      data-agent={props.agentName ?? ""}
+      data-api-key={props.apiKey ?? ""}
+      data-platform={props.agentPlatform ?? ""}
+      data-category={props.agentCategory ?? ""}
+    >
       <button data-testid="setup-close" onClick={() => props.onClose?.()}>Close</button>
       <button data-testid="setup-done" onClick={() => props.onDone?.()}>Done</button>
       <button data-testid="setup-go-routing" onClick={() => props.onGoToRouting?.()}>Go to routing</button>
@@ -111,8 +118,12 @@ vi.mock("../../src/components/Select.jsx", () => ({
 }));
 
 const mockIsRecentlyCreated = vi.fn(() => false);
+const mockIsSetupPending = vi.fn(() => false);
+const mockClearSetupPending = vi.fn();
 vi.mock("../../src/services/recent-agents.js", () => ({
   isRecentlyCreated: (...args: unknown[]) => mockIsRecentlyCreated(...args),
+  isSetupPending: (...args: unknown[]) => mockIsSetupPending(...args),
+  clearSetupPending: (...args: unknown[]) => mockClearSetupPending(...args),
 }));
 
 import Overview from "../../src/pages/Overview";
@@ -157,6 +168,8 @@ describe("Overview", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    mockIsRecentlyCreated.mockReturnValue(false);
+    mockIsSetupPending.mockReturnValue(false);
     mockAgentName = "test-agent";
     mockLocationState = null;
     mockGetCustomProviders.mockResolvedValue([]);
@@ -486,6 +499,7 @@ describe("Overview", () => {
         const modal = container.querySelector('[data-testid="setup-modal"]');
         expect(modal?.getAttribute("data-open")).toBe("false");
       });
+      expect(mockClearSetupPending).toHaveBeenCalledWith("test-agent");
     });
 
     it("marks setup as completed when onDone is called", async () => {
@@ -502,6 +516,57 @@ describe("Overview", () => {
       await vi.waitFor(() => {
         expect(localStorage.getItem("setup_completed_test-agent")).toBe("1");
       });
+      expect(mockClearSetupPending).toHaveBeenCalledWith("test-agent");
+    });
+
+    it("opens the setup modal on mount when setup is pending (survives a refresh)", async () => {
+      // has_data true → showEmptyState() is false, so the empty-state effect
+      // does NOT open the modal. The persistent pending flag is the only thing
+      // that opens it here, proving the gate survives a refresh.
+      mockIsSetupPending.mockReturnValue(true);
+      mockGetOverview.mockResolvedValue({
+        ...overviewData,
+        has_data: true,
+        has_providers: true,
+      });
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        const modal = container.querySelector('[data-testid="setup-modal"]');
+        expect(modal?.getAttribute("data-open")).toBe("true");
+      });
+      expect(mockIsSetupPending).toHaveBeenCalledWith("test-agent");
+    });
+
+    it("keeps the setup modal closed on mount when pending but already dismissed", async () => {
+      mockIsSetupPending.mockReturnValue(true);
+      localStorage.setItem("setup_dismissed_test-agent", "1");
+      mockGetOverview.mockResolvedValue({
+        ...overviewData,
+        has_data: true,
+        has_providers: true,
+      });
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector('[data-testid="setup-modal"]')).not.toBeNull();
+      });
+      const modal = container.querySelector('[data-testid="setup-modal"]');
+      expect(modal?.getAttribute("data-open")).toBe("false");
+    });
+
+    it("keeps the setup modal closed on mount when pending but already completed", async () => {
+      mockIsSetupPending.mockReturnValue(true);
+      localStorage.setItem("setup_completed_test-agent", "1");
+      mockGetOverview.mockResolvedValue({
+        ...overviewData,
+        has_data: true,
+        has_providers: true,
+      });
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector('[data-testid="setup-modal"]')).not.toBeNull();
+      });
+      const modal = container.querySelector('[data-testid="setup-modal"]');
+      expect(modal?.getAttribute("data-open")).toBe("false");
     });
   });
 

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -617,12 +617,12 @@ beforeEach(() => {
 });
 
 describe('Routing page', () => {
-  it('renders the page header with the agent display name', async () => {
-    render(() => <Routing />);
+  it('renders routing description without a duplicate page heading', async () => {
+    const { container } = render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText('Routing')).toBeDefined();
+      expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
     });
-    expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
+    expect(container.querySelector('h1')).toBeNull();
   });
 
   it('renders the empty providers state when no providers are connected', async () => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -70,8 +70,12 @@ vi.mock('../../src/services/agent-display-name.js', () => ({
 }));
 
 const mockIsRecentlyCreated = vi.fn(() => false);
+const mockIsSetupPending = vi.fn(() => false);
+const mockClearSetupPending = vi.fn();
 vi.mock('../../src/services/recent-agents.js', () => ({
   isRecentlyCreated: (...args: unknown[]) => mockIsRecentlyCreated(...args),
+  isSetupPending: (...args: unknown[]) => mockIsSetupPending(...args),
+  clearSetupPending: (...args: unknown[]) => mockClearSetupPending(...args),
 }));
 
 vi.mock('../../src/services/agent-platform-store.js', () => ({
@@ -631,6 +635,7 @@ beforeEach(() => {
   lastSetupModalProps = null;
   localStorage.clear();
   mockIsRecentlyCreated.mockReturnValue(false);
+  mockIsSetupPending.mockReturnValue(false);
   useParams.mockReturnValue({ agentName: 'demo' });
   useLocation.mockReturnValue({ state: undefined });
   useSearchParams.mockReturnValue([{}, setSearchParamsFn]);
@@ -1828,31 +1833,66 @@ describe('Routing page', () => {
       expect(screen.getByTestId('setup-modal').getAttribute('data-open')).toBe('true');
       expect(mockIsRecentlyCreated).toHaveBeenCalledWith('demo');
 
-      // (b) onDone marks the agent as completed and closes the modal.
+      // (b) onDone marks the agent as completed, clears pending, closes the modal.
       fireEvent.click(screen.getByTestId('setup-done'));
       await waitFor(() => {
         expect(localStorage.getItem('setup_completed_demo')).toBe('1');
         expect((lastSetupModalProps?.open as boolean)).toBe(false);
       });
+      expect(mockClearSetupPending).toHaveBeenCalledWith('demo');
       expect(screen.getByTestId('setup-modal').getAttribute('data-open')).toBe('false');
     });
 
-    it('marks the agent dismissed and closes when onClose fires', async () => {
+    it('opens the SetupModal when setup is pending (survives a refresh)', async () => {
+      // Refresh-simulated mount: the in-memory recently-created flag is gone,
+      // but the persistent pending flag is still set → modal must reopen.
+      mockIsRecentlyCreated.mockReturnValue(false);
+      mockIsSetupPending.mockReturnValue(true);
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('setup-modal').getAttribute('data-open')).toBe('true');
+      });
+      expect(mockIsSetupPending).toHaveBeenCalledWith('demo');
+    });
+
+    it('keeps the SetupModal closed when pending but already dismissed', async () => {
+      mockIsSetupPending.mockReturnValue(true);
+      localStorage.setItem('setup_dismissed_demo', '1');
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('setup-modal')).toBeDefined();
+      });
+      expect(screen.getByTestId('setup-modal').getAttribute('data-open')).toBe('false');
+    });
+
+    it('keeps the SetupModal closed when pending but already completed', async () => {
+      mockIsSetupPending.mockReturnValue(true);
+      localStorage.setItem('setup_completed_demo', '1');
+      render(() => <Routing />);
+      await waitFor(() => {
+        expect(screen.getByTestId('setup-modal')).toBeDefined();
+      });
+      expect(screen.getByTestId('setup-modal').getAttribute('data-open')).toBe('false');
+    });
+
+    it('marks the agent dismissed, clears pending, and closes when onClose fires', async () => {
       mockIsRecentlyCreated.mockReturnValue(true);
       render(() => <Routing />);
       await waitFor(() => {
         expect(screen.getByTestId('setup-modal').getAttribute('data-open')).toBe('true');
       });
-      // (c) onClose sets the dismissed flag and closes the modal.
+      // (c) onClose sets the dismissed flag, clears pending, and closes the modal.
       fireEvent.click(screen.getByTestId('setup-close'));
       await waitFor(() => {
         expect(localStorage.getItem('setup_dismissed_demo')).toBe('1');
         expect(screen.getByTestId('setup-modal').getAttribute('data-open')).toBe('false');
       });
+      expect(mockClearSetupPending).toHaveBeenCalledWith('demo');
     });
 
-    it('keeps the SetupModal closed for an agent that is not recently created', async () => {
+    it('keeps the SetupModal closed for an agent that is neither recent nor pending', async () => {
       mockIsRecentlyCreated.mockReturnValue(false);
+      mockIsSetupPending.mockReturnValue(false);
       render(() => <Routing />);
       await waitFor(() => {
         expect(screen.getByTestId('setup-modal')).toBeDefined();

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -138,9 +138,9 @@ describe("Settings", () => {
     mockUpdateAgent.mockResolvedValue({});
   });
 
-  it("renders Settings heading", () => {
-    render(() => <Settings />);
-    expect(screen.getByText("Settings")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Settings />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
   it("renders agent name input with value", () => {
@@ -330,9 +330,8 @@ describe("Settings", () => {
     });
   });
 
-  it("shows breadcrumb with agent name", () => {
+  it("shows settings description without duplicating the agent heading", () => {
     const { container } = render(() => <Settings />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Rename your agent");
   });
 

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -6,7 +6,7 @@ const mockNavigate = vi.fn();
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: mockAgentName }),
   useNavigate: () => mockNavigate,
-  useLocation: () => ({ pathname: `/agents/${mockAgentName}/settings`, state: null }),
+  useLocation: () => ({ pathname: `/harnesses/${mockAgentName}/settings`, state: null }),
 }));
 
 vi.mock("@solidjs/meta", () => ({
@@ -145,13 +145,13 @@ describe("Settings", () => {
 
   it("renders agent name input with value", () => {
     render(() => <Settings />);
-    const input = screen.getByLabelText("Agent name") as HTMLInputElement;
+    const input = screen.getByLabelText("Harness name") as HTMLInputElement;
     expect(input.value).toBe("test-agent");
   });
 
-  it("renders Agent type label", () => {
+  it("renders Harness type label", () => {
     render(() => <Settings />);
-    expect(screen.getByText("Agent type")).toBeDefined();
+    expect(screen.getByText("Harness type")).toBeDefined();
   });
 
   it("renders Change button for agent type", async () => {
@@ -166,7 +166,7 @@ describe("Settings", () => {
 
   it("renders API Key section", () => {
     render(() => <Settings />);
-    expect(screen.getByText("Agent API key")).toBeDefined();
+    expect(screen.getByText("Harness API key")).toBeDefined();
   });
 
   it("renders Setup section", () => {
@@ -179,9 +179,9 @@ describe("Settings", () => {
     expect(screen.getByText("Danger zone")).toBeDefined();
   });
 
-  it("renders Delete agent button", () => {
+  it("renders Delete harness button", () => {
     render(() => <Settings />);
-    expect(screen.getByText("Delete agent")).toBeDefined();
+    expect(screen.getByText("Delete harness")).toBeDefined();
   });
 
   it("shows key prefix after loading", async () => {
@@ -227,9 +227,9 @@ describe("Settings", () => {
     });
   });
 
-  it("opens delete modal on Delete agent click", () => {
+  it("opens delete modal on Delete harness click", () => {
     const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Delete agent"));
+    fireEvent.click(screen.getByText("Delete harness"));
     expect(container.textContent).toContain("Delete test-agent");
   });
 
@@ -252,7 +252,7 @@ describe("Settings", () => {
 
   it("save button enables when agent name changes", () => {
     render(() => <Settings />);
-    const input = screen.getByLabelText("Agent name") as HTMLInputElement;
+    const input = screen.getByLabelText("Harness name") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "new-name" } });
     const saveBtn = screen.getByText("Save") as HTMLButtonElement;
     expect(saveBtn.disabled).toBe(false);
@@ -263,17 +263,17 @@ describe("Settings", () => {
     const originalLocation = window.location;
     Object.defineProperty(window, "location", { value: { ...originalLocation, replace: replaceFn }, writable: true, configurable: true });
     render(() => <Settings />);
-    fireEvent.input(screen.getByLabelText("Agent name"), { target: { value: "new-name" } });
+    fireEvent.input(screen.getByLabelText("Harness name"), { target: { value: "new-name" } });
     fireEvent.click(screen.getByText("Save"));
     await vi.waitFor(() => { expect(mockRenameAgent).toHaveBeenCalledWith("test-agent", "new-name"); });
-    await vi.waitFor(() => { expect(replaceFn).toHaveBeenCalledWith("/agents/new-name/settings"); });
+    await vi.waitFor(() => { expect(replaceFn).toHaveBeenCalledWith("/harnesses/new-name/settings"); });
     Object.defineProperty(window, "location", { value: originalLocation, writable: true, configurable: true });
   });
 
   it("resets name on rename error", async () => {
     mockRenameAgent.mockRejectedValueOnce(new Error("Conflict"));
     render(() => <Settings />);
-    const input = screen.getByLabelText("Agent name") as HTMLInputElement;
+    const input = screen.getByLabelText("Harness name") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "bad-name" } });
     fireEvent.click(screen.getByText("Save"));
     await vi.waitFor(() => { expect(input.value).toBe("test-agent"); });
@@ -300,23 +300,23 @@ describe("Settings", () => {
 
   it("closes delete modal on Escape key", () => {
     const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Delete agent"));
+    fireEvent.click(screen.getByText("Delete harness"));
     fireEvent.keyDown(container.querySelector(".modal-overlay")!, { key: "Escape" });
     expect(container.querySelector(".modal-overlay")).toBeNull();
   });
 
   it("delete button is disabled until name matches", () => {
     const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Delete agent"));
-    const deleteBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Delete this agent")) as HTMLButtonElement;
+    fireEvent.click(screen.getByText("Delete harness"));
+    const deleteBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Delete this harness")) as HTMLButtonElement;
     expect(deleteBtn.disabled).toBe(true);
   });
 
   it("calls deleteAgent when confirmed", async () => {
     const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Delete agent"));
+    fireEvent.click(screen.getByText("Delete harness"));
     fireEvent.input(container.querySelector('.modal-overlay input[type="text"]')!, { target: { value: "test-agent" } });
-    const deleteBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Delete this agent"))!;
+    const deleteBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Delete this harness"))!;
     fireEvent.click(deleteBtn);
     await vi.waitFor(() => { expect(mockDeleteAgent).toHaveBeenCalledWith("test-agent"); });
   });
@@ -347,9 +347,9 @@ describe("Settings", () => {
   it("handles delete agent error gracefully", async () => {
     mockDeleteAgent.mockRejectedValue(new Error("Delete failed"));
     const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Delete agent"));
+    fireEvent.click(screen.getByText("Delete harness"));
     fireEvent.input(container.querySelector('.modal-overlay input[type="text"]')!, { target: { value: "test-agent" } });
-    const deleteBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Delete this agent"))!;
+    const deleteBtn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Delete this harness"))!;
     fireEvent.click(deleteBtn);
     await vi.waitFor(() => { expect(mockDeleteAgent).toHaveBeenCalled(); });
   });
@@ -418,7 +418,7 @@ describe("Settings", () => {
     )!;
     fireEvent.click(modalSaveBtn);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Set up agent");
+      expect(container.textContent).toContain("Set up harness");
     });
   });
 
@@ -432,7 +432,7 @@ describe("Settings", () => {
 
   it("closes delete modal when clicking overlay", () => {
     const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Delete agent"));
+    fireEvent.click(screen.getByText("Delete harness"));
     const overlay = container.querySelector(".modal-overlay")!;
     // Click on the overlay itself (not the modal card inside)
     fireEvent.click(overlay);
@@ -441,7 +441,7 @@ describe("Settings", () => {
 
   it("closes delete modal when clicking close button", () => {
     const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Delete agent"));
+    fireEvent.click(screen.getByText("Delete harness"));
     const closeBtn = container.querySelector('[aria-label="Close"]');
     expect(closeBtn).not.toBeNull();
     fireEvent.click(closeBtn!);
@@ -773,7 +773,7 @@ describe("Settings", () => {
 
   it("submits delete via Enter key on confirm input", async () => {
     const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Delete agent"));
+    fireEvent.click(screen.getByText("Delete harness"));
     const input = container.querySelector('.modal-overlay input[type="text"]') as HTMLInputElement;
     fireEvent.input(input, { target: { value: "test-agent" } });
     fireEvent.keyDown(input, { key: "Enter" });
@@ -782,7 +782,7 @@ describe("Settings", () => {
 
   it("does not delete via Enter when name does not match", async () => {
     const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Delete agent"));
+    fireEvent.click(screen.getByText("Delete harness"));
     const input = container.querySelector('.modal-overlay input[type="text"]') as HTMLInputElement;
     fireEvent.input(input, { target: { value: "wrong-name" } });
     fireEvent.keyDown(input, { key: "Enter" });

--- a/packages/frontend/tests/pages/Workspace-validation.test.tsx
+++ b/packages/frontend/tests/pages/Workspace-validation.test.tsx
@@ -71,6 +71,7 @@ vi.mock("../../src/components/AgentTypeSelect.jsx", () => ({
 const mockMarkAgentCreated = vi.fn();
 vi.mock("../../src/services/recent-agents.js", () => ({
   markAgentCreated: (...args: unknown[]) => mockMarkAgentCreated(...args),
+  markSetupPending: vi.fn(),
 }));
 
 vi.mock("manifest-shared", () => ({

--- a/packages/frontend/tests/pages/Workspace-validation.test.tsx
+++ b/packages/frontend/tests/pages/Workspace-validation.test.tsx
@@ -88,7 +88,7 @@ import Workspace from "../../src/pages/Workspace";
 
 const openModal = () => {
   const result = render(() => <Workspace />);
-  fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+  fireEvent.click(screen.getAllByText("Connect Harness")[0]);
   const input = result.container.querySelector(".modal-card__input") as HTMLInputElement;
   const createBtn = Array.from(
     result.container.querySelectorAll<HTMLButtonElement>(".modal-card button.btn--primary"),
@@ -150,7 +150,7 @@ describe("Workspace AddAgentModal - name validation", () => {
     expect(createBtn.disabled).toBe(false);
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/weird%2Fname/routing", expect.anything());
+      expect(mockNavigate).toHaveBeenCalledWith("/harnesses/weird%2Fname/routing", expect.anything());
     });
   });
 
@@ -160,7 +160,7 @@ describe("Workspace AddAgentModal - name validation", () => {
     fireEvent.input(input, { target: { value: "100%cool" } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/100%25cool/routing", expect.anything());
+      expect(mockNavigate).toHaveBeenCalledWith("/harnesses/100%25cool/routing", expect.anything());
     });
   });
 
@@ -171,7 +171,7 @@ describe("Workspace AddAgentModal - name validation", () => {
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        `/agents/${encodeURIComponent("bot-🚀")}/routing`,
+        `/harnesses/${encodeURIComponent("bot-🚀")}/routing`,
         expect.anything(),
       );
     });
@@ -253,7 +253,7 @@ describe("Workspace AddAgentModal - exact createAgent payload", () => {
     fireEvent.input(input, { target: { value: "Demo Agent" } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/demo-agent-1/routing", {
+      expect(mockNavigate).toHaveBeenCalledWith("/harnesses/demo-agent-1/routing", {
         state: { newApiKey: "key-xyz" },
       });
     });
@@ -267,7 +267,7 @@ describe("Workspace AddAgentModal - exact createAgent payload", () => {
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        `/agents/${encodeURIComponent("Fallback Agent")}/routing`,
+        `/harnesses/${encodeURIComponent("Fallback Agent")}/routing`,
         { state: { newApiKey: "k" } },
       );
     });

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -144,14 +144,14 @@ describe("Workspace", () => {
     mockGetGlobalProviders.mockResolvedValue({ providers: [{ provider: "openai" }] });
   });
 
-  it("renders My Agents heading", async () => {
+  it("renders My Harnesses heading", async () => {
     render(() => <Workspace />);
-    expect(screen.getByText("My Agents")).toBeDefined();
+    expect(screen.getByText("My Harnesses")).toBeDefined();
   });
 
-  it("renders Connect Agent button", () => {
+  it("renders Connect Harness button", () => {
     render(() => <Workspace />);
-    const buttons = screen.getAllByText("Connect Agent");
+    const buttons = screen.getAllByText("Connect Harness");
     expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -174,7 +174,7 @@ describe("Workspace", () => {
     mockGetAgents.mockResolvedValue({ agents: [] });
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("No agents yet");
+      expect(container.textContent).toContain("No harnesses yet");
     });
   });
 
@@ -184,9 +184,9 @@ describe("Workspace", () => {
     expect(container.querySelectorAll(".skeleton").length).toBeGreaterThan(0);
   });
 
-  it("opens create agent modal on Connect Agent click", () => {
+  it("opens create harness modal on Connect Harness click", () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText("Connect Harness")[0];
     fireEvent.click(btn);
     expect(container.querySelector(".modal-card__input")).not.toBeNull();
   });
@@ -194,7 +194,7 @@ describe("Workspace", () => {
   it("agents link to agent detail page", async () => {
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      const link = container.querySelector('a[href="/agents/demo-agent"]');
+      const link = container.querySelector('a[href="/harnesses/demo-agent"]');
       expect(link).not.toBeNull();
     });
   });
@@ -217,7 +217,7 @@ describe("Workspace", () => {
   it("creates agent when form submitted", async () => {
     mockCreateAgent.mockResolvedValue({ agent: { name: "new-agent" }, apiKey: "test-key" });
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText("Connect Harness")[0];
     fireEvent.click(btn);
     const input = container.querySelector(".modal-card__input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "new-agent" } });
@@ -233,7 +233,7 @@ describe("Workspace", () => {
 
   it("create button is disabled when name is empty", () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText("Connect Harness")[0];
     fireEvent.click(btn);
     const createBtn = screen.getByText("Create") as HTMLButtonElement;
     expect(createBtn.disabled).toBe(true);
@@ -241,21 +241,21 @@ describe("Workspace", () => {
 
   it("shows modal dialog title", () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText("Connect Harness")[0];
     fireEvent.click(btn);
-    expect(container.textContent).toContain("Name your agent to start tracking");
+    expect(container.textContent).toContain("Name your harness to start tracking");
   });
 
   it("shows breadcrumb text", () => {
     const { container } = render(() => <Workspace />);
-    expect(container.textContent).toContain("View and manage all your connected AI agents");
+    expect(container.textContent).toContain("View and manage all your connected harnesses");
   });
 
   it("shows connect button in empty state", async () => {
     mockGetAgents.mockResolvedValue({ agents: [] });
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Connect your first agent");
+      expect(container.textContent).toContain("Connect your first harness");
     });
   });
 
@@ -263,7 +263,7 @@ describe("Workspace", () => {
     let resolveCreate: (v: any) => void;
     mockCreateAgent.mockReturnValue(new Promise((r) => { resolveCreate = r; }));
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText("Connect Harness")[0];
     fireEvent.click(btn);
     const input = container.querySelector(".modal-card__input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "new-agent" } });
@@ -281,7 +281,7 @@ describe("Workspace", () => {
     let resolveCreate: (v: any) => void;
     mockCreateAgent.mockReturnValue(new Promise((r) => { resolveCreate = r; }));
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+    fireEvent.click(screen.getAllByText("Connect Harness")[0]);
     const input = container.querySelector(".modal-card__input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "new-agent" } });
     fireEvent.click(screen.getByText("Create"));
@@ -294,7 +294,7 @@ describe("Workspace", () => {
   it("handles createAgent error gracefully", async () => {
     mockCreateAgent.mockRejectedValue(new Error("Failed to create"));
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText("Connect Harness")[0];
     fireEvent.click(btn);
     const input = container.querySelector(".modal-card__input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "new-agent" } });
@@ -306,7 +306,7 @@ describe("Workspace", () => {
 
   it("creates agent on Enter key press", async () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText("Connect Harness")[0];
     fireEvent.click(btn);
     const input = container.querySelector(".modal-card__input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "enter-agent" } });
@@ -318,7 +318,7 @@ describe("Workspace", () => {
 
   it("closes modal and clears input on Escape key", () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText("Connect Harness")[0];
     fireEvent.click(btn);
     const input = container.querySelector(".modal-card__input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "test" } });
@@ -329,7 +329,7 @@ describe("Workspace", () => {
 
   it("closes modal on overlay click", () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText("Connect Harness")[0];
     fireEvent.click(btn);
     expect(container.querySelector(".modal-overlay")).not.toBeNull();
     const overlay = container.querySelector(".modal-overlay")!;
@@ -348,13 +348,13 @@ describe("Workspace", () => {
 
   it("shows AgentTypePicker in create modal", () => {
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+    fireEvent.click(screen.getAllByText("Connect Harness")[0]);
     expect(container.querySelector('[data-testid="agent-type-picker"]')).not.toBeNull();
   });
 
   it("sets first platform when category changes in create modal", () => {
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+    fireEvent.click(screen.getAllByText("Connect Harness")[0]);
     // First pick a platform
     fireEvent.click(container.querySelector('[data-testid="pick-platform"]')!);
     // Then change category which should set platform to first of new category
@@ -366,7 +366,7 @@ describe("Workspace", () => {
   it("sends category and platform with createAgent", async () => {
     mockCreateAgent.mockResolvedValue({ agent: { name: "typed-agent" }, apiKey: "k" });
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+    fireEvent.click(screen.getAllByText("Connect Harness")[0]);
     const input = container.querySelector(".modal-card__input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "typed-agent" } });
     fireEvent.click(container.querySelector('[data-testid="pick-category"]')!);
@@ -383,7 +383,7 @@ describe("Workspace", () => {
     // Navigation happens after the async providers lookup, so wait for it.
     await vi.waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        "/agents/typed-agent/routing",
+        "/harnesses/typed-agent/routing",
         expect.objectContaining({ state: expect.objectContaining({ newApiKey: "k" }) }),
       );
     });
@@ -391,7 +391,7 @@ describe("Workspace", () => {
 
   it("does not submit when name is empty", async () => {
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+    fireEvent.click(screen.getAllByText("Connect Harness")[0]);
     const input = container.querySelector(".modal-card__input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "   " } });
     fireEvent.click(screen.getByText("Create"));
@@ -443,10 +443,10 @@ describe("Workspace", () => {
     mockGetAgents.mockResolvedValue({ agents: [] });
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Connect your first agent");
+      expect(container.textContent).toContain("Connect your first harness");
     });
     const btn = Array.from(container.querySelectorAll("button")).find(
-      (b) => b.textContent?.includes("Connect your first agent"),
+      (b) => b.textContent?.includes("Connect your first harness"),
     )!;
     fireEvent.click(btn);
     expect(container.querySelector(".modal-card__input")).not.toBeNull();
@@ -470,7 +470,7 @@ describe("Workspace", () => {
     let resolveCreate: (v: any) => void;
     mockCreateAgent.mockReturnValue(new Promise((r) => { resolveCreate = r; }));
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+    fireEvent.click(screen.getAllByText("Connect Harness")[0]);
     const input = container.querySelector(".modal-card__input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "test" } });
     fireEvent.click(screen.getByText("Create"));
@@ -584,7 +584,7 @@ describe("Workspace", () => {
       await clickKebab(container);
       fireEvent.click(screen.getByText("Delete"));
       const deleteBtn = Array.from(container.querySelectorAll("button")).find(
-        (b) => b.textContent?.trim() === "Delete agent",
+        (b) => b.textContent?.trim() === "Delete harness",
       ) as HTMLButtonElement;
       expect(deleteBtn.hasAttribute("disabled")).toBe(true);
       const input = container.querySelector('input[placeholder="demo-agent"]') as HTMLInputElement;
@@ -605,7 +605,7 @@ describe("Workspace", () => {
       const input = container.querySelector('input[placeholder="demo-agent"]') as HTMLInputElement;
       fireEvent.input(input, { target: { value: "demo-agent" } });
       const deleteBtn = Array.from(container.querySelectorAll("button")).find(
-        (b) => b.textContent?.trim() === "Delete agent",
+        (b) => b.textContent?.trim() === "Delete harness",
       ) as HTMLButtonElement;
       fireEvent.click(deleteBtn);
       await vi.waitFor(() => {
@@ -622,7 +622,7 @@ describe("Workspace", () => {
       const input = container.querySelector('input[placeholder="demo-agent"]') as HTMLInputElement;
       fireEvent.input(input, { target: { value: "demo-agent" } });
       const deleteBtn = Array.from(container.querySelectorAll("button")).find(
-        (b) => b.textContent?.trim() === "Delete agent",
+        (b) => b.textContent?.trim() === "Delete harness",
       ) as HTMLButtonElement;
       fireEvent.click(deleteBtn);
       await vi.waitFor(() => {

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -94,6 +94,7 @@ vi.mock("../../src/components/AgentTypeSelect.jsx", () => ({
 const mockMarkAgentCreated = vi.fn();
 vi.mock("../../src/services/recent-agents.js", () => ({
   markAgentCreated: (...args: unknown[]) => mockMarkAgentCreated(...args),
+  markSetupPending: vi.fn(),
 }));
 
 vi.mock("manifest-shared", () => ({

--- a/packages/frontend/tests/services/analytics-api.test.ts
+++ b/packages/frontend/tests/services/analytics-api.test.ts
@@ -5,7 +5,7 @@ const mockFetch = vi.fn();
 
 beforeEach(() => {
   vi.stubGlobal('fetch', mockFetch);
-  vi.stubGlobal('location', { origin: 'http://localhost:3000', pathname: '/agents/test' });
+  vi.stubGlobal('location', { origin: 'http://localhost:3000', pathname: '/harnesses/test' });
   mockFetch.mockReset();
 });
 

--- a/packages/frontend/tests/services/recent-agents.test.ts
+++ b/packages/frontend/tests/services/recent-agents.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { markAgentCreated, isRecentlyCreated, clearRecentAgent } from '../../src/services/recent-agents';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  markAgentCreated,
+  isRecentlyCreated,
+  clearRecentAgent,
+  markSetupPending,
+  isSetupPending,
+  clearSetupPending,
+} from '../../src/services/recent-agents';
 
 describe('recent-agents', () => {
   beforeEach(() => {
@@ -34,5 +41,70 @@ describe('recent-agents', () => {
 
   it('clearRecentAgent is safe to call on non-existent slug', () => {
     expect(() => clearRecentAgent('never-added')).not.toThrow();
+  });
+});
+
+describe('recent-agents setup pending (persistent)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('returns false for a slug that was never marked pending', () => {
+    expect(isSetupPending('test-slug')).toBe(false);
+  });
+
+  it('persists the pending flag to localStorage and reads it back', () => {
+    markSetupPending('test-slug');
+    expect(localStorage.getItem('setup_pending_test-slug')).toBe('1');
+    expect(isSetupPending('test-slug')).toBe(true);
+  });
+
+  it('survives a simulated reload (re-reading from localStorage)', () => {
+    markSetupPending('test-slug');
+    // isSetupPending reads straight from localStorage, no in-memory state.
+    expect(isSetupPending('test-slug')).toBe(true);
+  });
+
+  it('clearSetupPending removes the flag', () => {
+    markSetupPending('test-slug');
+    clearSetupPending('test-slug');
+    expect(localStorage.getItem('setup_pending_test-slug')).toBeNull();
+    expect(isSetupPending('test-slug')).toBe(false);
+  });
+
+  it('tracks pending slugs independently', () => {
+    markSetupPending('test-slug');
+    markSetupPending('another-slug');
+    expect(isSetupPending('test-slug')).toBe(true);
+    expect(isSetupPending('another-slug')).toBe(true);
+    clearSetupPending('test-slug');
+    expect(isSetupPending('test-slug')).toBe(false);
+    expect(isSetupPending('another-slug')).toBe(true);
+  });
+
+  it('markSetupPending swallows storage errors', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('denied');
+    });
+    expect(() => markSetupPending('test-slug')).not.toThrow();
+  });
+
+  it('isSetupPending returns false when storage throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('denied');
+    });
+    expect(isSetupPending('test-slug')).toBe(false);
+  });
+
+  it('clearSetupPending swallows storage errors', () => {
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('denied');
+    });
+    expect(() => clearSetupPending('test-slug')).not.toThrow();
   });
 });

--- a/packages/frontend/tests/services/routing-useagent.test.tsx
+++ b/packages/frontend/tests/services/routing-useagent.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 
 vi.mock("@solidjs/router", () => ({
-  useLocation: () => ({ pathname: "/agents/test-agent/overview" }),
+  useLocation: () => ({ pathname: "/harnesses/test-agent/overview" }),
 }));
 
 import { useAgentName } from "../../src/services/routing";

--- a/packages/frontend/tests/services/routing.test.ts
+++ b/packages/frontend/tests/services/routing.test.ts
@@ -11,10 +11,10 @@ import {
 
 describe("agentPath", () => {
   it("builds path with agent name", () => {
-    expect(agentPath("my-agent", "/overview")).toBe("/agents/my-agent/overview");
+    expect(agentPath("my-agent", "/overview")).toBe("/harnesses/my-agent/overview");
   });
   it("encodes special characters in agent name", () => {
-    expect(agentPath("my agent", "/overview")).toBe("/agents/my%20agent/overview");
+    expect(agentPath("my agent", "/overview")).toBe("/harnesses/my%20agent/overview");
   });
   it("returns root when agent is null", () => {
     expect(agentPath(null, "/overview")).toBe("/");


### PR DESCRIPTION
## ✨ What changed
- Renamed the user-facing "Agent" concept to **"Harness"** across the dashboard: copy, page titles, the Messages "Harness" column, and the client routes `/agents` → `/harnesses` (with redirect routes from the old paths so existing links keep working).
- Replaced the static "Harnesses" sidebar link with a collapsible **HARNESSES** section that lists each harness inline (platform icon + name → `/harnesses/:name`), with a `+` create button and a caret to collapse.

## 💭 Why
This matches Seb's #2061 information architecture: harnesses live in the left nav as a switcher, not behind a separate grid page. It is frontend-only.

## 👤 For users
The left nav now lists your harnesses directly, and old `/agents/...` bookmarks redirect to `/harnesses/...`.

## 🔧 For operators
Frontend only. No API, schema, or env changes. Backend paths stay `/api/v1/agents` and the database stays `agents`.

## 📝 Notes
- The reserved Playground (system) agent is excluded from the sidebar list.
- Adds a "No harnesses yet" empty state (not present in #2061; easy to drop if unwanted).
- Stacked on PR7 (#2167); base `feat/onboarding-rework`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebranded “Agent” to “Harness” across the app and moved harness switching into the left sidebar. Switched routes from `/agents` to `/harnesses` with safe redirects, improved sidebar a11y, persisted the setup modal across refresh, and added a canonical backend cache key for the harness list so it never goes stale; backend APIs stay under `/api/v1/agents`.

- **New Features**
  - Collapsible HARNESSES section in the sidebar listing each harness (icon + name) linking to `/harnesses/:name`, with an inline `+` create button.
  - Shows an empty state when none exist; excludes the reserved Playground harness.

- **Bug Fixes**
  - Canonical cache key for GET `/api/v1/agents` (two per user: `:system=true/false`) and exhaustive invalidation on create/rename/delete to prevent stale harness lists.
  - Legacy `/agents` redirects now preserve query and hash; sidebar harness links URL-encode names.
  - HARNESSES toggle is a real button with aria-expanded; the `+` create button is keyboard/touch accessible.
  - Empty state no longer flashes during load; removed a redundant redirect route and deduped sidebar item CSS.
  - Setup modal now reopens after refresh until completed or dismissed (persistent setup-pending flag in localStorage); setup framework tabs scroll horizontally on desktop.
  - Removed duplicate page headings in agent detail child pages (Limits, Routing, Settings).

<sup>Written for commit e3481aca058a208c2da4ab70db820b9147c6ce43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

