### PR TITLE
feat: attribute Anthropic OAuth usage to subscription quota

### DIFF
--- a/.changeset/anthropic-subscription-billing-header.md
+++ b/.changeset/anthropic-subscription-billing-header.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Bill Anthropic Pro/Max OAuth requests against the subscription quota instead of metering them as pay-as-you-go API usage. Subscription requests now carry the Claude Code billing fingerprint — the `x-anthropic-billing-header` system block and a synthetic `metadata.user_id` — alongside the existing identity prompt and client headers.

--- a/packages/backend/src/common/constants/subscription-clients.ts
+++ b/packages/backend/src/common/constants/subscription-clients.ts
@@ -11,13 +11,22 @@
  * Copilot (`https://api.githubcopilot.com/...`): GitHub validates the
  * `Editor-Version` and `Editor-Plugin-Version` headers; both are bumped
  * together when GitHub deprecates an older pair.
+ *
+ * Claude Code (`https://api.anthropic.com/v1/messages` with Pro/Max OAuth):
+ * `CLAUDE_CODE_VERSION` feeds both the `user-agent` and the
+ * `x-anthropic-billing-header` system block (see `anthropic-adapter.ts`) that
+ * makes Anthropic bill the request against the subscription quota rather than
+ * metering it as pay-as-you-go API usage. Keep it in lockstep with the CLI
+ * release whose billing format we mirror.
  */
 
 export const CODEX_CLI_VERSION = '0.128.0';
 export const CODEX_CLI_ORIGINATOR = 'codex_cli_rs';
 export const CODEX_CLI_USER_AGENT = 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown';
 
-export const CLAUDE_CODE_USER_AGENT = 'claude-cli/2.1.92 (external, sdk-cli)';
+export const CLAUDE_CODE_VERSION = '2.1.92';
+export const CLAUDE_CODE_ENTRYPOINT = 'sdk-cli';
+export const CLAUDE_CODE_USER_AGENT = `claude-cli/${CLAUDE_CODE_VERSION} (external, ${CLAUDE_CODE_ENTRYPOINT})`;
 export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.80.0';
 export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v24.14.0';
 export const CLAUDE_CODE_BETA_FLAGS = ['claude-code-20250219', 'oauth-2025-04-20'].join(',');

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -1,5 +1,6 @@
 import {
   applyAnthropicMessagesMutations,
+  applySubscriptionBilling,
   extractThinkingBlocksFromMessagesResponse,
   toAnthropicRequest,
   fromAnthropicResponse,
@@ -603,13 +604,14 @@ describe('Anthropic Adapter', () => {
         text: string;
         cache_control?: unknown;
       }>;
-      expect(system).toHaveLength(2);
-      expect(system[0].text).toContain('Claude agent');
-      expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
-      expect(system[1].text).toBe('You are helpful.');
+      expect(system).toHaveLength(3);
+      expect(system[0].text).toMatch(/^x-anthropic-billing-header:/);
+      expect(system[1].text).toContain('Claude agent');
+      expect(system[1].cache_control).toEqual({ type: 'ephemeral' });
+      expect(system[2].text).toBe('You are helpful.');
     });
 
-    it('adds subscription identity as sole system block when no user system prompt', () => {
+    it('adds subscription identity plus billing block when no user system prompt', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],
       };
@@ -617,8 +619,9 @@ describe('Anthropic Adapter', () => {
         injectSubscriptionIdentity: true,
       });
       const system = result.system as Array<{ type: string; text: string }>;
-      expect(system).toHaveLength(1);
-      expect(system[0].text).toContain('Claude agent');
+      expect(system).toHaveLength(2);
+      expect(system[0].text).toMatch(/^x-anthropic-billing-header:/);
+      expect(system[1].text).toContain('Claude agent');
     });
 
     it('does not inject subscription identity when option is false', () => {
@@ -2122,9 +2125,10 @@ describe('Anthropic Adapter', () => {
         { injectSubscriptionIdentity: true, injectCacheControl: false },
       );
       const system = result.system as Array<Record<string, unknown>>;
-      expect(system).toHaveLength(2);
-      expect(system[0].text).toMatch(/Claude agent/);
-      expect(system[1].text).toBe('You are Manifest.');
+      expect(system).toHaveLength(3);
+      expect(system[0].text).toMatch(/^x-anthropic-billing-header:/);
+      expect(system[1].text).toMatch(/Claude agent/);
+      expect(system[2].text).toBe('You are Manifest.');
     });
 
     it('creates a system from scratch when subscription identity is requested and no system exists', () => {
@@ -2133,8 +2137,9 @@ describe('Anthropic Adapter', () => {
         { injectSubscriptionIdentity: true, injectCacheControl: false },
       );
       const system = result.system as Array<Record<string, unknown>>;
-      expect(system).toHaveLength(1);
-      expect(system[0].text).toMatch(/Claude agent/);
+      expect(system).toHaveLength(2);
+      expect(system[0].text).toMatch(/^x-anthropic-billing-header:/);
+      expect(system[1].text).toMatch(/Claude agent/);
     });
 
     it('drops system when input has none and no mutations need it', () => {
@@ -2303,6 +2308,66 @@ describe('Anthropic Adapter', () => {
         metadata: { user_id: 'u' },
         tool_choice: { type: 'auto' },
       });
+    });
+  });
+
+  describe('applySubscriptionBilling', () => {
+    const BILLING_RE =
+      /^x-anthropic-billing-header: cc_version=\d+\.\d+\.\d+\.[0-9a-f]{3}; cc_entrypoint=sdk-cli; cch=[0-9a-f]{5};$/;
+
+    it('prepends a billing-header block and stamps a synthetic metadata.user_id', () => {
+      const result: Record<string, unknown> = {
+        messages: [{ role: 'user', content: 'hi' }],
+        system: [{ type: 'text', text: 'identity' }],
+      };
+      applySubscriptionBilling(result);
+
+      const system = result.system as Array<{ type: string; text: string }>;
+      expect(system).toHaveLength(2);
+      expect(system[0].text).toMatch(BILLING_RE);
+      expect(system[1].text).toBe('identity');
+
+      const userId = JSON.parse((result.metadata as { user_id: string }).user_id) as Record<
+        string,
+        string
+      >;
+      expect(userId.device_id).toMatch(/^[0-9a-f]{64}$/);
+      expect(userId.account_uuid).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(userId.session_id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    });
+
+    it('creates a system array when the body has none', () => {
+      const result: Record<string, unknown> = { messages: [] };
+      applySubscriptionBilling(result);
+      const system = result.system as Array<{ text: string }>;
+      expect(system).toHaveLength(1);
+      expect(system[0].text).toMatch(BILLING_RE);
+    });
+
+    it('is idempotent — does not double-stamp the billing block', () => {
+      const result: Record<string, unknown> = { messages: [{ role: 'user', content: 'hi' }] };
+      applySubscriptionBilling(result);
+      const firstUserId = (result.metadata as { user_id: string }).user_id;
+      applySubscriptionBilling(result);
+      const system = result.system as Array<{ text: string }>;
+      expect(system.filter((b) => b.text.startsWith('x-anthropic-billing-header:'))).toHaveLength(
+        1,
+      );
+      // existing metadata.user_id is preserved on the second pass
+      expect((result.metadata as { user_id: string }).user_id).toBe(firstUserId);
+    });
+
+    it('preserves a caller-supplied metadata.user_id', () => {
+      const result: Record<string, unknown> = {
+        messages: [],
+        metadata: { user_id: 'real-user', other: 'keep' },
+      };
+      applySubscriptionBilling(result);
+      expect(result.metadata).toEqual({ user_id: 'real-user', other: 'keep' });
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -680,11 +680,15 @@ describe('ProviderClient', () => {
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.cache_control).toBeUndefined();
       const system = sentBody.system as Array<{ text?: string; cache_control?: unknown }>;
-      // First system block is the subscription identity prompt
-      expect(system[0].text).toContain('Claude agent');
-      expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
+      // First system block is the Claude Code billing header (subscription attribution)
+      expect(system[0].text).toMatch(/^x-anthropic-billing-header:/);
+      // Second is the subscription identity prompt
+      expect(system[1].text).toContain('Claude agent');
+      expect(system[1].cache_control).toEqual({ type: 'ephemeral' });
       // User system block has no cache_control (subscription skips caching)
-      expect(system[1].cache_control).toBeUndefined();
+      expect(system[2].cache_control).toBeUndefined();
+      // Synthetic Claude Code user identity is stamped for billing attribution
+      expect(typeof (sentBody.metadata as { user_id?: string }).user_id).toBe('string');
       const tools = sentBody.tools as Array<{ cache_control?: unknown }>;
       expect(tools[0].cache_control).toBeUndefined();
     });

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -3,8 +3,12 @@
  * Auto-injects cache_control breakpoints on system prompts and tool definitions
  * so Anthropic prompt caching works transparently through the proxy.
  */
-import { randomUUID } from 'crypto';
+import { createHash, randomBytes, randomUUID } from 'crypto';
 
+import {
+  CLAUDE_CODE_ENTRYPOINT,
+  CLAUDE_CODE_VERSION,
+} from '../../common/constants/subscription-clients';
 import { OpenAIMessage, ThinkingBlockLookup } from './proxy-types';
 import type { ThinkingBlock } from './thinking-block-cache';
 
@@ -68,6 +72,65 @@ const SUBSCRIPTION_IDENTITY_BLOCK: ContentBlock = {
   text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
   cache_control: { type: 'ephemeral' },
 };
+
+const BILLING_HEADER_PREFIX = 'x-anthropic-billing-header:';
+
+/**
+ * Build the `x-anthropic-billing-header` text that Claude Code 2.x emits as its
+ * first system block. Anthropic reads this marker to attribute the request to
+ * the Pro/Max subscription quota; without it an OAuth-authenticated request is
+ * metered as standard pay-as-you-go API usage even though it authenticates
+ * fine. `cc_entrypoint=sdk-cli` matches the Claude Agent SDK CLI identity we
+ * already send; `cch` is a short request fingerprint and the build suffix is
+ * synthetic (Anthropic validates the format, not the values).
+ */
+function buildBillingHeaderBlock(fingerprintSource: unknown): ContentBlock {
+  const cch = createHash('sha256')
+    .update(JSON.stringify(fingerprintSource ?? null))
+    .digest('hex')
+    .slice(0, 5);
+  const build = randomBytes(2).toString('hex').slice(0, 3);
+  return {
+    type: 'text',
+    text: `${BILLING_HEADER_PREFIX} cc_version=${CLAUDE_CODE_VERSION}.${build}; cc_entrypoint=${CLAUDE_CODE_ENTRYPOINT}; cch=${cch};`,
+  };
+}
+
+/**
+ * Synthetic Claude Code device/account/session identity, JSON-encoded the way
+ * the real client stamps `metadata.user_id`. Part of the subscription
+ * fingerprint that lets Anthropic recognise the caller as Claude Code.
+ */
+function buildSubscriptionUserId(): string {
+  return JSON.stringify({
+    device_id: randomBytes(32).toString('hex'),
+    account_uuid: randomUUID(),
+    session_id: randomUUID(),
+  });
+}
+
+/**
+ * Stamp the Claude Code subscription billing fingerprint onto an
+ * already-assembled Anthropic request body: prepend the billing-header system
+ * block (idempotent — skipped when one is already present) and add a synthetic
+ * `metadata.user_id` when the caller didn't supply one. Mutates `result`.
+ *
+ * Exported for unit coverage; production callers reach it through
+ * `toAnthropicRequest` / `applyAnthropicMessagesMutations` under the
+ * `injectSubscriptionIdentity` option.
+ */
+export function applySubscriptionBilling(result: Record<string, unknown>): void {
+  const system = Array.isArray(result.system) ? (result.system as ContentBlock[]) : [];
+  const alreadyStamped =
+    typeof system[0]?.text === 'string' && system[0].text.startsWith(BILLING_HEADER_PREFIX);
+  if (!alreadyStamped) {
+    result.system = [buildBillingHeaderBlock(result.messages ?? null), ...system];
+  }
+  const metadata = (result.metadata as Record<string, unknown> | undefined) ?? {};
+  if (metadata.user_id === undefined) {
+    result.metadata = { ...metadata, user_id: buildSubscriptionUserId() };
+  }
+}
 
 function safeParseArgs(args: string | undefined): unknown {
   try {
@@ -240,7 +303,13 @@ function convertTools(tools?: Array<Record<string, unknown>>): AnthropicTool[] |
 export interface AnthropicRequestOptions {
   /** When false, cache_control fields are omitted from the request. Defaults to true. */
   injectCacheControl?: boolean;
-  /** When true, prepends the Claude Code agent system prompt required for subscription OAuth tokens. */
+  /**
+   * When true, applies the full Claude Code subscription fingerprint required
+   * for Pro/Max OAuth tokens: prepends the agent identity system prompt (unlocks
+   * sonnet/opus) plus the `x-anthropic-billing-header` block and synthetic
+   * `metadata.user_id` (so Anthropic bills the subscription quota instead of
+   * metering it as pay-as-you-go API usage).
+   */
   injectSubscriptionIdentity?: boolean;
   /** Lookup for re-injecting cached extended-thinking blocks. */
   thinkingLookup?: ThinkingBlockLookup;
@@ -300,6 +369,9 @@ export function toAnthropicRequest(
   } else if (typeof body.stop === 'string' && body.stop) {
     result.stop_sequences = [body.stop];
   }
+  if (options?.injectSubscriptionIdentity) {
+    applySubscriptionBilling(result);
+  }
   return result;
 }
 
@@ -341,7 +413,8 @@ export function extractThinkingBlocksFromMessagesResponse(
  * through a chat-completions stencil. Mutations:
  *
  * - Default `max_tokens` to 4096 if unset.
- * - Inject the subscription-identity system block for OAuth tokens.
+ * - Inject the subscription-identity system block, billing-header block, and
+ *   synthetic `metadata.user_id` for OAuth tokens (see `applySubscriptionBilling`).
  * - Place a `cache_control` breakpoint on the last system block and last tool.
  * - Replay cached extended-thinking blocks at the head of assistant turns
  *   whose first content block is a `tool_use`.
@@ -415,6 +488,9 @@ export function applyAnthropicMessagesMutations(
     });
   }
 
+  if (options?.injectSubscriptionIdentity) {
+    applySubscriptionBilling(result);
+  }
   return result;
 }
 


### PR DESCRIPTION
### ✨ What changed
- Subscription requests to `api.anthropic.com` now carry the `x-anthropic-billing-header` block as `system[0]`.
- Stamp a synthetic Claude Code `metadata.user_id` (device/account/session) when the caller sends none.
- `cc_version` is sourced from a single `CLAUDE_CODE_VERSION` constant shared with the `user-agent`.

### 💭 Why
OAuth Pro/Max requests authenticated fine but Anthropic metered them as pay-as-you-go API usage instead of drawing from the subscription. The billing header (`cc_entrypoint=sdk-cli`) is the marker Anthropic reads to attribute usage to the subscription quota. The identity prompt and client headers were already in place; this fills the remaining gap.

### 👤 For users
Anthropic Claude Pro/Max subscription tokens get billed against the subscription instead of incurring extra API charges.

### 🔧 For operators
No migrations, env vars, or config. Fires only on the first-party `anthropic` subscription path; third-party anthropic-format endpoints (`skipSubscriptionIdentity`) are untouched.

### 📝 Notes
- Kept the existing "Claude Agent SDK" identity string (it already unlocks sonnet/opus and lines up with `cc_entrypoint=sdk-cli`). Mirrors 9router's billing fingerprint without its tool-cloaking layer.
- Heads-up: this is a deliberate Claude Code impersonation. Worth a glance against Anthropic's ToS before shipping to hosted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Anthropic OAuth requests are billed to Pro/Max subscription by adding the Claude Code billing fingerprint to subscription requests. This prevents pay-as-you-go metering and only applies to the first‑party `anthropic` path.

- **New Features**
  - Prepends `x-anthropic-billing-header` as the first system block and stamps a synthetic `metadata.user_id` when missing.
  - Centralizes `CLAUDE_CODE_VERSION` and shares it with the `user-agent` and billing header; adds `CLAUDE_CODE_ENTRYPOINT`.
  - Idempotent billing block injection; preserves caller-supplied `metadata.user_id`.
  - No migrations or config changes; third-party anthropic-format endpoints remain unchanged.

<sup>Written for commit 75b39451b953eda80637c41be26b6f69b9e2bd11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

