### PR TITLE
fix: correct the Anthropic subscription model catalog

### DIFF
--- a/.changeset/anthropic-fast-model-catalog.md
+++ b/.changeset/anthropic-fast-model-catalog.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Stop offering Anthropic `claude-*-fast` models in the subscription catalog. Those ids come from the pricing cache but 404 at `api.anthropic.com` — fast mode is an `anthropic-beta` header on the base Opus model, not a model id. Routing to them returned "model not found"; they're now filtered out via a per-provider `knownModelsExclude`.

--- a/.changeset/anthropic-fast-model-catalog.md
+++ b/.changeset/anthropic-fast-model-catalog.md
@@ -2,4 +2,4 @@
 "manifest": patch
 ---
 
-Stop offering Anthropic `claude-*-fast` models in the subscription catalog. Those ids come from the pricing cache but 404 at `api.anthropic.com` — fast mode is an `anthropic-beta` header on the base Opus model, not a model id. Routing to them returned "model not found"; they're now filtered out via a per-provider `knownModelsExclude`.
+Fix the Anthropic subscription model catalog. Drop the `claude-*-fast` ids it pulled from the pricing cache — those 404 at `api.anthropic.com` because fast mode is an `anthropic-beta` header on the base Opus model, not a model id. Also add `claude-fable-5` (Claude Fable 5), a new subscription model that didn't match the existing `claude-*-4` prefixes.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1370,6 +1370,7 @@ describe('ModelDiscoveryService', () => {
 
       expect(fetcher.fetch).not.toHaveBeenCalled();
       expect(result.map((m) => m.id)).toEqual([
+        'claude-fable-5',
         'claude-opus-4',
         'claude-sonnet-4',
         'claude-haiku-4',
@@ -1667,9 +1668,11 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Should only include models matching knownModels prefixes (claude-opus-4, claude-sonnet-4, claude-haiku-4)
-      // and NOT claude-2.1 or openai models
-      expect(result).toHaveLength(3);
+      // and NOT claude-2.1 or openai models. claude-fable-5 has no OpenRouter
+      // pricing entry, so it is appended directly as a zero-cost known model.
+      expect(result).toHaveLength(4);
       expect(result.map((m) => m.id).sort()).toEqual([
+        'claude-fable-5',
         'claude-haiku-4-20260301',
         'claude-opus-4-20260301',
         'claude-sonnet-4-20260301',
@@ -1867,8 +1870,9 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Even without pricingSync, knownModels are returned directly
-      expect(result).toHaveLength(3);
+      expect(result).toHaveLength(4);
       expect(result.map((m) => m.id).sort()).toEqual([
+        'claude-fable-5',
         'claude-haiku-4',
         'claude-opus-4',
         'claude-sonnet-4',
@@ -2246,8 +2250,9 @@ describe('ModelDiscoveryService', () => {
       const result = buildSubscriptionFallbackModels(null as never, 'anthropic');
 
       // No OpenRouter data, but knownModels are added directly
-      expect(result).toHaveLength(3);
+      expect(result).toHaveLength(4);
       expect(result.map((m) => m.id).sort()).toEqual([
+        'claude-fable-5',
         'claude-haiku-4',
         'claude-opus-4',
         'claude-sonnet-4',

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -300,6 +300,16 @@ describe('buildSubscriptionFallbackModels', () => {
     expect(ids.some((id) => id.includes('-fast'))).toBe(false);
   });
 
+  it('surfaces claude-fable-5 even when the pricing cache lacks it', () => {
+    // claude-fable-5 is a valid Anthropic subscription model with no pricing
+    // cache entry; the knownModels fallback must still offer it.
+    const ids = buildSubscriptionFallbackModels(makePricingSync(new Map()), 'anthropic').map(
+      (m) => m.id,
+    );
+
+    expect(ids).toContain('claude-fable-5');
+  });
+
   it('returns [] for opencode-go because its catalog is fetched dynamically', () => {
     // OpenCode Go has no hardcoded knownModels. The fallback path must stay empty
     // so we do not fabricate stale entries when the live catalog is unreachable.

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -280,6 +280,26 @@ describe('buildSubscriptionFallbackModels', () => {
     expect(result.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('excludes Anthropic claude-*-fast pseudo-models that 404 at the API', () => {
+    const cache = new Map([
+      [
+        'anthropic/claude-opus-4-8',
+        { input: 0.015, output: 0.075, displayName: 'Claude Opus 4.8' },
+      ],
+      [
+        'anthropic/claude-opus-4.8-fast',
+        { input: 0.015, output: 0.075, displayName: 'Claude Opus 4.8 (fast)' },
+      ],
+    ]);
+
+    const ids = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic').map(
+      (m) => m.id,
+    );
+
+    expect(ids).toContain('claude-opus-4-8');
+    expect(ids.some((id) => id.includes('-fast'))).toBe(false);
+  });
+
   it('returns [] for opencode-go because its catalog is fetched dynamically', () => {
     // OpenCode Go has no hardcoded knownModels. The fallback path must stay empty
     // so we do not fabricate stale entries when the live catalog is unreachable.

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -6,6 +6,7 @@ import {
 import {
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
+  getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
 } from 'manifest-shared';
 import { normalizeAnthropicShortModelId } from '../common/utils/anthropic-model-id';
@@ -232,6 +233,9 @@ export function buildSubscriptionFallbackModels(
   if (!knownPrefixes) return [];
   const normalizedKnownPrefixes = knownPrefixes.map((modelId) => modelId.toLowerCase());
   const matchMode = getSubscriptionKnownModelsMatch(providerId);
+  const excludedSubstrings = getSubscriptionExcludedModels(providerId).map((s) => s.toLowerCase());
+  const isExcluded = (lowerId: string): boolean =>
+    excludedSubstrings.some((sub) => lowerId.includes(sub));
 
   const capabilities = getSubscriptionCapabilities(providerId);
   const models: DiscoveredModel[] = [];
@@ -249,6 +253,9 @@ export function buildSubscriptionFallbackModels(
           ? normalizedKnownPrefixes.includes(lowerId)
           : normalizedKnownPrefixes.some((p: string) => lowerId.startsWith(p));
       if (!matches) continue;
+      // Drop pricing-cache pseudo-models (e.g. Anthropic `claude-*-fast`) that
+      // match a known prefix but 404 at the subscription endpoint.
+      if (isExcluded(lowerId)) continue;
       if (seen.has(modelId)) continue;
       seen.add(modelId);
 

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -290,6 +290,7 @@ describe('supportsSubscriptionProvider', () => {
 describe('getSubscriptionKnownModels', () => {
   it('returns known models for anthropic', () => {
     const models = getSubscriptionKnownModels('anthropic');
+    expect(models).toContain('claude-fable-5');
     expect(models).toContain('claude-opus-4');
     expect(models).toContain('claude-sonnet-4');
   });

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -5,6 +5,7 @@ import {
   supportsSubscriptionProvider,
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
+  getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
 } from '../src/subscription';
 
@@ -411,6 +412,20 @@ describe('getSubscriptionKnownModelsMatch', () => {
   it('is case-insensitive', () => {
     expect(getSubscriptionKnownModelsMatch('GEMINI')).toBe('exact');
     expect(getSubscriptionKnownModelsMatch('Anthropic')).toBe('prefix');
+  });
+});
+
+describe('getSubscriptionExcludedModels', () => {
+  it('returns the -fast exclusion for anthropic', () => {
+    expect(getSubscriptionExcludedModels('anthropic')).toEqual(['-fast']);
+  });
+
+  it('returns an empty array for providers with no exclusion configured', () => {
+    expect(getSubscriptionExcludedModels('gemini')).toEqual([]);
+  });
+
+  it('returns an empty array for unknown providers', () => {
+    expect(getSubscriptionExcludedModels('unknown')).toEqual([]);
   });
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -108,6 +108,7 @@ export {
   supportsSubscriptionProvider,
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
+  getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
 } from './subscription';
 export type { SubscriptionCapabilities, SubscriptionProviderConfig } from './subscription';

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -10,7 +10,12 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionKeyPlaceholder: 'Paste your setup-token',
     subscriptionCommand: 'claude setup-token',
     subscriptionTokenPrefix: 'sk-ant-oat',
-    knownModels: Object.freeze(['claude-opus-4', 'claude-sonnet-4', 'claude-haiku-4']),
+    knownModels: Object.freeze([
+      'claude-fable-5',
+      'claude-opus-4',
+      'claude-sonnet-4',
+      'claude-haiku-4',
+    ]),
     // `claude-*-fast` ids exist in the OpenRouter pricing cache but 404 at
     // api.anthropic.com — fast mode is an `anthropic-beta` header on the base
     // Opus model, not a distinct model id. Keep them out of the catalog.

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -11,6 +11,10 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionCommand: 'claude setup-token',
     subscriptionTokenPrefix: 'sk-ant-oat',
     knownModels: Object.freeze(['claude-opus-4', 'claude-sonnet-4', 'claude-haiku-4']),
+    // `claude-*-fast` ids exist in the OpenRouter pricing cache but 404 at
+    // api.anthropic.com — fast mode is an `anthropic-beta` header on the base
+    // Opus model, not a distinct model id. Keep them out of the catalog.
+    knownModelsExclude: Object.freeze(['-fast']),
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
       supportsPromptCaching: false,

--- a/packages/shared/src/subscription/helpers.ts
+++ b/packages/shared/src/subscription/helpers.ts
@@ -36,6 +36,11 @@ export function getSubscriptionKnownModelsMatch(providerId: string): 'prefix' | 
   return config?.knownModelsMatch ?? 'prefix';
 }
 
+export function getSubscriptionExcludedModels(providerId: string): readonly string[] {
+  const config = getSubscriptionProviderConfig(providerId);
+  return config?.knownModelsExclude ?? [];
+}
+
 export function getSubscriptionCapabilities(
   providerId: string,
 ): Readonly<SubscriptionCapabilities> | null {

--- a/packages/shared/src/subscription/index.ts
+++ b/packages/shared/src/subscription/index.ts
@@ -5,5 +5,6 @@ export {
   supportsSubscriptionProvider,
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
+  getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
 } from './helpers';

--- a/packages/shared/src/subscription/types.ts
+++ b/packages/shared/src/subscription/types.ts
@@ -22,5 +22,13 @@ export interface SubscriptionProviderConfig {
    *     strict whitelist (Gemini CodeAssist 404s on suffixed variants).
    */
   knownModelsMatch?: 'prefix' | 'exact';
+  /**
+   * Case-insensitive substrings that disqualify a model id from the curated
+   * subscription catalog, even when it matches `knownModels`. Used to drop
+   * pricing-cache entries that look like real models but 404 at the
+   * subscription endpoint — e.g. Anthropic's `claude-*-fast` ids, where "fast
+   * mode" is an `anthropic-beta` header on the base model, not a model id.
+   */
+  knownModelsExclude?: readonly string[];
   subscriptionCapabilities?: Readonly<SubscriptionCapabilities>;
 }


### PR DESCRIPTION
### ✨ What changed
- Add `knownModelsExclude` to subscription configs; set `['-fast']` on Anthropic so `claude-*-fast` ids are dropped from the curated catalog.
- Add `claude-fable-5` (Claude Fable 5) to the Anthropic `knownModels` — a new subscription model that didn't match the existing `claude-*-4` prefixes.

### 💭 Why
The curated Anthropic catalog prefix-matches the OpenRouter pricing cache. That pulled in `claude-opus-4.8-fast` (and 4.7/4.6), which 404 at `api.anthropic.com` — fast mode is an `anthropic-beta` header on the base Opus model, not a model id. Meanwhile `claude-fable-5` is a real subscription model that never showed up because no prefix covered it.

### 👤 For users
Anthropic subscription model lists and tier routing drop the `-fast` ids that 404, and now offer Claude Fable 5.

### 📝 Notes
- Verified live against the connected subscription: `/v1/models` lists `claude-fable-5`; a `/v1/messages` call returns 429 (rate limit), not 404 — so the id is valid and routable. `claude-opus-4.8-fast` returned 404 `not_found_error`.
- Real fast-mode support (base Opus + `fast-mode-*` beta header) is out of scope; follow-up if wanted.
- Found while testing #2175 (subscription billing): a `default`-tier override set to `claude-opus-4.8-fast` 404'd.