### PR TITLE
fix: compute limit period boundaries in local time, not UTC

### DIFF
--- a/.changeset/limits-local-time-boundaries.md
+++ b/.changeset/limits-local-time-boundaries.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix token/cost limits never blocking (or alerting) when the server's timezone isn't UTC. `computePeriodBoundaries`/`computePeriodResetDate` built their window in UTC, but `agent_messages.timestamp` rows are stored in the process's local time — so on a non-UTC host the window's upper bound sat behind the stored rows by the TZ offset and the consumption SUM read ~0, meaning hard limits silently never tripped and threshold alerts never fired. Boundaries are now computed in local time (matching `computeCutoff`), via a new `toLocalSqlTimestamp` helper.

--- a/packages/backend/src/common/utils/period.util.spec.ts
+++ b/packages/backend/src/common/utils/period.util.spec.ts
@@ -1,5 +1,9 @@
 import { computePeriodBoundaries, computePeriodResetDate } from './period.util';
 
+// Parse a local-time `YYYY-MM-DD HH:MM:SS` string (no tz suffix) back into a
+// Date using the same local-timezone interpretation the formatter used.
+const parseLocal = (s: string) => new Date(s.replace(' ', 'T'));
+
 describe('computePeriodBoundaries', () => {
   it('returns periodStart and periodEnd as formatted strings', () => {
     const { periodStart, periodEnd } = computePeriodBoundaries('day');
@@ -7,41 +11,41 @@ describe('computePeriodBoundaries', () => {
     expect(periodEnd).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
   });
 
-  it('hour: start is 1 hour before current hour', () => {
+  it('hour: start is 1 hour before the current local hour', () => {
     const now = new Date();
     const { periodStart } = computePeriodBoundaries('hour');
-    const start = new Date(periodStart.replace(' ', 'T') + 'Z');
-    const expectedHour = now.getUTCHours() - 1;
-    expect(start.getUTCHours()).toBe(expectedHour < 0 ? expectedHour + 24 : expectedHour);
-    expect(start.getUTCMinutes()).toBe(0);
-    expect(start.getUTCSeconds()).toBe(0);
+    const start = parseLocal(periodStart);
+    const expectedHour = now.getHours() - 1;
+    expect(start.getHours()).toBe(expectedHour < 0 ? expectedHour + 24 : expectedHour);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
   });
 
-  it('day: start is midnight UTC today', () => {
+  it('day: start is local midnight today', () => {
     const now = new Date();
     const { periodStart } = computePeriodBoundaries('day');
-    const start = new Date(periodStart.replace(' ', 'T') + 'Z');
-    expect(start.getUTCHours()).toBe(0);
-    expect(start.getUTCMinutes()).toBe(0);
-    expect(start.getUTCDate()).toBe(now.getUTCDate());
+    const start = parseLocal(periodStart);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getDate()).toBe(now.getDate());
   });
 
-  it('week: start is Monday at midnight UTC', () => {
+  it('week: start is Monday at local midnight', () => {
     const { periodStart } = computePeriodBoundaries('week');
-    const start = new Date(periodStart.replace(' ', 'T') + 'Z');
-    expect(start.getUTCHours()).toBe(0);
-    expect(start.getUTCMinutes()).toBe(0);
+    const start = parseLocal(periodStart);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
     // Monday is day 1
-    expect(start.getUTCDay()).toBe(1);
+    expect(start.getDay()).toBe(1);
   });
 
-  it('month: start is first of month at midnight UTC', () => {
+  it('month: start is first of month at local midnight', () => {
     const now = new Date();
     const { periodStart } = computePeriodBoundaries('month');
-    const start = new Date(periodStart.replace(' ', 'T') + 'Z');
-    expect(start.getUTCDate()).toBe(1);
-    expect(start.getUTCHours()).toBe(0);
-    expect(start.getUTCMonth()).toBe(now.getUTCMonth());
+    const start = parseLocal(periodStart);
+    expect(start.getDate()).toBe(1);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMonth()).toBe(now.getMonth());
   });
 
   it('unknown period: defaults to hour-like behavior', () => {
@@ -53,9 +57,28 @@ describe('computePeriodBoundaries', () => {
     const before = Date.now();
     const { periodEnd } = computePeriodBoundaries('day');
     const after = Date.now();
-    const end = new Date(periodEnd.replace(' ', 'T') + 'Z').getTime();
+    const end = parseLocal(periodEnd).getTime();
     expect(end).toBeGreaterThanOrEqual(before - 1000);
     expect(end).toBeLessThanOrEqual(after + 1000);
+  });
+
+  // Regression: the boundaries must be expressed in the process's LOCAL
+  // timezone, not UTC. `agent_messages.timestamp` rows are stored as local-time
+  // `timestamp without time zone`, so a UTC `periodEnd` (the old code formatted
+  // via toISOString) sits behind the stored rows by the process TZ offset and
+  // the consumption SUM silently reads ~0 — meaning token/cost limits never
+  // trip. We assert that periodEnd, interpreted as a local-time string,
+  // round-trips back to the real instant. With the old UTC formatting this only
+  // holds when the host TZ is UTC; on any other zone (every broken real-world
+  // deployment, and this CI host when run under TZ!=UTC) it fails.
+  it('formats periodEnd in local wall-clock so it round-trips to the real instant', () => {
+    const instant = new Date('2026-06-10T11:16:00.000Z');
+    jest.useFakeTimers().setSystemTime(instant);
+
+    const { periodEnd } = computePeriodBoundaries('day');
+    expect(parseLocal(periodEnd).getTime()).toBe(instant.getTime());
+
+    jest.useRealTimers();
   });
 });
 
@@ -65,59 +88,51 @@ describe('computePeriodResetDate', () => {
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
   });
 
-  it('hour: returns start of next hour UTC', () => {
+  it('hour: returns start of the next local hour', () => {
     const now = new Date();
-    const result = computePeriodResetDate('hour');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
-    const expectedHour = (now.getUTCHours() + 1) % 24;
-    expect(reset.getUTCHours()).toBe(expectedHour);
-    expect(reset.getUTCMinutes()).toBe(0);
-    expect(reset.getUTCSeconds()).toBe(0);
+    const reset = parseLocal(computePeriodResetDate('hour'));
+    const expectedHour = (now.getHours() + 1) % 24;
+    expect(reset.getHours()).toBe(expectedHour);
+    expect(reset.getMinutes()).toBe(0);
+    expect(reset.getSeconds()).toBe(0);
   });
 
-  it('day: returns midnight UTC next day', () => {
+  it('day: returns local midnight next day', () => {
     const now = new Date();
-    const result = computePeriodResetDate('day');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
-    expect(reset.getUTCHours()).toBe(0);
-    expect(reset.getUTCMinutes()).toBe(0);
-    const expectedDate = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
-    );
-    expect(reset.getUTCDate()).toBe(expectedDate.getUTCDate());
+    const reset = parseLocal(computePeriodResetDate('day'));
+    expect(reset.getHours()).toBe(0);
+    expect(reset.getMinutes()).toBe(0);
+    const expectedDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+    expect(reset.getDate()).toBe(expectedDate.getDate());
   });
 
-  it('week: returns next Monday at midnight UTC', () => {
-    const result = computePeriodResetDate('week');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
-    expect(reset.getUTCDay()).toBe(1); // Monday
-    expect(reset.getUTCHours()).toBe(0);
-    expect(reset.getUTCMinutes()).toBe(0);
+  it('week: returns next Monday at local midnight', () => {
+    const reset = parseLocal(computePeriodResetDate('week'));
+    expect(reset.getDay()).toBe(1); // Monday
+    expect(reset.getHours()).toBe(0);
+    expect(reset.getMinutes()).toBe(0);
     expect(reset.getTime()).toBeGreaterThan(Date.now());
   });
 
-  it('month: returns first of next month UTC', () => {
+  it('month: returns first of next month', () => {
     const now = new Date();
-    const result = computePeriodResetDate('month');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
-    expect(reset.getUTCDate()).toBe(1);
-    expect(reset.getUTCHours()).toBe(0);
-    const expectedMonth = (now.getUTCMonth() + 1) % 12;
-    expect(reset.getUTCMonth()).toBe(expectedMonth);
+    const reset = parseLocal(computePeriodResetDate('month'));
+    expect(reset.getDate()).toBe(1);
+    expect(reset.getHours()).toBe(0);
+    const expectedMonth = (now.getMonth() + 1) % 12;
+    expect(reset.getMonth()).toBe(expectedMonth);
   });
 
   it('week on a Monday: daysUntilMonday falls back to 7', () => {
-    // 2026-03-02 is a Monday (UTC day = 1)
-    const monday = new Date(Date.UTC(2026, 2, 2, 12, 0, 0));
+    // 2026-03-02 is a Monday — pin local noon so the local day is Monday.
     jest.useFakeTimers();
-    jest.setSystemTime(monday);
+    jest.setSystemTime(new Date(2026, 2, 2, 12, 0, 0));
 
-    const result = computePeriodResetDate('week');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
+    const reset = parseLocal(computePeriodResetDate('week'));
 
     // Should be next Monday, exactly 7 days later
-    expect(reset.getUTCDay()).toBe(1);
-    expect(reset.getUTCDate()).toBe(monday.getUTCDate() + 7);
+    expect(reset.getDay()).toBe(1);
+    expect(reset.getDate()).toBe(9);
 
     jest.useRealTimers();
   });
@@ -129,8 +144,7 @@ describe('computePeriodResetDate', () => {
 
   it('reset date is always in the future', () => {
     for (const period of ['hour', 'day', 'week', 'month']) {
-      const result = computePeriodResetDate(period);
-      const reset = new Date(result.replace(' ', 'T') + 'Z');
+      const reset = parseLocal(computePeriodResetDate(period));
       expect(reset.getTime()).toBeGreaterThan(Date.now() - 1000);
     }
   });

--- a/packages/backend/src/common/utils/period.util.ts
+++ b/packages/backend/src/common/utils/period.util.ts
@@ -1,71 +1,72 @@
-import { toSqlTimestamp } from './postgres-sql';
+import { toLocalSqlTimestamp } from './postgres-sql';
 
 export interface PeriodBoundaries {
   periodStart: string;
   periodEnd: string;
 }
 
+// Boundaries are computed in the Node process's LOCAL timezone, not UTC, because
+// they are compared against `agent_messages.timestamp` — which the pg driver
+// stores as a local-time `timestamp without time zone`. A UTC boundary would be
+// offset from the stored values by the process TZ, so `periodEnd` (UTC "now")
+// lands behind the local-time rows and the SUM silently reads ~0, meaning token
+// /cost limits never trip. Use local Date constructors + toLocalSqlTimestamp to
+// stay aligned with how the rows are written (see computeCutoff for the same
+// rationale on the analytics range cutoffs).
 export function computePeriodBoundaries(period: string): PeriodBoundaries {
   const now = new Date();
   let start: Date;
 
   switch (period) {
     case 'hour':
-      start = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() - 1),
-      );
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() - 1);
       break;
     case 'day':
-      start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
       break;
     case 'week': {
-      const dayOfWeek = now.getUTCDay();
-      const monday = now.getUTCDate() - ((dayOfWeek + 6) % 7);
-      start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), monday));
+      const dayOfWeek = now.getDay();
+      const monday = now.getDate() - ((dayOfWeek + 6) % 7);
+      start = new Date(now.getFullYear(), now.getMonth(), monday);
       break;
     }
     case 'month':
-      start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      start = new Date(now.getFullYear(), now.getMonth(), 1);
       break;
     default:
-      start = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() - 1),
-      );
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() - 1);
   }
 
   const end = new Date(now.getTime());
-  return { periodStart: toSqlTimestamp(start), periodEnd: toSqlTimestamp(end) };
+  return { periodStart: toLocalSqlTimestamp(start), periodEnd: toLocalSqlTimestamp(end) };
 }
 
+// Computed in local time for the same reason as computePeriodBoundaries: the
+// reset instant must line up with the local-time period window shown to the user
+// in threshold alerts.
 export function computePeriodResetDate(period: string): string {
   const now = new Date();
   let reset: Date;
 
   switch (period) {
     case 'hour':
-      reset = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 1),
-      );
+      reset = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() + 1);
       break;
     case 'day':
-      reset = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+      reset = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
       break;
     case 'week': {
-      const dayOfWeek = now.getUTCDay();
+      const dayOfWeek = now.getDay();
       const daysUntilMonday = (8 - dayOfWeek) % 7 || 7;
-      reset = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + daysUntilMonday),
-      );
+      reset = new Date(now.getFullYear(), now.getMonth(), now.getDate() + daysUntilMonday);
       break;
     }
     case 'month':
-      reset = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+      reset = new Date(now.getFullYear(), now.getMonth() + 1, 1);
       break;
     default:
-      reset = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 1),
-      );
+      reset = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() + 1);
   }
 
-  return toSqlTimestamp(reset);
+  return toLocalSqlTimestamp(reset);
 }

--- a/packages/backend/src/common/utils/postgres-sql.spec.ts
+++ b/packages/backend/src/common/utils/postgres-sql.spec.ts
@@ -9,6 +9,7 @@ import {
   timestampDefault,
   timestampType,
   toSqlTimestamp,
+  toLocalSqlTimestamp,
 } from './postgres-sql';
 
 describe('postgres-sql', () => {
@@ -110,6 +111,36 @@ describe('postgres-sql', () => {
       jest.useFakeTimers();
       jest.setSystemTime(new Date('2026-01-02T03:04:05.000Z').getTime());
       expect(toSqlTimestamp()).toBe('2026-01-02 03:04:05');
+      jest.useRealTimers();
+    });
+  });
+
+  describe('toLocalSqlTimestamp', () => {
+    it('formats a Date in local time as a space-separated string (no T or Z)', () => {
+      const d = new Date('2026-04-20T12:34:56.789Z');
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const expected =
+        `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+        `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+      const out = toLocalSqlTimestamp(d);
+      expect(out).toBe(expected);
+      expect(out).not.toContain('T');
+      expect(out).not.toContain('Z');
+      expect(out).toHaveLength(19);
+    });
+
+    it('round-trips to the same instant when parsed as local time', () => {
+      // Unlike toSqlTimestamp (UTC), the local string read back as local time
+      // recovers the original instant — this is the property period boundaries
+      // rely on to line up with locally-stored agent_messages.timestamp rows.
+      const d = new Date('2026-04-20T12:34:56.000Z');
+      expect(new Date(toLocalSqlTimestamp(d).replace(' ', 'T')).getTime()).toBe(d.getTime());
+    });
+
+    it('defaults to the current time when no Date is given', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-02T03:04:05.000Z').getTime());
+      expect(toLocalSqlTimestamp()).toBe(toLocalSqlTimestamp(new Date()));
       jest.useRealTimers();
     });
   });

--- a/packages/backend/src/common/utils/postgres-sql.ts
+++ b/packages/backend/src/common/utils/postgres-sql.ts
@@ -79,13 +79,37 @@ export function sqlCastInterval(paramName: string): string {
  * Format a Date as a Postgres-friendly timestamp string
  * (`YYYY-MM-DD HH:MM:SS` — space-separated, no timezone suffix).
  *
- * Used for notification-log / notification-rule writes and alert-period
- * boundaries. This emits UTC and is space-separated, intentionally distinct
- * from {@link sqlNow} / {@link computeCutoff}, which emit local-time,
- * `T`-separated strings for the analytics range cutoffs.
+ * Used for notification-log / notification-rule `created_at` / `sent_at` writes.
+ * This emits UTC and is space-separated, intentionally distinct from
+ * {@link sqlNow} / {@link computeCutoff}, which emit local-time strings for the
+ * analytics range cutoffs.
+ *
+ * Do NOT use this to build window boundaries compared against
+ * `agent_messages.timestamp` — those rows are stored in local time, so a UTC
+ * boundary is offset by the process TZ and silently drops rows. Use
+ * {@link toLocalSqlTimestamp} for that (see computePeriodBoundaries).
  */
 export function toSqlTimestamp(d: Date = new Date()): string {
   return d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+}
+
+/**
+ * Local-time variant of {@link toSqlTimestamp}: formats the wall-clock time in
+ * the Node process's local timezone as `YYYY-MM-DD HH:MM:SS` (space-separated,
+ * no timezone suffix).
+ *
+ * This is the correct format for period boundaries compared against
+ * `agent_messages.timestamp`: the pg driver serialises stored Dates in local
+ * time, so a UTC boundary would be offset from the stored values by the
+ * process's TZ offset — silently dropping rows near (and, for `periodEnd`, well
+ * within) the window. Mirrors the rationale on {@link computeCutoff}.
+ */
+export function toLocalSqlTimestamp(d: Date = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+  );
 }
 
 /**

--- a/packages/backend/src/notifications/services/notification-cron.service.edge-cases.spec.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.edge-cases.spec.ts
@@ -26,6 +26,23 @@ const baseRule = {
   period: 'day' as const,
 };
 
+// computePeriodBoundaries emits boundaries in the process's LOCAL timezone (to
+// match how agent_messages.timestamp is stored). These helpers rebuild the
+// expected start from the pinned instant the same way, so the assertions hold
+// regardless of the timezone CI runs under (UTC) vs a developer's machine.
+const pad = (n: number) => String(n).padStart(2, '0');
+const fmtLocal = (d: Date) =>
+  `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+  `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+const localDayStart = (iso: string) => {
+  const d = new Date(iso);
+  return fmtLocal(new Date(d.getFullYear(), d.getMonth(), d.getDate()));
+};
+const localHourStart = (iso: string) => {
+  const d = new Date(iso);
+  return fmtLocal(new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours() - 1));
+};
+
 describe('NotificationCronService — edge cases', () => {
   let service: NotificationCronService;
   let mockGetAllActiveRules: jest.Mock;
@@ -115,8 +132,8 @@ describe('NotificationCronService — edge cases', () => {
 
       expect(dedupPeriodStart).toBe(consumptionPeriodStart);
       expect(insertedPeriodStart).toBe(consumptionPeriodStart);
-      // Day period: midnight UTC. Fixed expectation.
-      expect(consumptionPeriodStart).toBe('2026-06-15 00:00:00');
+      // Day period: local midnight.
+      expect(consumptionPeriodStart).toBe(localDayStart('2026-06-15T12:00:00Z'));
     });
 
     it('emits an "hour" period that recomputes consistently within the same tick', async () => {
@@ -134,8 +151,8 @@ describe('NotificationCronService — edge cases', () => {
 
       const consumptionPeriodStart = mockGetConsumption.mock.calls[0][3];
       const dedupPeriodStart = mockHasAlreadySent.mock.calls[0][1];
-      // hour period: previous hour boundary (UTC).
-      expect(consumptionPeriodStart).toBe('2026-06-15 11:00:00');
+      // hour period: previous local-hour boundary.
+      expect(consumptionPeriodStart).toBe(localHourStart('2026-06-15T12:30:00Z'));
       expect(dedupPeriodStart).toBe(consumptionPeriodStart);
     });
 
@@ -163,14 +180,14 @@ describe('NotificationCronService — edge cases', () => {
       const insertedPeriodStart = mockInsertLog.mock.calls[0][0].periodStart;
 
       // The drift is real and observable: consumption was measured against the
-      // 10:00 start, but the dedup key + log row were written under the 11:00 start.
-      // This documents the current behaviour. When the source is refactored to
-      // capture periodStart once (e.g. pass it from checkThresholds into
-      // evaluateRule, or use a fixed epoch-modulo derivation), update these
-      // expectations to equality.
-      expect(consumptionPeriodStart).toBe('2026-06-15 10:00:00');
-      expect(dedupPeriodStart).toBe('2026-06-15 11:00:00');
-      expect(insertedPeriodStart).toBe('2026-06-15 11:00:00');
+      // earlier hour start, but the dedup key + log row were written under the
+      // next hour start (one hour later). This documents the current behaviour.
+      // When the source is refactored to capture periodStart once (e.g. pass it
+      // from checkThresholds into evaluateRule, or use a fixed epoch-modulo
+      // derivation), update these expectations to equality.
+      expect(consumptionPeriodStart).toBe(localHourStart('2026-06-15T11:59:59Z'));
+      expect(dedupPeriodStart).toBe(localHourStart('2026-06-15T12:00:01Z'));
+      expect(insertedPeriodStart).toBe(localHourStart('2026-06-15T12:00:01Z'));
       expect(dedupPeriodStart).not.toBe(consumptionPeriodStart);
     });
   });


### PR DESCRIPTION
Stacked on top of #2188.

## The bug

Token/cost **limits silently never block** (and threshold alerts never fire) whenever the server process runs in a **non-UTC timezone**. The hard-limit feature shipped in `dcfa4b6e` is affected on `main` too — a Railway/UTC container works by coincidence, but any self-hosted install in another zone gets non-functional limits.

## Root cause

`computePeriodBoundaries` / `computePeriodResetDate` build their window with `Date.UTC(...)` + `toSqlTimestamp` (which uses `toISOString()` → **UTC** wall-clock). But `agent_messages.timestamp` is `timestamp without time zone` written in the process's **local** time — the pg driver serialises JS Dates locally, and the rest of the analytics layer already compares against local cutoffs via `computeCutoff`/`formatLocalIso` (see the note in `postgres-sql.ts`).

On a non-UTC host the window's upper bound (`periodEnd` = UTC "now") lands **behind** the local-time rows by the TZ offset, so `getConsumption`'s `SUM(...)` matches ~0 rows. With `actual (≈0) < threshold`, `ProxyService.enforceLimits` never trips and `NotificationCronService` never alerts.

PR #2188 fixed a *different* limits bug (legacy null-`agent_id` rows), so this gap remained.

## Reproduction (UTC+2 host)

- Agent with a `tokens` limit of **1/day**, `action: both`, active.
- Agent had **522 tokens** recorded today.
- Buggy UTC boundaries: `WHERE timestamp >= '…00:00:00' AND < '…11:16:00'` (UTC) excludes every `13:xx` local row → consumption `0` → request **allowed (HTTP 200, real completion)**.
- After the fix: consumption `522` → request **blocked**:
  ```
  [🦚 Manifest M200] You hit your tokens limit: 522 used, 1/day allowed.
  ```

## The fix

- Add `toLocalSqlTimestamp` (local-time sibling of `toSqlTimestamp`) in `postgres-sql.ts`.
- Recompute both period helpers from **local** `Date` parts + `toLocalSqlTimestamp`.
- Update `period.util` / `postgres-sql` specs to assert local behaviour, plus a round-trip regression that has teeth on any non-UTC host (CI runs UTC, where the old code coincidentally passed and hid this).
- Make the `notification-cron` edge-case boundary assertions timezone-independent (they previously hard-coded UTC strings).

## Tests

- `period.util.spec.ts`, `postgres-sql.spec.ts`: 100% line/branch coverage on both changed files.
- `notification-cron.service.edge-cases.spec.ts`: updated, passing.
- Note: `baseline-cost.spec.ts` (`collectRoutedModelIds`) fails on this branch **before** this change too — pre-existing on the stack, unrelated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a timezone bug that made token/cost limits and threshold alerts fail on non-UTC servers by computing period windows in local time to match stored message timestamps. Hard limits now block correctly and alerts fire as expected.

- **Bug Fixes**
  - Added `toLocalSqlTimestamp` and used it for limit window boundaries and reset dates.
  - Rewrote `computePeriodBoundaries` and `computePeriodResetDate` to use local time (not UTC).
  - Updated tests and notification-cron assertions to be timezone-agnostic.

<sup>Written for commit c47c089c173e37d8edbc7d63aaaf6ec6e3939dc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

