### PR TITLE
fix: resolve subscription provider aliases

### DIFF
--- a/.changeset/gemini-subscription-alias-support.md
+++ b/.changeset/gemini-subscription-alias-support.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Resolve subscription provider aliases before checking subscription support so Gemini subscriptions stored or registered as "google" remain usable for routing.

--- a/packages/backend/src/common/utils/subscription-support.spec.ts
+++ b/packages/backend/src/common/utils/subscription-support.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from '@jest/globals';
+import { isManifestUsableProvider, isSupportedSubscriptionProvider } from './subscription-support';
+
+describe('subscription-support helpers', () => {
+  it('recognizes canonical subscription provider ids', () => {
+    expect(isSupportedSubscriptionProvider('gemini')).toBe(true);
+    expect(isManifestUsableProvider({ provider: 'gemini', auth_type: 'subscription' })).toBe(true);
+  });
+
+  it('recognizes subscription provider aliases', () => {
+    expect(isSupportedSubscriptionProvider('google')).toBe(true);
+    expect(isManifestUsableProvider({ provider: 'google', auth_type: 'subscription' })).toBe(true);
+  });
+
+  it('keeps non-subscription auth records usable regardless of provider support', () => {
+    expect(isManifestUsableProvider({ provider: 'deepseek', auth_type: 'api_key' })).toBe(true);
+    expect(isManifestUsableProvider({ provider: 'deepseek', auth_type: null })).toBe(true);
+  });
+
+  it('rejects unsupported subscription providers', () => {
+    expect(isSupportedSubscriptionProvider('deepseek')).toBe(false);
+    expect(isManifestUsableProvider({ provider: 'deepseek', auth_type: 'subscription' })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -538,6 +538,23 @@ describe('ProviderService — route-only cleanup paths', () => {
       expect(autoAssign.recalculate).not.toHaveBeenCalled();
     });
 
+    it('keeps supported subscription rows that use provider aliases', async () => {
+      const googleSubscription = {
+        id: 'p1',
+        agent_id: 'agent-1',
+        provider: 'google',
+        auth_type: 'subscription',
+        is_active: true,
+      } as UserProvider;
+      providerRepo.find.mockResolvedValue([googleSubscription]);
+
+      const result = await svc.getProviders('agent-1');
+
+      expect(result).toEqual([googleSubscription]);
+      expect(providerRepo.save).not.toHaveBeenCalled();
+      expect(autoAssign.recalculate).not.toHaveBeenCalled();
+    });
+
     it('deactivates unsupported subscription rows and triggers cleanup when no usable sibling remains', async () => {
       // Pretend 'foobar' is an unsupported subscription provider — neither
       // anthropic nor any usable sibling stays for the same provider.
@@ -580,6 +597,39 @@ describe('ProviderService — route-only cleanup paths', () => {
       const result = await svc.getProviders('agent-1');
       expect(result).toBe(cached);
       expect(providerRepo.find).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('registerSubscriptionProvider', () => {
+    it('registers keyless subscription providers that use provider aliases', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+
+      const result = await svc.registerSubscriptionProvider('agent-1', 'user-1', 'google');
+
+      expect(result).toEqual({ isNew: true });
+      expect(providerRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: 'user-1',
+          agent_id: 'agent-1',
+          provider: 'google',
+          auth_type: 'subscription',
+          label: 'Default',
+          priority: 0,
+          api_key_encrypted: null,
+          key_prefix: null,
+          is_active: true,
+        }),
+      );
+      expect(autoAssign.recalculate).toHaveBeenCalledWith('agent-1');
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('still ignores unsupported keyless subscription providers', async () => {
+      const result = await svc.registerSubscriptionProvider('agent-1', 'user-1', 'deepseek');
+
+      expect(result).toEqual({ isNew: false });
+      expect(providerRepo.insert).not.toHaveBeenCalled();
+      expect(autoAssign.recalculate).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -242,6 +242,11 @@ describe('getSubscriptionProviderConfig', () => {
     expect(getSubscriptionProviderConfig('OpenAI')).not.toBeNull();
   });
 
+  it('resolves provider aliases to subscription configs', () => {
+    expect(getSubscriptionProviderConfig('google')).toBe(getSubscriptionProviderConfig('gemini'));
+    expect(getSubscriptionProviderConfig('Google')).toBe(getSubscriptionProviderConfig('gemini'));
+  });
+
   it('returns null for unsupported providers', () => {
     expect(getSubscriptionProviderConfig('unknown')).toBeNull();
   });
@@ -267,6 +272,11 @@ describe('supportsSubscriptionProvider', () => {
     expect(supportsSubscriptionProvider('opencode-go')).toBe(true);
     expect(supportsSubscriptionProvider('gemini')).toBe(true);
     expect(supportsSubscriptionProvider('xai')).toBe(true);
+  });
+
+  it('returns true for aliases of supported providers', () => {
+    expect(supportsSubscriptionProvider('google')).toBe(true);
+    expect(supportsSubscriptionProvider('Google')).toBe(true);
   });
 
   it('returns false for unsupported providers', () => {

--- a/packages/shared/src/subscription/helpers.ts
+++ b/packages/shared/src/subscription/helpers.ts
@@ -1,8 +1,15 @@
 import type { SubscriptionCapabilities, SubscriptionProviderConfig } from './types';
 import { SUBSCRIPTION_PROVIDER_CONFIGS } from './configs';
+import { normalizeProviderName, SHARED_PROVIDER_BY_ID_OR_ALIAS } from '../providers';
 
 function normalizeProviderId(providerId: string): string {
-  return String(providerId || '').toLowerCase();
+  const lower = String(providerId || '')
+    .trim()
+    .toLowerCase();
+  const entry =
+    SHARED_PROVIDER_BY_ID_OR_ALIAS.get(lower) ??
+    SHARED_PROVIDER_BY_ID_OR_ALIAS.get(normalizeProviderName(lower));
+  return entry?.id ?? lower;
 }
 
 export function getSubscriptionProviderConfig(


### PR DESCRIPTION
## Summary

- Make shared subscription provider lookup resolve registered provider aliases before checking `SUBSCRIPTION_PROVIDER_CONFIGS`.
- Keep Gemini subscription rows stored as `google` usable instead of deactivating/filtering them as unsupported.
- Cover the keyless `/api/v1/routing/subscription-providers` path so alias registrations are not ignored.

## Context

This supersedes and builds on mnfst/manifest#2173. That PR correctly identified the bug, but fixed only `isManifestUsableProvider`; the keyless registration path still called `isSupportedSubscriptionProvider(provider)` directly, so `provider: "google"` could still be ignored before a row was inserted.

The commit includes:

Co-authored-by: phantomic12 <phantomic12@users.noreply.github.com>

## Validation

- `npm --workspace packages/shared run test -- subscription.spec.ts --runInBand`
- `npm --workspace packages/shared run build`
- `npm --workspace packages/backend run test -- subscription-support.spec.ts --runInBand`
- `npm --workspace packages/backend run test -- routing-core/__tests__/provider.service.spec.ts --runInBand`
- `npm --workspace packages/backend run build`
- `npx changeset status --since=upstream/main`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve subscription provider aliases before support checks. Keeps Gemini subscriptions stored or registered as `google` usable, and makes keyless registration honor aliases.

- **Bug Fixes**
  - Resolve aliases in shared subscription lookup before checking `SUBSCRIPTION_PROVIDER_CONFIGS`.
  - Honor aliases in the keyless `/api/v1/routing/subscription-providers` path to allow inserting `google` subscriptions.
  - Preserve active `google` subscription rows during routing cleanup instead of deactivating them.

<sup>Written for commit 96eba2db2aecdc3d4e767a7d9a31efa3b2bb1d0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

