### PR TITLE
fix: count legacy agent-name rows for limits

### DIFF
--- a/packages/backend/src/notifications/services/notification-rules.service.consumption.spec.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.consumption.spec.ts
@@ -185,6 +185,26 @@ describe('NotificationRulesService.getConsumption', () => {
     expect(andWhereCalls.some((sql) => sql.includes('deleted_at IS NULL'))).toBe(true);
   });
 
+  it('counts legacy rows that only have agent_name when agent_id is missing', async () => {
+    const qb = makeQb({ total: '42' });
+    messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+    const result = await service.getConsumption(
+      'tenant-A',
+      'agent-1',
+      'tokens',
+      '2026-02-01 00:00:00',
+      '2026-02-17 14:00:00',
+    );
+
+    expect(result).toBe(42);
+    const agentFilter = qb.andWhere.mock.calls
+      .map((c) => String(c[0]))
+      .find((sql) => sql.includes('at.agent_id ='));
+    expect(agentFilter).toContain('at.agent_id IS NULL');
+    expect(agentFilter).toContain('at.agent_name = :agentName');
+  });
+
   it('passes the period boundaries as inclusive-start, exclusive-end', async () => {
     const qb = makeQb({ total: '0' });
     messageRepo.createQueryBuilder.mockReturnValueOnce(qb);

--- a/packages/backend/src/notifications/services/notification-rules.service.consumption.spec.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.consumption.spec.ts
@@ -201,8 +201,8 @@ describe('NotificationRulesService.getConsumption', () => {
     const agentFilter = qb.andWhere.mock.calls
       .map((c) => String(c[0]))
       .find((sql) => sql.includes('at.agent_id ='));
-    expect(agentFilter).toContain('at.agent_id IS NULL');
-    expect(agentFilter).toContain('at.agent_name = :agentName');
+    expect(agentFilter).toEqual(expect.stringContaining('at.agent_id IS NULL'));
+    expect(agentFilter).toEqual(expect.stringContaining('at.agent_name = :agentName'));
   });
 
   it('passes the period boundaries as inclusive-start, exclusive-end', async () => {

--- a/packages/backend/src/notifications/services/notification-rules.service.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.ts
@@ -123,12 +123,18 @@ export class NotificationRulesService {
       .select(expr, 'total')
       .where('at.tenant_id = :tenantId', { tenantId })
       .andWhere(
-        `at.agent_id = (
-          SELECT id FROM agents
-          WHERE tenant_id = at.tenant_id
-            AND name = :agentName
-            AND deleted_at IS NULL
-          LIMIT 1
+        `(
+          at.agent_id = (
+            SELECT id FROM agents
+            WHERE tenant_id = at.tenant_id
+              AND name = :agentName
+              AND deleted_at IS NULL
+            LIMIT 1
+          )
+          OR (
+            at.agent_id IS NULL
+            AND at.agent_name = :agentName
+          )
         )`,
         { agentName },
       )


### PR DESCRIPTION
### ✨ What changed
- Counts legacy usage rows with `agent_name` when `agent_id` is missing.
- Keeps the new `agent_id` match as the preferred consumption path.
- Keeps the fallback scoped to the same tenant.

### 💭 Why
Older production message rows can miss `agent_id`. Limits read those rows as zero usage.

### 👤 For users
Hard limits apply to existing message history again after the stack upgrade.

### 📝 Notes
Validation passed backend notification/limit tests, frontend Limits tests, builds, and `git diff --check`.
