### PR TITLE
Stacked review: limits TZ fix + provider/chart/custom-name fixes (all-in-one)

### DIFF
--- a/.changeset/limits-local-time-boundaries.md
+++ b/.changeset/limits-local-time-boundaries.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix token/cost limits never blocking (or alerting) when the server's timezone isn't UTC. `computePeriodBoundaries`/`computePeriodResetDate` built their window in UTC, but `agent_messages.timestamp` rows are stored in the process's local time — so on a non-UTC host the window's upper bound sat behind the stored rows by the TZ offset and the consumption SUM read ~0, meaning hard limits silently never tripped and threshold alerts never fired. Boundaries are now computed in local time (matching `computeCutoff`), via a new `toLocalSqlTimestamp` helper.

--- a/.changeset/setup-modal-stale-platform.md
+++ b/.changeset/setup-modal-stale-platform.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix the post-create "Set up harness" modal showing the full harness picker instead of the harness you just chose. AgentGuard now refetches the agent list when the viewed agent changes, so a newly created agent's platform reaches the setup modal (previously the stale, source-less list left the platform unset whenever the agent was created from the always-present sidebar while another agent was open).

--- a/packages/backend/src/common/utils/period.util.spec.ts
+++ b/packages/backend/src/common/utils/period.util.spec.ts
@@ -1,5 +1,9 @@
 import { computePeriodBoundaries, computePeriodResetDate } from './period.util';
 
+// Parse a local-time `YYYY-MM-DD HH:MM:SS` string (no tz suffix) back into a
+// Date using the same local-timezone interpretation the formatter used.
+const parseLocal = (s: string) => new Date(s.replace(' ', 'T'));
+
 describe('computePeriodBoundaries', () => {
   it('returns periodStart and periodEnd as formatted strings', () => {
     const { periodStart, periodEnd } = computePeriodBoundaries('day');
@@ -7,41 +11,41 @@ describe('computePeriodBoundaries', () => {
     expect(periodEnd).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
   });
 
-  it('hour: start is 1 hour before current hour', () => {
+  it('hour: start is 1 hour before the current local hour', () => {
     const now = new Date();
     const { periodStart } = computePeriodBoundaries('hour');
-    const start = new Date(periodStart.replace(' ', 'T') + 'Z');
-    const expectedHour = now.getUTCHours() - 1;
-    expect(start.getUTCHours()).toBe(expectedHour < 0 ? expectedHour + 24 : expectedHour);
-    expect(start.getUTCMinutes()).toBe(0);
-    expect(start.getUTCSeconds()).toBe(0);
+    const start = parseLocal(periodStart);
+    const expectedHour = now.getHours() - 1;
+    expect(start.getHours()).toBe(expectedHour < 0 ? expectedHour + 24 : expectedHour);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
   });
 
-  it('day: start is midnight UTC today', () => {
+  it('day: start is local midnight today', () => {
     const now = new Date();
     const { periodStart } = computePeriodBoundaries('day');
-    const start = new Date(periodStart.replace(' ', 'T') + 'Z');
-    expect(start.getUTCHours()).toBe(0);
-    expect(start.getUTCMinutes()).toBe(0);
-    expect(start.getUTCDate()).toBe(now.getUTCDate());
+    const start = parseLocal(periodStart);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getDate()).toBe(now.getDate());
   });
 
-  it('week: start is Monday at midnight UTC', () => {
+  it('week: start is Monday at local midnight', () => {
     const { periodStart } = computePeriodBoundaries('week');
-    const start = new Date(periodStart.replace(' ', 'T') + 'Z');
-    expect(start.getUTCHours()).toBe(0);
-    expect(start.getUTCMinutes()).toBe(0);
+    const start = parseLocal(periodStart);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
     // Monday is day 1
-    expect(start.getUTCDay()).toBe(1);
+    expect(start.getDay()).toBe(1);
   });
 
-  it('month: start is first of month at midnight UTC', () => {
+  it('month: start is first of month at local midnight', () => {
     const now = new Date();
     const { periodStart } = computePeriodBoundaries('month');
-    const start = new Date(periodStart.replace(' ', 'T') + 'Z');
-    expect(start.getUTCDate()).toBe(1);
-    expect(start.getUTCHours()).toBe(0);
-    expect(start.getUTCMonth()).toBe(now.getUTCMonth());
+    const start = parseLocal(periodStart);
+    expect(start.getDate()).toBe(1);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMonth()).toBe(now.getMonth());
   });
 
   it('unknown period: defaults to hour-like behavior', () => {
@@ -53,9 +57,28 @@ describe('computePeriodBoundaries', () => {
     const before = Date.now();
     const { periodEnd } = computePeriodBoundaries('day');
     const after = Date.now();
-    const end = new Date(periodEnd.replace(' ', 'T') + 'Z').getTime();
+    const end = parseLocal(periodEnd).getTime();
     expect(end).toBeGreaterThanOrEqual(before - 1000);
     expect(end).toBeLessThanOrEqual(after + 1000);
+  });
+
+  // Regression: the boundaries must be expressed in the process's LOCAL
+  // timezone, not UTC. `agent_messages.timestamp` rows are stored as local-time
+  // `timestamp without time zone`, so a UTC `periodEnd` (the old code formatted
+  // via toISOString) sits behind the stored rows by the process TZ offset and
+  // the consumption SUM silently reads ~0 — meaning token/cost limits never
+  // trip. We assert that periodEnd, interpreted as a local-time string,
+  // round-trips back to the real instant. With the old UTC formatting this only
+  // holds when the host TZ is UTC; on any other zone (every broken real-world
+  // deployment, and this CI host when run under TZ!=UTC) it fails.
+  it('formats periodEnd in local wall-clock so it round-trips to the real instant', () => {
+    const instant = new Date('2026-06-10T11:16:00.000Z');
+    jest.useFakeTimers().setSystemTime(instant);
+
+    const { periodEnd } = computePeriodBoundaries('day');
+    expect(parseLocal(periodEnd).getTime()).toBe(instant.getTime());
+
+    jest.useRealTimers();
   });
 });
 
@@ -65,59 +88,51 @@ describe('computePeriodResetDate', () => {
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
   });
 
-  it('hour: returns start of next hour UTC', () => {
+  it('hour: returns start of the next local hour', () => {
     const now = new Date();
-    const result = computePeriodResetDate('hour');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
-    const expectedHour = (now.getUTCHours() + 1) % 24;
-    expect(reset.getUTCHours()).toBe(expectedHour);
-    expect(reset.getUTCMinutes()).toBe(0);
-    expect(reset.getUTCSeconds()).toBe(0);
+    const reset = parseLocal(computePeriodResetDate('hour'));
+    const expectedHour = (now.getHours() + 1) % 24;
+    expect(reset.getHours()).toBe(expectedHour);
+    expect(reset.getMinutes()).toBe(0);
+    expect(reset.getSeconds()).toBe(0);
   });
 
-  it('day: returns midnight UTC next day', () => {
+  it('day: returns local midnight next day', () => {
     const now = new Date();
-    const result = computePeriodResetDate('day');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
-    expect(reset.getUTCHours()).toBe(0);
-    expect(reset.getUTCMinutes()).toBe(0);
-    const expectedDate = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
-    );
-    expect(reset.getUTCDate()).toBe(expectedDate.getUTCDate());
+    const reset = parseLocal(computePeriodResetDate('day'));
+    expect(reset.getHours()).toBe(0);
+    expect(reset.getMinutes()).toBe(0);
+    const expectedDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+    expect(reset.getDate()).toBe(expectedDate.getDate());
   });
 
-  it('week: returns next Monday at midnight UTC', () => {
-    const result = computePeriodResetDate('week');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
-    expect(reset.getUTCDay()).toBe(1); // Monday
-    expect(reset.getUTCHours()).toBe(0);
-    expect(reset.getUTCMinutes()).toBe(0);
+  it('week: returns next Monday at local midnight', () => {
+    const reset = parseLocal(computePeriodResetDate('week'));
+    expect(reset.getDay()).toBe(1); // Monday
+    expect(reset.getHours()).toBe(0);
+    expect(reset.getMinutes()).toBe(0);
     expect(reset.getTime()).toBeGreaterThan(Date.now());
   });
 
-  it('month: returns first of next month UTC', () => {
+  it('month: returns first of next month', () => {
     const now = new Date();
-    const result = computePeriodResetDate('month');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
-    expect(reset.getUTCDate()).toBe(1);
-    expect(reset.getUTCHours()).toBe(0);
-    const expectedMonth = (now.getUTCMonth() + 1) % 12;
-    expect(reset.getUTCMonth()).toBe(expectedMonth);
+    const reset = parseLocal(computePeriodResetDate('month'));
+    expect(reset.getDate()).toBe(1);
+    expect(reset.getHours()).toBe(0);
+    const expectedMonth = (now.getMonth() + 1) % 12;
+    expect(reset.getMonth()).toBe(expectedMonth);
   });
 
   it('week on a Monday: daysUntilMonday falls back to 7', () => {
-    // 2026-03-02 is a Monday (UTC day = 1)
-    const monday = new Date(Date.UTC(2026, 2, 2, 12, 0, 0));
+    // 2026-03-02 is a Monday — pin local noon so the local day is Monday.
     jest.useFakeTimers();
-    jest.setSystemTime(monday);
+    jest.setSystemTime(new Date(2026, 2, 2, 12, 0, 0));
 
-    const result = computePeriodResetDate('week');
-    const reset = new Date(result.replace(' ', 'T') + 'Z');
+    const reset = parseLocal(computePeriodResetDate('week'));
 
     // Should be next Monday, exactly 7 days later
-    expect(reset.getUTCDay()).toBe(1);
-    expect(reset.getUTCDate()).toBe(monday.getUTCDate() + 7);
+    expect(reset.getDay()).toBe(1);
+    expect(reset.getDate()).toBe(9);
 
     jest.useRealTimers();
   });
@@ -129,8 +144,7 @@ describe('computePeriodResetDate', () => {
 
   it('reset date is always in the future', () => {
     for (const period of ['hour', 'day', 'week', 'month']) {
-      const result = computePeriodResetDate(period);
-      const reset = new Date(result.replace(' ', 'T') + 'Z');
+      const reset = parseLocal(computePeriodResetDate(period));
       expect(reset.getTime()).toBeGreaterThan(Date.now() - 1000);
     }
   });

--- a/packages/backend/src/common/utils/period.util.ts
+++ b/packages/backend/src/common/utils/period.util.ts
@@ -1,71 +1,72 @@
-import { toSqlTimestamp } from './postgres-sql';
+import { toLocalSqlTimestamp } from './postgres-sql';
 
 export interface PeriodBoundaries {
   periodStart: string;
   periodEnd: string;
 }
 
+// Boundaries are computed in the Node process's LOCAL timezone, not UTC, because
+// they are compared against `agent_messages.timestamp` — which the pg driver
+// stores as a local-time `timestamp without time zone`. A UTC boundary would be
+// offset from the stored values by the process TZ, so `periodEnd` (UTC "now")
+// lands behind the local-time rows and the SUM silently reads ~0, meaning token
+// /cost limits never trip. Use local Date constructors + toLocalSqlTimestamp to
+// stay aligned with how the rows are written (see computeCutoff for the same
+// rationale on the analytics range cutoffs).
 export function computePeriodBoundaries(period: string): PeriodBoundaries {
   const now = new Date();
   let start: Date;
 
   switch (period) {
     case 'hour':
-      start = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() - 1),
-      );
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() - 1);
       break;
     case 'day':
-      start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
       break;
     case 'week': {
-      const dayOfWeek = now.getUTCDay();
-      const monday = now.getUTCDate() - ((dayOfWeek + 6) % 7);
-      start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), monday));
+      const dayOfWeek = now.getDay();
+      const monday = now.getDate() - ((dayOfWeek + 6) % 7);
+      start = new Date(now.getFullYear(), now.getMonth(), monday);
       break;
     }
     case 'month':
-      start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      start = new Date(now.getFullYear(), now.getMonth(), 1);
       break;
     default:
-      start = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() - 1),
-      );
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() - 1);
   }
 
   const end = new Date(now.getTime());
-  return { periodStart: toSqlTimestamp(start), periodEnd: toSqlTimestamp(end) };
+  return { periodStart: toLocalSqlTimestamp(start), periodEnd: toLocalSqlTimestamp(end) };
 }
 
+// Computed in local time for the same reason as computePeriodBoundaries: the
+// reset instant must line up with the local-time period window shown to the user
+// in threshold alerts.
 export function computePeriodResetDate(period: string): string {
   const now = new Date();
   let reset: Date;
 
   switch (period) {
     case 'hour':
-      reset = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 1),
-      );
+      reset = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() + 1);
       break;
     case 'day':
-      reset = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+      reset = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
       break;
     case 'week': {
-      const dayOfWeek = now.getUTCDay();
+      const dayOfWeek = now.getDay();
       const daysUntilMonday = (8 - dayOfWeek) % 7 || 7;
-      reset = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + daysUntilMonday),
-      );
+      reset = new Date(now.getFullYear(), now.getMonth(), now.getDate() + daysUntilMonday);
       break;
     }
     case 'month':
-      reset = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+      reset = new Date(now.getFullYear(), now.getMonth() + 1, 1);
       break;
     default:
-      reset = new Date(
-        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 1),
-      );
+      reset = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() + 1);
   }
 
-  return toSqlTimestamp(reset);
+  return toLocalSqlTimestamp(reset);
 }

--- a/packages/backend/src/common/utils/postgres-sql.spec.ts
+++ b/packages/backend/src/common/utils/postgres-sql.spec.ts
@@ -9,6 +9,7 @@ import {
   timestampDefault,
   timestampType,
   toSqlTimestamp,
+  toLocalSqlTimestamp,
 } from './postgres-sql';
 
 describe('postgres-sql', () => {
@@ -110,6 +111,36 @@ describe('postgres-sql', () => {
       jest.useFakeTimers();
       jest.setSystemTime(new Date('2026-01-02T03:04:05.000Z').getTime());
       expect(toSqlTimestamp()).toBe('2026-01-02 03:04:05');
+      jest.useRealTimers();
+    });
+  });
+
+  describe('toLocalSqlTimestamp', () => {
+    it('formats a Date in local time as a space-separated string (no T or Z)', () => {
+      const d = new Date('2026-04-20T12:34:56.789Z');
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const expected =
+        `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+        `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+      const out = toLocalSqlTimestamp(d);
+      expect(out).toBe(expected);
+      expect(out).not.toContain('T');
+      expect(out).not.toContain('Z');
+      expect(out).toHaveLength(19);
+    });
+
+    it('round-trips to the same instant when parsed as local time', () => {
+      // Unlike toSqlTimestamp (UTC), the local string read back as local time
+      // recovers the original instant — this is the property period boundaries
+      // rely on to line up with locally-stored agent_messages.timestamp rows.
+      const d = new Date('2026-04-20T12:34:56.000Z');
+      expect(new Date(toLocalSqlTimestamp(d).replace(' ', 'T')).getTime()).toBe(d.getTime());
+    });
+
+    it('defaults to the current time when no Date is given', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-02T03:04:05.000Z').getTime());
+      expect(toLocalSqlTimestamp()).toBe(toLocalSqlTimestamp(new Date()));
       jest.useRealTimers();
     });
   });

--- a/packages/backend/src/common/utils/postgres-sql.ts
+++ b/packages/backend/src/common/utils/postgres-sql.ts
@@ -79,13 +79,37 @@ export function sqlCastInterval(paramName: string): string {
  * Format a Date as a Postgres-friendly timestamp string
  * (`YYYY-MM-DD HH:MM:SS` — space-separated, no timezone suffix).
  *
- * Used for notification-log / notification-rule writes and alert-period
- * boundaries. This emits UTC and is space-separated, intentionally distinct
- * from {@link sqlNow} / {@link computeCutoff}, which emit local-time,
- * `T`-separated strings for the analytics range cutoffs.
+ * Used for notification-log / notification-rule `created_at` / `sent_at` writes.
+ * This emits UTC and is space-separated, intentionally distinct from
+ * {@link sqlNow} / {@link computeCutoff}, which emit local-time strings for the
+ * analytics range cutoffs.
+ *
+ * Do NOT use this to build window boundaries compared against
+ * `agent_messages.timestamp` — those rows are stored in local time, so a UTC
+ * boundary is offset by the process TZ and silently drops rows. Use
+ * {@link toLocalSqlTimestamp} for that (see computePeriodBoundaries).
  */
 export function toSqlTimestamp(d: Date = new Date()): string {
   return d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+}
+
+/**
+ * Local-time variant of {@link toSqlTimestamp}: formats the wall-clock time in
+ * the Node process's local timezone as `YYYY-MM-DD HH:MM:SS` (space-separated,
+ * no timezone suffix).
+ *
+ * This is the correct format for period boundaries compared against
+ * `agent_messages.timestamp`: the pg driver serialises stored Dates in local
+ * time, so a UTC boundary would be offset from the stored values by the
+ * process's TZ offset — silently dropping rows near (and, for `periodEnd`, well
+ * within) the window. Mirrors the rationale on {@link computeCutoff}.
+ */
+export function toLocalSqlTimestamp(d: Date = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+  );
 }
 
 /**

--- a/packages/backend/src/notifications/services/notification-cron.service.edge-cases.spec.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.edge-cases.spec.ts
@@ -26,6 +26,23 @@ const baseRule = {
   period: 'day' as const,
 };
 
+// computePeriodBoundaries emits boundaries in the process's LOCAL timezone (to
+// match how agent_messages.timestamp is stored). These helpers rebuild the
+// expected start from the pinned instant the same way, so the assertions hold
+// regardless of the timezone CI runs under (UTC) vs a developer's machine.
+const pad = (n: number) => String(n).padStart(2, '0');
+const fmtLocal = (d: Date) =>
+  `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+  `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+const localDayStart = (iso: string) => {
+  const d = new Date(iso);
+  return fmtLocal(new Date(d.getFullYear(), d.getMonth(), d.getDate()));
+};
+const localHourStart = (iso: string) => {
+  const d = new Date(iso);
+  return fmtLocal(new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours() - 1));
+};
+
 describe('NotificationCronService — edge cases', () => {
   let service: NotificationCronService;
   let mockGetAllActiveRules: jest.Mock;
@@ -115,8 +132,8 @@ describe('NotificationCronService — edge cases', () => {
 
       expect(dedupPeriodStart).toBe(consumptionPeriodStart);
       expect(insertedPeriodStart).toBe(consumptionPeriodStart);
-      // Day period: midnight UTC. Fixed expectation.
-      expect(consumptionPeriodStart).toBe('2026-06-15 00:00:00');
+      // Day period: local midnight.
+      expect(consumptionPeriodStart).toBe(localDayStart('2026-06-15T12:00:00Z'));
     });
 
     it('emits an "hour" period that recomputes consistently within the same tick', async () => {
@@ -134,8 +151,8 @@ describe('NotificationCronService — edge cases', () => {
 
       const consumptionPeriodStart = mockGetConsumption.mock.calls[0][3];
       const dedupPeriodStart = mockHasAlreadySent.mock.calls[0][1];
-      // hour period: previous hour boundary (UTC).
-      expect(consumptionPeriodStart).toBe('2026-06-15 11:00:00');
+      // hour period: previous local-hour boundary.
+      expect(consumptionPeriodStart).toBe(localHourStart('2026-06-15T12:30:00Z'));
       expect(dedupPeriodStart).toBe(consumptionPeriodStart);
     });
 
@@ -163,14 +180,14 @@ describe('NotificationCronService — edge cases', () => {
       const insertedPeriodStart = mockInsertLog.mock.calls[0][0].periodStart;
 
       // The drift is real and observable: consumption was measured against the
-      // 10:00 start, but the dedup key + log row were written under the 11:00 start.
-      // This documents the current behaviour. When the source is refactored to
-      // capture periodStart once (e.g. pass it from checkThresholds into
-      // evaluateRule, or use a fixed epoch-modulo derivation), update these
-      // expectations to equality.
-      expect(consumptionPeriodStart).toBe('2026-06-15 10:00:00');
-      expect(dedupPeriodStart).toBe('2026-06-15 11:00:00');
-      expect(insertedPeriodStart).toBe('2026-06-15 11:00:00');
+      // earlier hour start, but the dedup key + log row were written under the
+      // next hour start (one hour later). This documents the current behaviour.
+      // When the source is refactored to capture periodStart once (e.g. pass it
+      // from checkThresholds into evaluateRule, or use a fixed epoch-modulo
+      // derivation), update these expectations to equality.
+      expect(consumptionPeriodStart).toBe(localHourStart('2026-06-15T11:59:59Z'));
+      expect(dedupPeriodStart).toBe(localHourStart('2026-06-15T12:00:01Z'));
+      expect(insertedPeriodStart).toBe(localHourStart('2026-06-15T12:00:01Z'));
       expect(dedupPeriodStart).not.toBe(consumptionPeriodStart);
     });
   });

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -476,6 +476,60 @@ describe('ProviderService — route-only cleanup paths', () => {
       expect(saved[0].override_route?.keyLabel).toBe('Renamed');
     });
 
+    it('relabels pinned routes on every agent of the user, not just the renaming one', async () => {
+      const pin = (keyLabel: string) => ({
+        provider: 'openai',
+        authType: 'api_key' as const,
+        model: 'gpt-4o',
+        keyLabel,
+      });
+      providerRepo.find.mockResolvedValue([
+        {
+          id: 'target',
+          provider: 'openai',
+          auth_type: 'api_key',
+          label: 'Key 2',
+          is_active: true,
+        },
+      ]);
+      tierRepo.find.mockResolvedValue([
+        {
+          id: 't1',
+          agent_id: 'agent-1',
+          override_route: pin('Key 2'),
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+        {
+          id: 't2',
+          agent_id: 'agent-2',
+          override_route: pin('Key 2'),
+          fallback_routes: [pin('Key 2')],
+        } as unknown as TierAssignment,
+      ]);
+      specRepo.find.mockResolvedValue([
+        {
+          id: 's1',
+          agent_id: 'agent-3',
+          override_route: pin('Key 2'),
+          fallback_routes: null,
+        } as unknown as SpecificityAssignment,
+      ]);
+      headerTierRepo.find.mockResolvedValue([]);
+
+      await svc.renameKey('agent-1', 'user-1', 'openai', 'api_key', 'Key 2', 'Renamed');
+
+      expect(tierRepo.find).toHaveBeenCalledWith({ where: { user_id: 'user-1' } });
+      const savedTiers = tierRepo.save.mock.calls[0][0] as TierAssignment[];
+      expect(savedTiers.map((t) => t.override_route?.keyLabel)).toEqual(['Renamed', 'Renamed']);
+      expect(savedTiers[1].fallback_routes?.[0]?.keyLabel).toBe('Renamed');
+      const savedSpecs = specRepo.save.mock.calls[0][0] as SpecificityAssignment[];
+      expect(savedSpecs[0].override_route?.keyLabel).toBe('Renamed');
+      // Per-agent tier caches must be flushed for every mutated agent.
+      for (const id of ['agent-1', 'agent-2', 'agent-3']) {
+        expect(routingCache.invalidateAgent).toHaveBeenCalledWith(id);
+      }
+    });
+
     it('blocks full provider disconnect while header tiers route to it', async () => {
       providerRepo.find.mockResolvedValue([
         {

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -355,7 +355,7 @@ export class ProviderService {
     target.label = trimmed;
     target.updated_at = new Date().toISOString();
     await this.providerRepo.save(target);
-    await this.relabelOverrides(agentId, provider, authType, previousLabel, trimmed);
+    await this.relabelOverrides(userId, provider, authType, previousLabel, trimmed);
     this.routingCache.invalidateAgent(agentId);
     this.routingCache.invalidateUser(userId);
     return target;
@@ -891,7 +891,7 @@ export class ProviderService {
    * the new primary key).
    */
   private async relabelOverrides(
-    agentId: string,
+    userId: string,
     provider: string,
     authType: AuthType,
     previousLabel: string,
@@ -916,7 +916,11 @@ export class ProviderService {
       keyLabel: nextLabel ?? null,
     });
 
-    const tiers = await this.tierRepo.find({ where: { agent_id: agentId } });
+    // Keys are user-global: a rename must rewrite pinned routes on every
+    // agent the user owns, not just the one whose page triggered it. Stale
+    // labels make the proxy silently fall back to the first key by priority.
+    const mutatedAgentIds = new Set<string>();
+    const tiers = await this.tierRepo.find({ where: { user_id: userId } });
     const tiersToSave: TierAssignment[] = [];
     const now = new Date().toISOString();
     for (const t of tiers) {
@@ -934,6 +938,7 @@ export class ProviderService {
       if (mutated) {
         t.updated_at = now;
         tiersToSave.push(t);
+        mutatedAgentIds.add(t.agent_id);
       }
     }
     if (tiersToSave.length > 0) await this.tierRepo.save(tiersToSave);
@@ -942,7 +947,7 @@ export class ProviderService {
     // fallback_routes. Cubic flagged P2: skipping specificity fallbacks left
     // stale key-label pins behind, which then misrouted next time the
     // specificity rule fired.
-    const specs = await this.specificityRepo.find({ where: { agent_id: agentId } });
+    const specs = await this.specificityRepo.find({ where: { user_id: userId } });
     const specsToSave: SpecificityAssignment[] = [];
     for (const s of specs) {
       let mutated = false;
@@ -959,6 +964,7 @@ export class ProviderService {
       if (mutated) {
         s.updated_at = now;
         specsToSave.push(s);
+        mutatedAgentIds.add(s.agent_id);
       }
     }
     if (specsToSave.length > 0) await this.specificityRepo.save(specsToSave);
@@ -967,7 +973,7 @@ export class ProviderService {
     // omitted here originally, so disconnecting one account out of several
     // (or renaming a key) left header-tier routes pinned to a label that no
     // longer exists — the account chip then renders blank. Relabel them too.
-    const headerTiers = await this.headerTierRepo.find({ where: { agent_id: agentId } });
+    const headerTiers = await this.headerTierRepo.find({ where: { user_id: userId } });
     const headerTiersToSave: HeaderTier[] = [];
     for (const h of headerTiers) {
       let mutated = false;
@@ -984,9 +990,14 @@ export class ProviderService {
       if (mutated) {
         h.updated_at = now;
         headerTiersToSave.push(h);
+        mutatedAgentIds.add(h.agent_id);
       }
     }
     if (headerTiersToSave.length > 0) await this.headerTierRepo.save(headerTiersToSave);
+
+    // invalidateUser() doesn't clear per-agent tier caches, so flush every
+    // agent whose rows were rewritten or stale routes would keep serving.
+    for (const id of mutatedAgentIds) this.routingCache.invalidateAgent(id);
   }
 
   private async renumberPriorities(

--- a/packages/frontend/src/components/AgentGuard.tsx
+++ b/packages/frontend/src/components/AgentGuard.tsx
@@ -21,7 +21,17 @@ interface AgentsData {
 const AgentGuard: ParentComponent = (props) => {
   const params = useParams<{ agentName: string }>();
 
-  const [data, { refetch }] = createResource(() => getAgents() as Promise<AgentsData>);
+  // Key the fetch on the agent param so the list is re-fetched whenever the
+  // viewed agent changes. AgentGuard stays mounted across `/harnesses/:agentName`
+  // navigations (only the param updates), so a source-less resource would keep
+  // serving the list captured on first mount. That stale list omits an agent
+  // created from the always-present sidebar while another agent is open, which
+  // left `setAgentPlatform(null)` below — making the post-create setup modal
+  // render its full harness picker instead of the harness the user just chose.
+  const [data, { refetch }] = createResource(
+    () => params.agentName,
+    () => getAgents() as Promise<AgentsData>,
+  );
 
   const agentExists = createMemo(() => {
     const decoded = decodeURIComponent(params.agentName);
@@ -46,7 +56,10 @@ const AgentGuard: ParentComponent = (props) => {
   });
 
   return (
-    <Show when={!data.loading} fallback={null}>
+    // Only blank on the very first load. Once a list has resolved, keep the
+    // children mounted while a param-change refetch is in flight so switching
+    // agents (and the post-create redirect) doesn't flash an empty page.
+    <Show when={!data.loading || data() !== undefined} fallback={null}>
       <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
         <Show when={data()?.agents}>
           <Show when={agentExists()} fallback={<NotFound />}>

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -4,6 +4,7 @@ import {
   createMemo,
   createEffect,
   createSignal,
+  on,
   onMount,
   type Component,
   type Accessor,
@@ -199,6 +200,10 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
       return;
     }
 
+    // Without an explicit label the backend's legacy path writes to the row
+    // labeled 'Default' — wrong target whenever the visible key is named
+    // anything else. Pin the update to the key this view is showing.
+    const targetLabel = label ?? activeKeys()[0]?.label;
     props.setBusy(true);
     try {
       await connectProvider(props.agentName, {
@@ -206,7 +211,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
         apiKey: props.keyInput().replace(/\s/g, ''),
         authType: props.selectedAuthType(),
         ...(endpointRegionPayload() && { region: endpointRegionPayload() }),
-        ...(label && { label }),
+        ...(targetLabel && { label: targetLabel }),
       });
       const noun = props.isSubMode() && !isApiKeyCredential() ? 'token' : 'key';
       toast.success(`${props.provDef.name} ${noun} updated`);
@@ -519,19 +524,23 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
 
   const defaultLabel = () => suggestNextProviderKeyLabel(props.existingLabels());
 
-  // Sync label suggestion when opened externally and auto-focus the API key field
-  createEffect(() => {
-    if (isOpen() && !label().trim()) {
-      setLabel(defaultLabel());
-    }
-    const defaultEndpointRegion = props.endpointRegions?.[0]?.value;
-    if (isOpen() && defaultEndpointRegion && !endpointRegion()) {
-      setEndpointRegion(props.initialEndpointRegion ?? defaultEndpointRegion);
-    }
-    if (isOpen()) {
-      requestAnimationFrame(() => apiKeyInputRef?.focus());
-    }
-  });
+  // Sync label suggestion when opened externally and auto-focus the API key field.
+  // Use `on()` with explicit deps to avoid tracking label/endpointRegion signals,
+  // which would re-fire the effect (and steal focus) on every keystroke.
+  createEffect(
+    on(isOpen, (open, prevOpen) => {
+      if (open && !label().trim()) {
+        setLabel(defaultLabel());
+      }
+      const defaultEndpointRegion = props.endpointRegions?.[0]?.value;
+      if (open && defaultEndpointRegion && !endpointRegion()) {
+        setEndpointRegion(props.initialEndpointRegion ?? defaultEndpointRegion);
+      }
+      if (open && !prevOpen) {
+        requestAnimationFrame(() => apiKeyInputRef?.focus());
+      }
+    }),
+  );
 
   const submit = async () => {
     const labelToUse = (label().trim() || defaultLabel()).slice(0, MAX_LABEL_LENGTH);

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -26,6 +26,7 @@ import {
 } from '../services/api/analytics.js';
 import { formatNumber, formatCost, formatTimeAgo } from '../services/formatters.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
+import { getModelDisplayName, preloadModelDisplayNames } from '../services/model-display.js';
 import { PROVIDERS } from '../services/providers.js';
 import { AGENT_COLORS } from '../components/MultiAgentTokenChart.jsx';
 import ProviderChartCard from '../components/ProviderChartCard.jsx';
@@ -125,6 +126,7 @@ function loadRange(): string {
 
 const GlobalOverview: Component = () => {
   const navigate = useNavigate();
+  preloadModelDisplayNames();
 
   // ── Range state (persisted in localStorage) ──────────────────────────
   const [chartRange, setChartRangeRaw] = createSignal(loadRange());
@@ -234,6 +236,29 @@ const GlobalOverview: Component = () => {
     (p) => costFetcher(p.range, p.group),
   );
 
+  // Provider-grouped series key custom providers as 'custom:<uuid>'. Remap
+  // those keys to the provider's display name so the filter, legend, and
+  // tooltip read like every other provider. Reactive to customProviderData,
+  // so names fill in once that resource resolves.
+  const displaySeriesName = (key: string) => {
+    const name = resolveCustomName(key);
+    // 'hour'/'date' are the row's bucket columns — never let a custom
+    // provider named like them clobber the axis.
+    return name && name !== 'hour' && name !== 'date' ? name : key;
+  };
+  const remapCustomSeries = (raw: TSResult | undefined): TSResult | undefined => {
+    if (!raw || !raw.agents.some((a) => a.startsWith('custom:'))) return raw;
+    return {
+      agents: raw.agents.map(displaySeriesName),
+      timeseries: raw.timeseries.map((row) =>
+        Object.fromEntries(Object.entries(row).map(([k, v]) => [displaySeriesName(k), v])),
+      ),
+    };
+  };
+  const tokenSeries = createMemo(() => remapCustomSeries(agentTimeseries()));
+  const messageSeries = createMemo(() => remapCustomSeries(agentMessageTimeseries()));
+  const costSeries = createMemo(() => remapCustomSeries(agentCostTimeseries()));
+
   // ── Harness filter state (sessionStorage) ────────────────────────────
   // Scope the persisted selection by groupBy(): the provider grouping and the
   // harness grouping list completely different series, so a single shared set
@@ -283,8 +308,8 @@ const GlobalOverview: Component = () => {
   }
 
   const allAgents = createMemo(() => {
-    const tokenAgents = agentTimeseries()?.agents ?? [];
-    const msgAgents = agentMessageTimeseries()?.agents ?? [];
+    const tokenAgents = tokenSeries()?.agents ?? [];
+    const msgAgents = messageSeries()?.agents ?? [];
     const set = new Set([...tokenAgents, ...msgAgents]);
     return [...set].sort();
   });
@@ -330,7 +355,7 @@ const GlobalOverview: Component = () => {
   };
 
   const filteredAgentTimeseries = createMemo(() => {
-    const raw = agentTimeseries();
+    const raw = tokenSeries();
     if (!raw) return undefined;
     const sel = effectiveSelected();
     if (sel.size === 0) return raw;
@@ -346,7 +371,7 @@ const GlobalOverview: Component = () => {
   });
 
   const filteredAgentMessageTimeseries = createMemo(() => {
-    const raw = agentMessageTimeseries();
+    const raw = messageSeries();
     if (!raw) return undefined;
     const sel = effectiveSelected();
     if (sel.size === 0) return raw;
@@ -362,7 +387,7 @@ const GlobalOverview: Component = () => {
   });
 
   const filteredAgentCostTimeseries = createMemo(() => {
-    const raw = agentCostTimeseries();
+    const raw = costSeries();
     if (!raw) return undefined;
     const sel = effectiveSelected();
     if (sel.size === 0) return raw;
@@ -983,7 +1008,7 @@ const GlobalOverview: Component = () => {
                             </span>
                           </Show>
                           <span style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm);">
-                            {row.model || '—'}
+                            {row.model ? getModelDisplayName(row.model) : '—'}
                           </span>
                         </div>
                       </td>
@@ -1047,7 +1072,7 @@ const GlobalOverview: Component = () => {
                             </span>
                           </Show>
                           <span style="font-weight: 500; color: hsl(var(--foreground));">
-                            {row.display_name || row.model}
+                            {row.display_name || getModelDisplayName(row.model)}
                           </span>
                         </div>
                       </td>

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -181,9 +181,18 @@ const MessageLog: Component = () => {
     setFeedbackModalOpen(false);
   };
 
-  const [customProviders] = createResource(
-    () => params.agentName,
-    (name) => getCustomProviders(decodeURIComponent(name)),
+  // Custom providers are user-global, so any agent name returns the full set.
+  // On the scoped log use the route agent; on the global ("All harnesses") log
+  // there is no route agent, so fall back to the first available agent —
+  // otherwise the resource source is undefined, the fetcher never runs, and
+  // custom:<uuid> models render as `custom:Custom/…` with no provider icon.
+  // Mirrors GlobalOverview's firstAgent() pattern.
+  const customProviderAgent = () =>
+    params.agentName
+      ? decodeURIComponent(params.agentName)
+      : ((agentListRaw() ?? [])[0]?.agent_name ?? '');
+  const [customProviders] = createResource(customProviderAgent, (name) =>
+    name ? getCustomProviders(name).catch(() => []) : Promise.resolve([]),
   );
 
   const [routingStatus] = createResource(

--- a/packages/frontend/src/styles/cards.css
+++ b/packages/frontend/src/styles/cards.css
@@ -108,6 +108,15 @@
 }
 
 .chart-card__stat--clickable {
+  /* These stats render as <button> for a11y — strip the native button
+     chrome (light UA background/border) so they match the card theme. */
+  appearance: none;
+  background: none;
+  border: none;
+  border-right: 1px solid hsl(var(--border));
+  font: inherit;
+  color: inherit;
+  text-align: left;
   cursor: pointer;
   transition: all var(--transition-fast);
   position: relative;

--- a/packages/frontend/tests/components/AgentGuard.test.tsx
+++ b/packages/frontend/tests/components/AgentGuard.test.tsx
@@ -1,8 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 
+// Reactive agent param so tests can simulate navigating between agents while
+// AgentGuard stays mounted (the resource is keyed on this).
+const [agentNameParam, setAgentNameParam] = createSignal("test-agent");
 vi.mock("@solidjs/router", () => ({
-  useParams: () => ({ agentName: "test-agent" }),
+  useParams: () => ({
+    get agentName() {
+      return agentNameParam();
+    },
+  }),
   A: (props: any) => <a href={props.href}>{props.children}</a>,
 }));
 
@@ -44,6 +52,7 @@ describe("AgentGuard", () => {
     mockSetAgentDisplayName.mockClear();
     mockIsRecentlyCreated.mockReturnValue(false);
     mockClearRecentAgent.mockClear();
+    setAgentNameParam("test-agent");
   });
 
   it("renders children when agent exists", async () => {
@@ -107,5 +116,37 @@ describe("AgentGuard", () => {
     await vi.waitFor(() => {
       expect(mockClearRecentAgent).toHaveBeenCalledWith("test-agent");
     });
+  });
+
+  it("refetches the agent list when the viewed agent changes", async () => {
+    // First load only knows about test-agent; a second agent is created later
+    // (e.g. from the sidebar while this guard stays mounted) and must trigger a
+    // fresh fetch rather than reusing the stale first-mount list.
+    mockGetAgents
+      .mockResolvedValueOnce({ agents: [{ agent_name: "test-agent" }] })
+      .mockResolvedValueOnce({
+        agents: [{ agent_name: "test-agent" }, { agent_name: "new-agent" }],
+      });
+    mockIsRecentlyCreated.mockImplementation((name: string) => name === "new-agent");
+
+    render(() => (
+      <AgentGuard>
+        <div data-testid="child">Child content</div>
+      </AgentGuard>
+    ));
+    await vi.waitFor(() => {
+      expect(mockGetAgents).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("child")).toBeDefined();
+    });
+
+    setAgentNameParam("new-agent");
+
+    await vi.waitFor(() => {
+      expect(mockGetAgents).toHaveBeenCalledTimes(2);
+    });
+    // Children stay mounted through the in-flight refetch (no blank flash) and
+    // the freshly fetched list resolves the new agent.
+    expect(screen.getByTestId("child")).toBeDefined();
+    expect(mockClearRecentAgent).toHaveBeenCalledWith("new-agent");
   });
 });

--- a/packages/frontend/tests/components/ProviderKeyForm.test.tsx
+++ b/packages/frontend/tests/components/ProviderKeyForm.test.tsx
@@ -451,6 +451,46 @@ describe('ProviderKeyForm', () => {
         apiKey: 'zai-new-key',
         authType: 'subscription',
         region: 'cn',
+        label: 'Default',
+      });
+    });
+
+    it('targets the visible key label on update so a non-Default key is not bypassed', async () => {
+      const def = makeProviderDef({ id: 'openai', name: 'OpenAI' });
+      const { container } = mount({
+        provDef: def,
+        provId: 'openai',
+        connected: true,
+        editing: true,
+        keyInput: 'sk-new-value',
+        providers: [
+          {
+            id: 'p2',
+            provider: 'openai',
+            auth_type: 'api_key' as const,
+            is_active: true,
+            has_api_key: true,
+            key_prefix: 'sk-old-',
+            label: 'second',
+            priority: 1,
+            region: null,
+            connected_at: '2026-04-27',
+          },
+        ],
+      });
+
+      const saveBtn = Array.from(container.querySelectorAll('.provider-detail__action')).find((b) =>
+        b.textContent?.includes('Save'),
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'openai',
+        apiKey: 'sk-new-value',
+        authType: 'api_key',
+        label: 'second',
       });
     });
 

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -652,6 +652,24 @@ describe("MessageLog", () => {
         expect(container.textContent).toContain("my-llama");
       });
     });
+
+    it("resolves custom provider name + icon in global mode via the first agent", async () => {
+      // Global ("All harnesses") log has no route agent. Custom providers are
+      // user-global, so the resource must fall back to the first agent —
+      // otherwise the source is undefined, the fetcher never runs, and
+      // custom:<uuid> models render as `custom:Custom/…` with no provider icon.
+      mockAgentName = undefined;
+      mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "agent-alpha" }] });
+      mockGetCustomProviders.mockResolvedValue([{ id: "abc-123", name: "Cerebras" }]);
+      mockGetMessages.mockResolvedValue(customMessagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector('img[alt="Cerebras"]')).not.toBeNull();
+        expect(container.textContent).not.toContain("custom:abc-123/");
+      });
+      // Resolved via the first available agent, not an undefined route param.
+      expect(mockGetCustomProviders).toHaveBeenCalledWith("agent-alpha");
+    });
   });
 
   describe("clear filters", () => {

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -215,6 +215,8 @@ vi.mock('../../src/services/connection-breadcrumb-store.js', () => ({
 vi.mock('manifest-shared', () => ({
   platformIcon: () => 'robot',
   PLATFORM_LABELS: { codex: 'Codex' },
+  SHARED_PROVIDERS: [],
+  inferProviderFromModel: () => undefined,
 }));
 
 import GlobalOverview from '../../src/pages/GlobalOverview';
@@ -614,6 +616,48 @@ describe('GlobalOverview (analytics)', () => {
     // Both providers still render despite the stale persisted set.
     expect(screen.getByTestId('ts-agents').textContent).toContain('openai');
     expect(screen.getByTestId('ts-agents').textContent).toContain('anthropic');
+  });
+
+  it('shows custom provider names instead of custom:<uuid> in provider series', async () => {
+    const customSeries = {
+      agents: ['openai', 'custom:cp-1'],
+      timeseries: [{ hour: '2026-06-04 10:00:00', openai: 1200, 'custom:cp-1': 300 }],
+    };
+    apiMocks.getGlobalPerProviderTimeseries.mockResolvedValue(customSeries);
+    apiMocks.getGlobalPerProviderMessageTimeseries.mockResolvedValue(customSeries);
+    apiMocks.getGlobalPerProviderCostTimeseries.mockResolvedValue(customSeries);
+    // A custom model with no display_name must render its stripped name, not
+    // the raw custom:<uuid>/ slug.
+    apiMocks.getOverview.mockResolvedValue({
+      ...overviewResponse,
+      cost_by_model: [
+        {
+          model: 'custom:cp-1/qwen-2.5',
+          display_name: null,
+          tokens: 300,
+          share_pct: 25,
+          estimated_cost: 0.1,
+          auth_type: 'api_key',
+          provider: 'custom:cp-1',
+        },
+      ],
+    });
+
+    render(() => <GlobalOverview />);
+    await waitFor(() => expect(screen.getByTestId('provider-chart-card')).toBeDefined());
+
+    // Chart series and filter list the resolved name once customProviderData loads.
+    await waitFor(() =>
+      expect(screen.getByTestId('ts-agents').textContent).toContain('Custom Provider'),
+    );
+    expect(screen.getByTestId('ts-agents').textContent).not.toContain('custom:cp-1');
+    fireEvent.click(screen.getByText('All providers (2)'));
+    expect(
+      screen.getAllByText('Custom Provider').some((el) => el.closest('.agent-filter-select')),
+    ).toBe(true);
+
+    // Model usage renders the stripped model name.
+    expect(screen.getByText('qwen-2.5')).toBeDefined();
   });
 
   it('shows the empty state when there are no harnesses and no providers', async () => {


### PR DESCRIPTION
**Aggregate branch for reviewing/testing the whole batch together — not for direct merge.** Merge the individual PRs below (each is small and independently reviewable); this branch just bundles their latest tips so you can run everything in one instance.

## Stack

All four PRs branch off **#2188** (`fix/limits-regression`), which is itself part of the global-providers stack. Two independent forks (disjoint files, clean merge):

```
#2188  fix/limits-regression            (base of this batch)
 ├─ #2191  fix/limits-tz-boundaries       → fix/limits-regression
 └─ #2189  fix/provider-key-edit-bugs     → fix/limits-regression
     └─ #2190  fix/chart-stat-button-styles   → fix/provider-key-edit-bugs
         └─ #2192  fix/custom-provider-display-names → fix/chart-stat-button-styles
```

This branch = merge(`#2191`, `#2192`) → contains #2188 + #2189 + #2190 + #2191 + #2192.

## What's in each PR

### #2188 — count legacy agent-name rows for limits *(base)*
Limit consumption query also counts rows where `agent_id IS NULL` and matches on `agent_name`, so legacy/global-provider rows are included in token/cost totals.

### #2191 — compute limit period boundaries in local time, not UTC
**Token/cost limits never blocked (or alerted) on non-UTC servers.** `computePeriodBoundaries`/`computePeriodResetDate` built the window in UTC, but `agent_messages.timestamp` is stored in the process's local time — so `periodEnd` sat behind the rows by the TZ offset and the consumption `SUM` read ~0. Now computed in local time (matching `computeCutoff`) via a new `toLocalSqlTimestamp`. Repro/fix verified on a UTC+2 host: a 1-token/day cap now blocks a 522-token agent (`M200`). *(Bug also present on `main`; UTC containers worked by luck.)*

### #2189 — target the visible provider key on edit and rename
Add-key form no longer steals focus on each keystroke; key edits land on the visible key (not the `Default` row); rename rewrites pinned routes across **all** the user's agents (keys are user-global) and flushes each mutated agent's routing cache.

### #2190 — strip native button chrome from chart stat tabs
Overview chart stat tabs (Cost/Messages/Tokens) render as `<button>` for a11y; reset the UA background/border/font so they match the card in both themes.

### #2192 — show custom provider names (+ icon) instead of `custom:<uuid>`
- **Overview**: provider-grouped series/filter/legend/tooltip and model tables remap `custom:<uuid>` → provider display name.
- **Messages log** *(follow-up commit)*: the global "All harnesses" view had no route agent, so the custom-providers resource never ran and rows showed `custom:Custom/<model>` with a letter badge. Now falls back to the first agent (custom providers are user-global), resolving the provider name + logo (e.g. "Hugging Face") like every other provider.

## Testing
- Backend: `period.util`/`postgres-sql` specs 100% line/branch; `notification-cron` edge cases TZ-independent.
- Frontend: `MessageLog.test.tsx` 93 tests incl. a global-mode custom-provider test; `MessageLog.tsx` 100% line coverage.
- Verified live on a self-hosted instance: limits block correctly; custom provider name + icon render in Messages.
- Pre-existing unrelated red on the stack: `baseline-cost.spec.ts` (`collectRoutedModelIds`).