### PR TITLE
fix: map image parts for Google routes

### DIFF
--- a/.changeset/google-image-parts.md
+++ b/.changeset/google-image-parts.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Forward OpenAI-compatible image inputs as Gemini inline or file data parts when routing requests to Google.

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -761,6 +761,77 @@ describe('Google Adapter', () => {
       expect(contents[0].parts[1].text).toBe('Second part');
     });
 
+    it('maps OpenAI image_url data URLs to Gemini inlineData without decoding', () => {
+      const body = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What is this image?' },
+              {
+                type: 'image_url',
+                image_url: {
+                  url: 'data:image/png;name=chart.png;charset=utf-8;base64,iVBORw0KGgo=',
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
+      expect(contents[0].parts).toEqual([
+        { text: 'What is this image?' },
+        { inlineData: { mimeType: 'image/png', data: 'iVBORw0KGgo=' } },
+      ]);
+    });
+
+    it('maps Responses input_image data URLs to Gemini inlineData', () => {
+      const body = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'Describe it.' },
+              { type: 'input_image', image_url: 'data:image/jpeg;base64,/9j/4AAQSkZJRg==' },
+            ],
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
+      expect(contents[0].parts).toEqual([
+        { text: 'Describe it.' },
+        { inlineData: { mimeType: 'image/jpeg', data: '/9j/4AAQSkZJRg==' } },
+      ]);
+    });
+
+    it('maps OpenAI image_url HTTP URLs to Gemini fileData', () => {
+      const body = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Describe it.' },
+              {
+                type: 'image_url',
+                image_url: { url: 'https://example.test/image.webp' },
+              },
+            ],
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
+      expect(contents[0].parts).toEqual([
+        { text: 'Describe it.' },
+        { fileData: { fileUri: 'https://example.test/image.webp' } },
+      ]);
+    });
+
     it('resolves functionResponse name from the assistant tool_calls history', () => {
       const body = {
         messages: [

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -48,6 +48,36 @@ describe('ProviderClient', () => {
       expect(result.isAnthropic).toBe(false);
     });
 
+    it('preserves image parts for OpenAI-compatible providers', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const imageBody = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Describe this.' },
+              {
+                type: 'image_url',
+                image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' },
+              },
+            ],
+          },
+        ],
+      };
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: imageBody,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toEqual(imageBody.messages);
+      expect(sentBody.model).toBe('gpt-4o');
+    });
+
     it('builds correct URL for deepseek', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const result = await client.forward({
@@ -771,6 +801,37 @@ describe('ProviderClient', () => {
       // Should not have OpenAI-style fields
       expect(sentBody.model).toBeUndefined();
       expect(sentBody.stream).toBeUndefined();
+    });
+
+    it('maps image parts onto the Google request body', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'google',
+        apiKey: 'AIza-test',
+        model: 'gemini-2.0-flash',
+        body: {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'Describe this.' },
+                {
+                  type: 'image_url',
+                  image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' },
+                },
+              ],
+            },
+          ],
+        },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.contents[0].parts).toEqual([
+        { text: 'Describe this.' },
+        { inlineData: { mimeType: 'image/png', data: 'iVBORw0KGgo=' } },
+      ]);
     });
   });
 

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -32,6 +32,8 @@ interface GeminiFunctionResponse {
 
 interface GeminiPart {
   text?: string;
+  inlineData?: { mimeType: string; data: string };
+  fileData?: { fileUri: string };
   functionCall?: GeminiFunctionCall;
   functionResponse?: GeminiFunctionResponse;
   // Google attaches thoughtSignature at the Part level (sibling of functionCall),
@@ -39,6 +41,8 @@ interface GeminiPart {
   // that don't round-trip this field.
   thoughtSignature?: string;
 }
+
+const DATA_IMAGE_URL_RE = /^data:([^;,]+)(?:;[^,]*)?;base64,(.*)$/is;
 
 /**
  * JSON Schema fields not supported by the Gemini API.
@@ -121,6 +125,26 @@ function mapRole(role: string): string {
   return 'user';
 }
 
+function extractImageUrl(imageUrl: unknown): string | null {
+  if (typeof imageUrl === 'string') return imageUrl;
+  if (!isRecord(imageUrl) || typeof imageUrl.url !== 'string') return null;
+  return imageUrl.url;
+}
+
+function imageUrlToGooglePart(imageUrl: unknown): GeminiPart | null {
+  const url = extractImageUrl(imageUrl);
+  if (!url) return null;
+
+  const dataUrl = DATA_IMAGE_URL_RE.exec(url);
+  if (dataUrl) {
+    const mimeType = dataUrl[1] || 'image/png';
+    if (!mimeType.toLowerCase().startsWith('image/')) return null;
+    return { inlineData: { mimeType, data: dataUrl[2] } };
+  }
+
+  return { fileData: { fileUri: url } };
+}
+
 /**
  * Scan the message list for assistant tool_calls and build a map from
  * tool_call_id to function name. Needed because OpenAI's tool-response
@@ -151,8 +175,14 @@ function messageToContent(
     parts.push({ text: msg.content });
   } else if (Array.isArray(msg.content)) {
     for (const block of msg.content as Array<Record<string, unknown>>) {
-      if (block.type === 'text' && typeof block.text === 'string') {
+      if (
+        typeof block.text === 'string' &&
+        (block.type === 'text' || block.type === 'input_text' || block.type === 'output_text')
+      ) {
         parts.push({ text: block.text });
+      } else if (block.type === 'image_url' || block.type === 'input_image') {
+        const imagePart = imageUrlToGooglePart(block.image_url);
+        if (imagePart) parts.push(imagePart);
       }
     }
   }


### PR DESCRIPTION
### ✨ What changed
- Google routes map OpenAI `image_url` and `input_image` parts to Gemini media parts.
- Data URLs become `inlineData`; URL images become `fileData`.
- OpenAI-compatible routes keep image parts unchanged.

### 💭 Why
Manifest should translate field shape, not drop media or pre-enforce provider media limits.

### 👤 For users
Gemini-routed vision requests now send the image instead of text-only prompts.

### 🔧 For operators
No env vars, migrations, or deploy order changes.

### 📝 Notes
Refs #2126.
Local checks: focused Google/provider-client/Anthropic Jest, shared build, backend build/lint, Prettier, changeset status, `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Google routing to forward image parts: maps OpenAI-style `image_url` and `input_image` to Gemini media parts so vision requests include the actual image. Addresses #2126.

- **Bug Fixes**
  - Map data URLs to `inlineData { mimeType, data }` (no base64 decoding); map HTTP(S) URLs to `fileData { fileUri }`.
  - Preserve image parts for OpenAI-compatible providers.
  - Add tests in `google-adapter.spec.ts` and `provider-client.spec.ts`.

<sup>Written for commit 8cbc0da3320a2d9f7c65b31fdfcf19e62aa48703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

