### PR TITLE
fix: strip native button chrome from chart stat tabs

### DIFF
--- a/packages/frontend/src/styles/cards.css
+++ b/packages/frontend/src/styles/cards.css
@@ -108,6 +108,15 @@
 }
 
 .chart-card__stat--clickable {
+  /* These stats render as <button> for a11y — strip the native button
+     chrome (light UA background/border) so they match the card theme. */
+  appearance: none;
+  background: none;
+  border: none;
+  border-right: 1px solid hsl(var(--border));
+  font: inherit;
+  color: inherit;
+  text-align: left;
   cursor: pointer;
   transition: all var(--transition-fast);
   position: relative;


### PR DESCRIPTION
### ✨ What changed
- `.chart-card__stat--clickable` resets the UA button background, border, and font.
- Keeps the themed divider border between stats.

### 💭 Why
The Cost/Messages/Token usage stats render as `<button>` for a11y, but the user-agent default styles painted them as light gray cards on the dark theme. Seb's design (#2061) uses plain divs with no chrome.

### 👤 For users
Overview chart stat tabs match the card background in both themes again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip default browser button styles from chart stat tabs so they match the card background in both themes; keeps the themed divider border.

<sup>Written for commit 17c8a15d8c0adf6395ed24b95c98a1f01b2b1a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

