### PR TITLE
fix: restore Message tab harness filtering and icons

### DIFF
--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -246,10 +246,10 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ renamed: true, name: 'bot-renamed', display_name: 'Bot Renamed' });
     expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'bot-renamed', 'Bot Renamed');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
-    // The Messages-filter variant (?includeSystem=true) is a distinct cache
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
+    // The Messages-filter variant (system agents included) is a distinct cache
     // entry and must also be cleared so it never goes stale after a rename.
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents?includeSystem=true');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
   });
 
   it('rejects rename with empty slug', async () => {
@@ -280,7 +280,10 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ deleted: true });
     expect(mockDeleteAgent).toHaveBeenCalledWith('u1', 'bot-1');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+    // Both canonical variants are cleared so neither the Workspace list nor the
+    // Messages filter (system agents included) goes stale after a delete.
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
   });
 
   it('passes agent_category and agent_platform to onboardAgent', async () => {
@@ -505,7 +508,7 @@ describe('AgentsController', () => {
     const result = await ctrl.createAgent(user as never, { name: 'My Agent' } as never);
 
     expect(result.agent.name).toBe('my-agent');
-    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=false');
   });
 
   it('rejects createAgent with empty slug', async () => {
@@ -627,7 +630,7 @@ describe('AgentsController', () => {
       name: 'bot-copy',
       displayName: 'Bot Copy',
     });
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
   });
 
   it('rejects duplicateAgent with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -508,7 +508,10 @@ describe('AgentsController', () => {
     const result = await ctrl.createAgent(user as never, { name: 'My Agent' } as never);
 
     expect(result.agent.name).toBe('my-agent');
+    // Both canonical variants are cleared so neither the Workspace list nor the
+    // Messages filter (system agents included) goes stale after a create.
     expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=false');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=true');
   });
 
   it('rejects createAgent with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -26,8 +26,8 @@ import { AuthUser } from '../../auth/auth.instance';
 import { CreateAgentDto } from '../../common/dto/create-agent.dto';
 import { DuplicateAgentDto } from '../../common/dto/duplicate-agent.dto';
 import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
-import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
-import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { AgentListCacheInterceptor } from '../../common/interceptors/agent-list-cache.interceptor';
+import { AGENT_LIST_CACHE_TTL_MS, agentListCacheKey } from '../../common/constants/cache.constants';
 import { slugify } from '../../common/utils/slugify';
 import { PLAYGROUND_AGENT_SLUG } from '../../common/constants/playground.constants';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
@@ -49,17 +49,17 @@ export class AgentsController {
   ) {}
 
   private async invalidateAgentListCache(userId: string): Promise<void> {
-    // GET /agents is cached per (user, originalUrl). The Messages filter hits the
-    // ?includeSystem=true variant, which is a distinct cache entry, so a single
-    // del() would leave it stale after a create/rename/delete. Clear both.
+    // GET /agents has exactly two canonical cache entries per user (system agents
+    // included or not — see AgentListCacheInterceptor). Clear both so neither the
+    // Workspace list nor the Messages filter goes stale after a mutation.
     await Promise.all([
-      this.cacheManager.del(`${userId}:/api/v1/agents`),
-      this.cacheManager.del(`${userId}:/api/v1/agents?includeSystem=true`),
+      this.cacheManager.del(agentListCacheKey(userId, false)),
+      this.cacheManager.del(agentListCacheKey(userId, true)),
     ]);
   }
 
   @Get('agents')
-  @UseInterceptors(UserCacheInterceptor)
+  @UseInterceptors(AgentListCacheInterceptor)
   @CacheTTL(AGENT_LIST_CACHE_TTL_MS)
   async getAgents(@CurrentUser() user: AuthUser, @Query('includeSystem') includeSystem?: string) {
     const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;

--- a/packages/backend/src/common/constants/cache.constants.ts
+++ b/packages/backend/src/common/constants/cache.constants.ts
@@ -3,3 +3,14 @@ export const AGENT_LIST_CACHE_TTL_MS = 60_000;
 export const MODEL_PRICES_CACHE_TTL_MS = 300_000;
 export const PUBLIC_STATS_CACHE_TTL_MS = 86_400_000;
 export const FREE_MODELS_CACHE_TTL_MS = 3_600_000;
+
+/**
+ * Canonical cache key for the GET /agents list. The route varies only by whether
+ * the reserved system (Playground) agent is included, so every query-string
+ * variant collapses to one of two keys keyed on that boolean — never the raw
+ * URL. This keeps the key set bounded (exactly two per user) so invalidation can
+ * enumerate it exhaustively and no variant is ever left stale.
+ */
+export function agentListCacheKey(userId: string, includeSystem: boolean): string {
+  return `${userId}:/api/v1/agents:system=${includeSystem}`;
+}

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
@@ -1,0 +1,75 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AgentListCacheInterceptor } from './agent-list-cache.interceptor';
+
+function createMockContext(
+  user: { id?: string } | undefined,
+  query: Record<string, string> | undefined,
+  method = 'GET',
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user, query, method, originalUrl: '/api/v1/agents' }),
+      getResponse: () => ({}),
+    }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    getArgs: () => [],
+    getArgByIndex: () => ({}),
+    switchToRpc: () => ({}) as never,
+    switchToWs: () => ({}) as never,
+    getType: () => 'http',
+  } as unknown as ExecutionContext;
+}
+
+describe('AgentListCacheInterceptor', () => {
+  let interceptor: AgentListCacheInterceptor;
+
+  beforeEach(() => {
+    const mockCacheManager = {} as never;
+    interceptor = new AgentListCacheInterceptor(mockCacheManager, new Reflector());
+  });
+
+  describe('trackBy', () => {
+    it('keys on the system=true canonical variant for ?includeSystem=true', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'true' }),
+      );
+      expect(key).toBe('u1:/api/v1/agents:system=true');
+    });
+
+    it('keys on the system=false canonical variant when no query param is present', () => {
+      const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, undefined));
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('collapses ?includeSystem=false onto the same system=false key (no stranded variant)', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'false' }),
+      );
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('collapses any non-"true" value onto the system=false key', () => {
+      const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, { includeSystem: '1' }));
+      expect(key).toBe('u1:/api/v1/agents:system=false');
+    });
+
+    it('returns undefined for non-GET requests', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includeSystem: 'true' }, 'POST'),
+      );
+      expect(key).toBeUndefined();
+    });
+
+    it('returns undefined when user is not present', () => {
+      const key = interceptor['trackBy'](createMockContext(undefined, undefined));
+      expect(key).toBeUndefined();
+    });
+
+    it('returns undefined when user has no id', () => {
+      const key = interceptor['trackBy'](createMockContext({}, undefined));
+      expect(key).toBeUndefined();
+    });
+  });
+});

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
@@ -1,0 +1,29 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+import { UserCacheInterceptor } from './user-cache.interceptor';
+import { agentListCacheKey } from '../constants/cache.constants';
+
+/**
+ * Cache interceptor for GET /agents. Unlike the generic URL-keyed
+ * UserCacheInterceptor, it collapses every query-string variant (no param,
+ * ?includeSystem=true, ?includeSystem=false, anything else) onto one of two
+ * canonical keys based on the normalized `includeSystem` boolean. That keeps the
+ * cached key set bounded to exactly two entries per user, so mutation handlers
+ * can invalidate it exhaustively (see agentListCacheKey) without a stray URL
+ * variant being left stale.
+ */
+@Injectable()
+export class AgentListCacheInterceptor extends UserCacheInterceptor {
+  protected trackBy(context: ExecutionContext): string | undefined {
+    const request = context.switchToHttp().getRequest<Request>();
+    if (request.method !== 'GET') return undefined;
+    const user = (request as unknown as Record<string, unknown>).user as
+      | { id?: string }
+      | undefined;
+    if (!user?.id) return undefined;
+
+    const includeSystem =
+      (request.query as { includeSystem?: string } | undefined)?.includeSystem === 'true';
+    return agentListCacheKey(user.id, includeSystem);
+  }
+}

--- a/packages/frontend/src/components/MessageTable.tsx
+++ b/packages/frontend/src/components/MessageTable.tsx
@@ -8,6 +8,9 @@ export interface MessageTableProps {
   columns: MessageColumnKey[];
   agentName?: string;
   customProviderName: (model: string) => string | undefined;
+  agentPlatformLookup?: (
+    name: string,
+  ) => { platform: string | null; category: string | null } | undefined;
   onFallbackErrorClick?: (model: string) => void;
   onFeedbackLike?: (id: string) => void;
   onFeedbackDislike?: (id: string) => void;
@@ -68,6 +71,7 @@ function ExpandableRow(props: {
   const ctx = {
     agentName: props.tableProps.agentName,
     customProviderName: props.tableProps.customProviderName,
+    agentPlatformLookup: props.tableProps.agentPlatformLookup,
     onFallbackErrorClick: props.tableProps.onFallbackErrorClick,
     onFeedbackLike: props.tableProps.onFeedbackLike,
     onFeedbackDislike: props.tableProps.onFeedbackDislike,
@@ -139,6 +143,7 @@ function PlainRow(props: {
   const ctx = {
     agentName: props.tableProps.agentName,
     customProviderName: props.tableProps.customProviderName,
+    agentPlatformLookup: props.tableProps.agentPlatformLookup,
     onFallbackErrorClick: props.tableProps.onFallbackErrorClick,
     onFeedbackLike: props.tableProps.onFeedbackLike,
     onFeedbackDislike: props.tableProps.onFeedbackDislike,

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -21,6 +21,7 @@ import { PROVIDERS } from '../services/providers.js';
 import { getModelDisplayName } from '../services/model-display.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.jsx';
 import { authBadgeFor, authLabel } from './AuthBadge.js';
+import { platformIcon } from 'manifest-shared';
 
 const MONO = 'font-family: var(--font-mono);';
 const MONO_XS =
@@ -346,8 +347,26 @@ export function DurationCell(item: MessageRow): JSX.Element {
   );
 }
 
-export function AgentCell(item: MessageRow): JSX.Element {
-  return <td>{item.agent_name ?? '—'}</td>;
+export function AgentCell(
+  item: MessageRow,
+  platformLookup?: (
+    name: string,
+  ) => { platform: string | null; category: string | null } | undefined,
+): JSX.Element {
+  const icon = () => {
+    const info = item.agent_name && platformLookup ? platformLookup(item.agent_name) : undefined;
+    return info?.platform ? platformIcon(info.platform, info.category) : undefined;
+  };
+  return (
+    <td style="white-space: nowrap; font-weight: 500; font-size: var(--font-size-xs);">
+      <span style="display: inline-flex; align-items: center; gap: 5px;">
+        <Show when={icon()}>
+          {(src) => <img src={src()} alt="" width="14" height="14" style="flex-shrink: 0;" />}
+        </Show>
+        {item.agent_name ?? '\u2014'}
+      </span>
+    </td>
+  );
 }
 
 export function StatusCell(
@@ -454,6 +473,9 @@ export function FeedbackCell(
 export interface CellRenderContext {
   agentName?: string;
   customProviderName: (model: string) => string | undefined;
+  agentPlatformLookup?: (
+    name: string,
+  ) => { platform: string | null; category: string | null } | undefined;
   onFallbackErrorClick?: (model: string) => void;
   onFeedbackLike?: (id: string) => void;
   onFeedbackDislike?: (id: string) => void;
@@ -495,6 +517,6 @@ export function renderCell(
         ctx.onFeedbackClear ?? (() => {}),
       );
     case 'agent':
-      return AgentCell(item);
+      return AgentCell(item, ctx.agentPlatformLookup);
   }
 }

--- a/packages/frontend/src/pages/AgentMessagesRedirect.tsx
+++ b/packages/frontend/src/pages/AgentMessagesRedirect.tsx
@@ -1,10 +1,15 @@
-import { Navigate } from '@solidjs/router';
+import { Navigate, useParams } from '@solidjs/router';
 import type { Component } from 'solid-js';
 
 /**
- * Redirects /harnesses/:agentName/messages → /messages (global message log).
- * Keeps backward-compat now that messages has a global home from PR1.
+ * Redirects /harnesses/:agentName/messages → /messages (global message log),
+ * carrying the agent through as a filter so the global log opens pre-scoped to
+ * the harness the user came from. Keeps backward-compat now that messages has a
+ * global home from PR1.
  */
-const AgentMessagesRedirect: Component = () => <Navigate href="/messages" />;
+const AgentMessagesRedirect: Component = () => {
+  const params = useParams<{ agentName: string }>();
+  return <Navigate href={`/messages?agent=${encodeURIComponent(params.agentName)}`} />;
+};
 
 export default AgentMessagesRedirect;

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -130,13 +130,9 @@ const Limits: Component = () => {
       />
 
       <div class="page-header">
-        <div>
-          <h1>Limits</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Get notified or block requests when token
-            or cost thresholds are exceeded
-          </span>
-        </div>
+        <span class="breadcrumb">
+          Get notified or block requests when token or cost thresholds are exceeded
+        </span>
         <button
           class="btn btn--primary btn--sm"
           onClick={() => {

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -1,5 +1,5 @@
 import { Meta, Title } from '@solidjs/meta';
-import { A, useNavigate, useParams } from '@solidjs/router';
+import { A, useNavigate, useParams, useSearchParams } from '@solidjs/router';
 import {
   createEffect,
   createMemo,
@@ -59,6 +59,7 @@ const HEADER_TIER_FILTER_PREFIX = 'header:';
 
 const MessageLog: Component = () => {
   const params = useParams<{ agentName: string }>();
+  const [searchParams] = useSearchParams<{ agent?: string }>();
   const navigate = useNavigate();
 
   preloadModelDisplayNames();
@@ -75,7 +76,11 @@ const MessageLog: Component = () => {
     const at = base.indexOf('model');
     return [...base.slice(0, at), 'agent' as const, ...base.slice(at)];
   };
-  const [agentFilter, setAgentFilter] = createSignal('');
+  // Seed the agent filter from ?agent= so the "View more" link on a harness's
+  // Recent Messages opens the global log pre-scoped to that harness.
+  const [agentFilter, setAgentFilter] = createSignal(
+    typeof searchParams.agent === 'string' ? searchParams.agent : '',
+  );
   const [agentList] = createResource(
     () => !params.agentName,
     async (isGlobal) => {

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -54,6 +54,12 @@ interface MessagesData {
   providers: string[];
 }
 
+interface AgentFilterOption {
+  agent_name: string;
+  agent_platform?: string | null;
+  agent_category?: string | null;
+}
+
 const SPECIFICITY_FILTER_PREFIX = 'specificity:';
 const HEADER_TIER_FILTER_PREFIX = 'header:';
 
@@ -81,21 +87,29 @@ const MessageLog: Component = () => {
   const [agentFilter, setAgentFilter] = createSignal(
     typeof searchParams.agent === 'string' ? searchParams.agent : '',
   );
-  const [agentList] = createResource(
+  const [agentListRaw] = createResource(
     () => !params.agentName,
     async (isGlobal) => {
-      if (!isGlobal) return [] as string[];
+      if (!isGlobal) return [] as AgentFilterOption[];
       // includeSystem=true so the reserved Playground agent appears in the
       // filter and the log can be narrowed to Playground runs.
       const data = (await getAgents(true)) as
-        | { agents?: Array<{ agent_name: string }> }
-        | Array<{ agent_name: string }>;
-      const list = (Array.isArray(data) ? data : (data?.agents ?? [])) as Array<{
-        agent_name: string;
-      }>;
-      return list.map((a) => a.agent_name).sort();
+        | { agents?: AgentFilterOption[] }
+        | AgentFilterOption[];
+      return (Array.isArray(data) ? data : (data?.agents ?? [])) as AgentFilterOption[];
     },
   );
+  const agentList = createMemo(() => (agentListRaw() ?? []).map((a) => a.agent_name).sort());
+  const agentPlatformMap = createMemo(() => {
+    const map = new Map<string, { platform: string | null; category: string | null }>();
+    for (const a of agentListRaw() ?? []) {
+      map.set(a.agent_name, {
+        platform: a.agent_platform ?? null,
+        category: a.agent_category ?? null,
+      });
+    }
+    return map;
+  });
   const agentFilterOptions = createMemo(() => [
     { label: 'All harnesses', value: '' },
     ...(agentList() ?? []).map((a) => ({ label: a, value: a })),
@@ -581,6 +595,7 @@ const MessageLog: Component = () => {
                   columns={columns()}
                   agentName={params.agentName}
                   customProviderName={customProviderName}
+                  agentPlatformLookup={(name) => agentPlatformMap().get(name)}
                   onFallbackErrorClick={scrollToFallbackSuccess}
                   onFeedbackLike={isSelfHosted() ? undefined : handleFeedbackLike}
                   onFeedbackDislike={isSelfHosted() ? undefined : handleFeedbackDislike}

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -435,13 +435,7 @@ const Routing: Component = () => {
       />
 
       <div class="page-header routing-page-header">
-        <div>
-          <h1>Routing</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Pick which model handles each type of
-            request
-          </span>
-        </div>
+        <span class="breadcrumb">Pick which model handles each type of request</span>
         <Show when={!connectedProviders.loading}>
           <div style="display: flex; gap: 8px;">
             <Show when={isEnabled()}>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -182,15 +182,9 @@ const Settings: Component = () => {
         name="description"
         content={`Configure settings for ${agentDisplayName() ?? agentName()}.`}
       />
-      <div class="page-header">
-        <div>
-          <h1>Settings</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Rename your agent, manage API keys, and
-            view setup instructions
-          </span>
-        </div>
-      </div>
+      <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); margin: 0 0 var(--gap-lg);">
+        Rename your agent, manage API keys, and view setup instructions
+      </p>
 
       {/* -- Agent Name ------------------------------ */}
       <div class="settings-card">

--- a/packages/frontend/tests/pages/AgentMessagesRedirect.test.tsx
+++ b/packages/frontend/tests/pages/AgentMessagesRedirect.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@solidjs/testing-library";
+
+let mockAgentName = "demo-agent";
+vi.mock("@solidjs/router", () => ({
+  useParams: () => ({ agentName: mockAgentName }),
+  Navigate: (props: any) => <div data-testid="navigate" data-href={props.href} />,
+}));
+
+import AgentMessagesRedirect from "../../src/pages/AgentMessagesRedirect.jsx";
+
+describe("AgentMessagesRedirect", () => {
+  it("redirects to the global log pre-scoped to the harness via ?agent=", () => {
+    mockAgentName = "demo-agent";
+    const { getByTestId } = render(() => <AgentMessagesRedirect />);
+    expect(getByTestId("navigate").getAttribute("data-href")).toBe("/messages?agent=demo-agent");
+  });
+
+  it("URL-encodes the agent name", () => {
+    mockAgentName = "my agent/v2";
+    const { getByTestId } = render(() => <AgentMessagesRedirect />);
+    expect(getByTestId("navigate").getAttribute("data-href")).toBe(
+      "/messages?agent=my%20agent%2Fv2",
+    );
+  });
+});

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -61,14 +61,13 @@ describe("Limits page", () => {
     mockRoutingStatus = { enabled: false };
   });
 
-  it("renders page title", () => {
-    render(() => <Limits />);
-    expect(screen.getByText("Limits")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Limits />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
-  it("renders breadcrumb with agent name", () => {
+  it("renders page description without duplicating the agent heading", () => {
     const { container } = render(() => <Limits />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Get notified or block requests when token or cost thresholds are exceeded");
   });
 

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@solidjs/testing-library";
 
 let mockAgentName = "test-agent";
+let mockSearchParams: Record<string, string | undefined> = {};
 const mockNavigate = vi.fn();
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: mockAgentName }),
+  useSearchParams: () => [mockSearchParams, vi.fn()],
   useNavigate: () => mockNavigate,
   A: (props: any) => <a href={props.href} style={props.style} class={props.class}>{props.children}</a>,
 }));
@@ -134,6 +136,7 @@ describe("MessageLog", () => {
     vi.clearAllMocks();
     localStorage.clear();
     mockAgentName = "test-agent";
+    mockSearchParams = {};
     mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "agent-alpha" }, { agent_name: "agent-beta" }] });
     mockGetCustomProviders.mockResolvedValue([]);
     mockGetSpecificityAssignments.mockResolvedValue([]);
@@ -1343,6 +1346,18 @@ describe("MessageLog", () => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
         expect(lastQ.agent_name).toBe("agent-alpha");
+      });
+    });
+
+    it("pre-seeds the agent filter from the ?agent= query param (View more deep-link)", async () => {
+      mockAgentName = "";
+      mockSearchParams = { agent: "agent-beta" };
+      mockGetMessages.mockResolvedValue(messagesData);
+      render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        const calls = mockGetMessages.mock.calls;
+        const lastQ = calls[calls.length - 1]?.[0] ?? {};
+        expect(lastQ.agent_name).toBe("agent-beta");
       });
     });
 

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -1526,6 +1526,28 @@ describe("MessageLog", () => {
         expect(container.textContent).toContain("beta-bot");
       });
     });
+
+    it("renders harness platform icons in global Harness column cells", async () => {
+      mockAgentName = "";
+      mockGetAgents.mockResolvedValue({
+        agents: [
+          {
+            agent_name: "alpha-bot",
+            agent_platform: "openclaw",
+            agent_category: "personal",
+          },
+        ],
+      });
+      mockGetMessages.mockResolvedValue({
+        ...messagesData,
+        items: [{ ...messagesData.items[0], agent_name: "alpha-bot" }],
+      });
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("alpha-bot");
+        expect(container.querySelector('td img[src="/icons/openclaw.png"]')).not.toBeNull();
+      });
+    });
   });
 
   describe("global mode title and CTA (Bug 2 + Bug 3)", () => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -617,12 +617,12 @@ beforeEach(() => {
 });
 
 describe('Routing page', () => {
-  it('renders the page header with the agent display name', async () => {
-    render(() => <Routing />);
+  it('renders routing description without a duplicate page heading', async () => {
+    const { container } = render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText('Routing')).toBeDefined();
+      expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
     });
-    expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
+    expect(container.querySelector('h1')).toBeNull();
   });
 
   it('renders the empty providers state when no providers are connected', async () => {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -138,9 +138,9 @@ describe("Settings", () => {
     mockUpdateAgent.mockResolvedValue({});
   });
 
-  it("renders Settings heading", () => {
-    render(() => <Settings />);
-    expect(screen.getByText("Settings")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Settings />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
   it("renders agent name input with value", () => {
@@ -330,9 +330,8 @@ describe("Settings", () => {
     });
   });
 
-  it("shows breadcrumb with agent name", () => {
+  it("shows settings description without duplicating the agent heading", () => {
     const { container } = render(() => <Settings />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Rename your agent");
   });
 


### PR DESCRIPTION
### ✨ What changed
- Harness View more carries `?agent=` into global Messages.
- Global Messages seeds its harness filter from the query param.
- The Harness column stays visible in the global table.
- Harness cells show the saved platform icon when metadata exists.

### 💭 Why
These Message tab affordances were lost while the stack was split.

### 👤 For users
Harness-level View more opens the global log already filtered to that harness.