### PR TITLE
feat: enrich provider pages

### DIFF
--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -246,10 +246,10 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ renamed: true, name: 'bot-renamed', display_name: 'Bot Renamed' });
     expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'bot-renamed', 'Bot Renamed');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
-    // The Messages-filter variant (?includeSystem=true) is a distinct cache
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
+    // The Messages-filter variant (system agents included) is a distinct cache
     // entry and must also be cleared so it never goes stale after a rename.
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents?includeSystem=true');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
   });
 
   it('rejects rename with empty slug', async () => {
@@ -280,7 +280,10 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ deleted: true });
     expect(mockDeleteAgent).toHaveBeenCalledWith('u1', 'bot-1');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+    // Both canonical variants are cleared so neither the Workspace list nor the
+    // Messages filter (system agents included) goes stale after a delete.
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
   });
 
   it('passes agent_category and agent_platform to onboardAgent', async () => {
@@ -505,7 +508,7 @@ describe('AgentsController', () => {
     const result = await ctrl.createAgent(user as never, { name: 'My Agent' } as never);
 
     expect(result.agent.name).toBe('my-agent');
-    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=false');
   });
 
   it('rejects createAgent with empty slug', async () => {
@@ -627,7 +630,7 @@ describe('AgentsController', () => {
       name: 'bot-copy',
       displayName: 'Bot Copy',
     });
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
   });
 
   it('rejects duplicateAgent with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -508,7 +508,10 @@ describe('AgentsController', () => {
     const result = await ctrl.createAgent(user as never, { name: 'My Agent' } as never);
 
     expect(result.agent.name).toBe('my-agent');
+    // Both canonical variants are cleared so neither the Workspace list nor the
+    // Messages filter (system agents included) goes stale after a create.
     expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=false');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=true');
   });
 
   it('rejects createAgent with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -26,8 +26,8 @@ import { AuthUser } from '../../auth/auth.instance';
 import { CreateAgentDto } from '../../common/dto/create-agent.dto';
 import { DuplicateAgentDto } from '../../common/dto/duplicate-agent.dto';
 import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
-import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
-import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { AgentListCacheInterceptor } from '../../common/interceptors/agent-list-cache.interceptor';
+import { AGENT_LIST_CACHE_TTL_MS, agentListCacheKey } from '../../common/constants/cache.constants';
 import { slugify } from '../../common/utils/slugify';
 import { PLAYGROUND_AGENT_SLUG } from '../../common/constants/playground.constants';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
@@ -49,17 +49,17 @@ export class AgentsController {
   ) {}
 
   private async invalidateAgentListCache(userId: string): Promise<void> {
-    // GET /agents is cached per (user, originalUrl). The Messages filter hits the
-    // ?includeSystem=true variant, which is a distinct cache entry, so a single
-    // del() would leave it stale after a create/rename/delete. Clear both.
+    // GET /agents has exactly two canonical cache entries per user (system agents
+    // included or not — see AgentListCacheInterceptor). Clear both so neither the
+    // Workspace list nor the Messages filter goes stale after a mutation.
     await Promise.all([
-      this.cacheManager.del(`${userId}:/api/v1/agents`),
-      this.cacheManager.del(`${userId}:/api/v1/agents?includeSystem=true`),
+      this.cacheManager.del(agentListCacheKey(userId, false)),
+      this.cacheManager.del(agentListCacheKey(userId, true)),
     ]);
   }
 
   @Get('agents')
-  @UseInterceptors(UserCacheInterceptor)
+  @UseInterceptors(AgentListCacheInterceptor)
   @CacheTTL(AGENT_LIST_CACHE_TTL_MS)
   async getAgents(@CurrentUser() user: AuthUser, @Query('includeSystem') includeSystem?: string) {
     const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;

--- a/packages/backend/src/common/constants/cache.constants.ts
+++ b/packages/backend/src/common/constants/cache.constants.ts
@@ -3,3 +3,14 @@ export const AGENT_LIST_CACHE_TTL_MS = 60_000;
 export const MODEL_PRICES_CACHE_TTL_MS = 300_000;
 export const PUBLIC_STATS_CACHE_TTL_MS = 86_400_000;
 export const FREE_MODELS_CACHE_TTL_MS = 3_600_000;
+
+/**
+ * Canonical cache key for the GET /agents list. The route varies only by whether
+ * the reserved system (Playground) agent is included, so every query-string
+ * variant collapses to one of two keys keyed on that boolean — never the raw
+ * URL. This keeps the key set bounded (exactly two per user) so invalidation can
+ * enumerate it exhaustively and no variant is ever left stale.
+ */
+export function agentListCacheKey(userId: string, includeSystem: boolean): string {
+  return `${userId}:/api/v1/agents:system=${includeSystem}`;
+}

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
@@ -1,0 +1,75 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AgentListCacheInterceptor } from './agent-list-cache.interceptor';
+
+function createMockContext(
+  user: { id?: string } | undefined,
+  query: Record<string, string> | undefined,
+  method = 'GET',
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user, query, method, originalUrl: '/api/v1/agents' }),
+      getResponse: () => ({}),
+    }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    getArgs: () => [],
+    getArgByIndex: () => ({}),
+    switchToRpc: () => ({}) as never,
+    switchToWs: () => ({}) as never,
+    getType: () => 'http',
+  } as unknown as ExecutionContext;
+}
+
+describe('AgentListCacheInterceptor', () => {
+  let interceptor: AgentListCacheInterceptor;
+
+  beforeEach(() => {
+    const mockCacheManager = {} as never;
+    interceptor = new AgentListCacheInterceptor(mockCacheManager, new Reflector());
+  });
+
+  describe('trackBy', () => {
+    it('keys on the system=true canonical variant for ?includeSystem=true', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'true' }),
+      );
+      expect(key).toBe('u1:/api/v1/agents:system=true');
+    });
+
+    it('keys on the system=false canonical variant when no query param is present', () => {
+      const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, undefined));
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('collapses ?includeSystem=false onto the same system=false key (no stranded variant)', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'false' }),
+      );
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('collapses any non-"true" value onto the system=false key', () => {
+      const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, { includeSystem: '1' }));
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('returns undefined for non-GET requests', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'true' }, 'POST'),
+      );
+      expect(key).toBeUndefined();
+    });
+
+    it('returns undefined when user is not present', () => {
+      const key = interceptor['trackBy'](createMockContext(undefined, undefined));
+      expect(key).toBeUndefined();
+    });
+
+    it('returns undefined when user has no id', () => {
+      const key = interceptor['trackBy'](createMockContext({}, undefined));
+      expect(key).toBeUndefined();
+    });
+  });
+});

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
@@ -1,0 +1,29 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+import { UserCacheInterceptor } from './user-cache.interceptor';
+import { agentListCacheKey } from '../constants/cache.constants';
+
+/**
+ * Cache interceptor for GET /agents. Unlike the generic URL-keyed
+ * UserCacheInterceptor, it collapses every query-string variant (no param,
+ * ?includeSystem=true, ?includeSystem=false, anything else) onto one of two
+ * canonical keys based on the normalized `includeSystem` boolean. That keeps the
+ * cached key set bounded to exactly two entries per user, so mutation handlers
+ * can invalidate it exhaustively (see agentListCacheKey) without a stray URL
+ * variant being left stale.
+ */
+@Injectable()
+export class AgentListCacheInterceptor extends UserCacheInterceptor {
+  protected trackBy(context: ExecutionContext): string | undefined {
+    const request = context.switchToHttp().getRequest<Request>();
+    if (request.method !== 'GET') return undefined;
+    const user = (request as unknown as Record<string, unknown>).user as
+      | { id?: string }
+      | undefined;
+    if (!user?.id) return undefined;
+
+    const includeSystem =
+      (request.query as { includeSystem?: string } | undefined)?.includeSystem === 'true';
+    return agentListCacheKey(user.id, includeSystem);
+  }
+}

--- a/packages/frontend/src/components/ProviderSelectContent.tsx
+++ b/packages/frontend/src/components/ProviderSelectContent.tsx
@@ -25,6 +25,7 @@ export interface ProviderSelectContentProps {
   customProviders?: CustomProviderData[];
   customProviderPrefill?: CustomProviderPrefill | null;
   providerDeepLink?: ProviderDeepLink | null;
+  initialTab?: 'subscription' | 'api_key' | 'local';
   onUpdate: () => void | Promise<void>;
   onClose?: () => void;
   showHeader?: boolean;
@@ -47,7 +48,7 @@ const ProviderSelectContent: Component<ProviderSelectContentProps> = (props) => 
     : null;
 
   const [activeTab, setActiveTab] = createSignal<'subscription' | 'api_key' | 'local'>(
-    'subscription',
+    deepLink?.authType ?? props.initialTab ?? 'subscription',
   );
   const [isSelfHosted, setIsSelfHosted] = createSignal(false);
   onMount(async () => {

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -9,6 +9,7 @@ interface Props {
   customProviders?: CustomProviderData[];
   customProviderPrefill?: CustomProviderPrefill | null;
   providerDeepLink?: ProviderDeepLink | null;
+  initialTab?: 'subscription' | 'api_key' | 'local';
   onClose: () => void;
   onUpdate: () => void | Promise<void>;
 }
@@ -37,6 +38,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
           customProviders={props.customProviders}
           customProviderPrefill={props.customProviderPrefill}
           providerDeepLink={props.providerDeepLink}
+          initialTab={props.initialTab}
           onUpdate={props.onUpdate}
           onClose={props.onClose}
         />

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -130,13 +130,9 @@ const Limits: Component = () => {
       />
 
       <div class="page-header">
-        <div>
-          <h1>Limits</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Get notified or block requests when token
-            or cost thresholds are exceeded
-          </span>
-        </div>
+        <span class="breadcrumb">
+          Get notified or block requests when token or cost thresholds are exceeded
+        </span>
         <button
           class="btn btn--primary btn--sm"
           onClick={() => {

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -435,13 +435,7 @@ const Routing: Component = () => {
       />
 
       <div class="page-header routing-page-header">
-        <div>
-          <h1>Routing</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Pick which model handles each type of
-            request
-          </span>
-        </div>
+        <span class="breadcrumb">Pick which model handles each type of request</span>
         <Show when={!connectedProviders.loading}>
           <div style="display: flex; gap: 8px;">
             <Show when={isEnabled()}>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -182,15 +182,9 @@ const Settings: Component = () => {
         name="description"
         content={`Configure settings for ${agentDisplayName() ?? agentName()}.`}
       />
-      <div class="page-header">
-        <div>
-          <h1>Settings</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Rename your agent, manage API keys, and
-            view setup instructions
-          </span>
-        </div>
-      </div>
+      <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); margin: 0 0 var(--gap-lg);">
+        Rename your agent, manage API keys, and view setup instructions
+      </p>
 
       {/* -- Agent Name ------------------------------ */}
       <div class="settings-card">

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -282,13 +282,6 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
     return map;
   };
 
-  const modelCount = (providerId: string) => {
-    const summary = connectedByProvider().get(providerId);
-    if (summary && summary.total_models > 0) return summary.total_models;
-    const counts = data()?.model_counts ?? {};
-    return counts[providerId.toLowerCase()] ?? counts[providerId] ?? null;
-  };
-
   const activeConnectionCount = (providerId: string) =>
     connectedByProvider()
       .get(providerId)
@@ -316,11 +309,6 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
 
   const showMetricCard = () =>
     !!copy().metricLabel && (connectedRows().length > 0 || totalApiCost() > 0);
-
-  // Model counts come from discovery for subscription/BYOK providers and are
-  // unreliable there (discovery may be partial or stale); only the local page
-  // shows them, where the count is read straight from the local server.
-  const showModels = () => props.kind === 'local';
 
   const activeLabel = (count: number) => {
     if (props.kind === 'local') return 'Connected';
@@ -410,9 +398,6 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
             <colgroup>
               <col style="width: 214px;" />
               <col style="width: 120px;" />
-              <Show when={showModels()}>
-                <col style="width: 70px;" />
-              </Show>
               <col />
               <Show when={copy().rowMetricHeading}>
                 <col style="width: 110px;" />
@@ -425,9 +410,6 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
               <tr>
                 <th>Provider</th>
                 <th>Connection</th>
-                <Show when={showModels()}>
-                  <th>Models</th>
-                </Show>
                 <th>Usage (30d)</th>
                 <Show when={copy().rowMetricHeading}>
                   <th>{copy().rowMetricHeading}</th>
@@ -464,11 +446,6 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                       </span>
                     </td>
                     <td style="color: hsl(var(--muted-foreground));">{row.connection.label}</td>
-                    <Show when={showModels()}>
-                      <td>
-                        {row.connection.cached_model_count || row.summary.total_models || '-'}
-                      </td>
-                    </Show>
                     <td>
                       <div style="display: flex; align-items: center; gap: 8px;">
                         <Show when={row.summary.sparkline_7d?.length}>
@@ -545,17 +522,11 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
           <table class="data-table" style="min-width: 520px;">
             <colgroup>
               <col style="width: 240px;" />
-              <Show when={showModels()}>
-                <col style="width: 100px;" />
-              </Show>
               <col />
             </colgroup>
             <thead>
               <tr>
                 <th>Provider</th>
-                <Show when={showModels()}>
-                  <th>Models</th>
-                </Show>
                 <th />
               </tr>
             </thead>
@@ -571,11 +542,6 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                           <span style="font-weight: 500;">{provider.name}</span>
                         </span>
                       </td>
-                      <Show when={showModels()}>
-                        <td style="color: hsl(var(--muted-foreground));">
-                          {modelCount(provider.id) ?? '-'}
-                        </td>
-                      </Show>
                       <td style="text-align: right;">
                         <span style="display: inline-flex; align-items: center; justify-content: flex-end; gap: 8px;">
                           <Show when={activeCount() > 0}>
@@ -628,11 +594,6 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                         {provider.name}
                       </span>
                     </div>
-                    <Show when={showModels()}>
-                      <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); white-space: nowrap;">
-                        {modelCount(provider.id) ?? 0} models
-                      </span>
-                    </Show>
                   </div>
                   <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px;">
                     <Show when={activeCount() > 0} fallback={<span />}>

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -354,6 +354,9 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
     );
   };
 
+  const connectionLastUsedAt = (summary: UserProviderSummary) =>
+    summary.connections.length === 1 ? summary.last_used_at : null;
+
   const showMetricCard = () =>
     props.kind === 'subscriptions' || connectedRows().length > 0 || pageMetricTotal() > 0;
 
@@ -470,6 +473,14 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                   <tr
                     style="cursor: pointer;"
                     onClick={() => navigate(`/providers/connections/${row.connection.id}`)}
+                    onKeyDown={(event) => {
+                      if (event.target !== event.currentTarget) return;
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        navigate(`/providers/connections/${row.connection.id}`);
+                      }
+                    }}
+                    tabindex="0"
                   >
                     <td>
                       <span style="display: flex; align-items: center; gap: 10px;">
@@ -499,7 +510,9 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                       <StatusBadge active={row.connection.is_active} />
                     </td>
                     <td style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-xs);">
-                      {row.summary.last_used_at ? formatTimeAgo(row.summary.last_used_at) : '-'}
+                      {connectionLastUsedAt(row.summary)
+                        ? formatTimeAgo(connectionLastUsedAt(row.summary)!)
+                        : '-'}
                     </td>
                     <td style="text-align: right;">
                       <button

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -317,6 +317,11 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
   const showMetricCard = () =>
     !!copy().metricLabel && (connectedRows().length > 0 || totalApiCost() > 0);
 
+  // Model counts come from discovery for subscription/BYOK providers and are
+  // unreliable there (discovery may be partial or stale); only the local page
+  // shows them, where the count is read straight from the local server.
+  const showModels = () => props.kind === 'local';
+
   const activeLabel = (count: number) => {
     if (props.kind === 'local') return 'Connected';
     return `${count} active ${count === 1 ? copy().activeSingular : copy().activePlural}`;
@@ -405,7 +410,9 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
             <colgroup>
               <col style="width: 214px;" />
               <col style="width: 120px;" />
-              <col style="width: 70px;" />
+              <Show when={showModels()}>
+                <col style="width: 70px;" />
+              </Show>
               <col />
               <Show when={copy().rowMetricHeading}>
                 <col style="width: 110px;" />
@@ -418,7 +425,9 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
               <tr>
                 <th>Provider</th>
                 <th>Connection</th>
-                <th>Models</th>
+                <Show when={showModels()}>
+                  <th>Models</th>
+                </Show>
                 <th>Usage (30d)</th>
                 <Show when={copy().rowMetricHeading}>
                   <th>{copy().rowMetricHeading}</th>
@@ -455,7 +464,11 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                       </span>
                     </td>
                     <td style="color: hsl(var(--muted-foreground));">{row.connection.label}</td>
-                    <td>{row.connection.cached_model_count || row.summary.total_models || '-'}</td>
+                    <Show when={showModels()}>
+                      <td>
+                        {row.connection.cached_model_count || row.summary.total_models || '-'}
+                      </td>
+                    </Show>
                     <td>
                       <div style="display: flex; align-items: center; gap: 8px;">
                         <Show when={row.summary.sparkline_7d?.length}>
@@ -532,13 +545,17 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
           <table class="data-table" style="min-width: 520px;">
             <colgroup>
               <col style="width: 240px;" />
-              <col style="width: 100px;" />
+              <Show when={showModels()}>
+                <col style="width: 100px;" />
+              </Show>
               <col />
             </colgroup>
             <thead>
               <tr>
                 <th>Provider</th>
-                <th>Models</th>
+                <Show when={showModels()}>
+                  <th>Models</th>
+                </Show>
                 <th />
               </tr>
             </thead>
@@ -554,9 +571,11 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                           <span style="font-weight: 500;">{provider.name}</span>
                         </span>
                       </td>
-                      <td style="color: hsl(var(--muted-foreground));">
-                        {modelCount(provider.id) ?? '-'}
-                      </td>
+                      <Show when={showModels()}>
+                        <td style="color: hsl(var(--muted-foreground));">
+                          {modelCount(provider.id) ?? '-'}
+                        </td>
+                      </Show>
                       <td style="text-align: right;">
                         <span style="display: inline-flex; align-items: center; justify-content: flex-end; gap: 8px;">
                           <Show when={activeCount() > 0}>
@@ -609,9 +628,11 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                         {provider.name}
                       </span>
                     </div>
-                    <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); white-space: nowrap;">
-                      {modelCount(provider.id) ?? 0} models
-                    </span>
+                    <Show when={showModels()}>
+                      <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); white-space: nowrap;">
+                        {modelCount(provider.id) ?? 0} models
+                      </span>
+                    </Show>
                   </div>
                   <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px;">
                     <Show when={activeCount() > 0} fallback={<span />}>

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -6,7 +6,6 @@ import {
   getCustomProviders,
   getProviders as getAgentProviders,
 } from '../../services/api.js';
-import { getOverview } from '../../services/api/analytics.js';
 import {
   getProviders as getGlobalProviders,
   type UserProviderSummary,
@@ -37,13 +36,6 @@ interface AgentRow {
   agent_name: string;
 }
 
-interface OverviewData {
-  cost_by_model?: Array<{
-    estimated_cost?: number;
-    auth_type?: string | null;
-  }>;
-}
-
 const PAGE_COPY: Record<
   ProviderPageKind,
   {
@@ -55,9 +47,11 @@ const PAGE_COPY: Record<
     connectedHeading: string;
     supportedHeading: string;
     authType: AuthType;
-    metricLabel: string;
-    metricTooltip: string;
-    rowMetricHeading: string;
+    /** Cost metric (stat card + per-row column) — BYOK only. Subscriptions and
+     *  local providers have no real cost figure to show (savings was removed). */
+    metricLabel?: string;
+    metricTooltip?: string;
+    rowMetricHeading?: string;
     activeSingular: string;
     activePlural: string;
   }
@@ -70,9 +64,6 @@ const PAGE_COPY: Record<
     connectedHeading: 'My Subscriptions',
     supportedHeading: 'Supported subscriptions',
     authType: 'subscription',
-    metricLabel: 'Estimated savings (30d)',
-    metricTooltip: 'Equivalent API cost you saved by using subscriptions instead of pay-per-use.',
-    rowMetricHeading: 'Savings (30d)',
     activeSingular: 'connection',
     activePlural: 'connections',
   },
@@ -99,10 +90,6 @@ const PAGE_COPY: Record<
     connectedHeading: 'My Local Providers',
     supportedHeading: 'Supported local providers',
     authType: 'local',
-    metricLabel: 'Estimated savings (30d)',
-    metricTooltip:
-      'Equivalent API cost you saved by running models locally instead of using paid API keys.',
-    rowMetricHeading: 'Savings (30d)',
     activeSingular: 'connection',
     activePlural: 'connections',
   },
@@ -222,14 +209,6 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
     }
   });
 
-  const [overview] = createResource(async (): Promise<OverviewData> => {
-    try {
-      return (await getOverview('30d')) as OverviewData;
-    } catch {
-      return { cost_by_model: [] };
-    }
-  });
-
   const [agents] = createResource(async () => {
     try {
       const result = (await getAgents()) as { agents?: AgentRow[] } | AgentRow[];
@@ -315,22 +294,9 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
       .get(providerId)
       ?.connections.filter((connection) => connection.is_active).length ?? 0;
 
-  const totalEstimatedSavings = createMemo(() => {
-    if (copy().authType === 'api_key') return 0;
-    return (overview()?.cost_by_model ?? [])
-      .filter((row) => row.auth_type === copy().authType)
-      .reduce((sum, row) => sum + (row.estimated_cost ?? 0), 0);
-  });
-
   const totalApiCost = createMemo(() =>
     connectedSummaries().reduce((sum, summary) => sum + summary.consumption_cost, 0),
   );
-
-  const pageMetricTotal = () =>
-    copy().authType === 'api_key' ? totalApiCost() : totalEstimatedSavings();
-
-  const totalKindTokens = () =>
-    connectedSummaries().reduce((sum, summary) => sum + summary.consumption_tokens, 0);
 
   const connectionDenominator = (summary: UserProviderSummary) =>
     Math.max(
@@ -342,23 +308,14 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
   const perConnectionTokens = (summary: UserProviderSummary) =>
     Math.round(summary.consumption_tokens / connectionDenominator(summary));
 
-  const perConnectionMetric = (summary: UserProviderSummary) => {
-    if (copy().authType === 'api_key') {
-      return summary.consumption_cost / connectionDenominator(summary);
-    }
-    const tokens = totalKindTokens();
-    if (tokens <= 0) return 0;
-    return (
-      ((summary.consumption_tokens / tokens) * totalEstimatedSavings()) /
-      connectionDenominator(summary)
-    );
-  };
+  const perConnectionCost = (summary: UserProviderSummary) =>
+    summary.consumption_cost / connectionDenominator(summary);
 
   const connectionLastUsedAt = (summary: UserProviderSummary) =>
     summary.connections.length === 1 ? summary.last_used_at : null;
 
   const showMetricCard = () =>
-    props.kind === 'subscriptions' || connectedRows().length > 0 || pageMetricTotal() > 0;
+    !!copy().metricLabel && (connectedRows().length > 0 || totalApiCost() > 0);
 
   const activeLabel = (count: number) => {
     if (props.kind === 'local') return 'Connected';
@@ -431,10 +388,10 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
         <div class="chart-card" style="margin-bottom: 24px; padding: 20px 24px;">
           <span class="chart-card__label" style="display: flex; align-items: center; gap: 0;">
             {copy().metricLabel}
-            <InfoTooltip text={copy().metricTooltip} />
+            <InfoTooltip text={copy().metricTooltip!} />
           </span>
           <div class="chart-card__value-row" style="margin-top: 4px;">
-            <span class="chart-card__value">{formatCost(pageMetricTotal()) ?? '$0.00'}</span>
+            <span class="chart-card__value">{formatCost(totalApiCost()) ?? '$0.00'}</span>
           </div>
         </div>
       </Show>
@@ -450,7 +407,9 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
               <col style="width: 120px;" />
               <col style="width: 70px;" />
               <col />
-              <col style="width: 110px;" />
+              <Show when={copy().rowMetricHeading}>
+                <col style="width: 110px;" />
+              </Show>
               <col style="width: 90px;" />
               <col style="width: 90px;" />
               <col style="width: 110px;" />
@@ -461,7 +420,9 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                 <th>Connection</th>
                 <th>Models</th>
                 <th>Usage (30d)</th>
-                <th>{copy().rowMetricHeading}</th>
+                <Show when={copy().rowMetricHeading}>
+                  <th>{copy().rowMetricHeading}</th>
+                </Show>
                 <th>Status</th>
                 <th>Last used</th>
                 <th />
@@ -505,7 +466,9 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                         <span>{formatNumber(perConnectionTokens(row.summary))} tokens</span>
                       </div>
                     </td>
-                    <td>{formatCost(perConnectionMetric(row.summary)) ?? '$0.00'}</td>
+                    <Show when={copy().rowMetricHeading}>
+                      <td>{formatCost(perConnectionCost(row.summary)) ?? '$0.00'}</td>
+                    </Show>
                     <td>
                       <StatusBadge active={row.connection.is_active} />
                     </td>

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -1,24 +1,33 @@
 import { Title } from '@solidjs/meta';
-import { useSearchParams } from '@solidjs/router';
-import { createResource, createSignal, For, Show, type Component } from 'solid-js';
+import { useNavigate, useSearchParams } from '@solidjs/router';
+import { createMemo, createResource, createSignal, For, Show, type Component } from 'solid-js';
 import {
   getAgents,
   getCustomProviders,
   getProviders as getAgentProviders,
 } from '../../services/api.js';
+import { getOverview } from '../../services/api/analytics.js';
 import {
   getProviders as getGlobalProviders,
   type UserProviderSummary,
 } from '../../services/api/providers.js';
 import type { AuthType, CustomProviderData, RoutingProvider } from '../../services/api.js';
-import type { ProviderDeepLink } from '../../services/routing-params.js';
+import type { CustomProviderPrefill, ProviderDeepLink } from '../../services/routing-params.js';
 import { PROVIDERS, type ProviderDef } from '../../services/providers.js';
-import { customProviderColor, formatNumber, formatTimeAgo } from '../../services/formatters.js';
+import {
+  customProviderColor,
+  formatCost,
+  formatNumber,
+  formatTimeAgo,
+} from '../../services/formatters.js';
 import { providerIcon } from '../../components/ProviderIcon.jsx';
+import InfoTooltip from '../../components/InfoTooltip.jsx';
 import ProviderSelectModal from '../../components/ProviderSelectModal.jsx';
+import Sparkline from '../../components/Sparkline.jsx';
 import '../../styles/routing.css';
 
 type ProviderPageKind = 'subscriptions' | 'byok' | 'local';
+type ViewMode = 'list' | 'grid';
 
 interface ProviderConnectionsPageProps {
   kind: ProviderPageKind;
@@ -28,6 +37,13 @@ interface AgentRow {
   agent_name: string;
 }
 
+interface OverviewData {
+  cost_by_model?: Array<{
+    estimated_cost?: number;
+    auth_type?: string | null;
+  }>;
+}
+
 const PAGE_COPY: Record<
   ProviderPageKind,
   {
@@ -35,9 +51,15 @@ const PAGE_COPY: Record<
     heading: string;
     subtitle: string;
     addLabel: string;
+    customAddLabel?: string;
     connectedHeading: string;
     supportedHeading: string;
     authType: AuthType;
+    metricLabel: string;
+    metricTooltip: string;
+    rowMetricHeading: string;
+    activeSingular: string;
+    activePlural: string;
   }
 > = {
   subscriptions: {
@@ -48,15 +70,26 @@ const PAGE_COPY: Record<
     connectedHeading: 'My Subscriptions',
     supportedHeading: 'Supported subscriptions',
     authType: 'subscription',
+    metricLabel: 'Estimated savings (30d)',
+    metricTooltip: 'Equivalent API cost you saved by using subscriptions instead of pay-per-use.',
+    rowMetricHeading: 'Savings (30d)',
+    activeSingular: 'connection',
+    activePlural: 'connections',
   },
   byok: {
     title: 'BYOK | Manifest',
     heading: 'BYOK',
     subtitle: 'Connect provider API keys managed at the workspace level.',
     addLabel: 'Add API key',
+    customAddLabel: 'Add custom provider',
     connectedHeading: 'My API Keys',
     supportedHeading: 'Supported API key providers',
     authType: 'api_key',
+    metricLabel: 'Total API cost (30d)',
+    metricTooltip: 'Sum of all API key usage costs across your connected providers.',
+    rowMetricHeading: 'Cost (30d)',
+    activeSingular: 'key',
+    activePlural: 'keys',
   },
   local: {
     title: 'Local Providers | Manifest',
@@ -66,6 +99,12 @@ const PAGE_COPY: Record<
     connectedHeading: 'My Local Providers',
     supportedHeading: 'Supported local providers',
     authType: 'local',
+    metricLabel: 'Estimated savings (30d)',
+    metricTooltip:
+      'Equivalent API cost you saved by running models locally instead of using paid API keys.',
+    rowMetricHeading: 'Savings (30d)',
+    activeSingular: 'connection',
+    activePlural: 'connections',
   },
 };
 
@@ -94,38 +133,85 @@ const providerDisplayName = (
 ): string =>
   customProviderName(providerId, customProviders) ?? standardProviderName(providerId) ?? providerId;
 
-const ProviderMark: Component<{ providerId: string; name: string }> = (props) => (
+const StatusBadge: Component<{ active: boolean }> = (props) => (
   <Show
-    when={providerIcon(props.providerId, 20)}
+    when={props.active}
     fallback={
-      <span
-        style={{
-          display: 'inline-flex',
-          'align-items': 'center',
-          'justify-content': 'center',
-          width: '20px',
-          height: '20px',
-          'border-radius': '4px',
-          'font-size': '11px',
-          'font-weight': '600',
-          color: 'white',
-          background: customProviderColor(props.name),
-        }}
-      >
-        {props.name.charAt(0).toUpperCase()}
+      <span style="display: inline-flex; align-items: center; padding: 2px 8px; border-radius: var(--radius-sm); background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); font-size: var(--font-size-xs); font-weight: 500;">
+        Inactive
       </span>
     }
   >
-    <span style="display: flex; align-items: center; width: 20px; height: 20px;">
-      {providerIcon(props.providerId, 20)}
+    <span style="display: inline-flex; align-items: center; padding: 2px 8px; border-radius: var(--radius-sm); background: hsl(var(--success)); color: white; font-size: var(--font-size-xs); font-weight: 600;">
+      Active
     </span>
   </Show>
 );
 
+const ProviderMark: Component<{ providerId: string; name: string; size?: number }> = (props) => {
+  const size = () => props.size ?? 20;
+  return (
+    <Show
+      when={providerIcon(props.providerId, size())}
+      fallback={
+        <span
+          style={{
+            display: 'inline-flex',
+            'align-items': 'center',
+            'justify-content': 'center',
+            width: `${size()}px`,
+            height: `${size()}px`,
+            'border-radius': '4px',
+            'font-size': size() > 20 ? '12px' : '11px',
+            'font-weight': '600',
+            color: 'white',
+            background: customProviderColor(props.name || props.providerId),
+          }}
+        >
+          {(props.name || props.providerId).charAt(0).toUpperCase()}
+        </span>
+      }
+    >
+      <span style={`display: flex; align-items: center; width: ${size()}px; height: ${size()}px;`}>
+        {providerIcon(props.providerId, size())}
+      </span>
+    </Show>
+  );
+};
+
+const ListIcon: Component = () => (
+  <svg width="16" height="16" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M4 6h16v2H4zM4 11h16v2H4zM4 16h16v2H4z" />
+  </svg>
+);
+
+const GridIcon: Component = () => (
+  <svg width="16" height="16" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M3 3h7v7H3zM14 3h7v7h-7zM3 14h7v7H3zM14 14h7v7h-7z" />
+  </svg>
+);
+
+const CustomProviderIcon: Component = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path d="M7 11h10c.37 0 .72-.21.89-.54s.14-.73-.08-1.04l-5-7c-.38-.53-1.25-.53-1.63 0l-5 7A.997.997 0 0 0 6.99 11Zm5-6.28L15.06 9H8.95l3.06-4.28ZM17.5 13c-2.48 0-4.5 2.02-4.5 4.5s2.02 4.5 4.5 4.5 4.5-2.02 4.5-4.5-2.02-4.5-4.5-4.5m0 7a2.5 2.5 0 0 1 0-5 2.5 2.5 0 0 1 0 5M3 22h7c.55 0 1-.45 1-1v-7c0-.55-.45-1-1-1H3c-.55 0-1 .45-1 1v7c0 .55.45 1 1 1m1-7h5v5H4z" />
+  </svg>
+);
+
 const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props) => {
   const copy = () => PAGE_COPY[props.kind];
+  const navigate = useNavigate();
   const [showModal, setShowModal] = createSignal(false);
   const [deepLink, setDeepLink] = createSignal<ProviderDeepLink | null>(null);
+  const [customProviderPrefill, setCustomProviderPrefill] =
+    createSignal<CustomProviderPrefill | null>(null);
+  const [viewMode, setViewMode] = createSignal<ViewMode>('list');
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [data, { refetch: refetchGlobalProviders }] = createResource(async () => {
@@ -133,6 +219,14 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
       return await getGlobalProviders();
     } catch {
       return { providers: [], model_counts: {} };
+    }
+  });
+
+  const [overview] = createResource(async (): Promise<OverviewData> => {
+    try {
+      return (await getOverview('30d')) as OverviewData;
+    } catch {
+      return { cost_by_model: [] };
     }
   });
 
@@ -174,12 +268,15 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
   if (searchParams.add === 'true') {
     queueMicrotask(() => {
       setSearchParams({ add: undefined });
-      setShowModal(true);
+      openModal();
     });
   }
 
   const connectedSummaries = () =>
     (data()?.providers ?? []).filter((provider) => provider.auth_type === copy().authType);
+
+  const hasUsage = (summary: UserProviderSummary) =>
+    summary.consumption_tokens > 0 || summary.consumption_messages > 0;
 
   const connectedRows = () => {
     const rows: Array<{
@@ -188,9 +285,8 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
       name: string;
     }> = [];
     for (const summary of connectedSummaries()) {
-      const hasUsage = summary.consumption_tokens > 0 || summary.consumption_messages > 0;
       for (const connection of summary.connections) {
-        if (!connection.is_active && !hasUsage) continue;
+        if (!connection.is_active && !hasUsage(summary)) continue;
         rows.push({
           summary,
           connection,
@@ -219,7 +315,55 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
       .get(providerId)
       ?.connections.filter((connection) => connection.is_active).length ?? 0;
 
+  const totalEstimatedSavings = createMemo(() => {
+    if (copy().authType === 'api_key') return 0;
+    return (overview()?.cost_by_model ?? [])
+      .filter((row) => row.auth_type === copy().authType)
+      .reduce((sum, row) => sum + (row.estimated_cost ?? 0), 0);
+  });
+
+  const totalApiCost = createMemo(() =>
+    connectedSummaries().reduce((sum, summary) => sum + summary.consumption_cost, 0),
+  );
+
+  const pageMetricTotal = () =>
+    copy().authType === 'api_key' ? totalApiCost() : totalEstimatedSavings();
+
+  const totalKindTokens = () =>
+    connectedSummaries().reduce((sum, summary) => sum + summary.consumption_tokens, 0);
+
+  const connectionDenominator = (summary: UserProviderSummary) =>
+    Math.max(
+      summary.connections.filter((connection) => connection.is_active || hasUsage(summary)).length,
+      summary.connection_count,
+      1,
+    );
+
+  const perConnectionTokens = (summary: UserProviderSummary) =>
+    Math.round(summary.consumption_tokens / connectionDenominator(summary));
+
+  const perConnectionMetric = (summary: UserProviderSummary) => {
+    if (copy().authType === 'api_key') {
+      return summary.consumption_cost / connectionDenominator(summary);
+    }
+    const tokens = totalKindTokens();
+    if (tokens <= 0) return 0;
+    return (
+      ((summary.consumption_tokens / tokens) * totalEstimatedSavings()) /
+      connectionDenominator(summary)
+    );
+  };
+
+  const showMetricCard = () =>
+    props.kind === 'subscriptions' || connectedRows().length > 0 || pageMetricTotal() > 0;
+
+  const activeLabel = (count: number) => {
+    if (props.kind === 'local') return 'Connected';
+    return `${count} active ${count === 1 ? copy().activeSingular : copy().activePlural}`;
+  };
+
   const openModal = (providerId?: string) => {
+    setCustomProviderPrefill(null);
     // Deep-link with the page's auth type so the connection form opens in the
     // matching mode (e.g. the Subscriptions page opens the OAuth/subscription
     // flow rather than the API-key form for providers that support both).
@@ -228,9 +372,17 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
     setShowModal(true);
   };
 
+  const openCustomProvider = () => {
+    setDeepLink(null);
+    setCustomProviderPrefill({ name: '', baseUrl: '' });
+    void refetchModalProviders();
+    setShowModal(true);
+  };
+
   const handleModalClose = () => {
     setShowModal(false);
     setDeepLink(null);
+    setCustomProviderPrefill(null);
     void refetchGlobalProviders();
   };
 
@@ -250,27 +402,55 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
           <h1 class="page-header__title">{copy().heading}</h1>
           <p class="page-header__subtitle">{copy().subtitle}</p>
         </div>
-        <button
-          class="btn btn--primary btn--sm"
-          disabled={!firstAgentName()}
-          onClick={() => openModal()}
-        >
-          {copy().addLabel}
-        </button>
+        <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end;">
+          <Show when={copy().customAddLabel}>
+            <button
+              class="btn btn--outline btn--sm"
+              disabled={!firstAgentName()}
+              onClick={openCustomProvider}
+              style="display: inline-flex; align-items: center; gap: 6px;"
+            >
+              <CustomProviderIcon />
+              {copy().customAddLabel}
+            </button>
+          </Show>
+          <button
+            class="btn btn--primary btn--sm"
+            disabled={!firstAgentName()}
+            onClick={() => openModal()}
+          >
+            {copy().addLabel}
+          </button>
+        </div>
       </div>
+
+      <Show when={showMetricCard()}>
+        <div class="chart-card" style="margin-bottom: 24px; padding: 20px 24px;">
+          <span class="chart-card__label" style="display: flex; align-items: center; gap: 0;">
+            {copy().metricLabel}
+            <InfoTooltip text={copy().metricTooltip} />
+          </span>
+          <div class="chart-card__value-row" style="margin-top: 4px;">
+            <span class="chart-card__value">{formatCost(pageMetricTotal()) ?? '$0.00'}</span>
+          </div>
+        </div>
+      </Show>
 
       <Show when={connectedRows().length > 0}>
         <h3 style="font-size: var(--font-size-base); font-weight: 600; color: hsl(var(--foreground)); margin-bottom: 12px;">
           {copy().connectedHeading}
         </h3>
         <div class="panel" style="padding: 0; margin-bottom: 24px; overflow-x: auto;">
-          <table class="data-table" style="min-width: 640px;">
+          <table class="data-table" style="min-width: 860px;">
             <colgroup>
-              <col style="width: 220px;" />
+              <col style="width: 214px;" />
               <col style="width: 120px;" />
-              <col style="width: 90px;" />
+              <col style="width: 70px;" />
               <col />
-              <col style="width: 100px;" />
+              <col style="width: 110px;" />
+              <col style="width: 90px;" />
+              <col style="width: 90px;" />
+              <col style="width: 110px;" />
             </colgroup>
             <thead>
               <tr>
@@ -278,42 +458,60 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
                 <th>Connection</th>
                 <th>Models</th>
                 <th>Usage (30d)</th>
+                <th>{copy().rowMetricHeading}</th>
                 <th>Status</th>
+                <th>Last used</th>
+                <th />
               </tr>
             </thead>
             <tbody>
               <For each={connectedRows()}>
                 {(row) => (
-                  <tr>
+                  <tr
+                    style="cursor: pointer;"
+                    onClick={() => navigate(`/providers/connections/${row.connection.id}`)}
+                  >
                     <td>
                       <span style="display: flex; align-items: center; gap: 10px;">
                         <ProviderMark providerId={row.summary.provider} name={row.name} />
                         <span style="font-weight: 500;">{row.name}</span>
+                        <Show when={row.summary.provider.startsWith('custom:')}>
+                          <span style="display: inline-flex; padding: 1px 6px; border-radius: var(--radius-sm); border: 1px solid hsl(var(--border)); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                            Custom
+                          </span>
+                        </Show>
                       </span>
                     </td>
                     <td style="color: hsl(var(--muted-foreground));">{row.connection.label}</td>
                     <td>{row.connection.cached_model_count || row.summary.total_models || '-'}</td>
-                    <td>{formatNumber(row.summary.consumption_tokens)} tokens</td>
                     <td>
-                      <Show
-                        when={row.connection.is_active}
-                        fallback={
-                          <span style="display: inline-flex; align-items: center; padding: 2px 8px; border-radius: var(--radius-sm); background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); font-size: var(--font-size-xs); font-weight: 500;">
-                            Inactive
+                      <div style="display: flex; align-items: center; gap: 8px;">
+                        <Show when={row.summary.sparkline_7d?.length}>
+                          <span style="flex-shrink: 0;">
+                            <Sparkline data={row.summary.sparkline_7d} width={60} height={20} />
                           </span>
-                        }
+                        </Show>
+                        <span>{formatNumber(perConnectionTokens(row.summary))} tokens</span>
+                      </div>
+                    </td>
+                    <td>{formatCost(perConnectionMetric(row.summary)) ?? '$0.00'}</td>
+                    <td>
+                      <StatusBadge active={row.connection.is_active} />
+                    </td>
+                    <td style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-xs);">
+                      {row.summary.last_used_at ? formatTimeAgo(row.summary.last_used_at) : '-'}
+                    </td>
+                    <td style="text-align: right;">
+                      <button
+                        class="btn btn--outline btn--sm"
+                        style="font-size: var(--font-size-xs); white-space: nowrap;"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          navigate(`/providers/connections/${row.connection.id}`);
+                        }}
                       >
-                        <span
-                          title={
-                            row.summary.last_used_at
-                              ? `Last used ${formatTimeAgo(row.summary.last_used_at)}`
-                              : undefined
-                          }
-                          style="display: inline-flex; align-items: center; padding: 2px 8px; border-radius: var(--radius-sm); background: hsl(var(--success)); color: white; font-size: var(--font-size-xs); font-weight: 600;"
-                        >
-                          Active
-                        </span>
-                      </Show>
+                        View details
+                      </button>
                     </td>
                   </tr>
                 )}
@@ -323,66 +521,161 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
         </div>
       </Show>
 
-      <h3 style="font-size: var(--font-size-base); font-weight: 600; color: hsl(var(--foreground)); margin-bottom: 12px;">
-        {copy().supportedHeading}
-      </h3>
-      <div class="panel" style="padding: 0; overflow-x: auto;">
-        <table class="data-table" style="min-width: 520px;">
-          <colgroup>
-            <col style="width: 240px;" />
-            <col style="width: 100px;" />
-            <col />
-          </colgroup>
-          <thead>
-            <tr>
-              <th>Provider</th>
-              <th>Models</th>
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            <For each={providerListForKind(props.kind)}>
-              {(provider) => {
-                const activeCount = () => activeConnectionCount(provider.id);
-                return (
-                  <tr>
-                    <td>
-                      <span style="display: flex; align-items: center; gap: 10px;">
-                        <ProviderMark providerId={provider.id} name={provider.name} />
-                        <span style="font-weight: 500;">{provider.name}</span>
-                      </span>
-                    </td>
-                    <td style="color: hsl(var(--muted-foreground));">
-                      {modelCount(provider.id) ?? '-'}
-                    </td>
-                    <td style="text-align: right;">
-                      <Show when={activeCount() > 0}>
-                        <span style="color: hsl(var(--success)); font-size: var(--font-size-xs); font-weight: 500; margin-right: 8px;">
-                          {activeCount()} active
-                        </span>
-                      </Show>
-                      <button
-                        class="btn btn--outline btn--sm"
-                        disabled={!firstAgentName()}
-                        onClick={() => openModal(provider.id)}
-                      >
-                        {copy().addLabel}
-                      </button>
-                    </td>
-                  </tr>
-                );
-              }}
-            </For>
-          </tbody>
-        </table>
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px;">
+        <h3 style="font-size: var(--font-size-base); font-weight: 600; color: hsl(var(--foreground)); margin: 0;">
+          {copy().supportedHeading}
+        </h3>
+        <div class="panel__tabs" role="tablist" style="height: 30px;">
+          <button
+            role="tab"
+            aria-selected={viewMode() === 'list'}
+            class="panel__tab"
+            classList={{ 'panel__tab--active': viewMode() === 'list' }}
+            onClick={() => setViewMode('list')}
+            aria-label="List view"
+            style="padding: 0 8px;"
+          >
+            <ListIcon />
+          </button>
+          <button
+            role="tab"
+            aria-selected={viewMode() === 'grid'}
+            class="panel__tab"
+            classList={{ 'panel__tab--active': viewMode() === 'grid' }}
+            onClick={() => setViewMode('grid')}
+            aria-label="Grid view"
+            style="padding: 0 8px;"
+          >
+            <GridIcon />
+          </button>
+        </div>
       </div>
+
+      <Show when={viewMode() === 'list'}>
+        <div class="panel" style="padding: 0; overflow-x: auto;">
+          <table class="data-table" style="min-width: 520px;">
+            <colgroup>
+              <col style="width: 240px;" />
+              <col style="width: 100px;" />
+              <col />
+            </colgroup>
+            <thead>
+              <tr>
+                <th>Provider</th>
+                <th>Models</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              <For each={providerListForKind(props.kind)}>
+                {(provider) => {
+                  const activeCount = () => activeConnectionCount(provider.id);
+                  return (
+                    <tr>
+                      <td>
+                        <span style="display: flex; align-items: center; gap: 10px;">
+                          <ProviderMark providerId={provider.id} name={provider.name} />
+                          <span style="font-weight: 500;">{provider.name}</span>
+                        </span>
+                      </td>
+                      <td style="color: hsl(var(--muted-foreground));">
+                        {modelCount(provider.id) ?? '-'}
+                      </td>
+                      <td style="text-align: right;">
+                        <span style="display: inline-flex; align-items: center; justify-content: flex-end; gap: 8px;">
+                          <Show when={activeCount() > 0}>
+                            <span style="color: hsl(var(--success)); font-size: var(--font-size-xs); font-weight: 500; white-space: nowrap; display: inline-flex; align-items: center; gap: 4px;">
+                              <svg
+                                width="8"
+                                height="8"
+                                fill="currentColor"
+                                viewBox="0 0 24 24"
+                                aria-hidden="true"
+                              >
+                                <path d="M12 5a7 7 0 1 0 0 14 7 7 0 1 0 0-14" />
+                              </svg>
+                              {activeLabel(activeCount())}
+                            </span>
+                          </Show>
+                          <button
+                            class="btn btn--outline btn--sm"
+                            disabled={!firstAgentName()}
+                            style="white-space: nowrap;"
+                            onClick={() => openModal(provider.id)}
+                          >
+                            {copy().addLabel}
+                          </button>
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                }}
+              </For>
+            </tbody>
+          </table>
+        </div>
+      </Show>
+
+      <Show when={viewMode() === 'grid'}>
+        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px;">
+          <For each={providerListForKind(props.kind)}>
+            {(provider) => {
+              const activeCount = () => activeConnectionCount(provider.id);
+              return (
+                <div
+                  class="panel"
+                  style="padding: 16px; display: flex; flex-direction: column; gap: 12px; margin-bottom: 0;"
+                >
+                  <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px;">
+                    <div style="display: flex; align-items: center; gap: 10px; min-width: 0;">
+                      <ProviderMark providerId={provider.id} name={provider.name} size={24} />
+                      <span style="font-weight: 600; font-size: var(--font-size-sm); color: hsl(var(--foreground)); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                        {provider.name}
+                      </span>
+                    </div>
+                    <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); white-space: nowrap;">
+                      {modelCount(provider.id) ?? 0} models
+                    </span>
+                  </div>
+                  <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px;">
+                    <Show when={activeCount() > 0} fallback={<span />}>
+                      <span style="color: hsl(var(--success)); font-size: var(--font-size-xs); font-weight: 500; display: inline-flex; align-items: center; gap: 4px;">
+                        <svg
+                          width="8"
+                          height="8"
+                          fill="currentColor"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <path d="M12 5a7 7 0 1 0 0 14 7 7 0 1 0 0-14" />
+                        </svg>
+                        {activeLabel(activeCount())}
+                      </span>
+                    </Show>
+                    <button
+                      class="btn btn--outline btn--sm"
+                      disabled={!firstAgentName()}
+                      style="font-size: var(--font-size-xs); white-space: nowrap;"
+                      onClick={() => openModal(provider.id)}
+                    >
+                      {copy().addLabel}
+                    </button>
+                  </div>
+                </div>
+              );
+            }}
+          </For>
+        </div>
+      </Show>
 
       <Show when={showModal() && firstAgentName()}>
         <ProviderSelectModal
           agentName={firstAgentName()}
           providers={modalProviders() ?? []}
           customProviders={customProviders() ?? []}
+          customProviderPrefill={customProviderPrefill()}
           providerDeepLink={deepLink()}
+          initialTab={copy().authType}
           onUpdate={handleModalUpdate}
           onClose={handleModalClose}
         />

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -61,14 +61,13 @@ describe("Limits page", () => {
     mockRoutingStatus = { enabled: false };
   });
 
-  it("renders page title", () => {
-    render(() => <Limits />);
-    expect(screen.getByText("Limits")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Limits />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
-  it("renders breadcrumb with agent name", () => {
+  it("renders page description without duplicating the agent heading", () => {
     const { container } = render(() => <Limits />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Get notified or block requests when token or cost thresholds are exceeded");
   });
 

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -9,8 +9,10 @@ const mockGetAgentProviders = vi.fn();
 const mockGetCustomProviders = vi.fn();
 const mockProviderSelectModal = vi.fn();
 
+const mockNavigate = vi.fn();
 vi.mock('@solidjs/router', () => ({
   useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+  useNavigate: () => mockNavigate,
 }));
 
 vi.mock('@solidjs/meta', () => ({
@@ -46,6 +48,7 @@ vi.mock('../../src/services/providers.js', () => ({
 vi.mock('../../src/services/formatters.js', () => ({
   customProviderColor: () => '#654321',
   formatNumber: (value: number) => String(value),
+  formatCost: (value: number) => `$${value.toFixed(2)}`,
   formatTimeAgo: () => 'recently',
 }));
 
@@ -241,9 +244,7 @@ describe('provider pages', () => {
     await waitFor(() => {
       expect(screen.getByText('Supported subscriptions')).toBeDefined();
       expect(screen.getByText('OpenAI')).toBeDefined();
-      expect((screen.getAllByText('Add subscription')[0] as HTMLButtonElement).disabled).toBe(
-        true,
-      );
+      expect((screen.getAllByText('Add subscription')[0] as HTMLButtonElement).disabled).toBe(true);
     });
   });
 

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -617,12 +617,12 @@ beforeEach(() => {
 });
 
 describe('Routing page', () => {
-  it('renders the page header with the agent display name', async () => {
-    render(() => <Routing />);
+  it('renders routing description without a duplicate page heading', async () => {
+    const { container } = render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText('Routing')).toBeDefined();
+      expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
     });
-    expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
+    expect(container.querySelector('h1')).toBeNull();
   });
 
   it('renders the empty providers state when no providers are connected', async () => {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -138,9 +138,9 @@ describe("Settings", () => {
     mockUpdateAgent.mockResolvedValue({});
   });
 
-  it("renders Settings heading", () => {
-    render(() => <Settings />);
-    expect(screen.getByText("Settings")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Settings />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
   it("renders agent name input with value", () => {
@@ -330,9 +330,8 @@ describe("Settings", () => {
     });
   });
 
-  it("shows breadcrumb with agent name", () => {
+  it("shows settings description without duplicating the agent heading", () => {
     const { container } = render(() => <Settings />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Rename your agent");
   });
 


### PR DESCRIPTION
### ✨ What changed
- Added 30d savings/cost cards and sparklines to provider pages.
- Restored last-used, row click-through, and View details actions.
- Restored the supported-provider list/grid switch.
- Added the BYOK header Add custom provider action.

### 💭 Why
The shared provider pages had lost the richer subscription-management cues from the design PR. Provider details were also harder to reach from those pages.

### 👤 For users
Provider pages now make cost, savings, usage, and connection details easier to scan.

### 📝 Notes
Validation passed targeted ESLint, shared/frontend builds, diff check, changeset status, and browser smoke on Subscriptions, BYOK, and Local.
Cubic follow-up fixed keyboard row activation and multi-connection last-used display.