### PR TITLE
fix: target the visible provider key on edit and rename

### DIFF
--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -476,6 +476,60 @@ describe('ProviderService — route-only cleanup paths', () => {
       expect(saved[0].override_route?.keyLabel).toBe('Renamed');
     });
 
+    it('relabels pinned routes on every agent of the user, not just the renaming one', async () => {
+      const pin = (keyLabel: string) => ({
+        provider: 'openai',
+        authType: 'api_key' as const,
+        model: 'gpt-4o',
+        keyLabel,
+      });
+      providerRepo.find.mockResolvedValue([
+        {
+          id: 'target',
+          provider: 'openai',
+          auth_type: 'api_key',
+          label: 'Key 2',
+          is_active: true,
+        },
+      ]);
+      tierRepo.find.mockResolvedValue([
+        {
+          id: 't1',
+          agent_id: 'agent-1',
+          override_route: pin('Key 2'),
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+        {
+          id: 't2',
+          agent_id: 'agent-2',
+          override_route: pin('Key 2'),
+          fallback_routes: [pin('Key 2')],
+        } as unknown as TierAssignment,
+      ]);
+      specRepo.find.mockResolvedValue([
+        {
+          id: 's1',
+          agent_id: 'agent-3',
+          override_route: pin('Key 2'),
+          fallback_routes: null,
+        } as unknown as SpecificityAssignment,
+      ]);
+      headerTierRepo.find.mockResolvedValue([]);
+
+      await svc.renameKey('agent-1', 'user-1', 'openai', 'api_key', 'Key 2', 'Renamed');
+
+      expect(tierRepo.find).toHaveBeenCalledWith({ where: { user_id: 'user-1' } });
+      const savedTiers = tierRepo.save.mock.calls[0][0] as TierAssignment[];
+      expect(savedTiers.map((t) => t.override_route?.keyLabel)).toEqual(['Renamed', 'Renamed']);
+      expect(savedTiers[1].fallback_routes?.[0]?.keyLabel).toBe('Renamed');
+      const savedSpecs = specRepo.save.mock.calls[0][0] as SpecificityAssignment[];
+      expect(savedSpecs[0].override_route?.keyLabel).toBe('Renamed');
+      // Per-agent tier caches must be flushed for every mutated agent.
+      for (const id of ['agent-1', 'agent-2', 'agent-3']) {
+        expect(routingCache.invalidateAgent).toHaveBeenCalledWith(id);
+      }
+    });
+
     it('blocks full provider disconnect while header tiers route to it', async () => {
       providerRepo.find.mockResolvedValue([
         {

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -355,7 +355,7 @@ export class ProviderService {
     target.label = trimmed;
     target.updated_at = new Date().toISOString();
     await this.providerRepo.save(target);
-    await this.relabelOverrides(agentId, provider, authType, previousLabel, trimmed);
+    await this.relabelOverrides(userId, provider, authType, previousLabel, trimmed);
     this.routingCache.invalidateAgent(agentId);
     this.routingCache.invalidateUser(userId);
     return target;
@@ -891,7 +891,7 @@ export class ProviderService {
    * the new primary key).
    */
   private async relabelOverrides(
-    agentId: string,
+    userId: string,
     provider: string,
     authType: AuthType,
     previousLabel: string,
@@ -916,7 +916,11 @@ export class ProviderService {
       keyLabel: nextLabel ?? null,
     });
 
-    const tiers = await this.tierRepo.find({ where: { agent_id: agentId } });
+    // Keys are user-global: a rename must rewrite pinned routes on every
+    // agent the user owns, not just the one whose page triggered it. Stale
+    // labels make the proxy silently fall back to the first key by priority.
+    const mutatedAgentIds = new Set<string>();
+    const tiers = await this.tierRepo.find({ where: { user_id: userId } });
     const tiersToSave: TierAssignment[] = [];
     const now = new Date().toISOString();
     for (const t of tiers) {
@@ -934,6 +938,7 @@ export class ProviderService {
       if (mutated) {
         t.updated_at = now;
         tiersToSave.push(t);
+        mutatedAgentIds.add(t.agent_id);
       }
     }
     if (tiersToSave.length > 0) await this.tierRepo.save(tiersToSave);
@@ -942,7 +947,7 @@ export class ProviderService {
     // fallback_routes. Cubic flagged P2: skipping specificity fallbacks left
     // stale key-label pins behind, which then misrouted next time the
     // specificity rule fired.
-    const specs = await this.specificityRepo.find({ where: { agent_id: agentId } });
+    const specs = await this.specificityRepo.find({ where: { user_id: userId } });
     const specsToSave: SpecificityAssignment[] = [];
     for (const s of specs) {
       let mutated = false;
@@ -959,6 +964,7 @@ export class ProviderService {
       if (mutated) {
         s.updated_at = now;
         specsToSave.push(s);
+        mutatedAgentIds.add(s.agent_id);
       }
     }
     if (specsToSave.length > 0) await this.specificityRepo.save(specsToSave);
@@ -967,7 +973,7 @@ export class ProviderService {
     // omitted here originally, so disconnecting one account out of several
     // (or renaming a key) left header-tier routes pinned to a label that no
     // longer exists — the account chip then renders blank. Relabel them too.
-    const headerTiers = await this.headerTierRepo.find({ where: { agent_id: agentId } });
+    const headerTiers = await this.headerTierRepo.find({ where: { user_id: userId } });
     const headerTiersToSave: HeaderTier[] = [];
     for (const h of headerTiers) {
       let mutated = false;
@@ -984,9 +990,14 @@ export class ProviderService {
       if (mutated) {
         h.updated_at = now;
         headerTiersToSave.push(h);
+        mutatedAgentIds.add(h.agent_id);
       }
     }
     if (headerTiersToSave.length > 0) await this.headerTierRepo.save(headerTiersToSave);
+
+    // invalidateUser() doesn't clear per-agent tier caches, so flush every
+    // agent whose rows were rewritten or stale routes would keep serving.
+    for (const id of mutatedAgentIds) this.routingCache.invalidateAgent(id);
   }
 
   private async renumberPriorities(

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -4,6 +4,7 @@ import {
   createMemo,
   createEffect,
   createSignal,
+  on,
   onMount,
   type Component,
   type Accessor,
@@ -199,6 +200,10 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
       return;
     }
 
+    // Without an explicit label the backend's legacy path writes to the row
+    // labeled 'Default' — wrong target whenever the visible key is named
+    // anything else. Pin the update to the key this view is showing.
+    const targetLabel = label ?? activeKeys()[0]?.label;
     props.setBusy(true);
     try {
       await connectProvider(props.agentName, {
@@ -206,7 +211,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
         apiKey: props.keyInput().replace(/\s/g, ''),
         authType: props.selectedAuthType(),
         ...(endpointRegionPayload() && { region: endpointRegionPayload() }),
-        ...(label && { label }),
+        ...(targetLabel && { label: targetLabel }),
       });
       const noun = props.isSubMode() && !isApiKeyCredential() ? 'token' : 'key';
       toast.success(`${props.provDef.name} ${noun} updated`);
@@ -519,19 +524,23 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
 
   const defaultLabel = () => suggestNextProviderKeyLabel(props.existingLabels());
 
-  // Sync label suggestion when opened externally and auto-focus the API key field
-  createEffect(() => {
-    if (isOpen() && !label().trim()) {
-      setLabel(defaultLabel());
-    }
-    const defaultEndpointRegion = props.endpointRegions?.[0]?.value;
-    if (isOpen() && defaultEndpointRegion && !endpointRegion()) {
-      setEndpointRegion(props.initialEndpointRegion ?? defaultEndpointRegion);
-    }
-    if (isOpen()) {
-      requestAnimationFrame(() => apiKeyInputRef?.focus());
-    }
-  });
+  // Sync label suggestion when opened externally and auto-focus the API key field.
+  // Use `on()` with explicit deps to avoid tracking label/endpointRegion signals,
+  // which would re-fire the effect (and steal focus) on every keystroke.
+  createEffect(
+    on(isOpen, (open, prevOpen) => {
+      if (open && !label().trim()) {
+        setLabel(defaultLabel());
+      }
+      const defaultEndpointRegion = props.endpointRegions?.[0]?.value;
+      if (open && defaultEndpointRegion && !endpointRegion()) {
+        setEndpointRegion(props.initialEndpointRegion ?? defaultEndpointRegion);
+      }
+      if (open && !prevOpen) {
+        requestAnimationFrame(() => apiKeyInputRef?.focus());
+      }
+    }),
+  );
 
   const submit = async () => {
     const labelToUse = (label().trim() || defaultLabel()).slice(0, MAX_LABEL_LENGTH);

--- a/packages/frontend/tests/components/ProviderKeyForm.test.tsx
+++ b/packages/frontend/tests/components/ProviderKeyForm.test.tsx
@@ -451,6 +451,46 @@ describe('ProviderKeyForm', () => {
         apiKey: 'zai-new-key',
         authType: 'subscription',
         region: 'cn',
+        label: 'Default',
+      });
+    });
+
+    it('targets the visible key label on update so a non-Default key is not bypassed', async () => {
+      const def = makeProviderDef({ id: 'openai', name: 'OpenAI' });
+      const { container } = mount({
+        provDef: def,
+        provId: 'openai',
+        connected: true,
+        editing: true,
+        keyInput: 'sk-new-value',
+        providers: [
+          {
+            id: 'p2',
+            provider: 'openai',
+            auth_type: 'api_key' as const,
+            is_active: true,
+            has_api_key: true,
+            key_prefix: 'sk-old-',
+            label: 'second',
+            priority: 1,
+            region: null,
+            connected_at: '2026-04-27',
+          },
+        ],
+      });
+
+      const saveBtn = Array.from(container.querySelectorAll('.provider-detail__action')).find((b) =>
+        b.textContent?.includes('Save'),
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'openai',
+        apiKey: 'sk-new-value',
+        authType: 'api_key',
+        label: 'second',
       });
     });
 


### PR DESCRIPTION
### ✨ What changed
- Add-key form no longer steals focus to the key field on every name keystroke.
- Updating a key value targets the visible key's label instead of the 'Default' row.
- Key rename rewrites pinned routes across all the user's agents, not just one.
- Mutated agents get their routing cache flushed after a rename.

### 💭 Why
Three multi-key bugs found while testing the stack: the name field was untypable past one character, key edits silently landed on the first key, and renames left stale pins that made the proxy fall back to the default key.

### 👤 For users
Naming a second API key works, and editing or renaming a key affects the key you're looking at.

### 📝 Notes
Focus fix ported from #2061. Backend (54) and frontend (48) suites pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-key editing and renaming so updates apply to the visible key and renames relabel routes across all of a user’s agents. The add-key modal no longer steals focus, making the name field typeable.

- **Bug Fixes**
  - Frontend: Updates now include the visible key’s label to avoid writing to the `Default` row.
  - Frontend: The add-key modal focuses the API key field only on open (tracks `isOpen` via `on()`), preventing focus theft while typing the name.
  - Backend: Renaming a key relabels pinned routes across all of the user’s agents (tiers, specificity, and header tiers) and flushes each mutated agent’s routing cache.

<sup>Written for commit 5dcb1a470666adf77d03770be1f265e8f8c75893. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

