### PR TITLE
fix(auth): lazy-load better-auth/node to avoid CommonJS require errors

### DIFF
--- a/.changeset/cjs-better-auth-lazy-load.md
+++ b/.changeset/cjs-better-auth-lazy-load.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Lazy-load `better-auth/node` inside `SessionGuard` to avoid ESM-only require errors when running in a CommonJS environment.

--- a/packages/backend/src/auth/session.guard.ts
+++ b/packages/backend/src/auth/session.guard.ts
@@ -1,12 +1,13 @@
 import { CanActivate, ExecutionContext, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
-import { fromNodeHeaders } from 'better-auth/node';
 import { createHash } from 'crypto';
 import { auth } from './auth.instance';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
 import { isLoopbackPeer } from '../common/utils/local-ip';
 import { isSelfHosted } from '../common/utils/detect-self-hosted';
+
+let fromNodeHeadersFn: ((headers: any) => any) | null = null;
 
 interface CachedSession {
   user: unknown;
@@ -68,8 +69,12 @@ export class SessionGuard implements CanActivate, OnModuleDestroy {
     }
 
     try {
+      if (!fromNodeHeadersFn) {
+        const { fromNodeHeaders } = await import('better-auth/node');
+        fromNodeHeadersFn = fromNodeHeaders;
+      }
       const session = await auth.api.getSession({
-        headers: fromNodeHeaders(request.headers),
+        headers: fromNodeHeadersFn(request.headers),
       });
 
       if (session) {


### PR DESCRIPTION
This PR lazy-loads `better-auth/node` in `SessionGuard` to prevent ESM import require errors in environments running Manifest under CommonJS/CJS configurations. Since `better-auth/node` is exported as ESM-only in newer versions, importing it statically at module level causes startup failure in CommonJS runtimes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load `better-auth/node` in `SessionGuard` to prevent ESM-only require errors in CommonJS runtimes. We dynamically import and memoize `fromNodeHeaders` on first use, fixing CJS startup without changing auth behavior.

<sup>Written for commit 28cc392d644b0fa355c3d625959a7f8efd8d10c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

