### PR TITLE
fix: resolve provider aliases before checking subscription support

### DIFF
--- a/.changeset/gemini-subscription-alias-support.md
+++ b/.changeset/gemini-subscription-alias-support.md
@@ -1,0 +1,11 @@
+---
+"manifest": patch
+---
+
+Fix Gemini subscription not being recognized when provider is stored with alias 'google' instead of canonical 'gemini' id.
+
+The `isManifestUsableProvider` function was checking if a subscription provider was supported by looking up the provider name directly in `SUBSCRIPTION_PROVIDER_CONFIGS`. However, `SUBSCRIPTION_PROVIDER_CONFIGS` only has 'gemini' as a key, not 'google' (which is an alias for 'gemini' in the provider registry).
+
+When a subscription record was stored with `provider: 'google'` (the alias) instead of `provider: 'gemini'` (the canonical id), the check would fail and the provider would be incorrectly filtered out as "not usable" for routing.
+
+The fix resolves the provider to its canonical ID using the shared provider registry before checking subscription support, so both 'gemini' and 'google' are correctly recognized as supported subscription providers.

--- a/packages/backend/src/common/utils/subscription-support.spec.ts
+++ b/packages/backend/src/common/utils/subscription-support.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from '@jest/globals';
+import { isManifestUsableProvider, isSupportedSubscriptionProvider } from './subscription-support';
+
+describe('isSupportedSubscriptionProvider', () => {
+  it('returns true for gemini (canonical id)', () => {
+    expect(isSupportedSubscriptionProvider('gemini')).toBe(true);
+  });
+
+  it('returns false for google (alias of gemini) because SUBSCRIPTION_PROVIDER_CONFIGS key is gemini', () => {
+    // getSubscriptionProviderConfig normalizes the input to lowercase,
+    // but the SUBSCRIPTION_PROVIDER_CONFIGS key is 'gemini', not 'google',
+    // so this returns false. This is the pre-existing behavior of
+    // isSupportedSubscriptionProvider itself.
+    expect(isSupportedSubscriptionProvider('google')).toBe(false);
+  });
+});
+
+describe('isManifestUsableProvider', () => {
+  it('returns true for non-subscription auth records regardless of provider', () => {
+    expect(isManifestUsableProvider({ provider: 'gemini', auth_type: 'api_key' })).toBe(true);
+    expect(isManifestUsableProvider({ provider: 'google', auth_type: 'api_key' })).toBe(true);
+    expect(isManifestUsableProvider({ provider: 'openai', auth_type: 'api_key' })).toBe(true);
+  });
+
+  it('returns true for local auth type', () => {
+    expect(isManifestUsableProvider({ provider: 'gemini', auth_type: 'local' })).toBe(true);
+  });
+
+  it('returns true for subscription providers with canonical gemini id', () => {
+    expect(isManifestUsableProvider({ provider: 'gemini', auth_type: 'subscription' })).toBe(true);
+  });
+
+  it('returns true for subscription providers with google alias (bug fix)', () => {
+    // This is the key test for the bug fix. Before the fix, 'google' was not
+    // recognized as a supported subscription provider because the provider
+    // was not normalized to its canonical form ('gemini') before checking.
+    // After the fix, we resolve the provider to its canonical ID using the
+    // shared provider registry, so 'google' → 'gemini' → supported.
+    expect(isManifestUsableProvider({ provider: 'google', auth_type: 'subscription' })).toBe(true);
+  });
+
+  it('returns true for openai subscription', () => {
+    expect(isManifestUsableProvider({ provider: 'openai', auth_type: 'subscription' })).toBe(true);
+  });
+
+  it('returns false for unsupported subscription providers', () => {
+    expect(isManifestUsableProvider({ provider: 'deepseek', auth_type: 'subscription' })).toBe(
+      false,
+    );
+    expect(isManifestUsableProvider({ provider: 'groq', auth_type: 'subscription' })).toBe(false);
+  });
+
+  it('handles case-insensitive provider names', () => {
+    expect(isManifestUsableProvider({ provider: 'GEMINI', auth_type: 'subscription' })).toBe(true);
+    expect(isManifestUsableProvider({ provider: 'Google', auth_type: 'subscription' })).toBe(true);
+    expect(isManifestUsableProvider({ provider: 'OPENAI', auth_type: 'subscription' })).toBe(true);
+  });
+
+  it('handles null/undefined auth_type as non-subscription', () => {
+    expect(isManifestUsableProvider({ provider: 'gemini', auth_type: null })).toBe(true);
+    expect(isManifestUsableProvider({ provider: 'gemini', auth_type: undefined })).toBe(true);
+  });
+});

--- a/packages/backend/src/common/utils/subscription-support.ts
+++ b/packages/backend/src/common/utils/subscription-support.ts
@@ -1,15 +1,36 @@
 import type { AuthType } from 'manifest-shared';
-import { supportsSubscriptionProvider } from 'manifest-shared';
+import { supportsSubscriptionProvider, SHARED_PROVIDER_BY_ID_OR_ALIAS } from 'manifest-shared';
 
 type ProviderAuthRecord = {
   provider: string;
   auth_type?: AuthType | null;
 };
 
+/**
+ * Resolve a provider ID or alias to its canonical form using the shared provider
+ * registry. Returns the canonical ID (e.g. 'gemini' for 'google') or the original
+ * input if no match is found.
+ */
+function resolveCanonicalProviderId(provider: string): string {
+  const entry = SHARED_PROVIDER_BY_ID_OR_ALIAS.get(provider.toLowerCase());
+  return entry?.id ?? provider.toLowerCase();
+}
+
 export function isSupportedSubscriptionProvider(provider: string): boolean {
   return supportsSubscriptionProvider(provider);
 }
 
+/**
+ * Determines whether a provider record is usable for routing in Manifest.
+ *
+ * For subscription auth records, this also checks whether the provider is
+ * supported by Manifest's subscription system. Provider aliases (e.g. 'google'
+ * for 'gemini') are resolved to their canonical form before checking against
+ * the subscription config, so records stored with an alias are not incorrectly
+ * filtered out.
+ */
 export function isManifestUsableProvider(record: ProviderAuthRecord): boolean {
-  return record.auth_type !== 'subscription' || isSupportedSubscriptionProvider(record.provider);
+  if (record.auth_type !== 'subscription') return true;
+  const canonical = resolveCanonicalProviderId(record.provider);
+  return isSupportedSubscriptionProvider(canonical);
 }


### PR DESCRIPTION
## Summary

Fixes an issue where subscription providers stored with an alias (e.g. `google` instead of `gemini`) were incorrectly filtered out as unusable for routing.

### Root Cause

The `isManifestUsableProvider` function was checking if a subscription provider was supported by looking up the provider name directly in `SUBSCRIPTION_PROVIDER_CONFIGS`. However, `SUBSCRIPTION_PROVIDER_CONFIGS` only has `gemini` as a key, not `google` (which is an alias for `gemini` in the provider registry).

When a subscription record was stored with `provider: "google"` (the alias) instead of `provider: "gemini"` (the canonical id), the check would fail and the provider would be incorrectly filtered out as "not usable" for routing.

### Fix

The `isManifestUsableProvider` function now resolves the provider to its canonical ID using the shared provider registry (`SHARED_PROVIDER_BY_ID_OR_ALIAS`) before checking subscription support. This ensures that both `gemini` and `google` are correctly recognized as supported subscription providers.

### Changes

- `packages/backend/src/common/utils/subscription-support.ts`: Added `resolveCanonicalProviderId` helper and updated `isManifestUsableProvider` to use it
- `packages/backend/src/common/utils/subscription-support.spec.ts`: Added test coverage for the fix

### Testing

All existing tests pass. Added new tests to verify:
- Providers stored with alias (`google`) are correctly recognized
- Case-insensitive provider names work correctly
- Non-subscription auth types are unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix routing for subscription providers saved with an alias by resolving to canonical IDs before checking support. Ensures Gemini subscriptions are recognized when stored as "google".

- **Bug Fixes**
  - Resolve provider aliases to canonical IDs via `SHARED_PROVIDER_BY_ID_OR_ALIAS` in `isManifestUsableProvider`.
  - Added tests to verify alias handling and case-insensitive provider names; non-subscription auth types remain unaffected.

<sup>Written for commit 1b871581133014a9b7280eb8dd7b25c274953e35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

