### PR TITLE
fix: remove workspace from agent header breadcrumb

### DIFF
--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -134,10 +134,6 @@ const Header: Component<HeaderProps> = (props) => {
         )}
         <Show when={getAgentName()}>
           <span class="header__separator">/</span>
-          <A href="/harnesses" class="header__breadcrumb-link">
-            Workspace
-          </A>
-          <span class="header__separator">/</span>
           <span class="header__breadcrumb-current">
             <Show when={agentPlatformIcon()}>
               <img

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -296,10 +296,14 @@ describe("Header - breadcrumb", () => {
     expect(logoLink.getAttribute("href")).toBe("/");
   });
 
-  it("shows Workspace breadcrumb when agent is active", () => {
+  it("shows only the active agent breadcrumb when agent is active", () => {
     mockAgentName = "my-agent";
-    render(() => <Header />);
-    expect(screen.getByText("Workspace")).toBeDefined();
+    const { container } = render(() => <Header />);
+    expect(screen.queryByText("Workspace")).toBeNull();
+    expect(container.querySelector(".header__breadcrumb-current")?.textContent).toContain(
+      "my-agent",
+    );
+    expect(container.querySelectorAll(".header__separator").length).toBe(1);
   });
 });
 


### PR DESCRIPTION
### ✨ What changed
- Removes the deprecated `Workspace` segment from the agent header breadcrumb.
- Keeps the agent breadcrumb label and action menu intact.

### 💭 Why
Workspace is no longer part of the product path. Agent pages should read as `/ Agent`.

### 👤 For users
Agent pages no longer show `/ Workspace / Agent` in the top-left path.

### 📝 Notes
Validation passed `Header.test.tsx` and `git diff --check`.
