### PR TITLE
fix: show custom provider names in overview series and models

### DIFF
--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -26,6 +26,7 @@ import {
 } from '../services/api/analytics.js';
 import { formatNumber, formatCost, formatTimeAgo } from '../services/formatters.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
+import { getModelDisplayName, preloadModelDisplayNames } from '../services/model-display.js';
 import { PROVIDERS } from '../services/providers.js';
 import { AGENT_COLORS } from '../components/MultiAgentTokenChart.jsx';
 import ProviderChartCard from '../components/ProviderChartCard.jsx';
@@ -125,6 +126,7 @@ function loadRange(): string {
 
 const GlobalOverview: Component = () => {
   const navigate = useNavigate();
+  preloadModelDisplayNames();
 
   // ── Range state (persisted in localStorage) ──────────────────────────
   const [chartRange, setChartRangeRaw] = createSignal(loadRange());
@@ -234,6 +236,29 @@ const GlobalOverview: Component = () => {
     (p) => costFetcher(p.range, p.group),
   );
 
+  // Provider-grouped series key custom providers as 'custom:<uuid>'. Remap
+  // those keys to the provider's display name so the filter, legend, and
+  // tooltip read like every other provider. Reactive to customProviderData,
+  // so names fill in once that resource resolves.
+  const displaySeriesName = (key: string) => {
+    const name = resolveCustomName(key);
+    // 'hour'/'date' are the row's bucket columns — never let a custom
+    // provider named like them clobber the axis.
+    return name && name !== 'hour' && name !== 'date' ? name : key;
+  };
+  const remapCustomSeries = (raw: TSResult | undefined): TSResult | undefined => {
+    if (!raw || !raw.agents.some((a) => a.startsWith('custom:'))) return raw;
+    return {
+      agents: raw.agents.map(displaySeriesName),
+      timeseries: raw.timeseries.map((row) =>
+        Object.fromEntries(Object.entries(row).map(([k, v]) => [displaySeriesName(k), v])),
+      ),
+    };
+  };
+  const tokenSeries = createMemo(() => remapCustomSeries(agentTimeseries()));
+  const messageSeries = createMemo(() => remapCustomSeries(agentMessageTimeseries()));
+  const costSeries = createMemo(() => remapCustomSeries(agentCostTimeseries()));
+
   // ── Harness filter state (sessionStorage) ────────────────────────────
   // Scope the persisted selection by groupBy(): the provider grouping and the
   // harness grouping list completely different series, so a single shared set
@@ -283,8 +308,8 @@ const GlobalOverview: Component = () => {
   }
 
   const allAgents = createMemo(() => {
-    const tokenAgents = agentTimeseries()?.agents ?? [];
-    const msgAgents = agentMessageTimeseries()?.agents ?? [];
+    const tokenAgents = tokenSeries()?.agents ?? [];
+    const msgAgents = messageSeries()?.agents ?? [];
     const set = new Set([...tokenAgents, ...msgAgents]);
     return [...set].sort();
   });
@@ -330,7 +355,7 @@ const GlobalOverview: Component = () => {
   };
 
   const filteredAgentTimeseries = createMemo(() => {
-    const raw = agentTimeseries();
+    const raw = tokenSeries();
     if (!raw) return undefined;
     const sel = effectiveSelected();
     if (sel.size === 0) return raw;
@@ -346,7 +371,7 @@ const GlobalOverview: Component = () => {
   });
 
   const filteredAgentMessageTimeseries = createMemo(() => {
-    const raw = agentMessageTimeseries();
+    const raw = messageSeries();
     if (!raw) return undefined;
     const sel = effectiveSelected();
     if (sel.size === 0) return raw;
@@ -362,7 +387,7 @@ const GlobalOverview: Component = () => {
   });
 
   const filteredAgentCostTimeseries = createMemo(() => {
-    const raw = agentCostTimeseries();
+    const raw = costSeries();
     if (!raw) return undefined;
     const sel = effectiveSelected();
     if (sel.size === 0) return raw;
@@ -983,7 +1008,7 @@ const GlobalOverview: Component = () => {
                             </span>
                           </Show>
                           <span style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm);">
-                            {row.model || '—'}
+                            {row.model ? getModelDisplayName(row.model) : '—'}
                           </span>
                         </div>
                       </td>
@@ -1047,7 +1072,7 @@ const GlobalOverview: Component = () => {
                             </span>
                           </Show>
                           <span style="font-weight: 500; color: hsl(var(--foreground));">
-                            {row.display_name || row.model}
+                            {row.display_name || getModelDisplayName(row.model)}
                           </span>
                         </div>
                       </td>

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -181,9 +181,18 @@ const MessageLog: Component = () => {
     setFeedbackModalOpen(false);
   };
 
-  const [customProviders] = createResource(
-    () => params.agentName,
-    (name) => getCustomProviders(decodeURIComponent(name)),
+  // Custom providers are user-global, so any agent name returns the full set.
+  // On the scoped log use the route agent; on the global ("All harnesses") log
+  // there is no route agent, so fall back to the first available agent —
+  // otherwise the resource source is undefined, the fetcher never runs, and
+  // custom:<uuid> models render as `custom:Custom/…` with no provider icon.
+  // Mirrors GlobalOverview's firstAgent() pattern.
+  const customProviderAgent = () =>
+    params.agentName
+      ? decodeURIComponent(params.agentName)
+      : ((agentListRaw() ?? [])[0]?.agent_name ?? '');
+  const [customProviders] = createResource(customProviderAgent, (name) =>
+    name ? getCustomProviders(name).catch(() => []) : Promise.resolve([]),
   );
 
   const [routingStatus] = createResource(

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -652,6 +652,24 @@ describe("MessageLog", () => {
         expect(container.textContent).toContain("my-llama");
       });
     });
+
+    it("resolves custom provider name + icon in global mode via the first agent", async () => {
+      // Global ("All harnesses") log has no route agent. Custom providers are
+      // user-global, so the resource must fall back to the first agent —
+      // otherwise the source is undefined, the fetcher never runs, and
+      // custom:<uuid> models render as `custom:Custom/…` with no provider icon.
+      mockAgentName = undefined;
+      mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "agent-alpha" }] });
+      mockGetCustomProviders.mockResolvedValue([{ id: "abc-123", name: "Cerebras" }]);
+      mockGetMessages.mockResolvedValue(customMessagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector('img[alt="Cerebras"]')).not.toBeNull();
+        expect(container.textContent).not.toContain("custom:abc-123/");
+      });
+      // Resolved via the first available agent, not an undefined route param.
+      expect(mockGetCustomProviders).toHaveBeenCalledWith("agent-alpha");
+    });
   });
 
   describe("clear filters", () => {

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -215,6 +215,8 @@ vi.mock('../../src/services/connection-breadcrumb-store.js', () => ({
 vi.mock('manifest-shared', () => ({
   platformIcon: () => 'robot',
   PLATFORM_LABELS: { codex: 'Codex' },
+  SHARED_PROVIDERS: [],
+  inferProviderFromModel: () => undefined,
 }));
 
 import GlobalOverview from '../../src/pages/GlobalOverview';
@@ -614,6 +616,48 @@ describe('GlobalOverview (analytics)', () => {
     // Both providers still render despite the stale persisted set.
     expect(screen.getByTestId('ts-agents').textContent).toContain('openai');
     expect(screen.getByTestId('ts-agents').textContent).toContain('anthropic');
+  });
+
+  it('shows custom provider names instead of custom:<uuid> in provider series', async () => {
+    const customSeries = {
+      agents: ['openai', 'custom:cp-1'],
+      timeseries: [{ hour: '2026-06-04 10:00:00', openai: 1200, 'custom:cp-1': 300 }],
+    };
+    apiMocks.getGlobalPerProviderTimeseries.mockResolvedValue(customSeries);
+    apiMocks.getGlobalPerProviderMessageTimeseries.mockResolvedValue(customSeries);
+    apiMocks.getGlobalPerProviderCostTimeseries.mockResolvedValue(customSeries);
+    // A custom model with no display_name must render its stripped name, not
+    // the raw custom:<uuid>/ slug.
+    apiMocks.getOverview.mockResolvedValue({
+      ...overviewResponse,
+      cost_by_model: [
+        {
+          model: 'custom:cp-1/qwen-2.5',
+          display_name: null,
+          tokens: 300,
+          share_pct: 25,
+          estimated_cost: 0.1,
+          auth_type: 'api_key',
+          provider: 'custom:cp-1',
+        },
+      ],
+    });
+
+    render(() => <GlobalOverview />);
+    await waitFor(() => expect(screen.getByTestId('provider-chart-card')).toBeDefined());
+
+    // Chart series and filter list the resolved name once customProviderData loads.
+    await waitFor(() =>
+      expect(screen.getByTestId('ts-agents').textContent).toContain('Custom Provider'),
+    );
+    expect(screen.getByTestId('ts-agents').textContent).not.toContain('custom:cp-1');
+    fireEvent.click(screen.getByText('All providers (2)'));
+    expect(
+      screen.getAllByText('Custom Provider').some((el) => el.closest('.agent-filter-select')),
+    ).toBe(true);
+
+    // Model usage renders the stripped model name.
+    expect(screen.getByText('qwen-2.5')).toBeDefined();
   });
 
   it('shows the empty state when there are no harnesses and no providers', async () => {


### PR DESCRIPTION
### ✨ What changed
- Provider-grouped chart series remap `custom:<uuid>` keys to the provider's display name.
- The provider filter, legend, and tooltip pick the name up automatically.
- Recent Messages and Model usage run model names through `getModelDisplayName`, so `custom:<uuid>/model` slugs render as the bare model name.

### 💭 Why
A custom provider named "Hugging Face" showed up as `custom:4b580cbf-...` in the Overview filter, chart tooltip, and model tables.

### 👤 For users
Custom providers read by their name everywhere on the Overview, same as built-in providers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows custom provider names across the Overview and global Messages log. Replaces `custom:<uuid>` with provider names and strips `custom:<uuid>/model` slugs to show only the model.

- **Bug Fixes**
  - Remap provider-grouped chart series keys to provider display names; updates charts, filters, legends, and tooltips once custom provider data resolves.
  - In the global Messages log, fall back to the first available agent when no route agent is present so custom providers load and their name + icon render correctly; prevents `custom:<uuid>/…` labels.

<sup>Written for commit 39b247904a8dd558832877ab1dbfc2cc9eaadfbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

