### PR TITLE
fix: surface OpenAI Responses stream failures

### DIFF
--- a/.changeset/openai-deep-research-responses.md
+++ b/.changeset/openai-deep-research-responses.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Route already-resolved OpenAI `o3-deep-research` API-key requests through the Responses endpoint, matching the existing deep-research handling for `o4-mini-deep-research` without adding unavailable models to discovery. Preserve non-streaming mode when forwarding Chat Completions-shaped requests to OpenAI Responses, and surface collected Responses SSE error events as upstream failures instead of empty successful completions.

--- a/packages/backend/src/common/constants/openai-models.ts
+++ b/packages/backend/src/common/constants/openai-models.ts
@@ -8,7 +8,7 @@
  * so neither module imports from the other just for this pattern.
  */
 export const OPENAI_RESPONSES_ONLY_RE =
-  /(?:-codex(?!-mini-latest)|^gpt-5[^/]*-pro(?:-|$)|^o1-pro|^o4-mini-deep-research)/i;
+  /(?:-codex(?!-mini-latest)|^gpt-5[^/]*-pro(?:-|$)|^o1-pro|^o\d(?:-mini)?-deep-research(?:-|$))/i;
 
 /** Strip a single leading vendor prefix ("openai/foo" → "foo"). No-op if none. */
 export function stripVendorPrefix(model: string): string {

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-request.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-request.spec.ts
@@ -16,6 +16,16 @@ describe('ChatGPT Adapter – toResponsesRequest', () => {
     expect(result.instructions).toBe('You are a helpful assistant.');
   });
 
+  it('honors an explicit non-streaming upstream option', () => {
+    const body = {
+      messages: [{ role: 'user', content: 'Hello world' }],
+    };
+
+    const result = toResponsesRequest(body, 'gpt-5', { stream: false });
+
+    expect(result.stream).toBe(false);
+  });
+
   it('extracts system message as instructions', () => {
     const body = {
       messages: [

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -939,21 +939,26 @@ describe('ProviderClient', () => {
       expect(result.isChatGpt).toBe(true);
     });
 
-    it('routes api_key + o4-mini-deep-research to /v1/responses', async () => {
-      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+    it.each(['o3-deep-research', 'o4-mini-deep-research'])(
+      'routes already-resolved api_key + %s to /v1/responses',
+      async (model) => {
+        mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
-      const result = await client.forward({
-        provider: 'openai',
-        apiKey: 'sk-test',
-        model: 'o4-mini-deep-research',
-        body,
-        stream: false,
-      });
+        const result = await client.forward({
+          provider: 'openai',
+          apiKey: 'sk-test',
+          model,
+          body,
+          stream: false,
+        });
 
-      const url = mockFetch.mock.calls[0][0] as string;
-      expect(url).toBe('https://api.openai.com/v1/responses');
-      expect(result.isChatGpt).toBe(true);
-    });
+        const url = mockFetch.mock.calls[0][0] as string;
+        expect(url).toBe('https://api.openai.com/v1/responses');
+        const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(sentBody.stream).toBe(false);
+        expect(result.isChatGpt).toBe(true);
+      },
+    );
 
     it('detects Responses-only models after stripping an OpenRouter-style vendor prefix', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
@@ -972,6 +977,24 @@ describe('ProviderClient', () => {
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       // Vendor prefix is stripped before being sent to OpenAI.
       expect(sentBody.model).toBe('gpt-5.3-codex');
+    });
+
+    it('detects already-resolved o3-deep-research after stripping an OpenRouter-style vendor prefix', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'openai/o3-deep-research',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.openai.com/v1/responses');
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('o3-deep-research');
     });
 
     // Regression guard: models that DO support /v1/chat/completions must stay

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -6,6 +6,7 @@ import { IngestEventBusService } from '../../../common/services/ingest-event-bus
 import { ThoughtSignatureCache } from '../thought-signature-cache';
 import { ThinkingBlockCache } from '../thinking-block-cache';
 import { ReasoningContentCache } from '../reasoning-content-cache';
+import { ResponsesSseError } from '../chatgpt-adapter';
 
 /**
  * Flush enough microtasks for the recorder's fire-and-forget chain to
@@ -847,6 +848,36 @@ describe('ProxyController', () => {
         }),
       }),
     );
+  });
+
+  it('should surface collected Responses SSE failures as upstream errors', async () => {
+    proxyService.proxyRequest.mockRejectedValue(
+      new ResponsesSseError(
+        'Model unavailable',
+        404,
+        JSON.stringify({
+          error: {
+            message: 'Model unavailable',
+            code: 'model_not_found',
+            type: 'invalid_request_error',
+          },
+        }),
+      ),
+    );
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        message: 'Model unavailable',
+        type: 'upstream_error',
+        status: 404,
+      },
+    });
   });
 
   it('should forward HttpException as friendly chat message', async () => {

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
@@ -1,6 +1,7 @@
 import {
   collectChatGptSseResponse,
   fromResponsesResponse,
+  ResponsesSseError,
   toResponsesRequest,
   transformResponsesStreamChunk,
 } from './chatgpt-adapter';
@@ -410,6 +411,35 @@ describe('chatgpt-adapter', () => {
       expect(out.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
       const choices = out.choices as Array<Record<string, unknown>>;
       expect((choices[0].message as Record<string, unknown>).content).toBeNull();
+    });
+
+    it('throws an upstream error when the Responses stream emits an error event', () => {
+      const sse =
+        'event: error\ndata: {"type":"invalid_request_error","code":"model_not_found","message":"Model unavailable"}';
+
+      expect(() => collectChatGptSseResponse(sse, 'gpt-5')).toThrow(ResponsesSseError);
+
+      try {
+        collectChatGptSseResponse(sse, 'gpt-5');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ResponsesSseError);
+        expect((err as ResponsesSseError).status).toBe(404);
+        expect((err as ResponsesSseError).body).toContain('Model unavailable');
+      }
+    });
+
+    it('throws an upstream error when the Responses stream emits response.failed', () => {
+      const sse =
+        'event: response.failed\ndata: {"response":{"error":{"code":"rate_limit_exceeded","message":"Too many requests"}}}';
+
+      try {
+        collectChatGptSseResponse(sse, 'gpt-5');
+        fail('Expected ResponsesSseError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ResponsesSseError);
+        expect((err as ResponsesSseError).status).toBe(429);
+        expect((err as ResponsesSseError).body).toContain('Too many requests');
+      }
     });
 
     it('drops function_call_arguments deltas that arrive for an unknown output_index', () => {

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -19,6 +19,17 @@ import {
 } from './chatgpt-helpers';
 import { OpenAIMessage } from './proxy-types';
 
+export class ResponsesSseError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(message);
+    this.name = 'ResponsesSseError';
+  }
+}
+
 /* ── Request conversion ── */
 
 export interface ToResponsesRequestOptions {
@@ -29,6 +40,11 @@ export interface ToResponsesRequestOptions {
    * leave this disabled. API-key /responses and Copilot /responses accept it.
    */
   mapMaxOutputTokens?: boolean;
+  /**
+   * Explicit upstream streaming mode. Omit to preserve the historical
+   * ChatGPT-subscription behavior, which expects SSE collection.
+   */
+  stream?: boolean;
 }
 
 export function toResponsesRequest(
@@ -70,7 +86,7 @@ export function toResponsesRequest(
   const request: Record<string, unknown> = {
     model,
     input,
-    stream: body.stream !== false,
+    stream: options.stream ?? body.stream !== false,
     store: false,
     instructions: extractInstructions(messages),
   };
@@ -310,7 +326,9 @@ export function collectChatGptSseResponse(sseText: string, model: string): Recor
     const data = safeParse(dataStr);
     if (!data) continue;
 
-    if (eventType === 'response.output_text.delta') {
+    if (eventType === 'error' || eventType === 'response.failed') {
+      throw buildResponsesSseError(data);
+    } else if (eventType === 'response.output_text.delta') {
       text += typeof data.delta === 'string' ? data.delta : '';
     } else if (eventType === 'response.output_item.added') {
       const item = isObjectRecord(data.item) ? data.item : undefined;
@@ -366,4 +384,39 @@ export function collectChatGptSseResponse(sseText: string, model: string): Recor
     ],
     usage: usage ?? { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
   };
+}
+
+function buildResponsesSseError(data: Record<string, unknown>): ResponsesSseError {
+  const response = isObjectRecord(data.response) ? data.response : undefined;
+  const error = isObjectRecord(data.error)
+    ? data.error
+    : isObjectRecord(response?.error)
+      ? response.error
+      : data;
+  const message =
+    typeof error.message === 'string' && error.message
+      ? error.message
+      : 'OpenAI Responses stream failed';
+  const code = typeof error.code === 'string' ? error.code : undefined;
+  const type = typeof error.type === 'string' ? error.type : undefined;
+  const status = statusFromResponsesError(code, type);
+  const body = JSON.stringify({
+    error: {
+      message,
+      ...(code ? { code } : {}),
+      ...(type ? { type } : {}),
+    },
+  });
+  return new ResponsesSseError(message, status, body);
+}
+
+function statusFromResponsesError(code: string | undefined, type: string | undefined): number {
+  const value = (code ?? type ?? '').toLowerCase();
+  if (value.includes('model_not_found') || value.includes('not_found')) return 404;
+  if (value.includes('rate_limit')) return 429;
+  if (value.includes('invalid') || value.includes('bad_request')) return 400;
+  if (value.includes('unauthorized') || value.includes('authentication')) return 401;
+  if (value.includes('forbidden') || value.includes('permission')) return 403;
+  if (value.includes('server')) return 500;
+  return 502;
 }

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -413,6 +413,10 @@ export class ProviderClient {
               stripCodexUnsupported: endpointKey === 'openai-subscription',
             })
           : toResponsesRequest(requestSource, bareModel, {
+              stream:
+                endpointKey === 'openai-responses' || endpointKey === 'xai-responses'
+                  ? ctx.stream
+                  : undefined,
               // The ChatGPT subscription backend rejects max_output_tokens with
               // unsupported_parameter; only opt in for the API-key paths.
               mapMaxOutputTokens:

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -37,6 +37,8 @@ import { ProxyExceptionFilter, isChatRenderingClient } from './proxy-exception.f
 import { sendFriendlyResponse } from './proxy-friendly-response';
 import { formatManifestError } from '../../common/errors/error-codes';
 import type { ProxyApiMode } from './proxy-types';
+import { ResponsesSseError } from './chatgpt-adapter';
+import { sanitizeProviderError } from './proxy-error-sanitizer';
 
 const MAX_SEEN_USERS = 10_000;
 const SEEN_USER_TTL_MS = 24 * 60 * 60 * 1000;
@@ -256,11 +258,17 @@ export class ProxyController {
     }
 
     const message = err instanceof Error ? err.message : String(err);
-    const status = err instanceof HttpException ? err.getStatus() : 500;
+    const status =
+      err instanceof ResponsesSseError
+        ? err.status
+        : err instanceof HttpException
+          ? err.getStatus()
+          : 500;
+    const providerErrorBody = err instanceof ResponsesSseError ? err.body : message;
     this.logger.error(`Proxy error: ${message}`);
 
     this.recorder
-      .recordProviderError(req.ingestionContext, status, message, {
+      .recordProviderError(req.ingestionContext, status, providerErrorBody, {
         traceId,
         callerAttribution,
         requestHeaders,
@@ -269,6 +277,17 @@ export class ProxyController {
 
     if (headersSent) {
       if (!res.writableEnded) res.end();
+      return;
+    }
+
+    if (err instanceof ResponsesSseError) {
+      res.status(err.status).json({
+        error: {
+          message: sanitizeProviderError(err.status, err.body, process.env.NODE_ENV),
+          type: 'upstream_error',
+          status: err.status,
+        },
+      });
       return;
     }
 


### PR DESCRIPTION
### ✨ What changed
- Route already-resolved OpenAI deep-research models to `/v1/responses`.
- Preserve `stream:false` when converting Chat Completions requests to Responses.
- Return Responses SSE failures as upstream errors, not empty completions.

### 💭 Why
OpenAI Responses can report failures inside SSE events. Manifest was collecting those streams as successful empty completions.

### 👤 For users
Unavailable or failing deep-research calls now show the upstream error clearly.

### 📝 Notes
Fixes #2146

`o3-deep-research` was not added to discovery because the account does not list it.

Validated with focused backend tests, backend build, changeset status, and `git diff --check`.