### PR TITLE
fix: route header docs link by current page

### DIFF
--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -12,6 +12,7 @@ const STAR_DISMISSED_KEY = 'github-star-dismissed';
 const STAR_CACHE_KEY = 'github-star-count';
 const STAR_CACHE_TS_KEY = 'github-star-ts';
 const STAR_CACHE_TTL = 3600000; // 1 hour
+const DOCS_BASE_URL = 'https://manifest.build/docs';
 
 interface HeaderProps {
   showMobileNavToggle?: boolean;
@@ -70,9 +71,15 @@ const Header: Component<HeaderProps> = (props) => {
   const effectiveName = () => user()?.name ?? 'User';
   const docsUrl = () => {
     const p = location.pathname;
-    if (p.includes('/limits')) return 'https://manifest.build/docs/set-limits';
-    if (p.includes('/routing')) return 'https://manifest.build/docs/routing';
-    return 'https://manifest.build/docs/introduction';
+    if (p.includes('/guardrails') || p.includes('/limits')) return `${DOCS_BASE_URL}/set-limits`;
+    if (p.includes('/routing')) return `${DOCS_BASE_URL}/routing`;
+    if (p.startsWith('/providers/subscriptions')) {
+      return `${DOCS_BASE_URL}/providers/subscription-based-providers`;
+    }
+    if (p.startsWith('/providers/byok')) return `${DOCS_BASE_URL}/providers/api-key-providers`;
+    if (p.startsWith('/providers/local')) return `${DOCS_BASE_URL}/providers/local-models`;
+    if (p.includes('/providers')) return `${DOCS_BASE_URL}/providers/api-key-providers`;
+    return `${DOCS_BASE_URL}/introduction`;
   };
 
   const initials = () => {

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -3,11 +3,12 @@ import { render, screen, fireEvent } from "@solidjs/testing-library";
 
 const mockSignOut = vi.fn().mockResolvedValue(undefined);
 const mockNavigate = vi.fn();
+let mockPathname = "/";
 
 vi.mock("@solidjs/router", () => ({
   A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
   useNavigate: () => mockNavigate,
-  useLocation: () => ({ pathname: "/" }),
+  useLocation: () => ({ pathname: mockPathname }),
 }));
 
 vi.mock("../../src/services/auth-client.js", () => ({
@@ -53,6 +54,7 @@ import Header from "../../src/components/Header";
 beforeEach(() => {
   vi.restoreAllMocks();
   sessionStorage.clear();
+  mockPathname = "/";
   mockAgentName = null;
   mockAgentDisplayName = null;
   mockCheckIsSelfHosted.mockReset();
@@ -304,6 +306,53 @@ describe("Header - breadcrumb", () => {
       "my-agent",
     );
     expect(container.querySelectorAll(".header__separator").length).toBe(1);
+  });
+});
+
+describe("Header - docs link", () => {
+  const docsHref = (container: HTMLElement) =>
+    container.querySelector(".header__docs-link")?.getAttribute("href");
+
+  it("links agent routing pages to routing docs", () => {
+    mockPathname = "/harnesses/my-agent/routing";
+    const { container } = render(() => <Header />);
+    expect(docsHref(container)).toBe("https://manifest.build/docs/routing");
+  });
+
+  it("links the current Limits route to limits docs", () => {
+    mockPathname = "/harnesses/my-agent/guardrails";
+    const { container } = render(() => <Header />);
+    expect(docsHref(container)).toBe("https://manifest.build/docs/set-limits");
+  });
+
+  it("keeps the legacy Limits route mapped to limits docs", () => {
+    mockPathname = "/harnesses/my-agent/limits";
+    const { container } = render(() => <Header />);
+    expect(docsHref(container)).toBe("https://manifest.build/docs/set-limits");
+  });
+
+  it("links provider pages to matching provider docs", () => {
+    mockPathname = "/providers/subscriptions";
+    const subscriptions = render(() => <Header />);
+    expect(docsHref(subscriptions.container)).toBe(
+      "https://manifest.build/docs/providers/subscription-based-providers",
+    );
+
+    mockPathname = "/providers/byok";
+    const byok = render(() => <Header />);
+    expect(docsHref(byok.container)).toBe(
+      "https://manifest.build/docs/providers/api-key-providers",
+    );
+
+    mockPathname = "/providers/local";
+    const local = render(() => <Header />);
+    expect(docsHref(local.container)).toBe("https://manifest.build/docs/providers/local-models");
+  });
+
+  it("falls back to introduction docs for unmapped pages", () => {
+    mockPathname = "/messages";
+    const { container } = render(() => <Header />);
+    expect(docsHref(container)).toBe("https://manifest.build/docs/introduction");
   });
 });
 


### PR DESCRIPTION
### ✨ What changed
- Routes header Docs links by the current page.
- Maps Limits, Routing, and provider pages to their matching docs.
- Keeps the introduction docs as the fallback.

### 💭 Why
Production already sends users to relevant docs. The stacked UI should keep that behavior.

### 👤 For users
Docs opens the page-specific documentation instead of always opening the main docs page.

### 📝 Notes
Validation passed `Header.test.tsx` and `git diff --check`.
