### PR TITLE
fix: setup modal respects the harness chosen at agent creation

### DIFF
--- a/.changeset/setup-modal-stale-platform.md
+++ b/.changeset/setup-modal-stale-platform.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix the post-create "Set up harness" modal showing the full harness picker instead of the harness you just chose. AgentGuard now refetches the agent list when the viewed agent changes, so a newly created agent's platform reaches the setup modal (previously the stale, source-less list left the platform unset whenever the agent was created from the always-present sidebar while another agent was open).

--- a/packages/frontend/src/components/AgentGuard.tsx
+++ b/packages/frontend/src/components/AgentGuard.tsx
@@ -21,7 +21,17 @@ interface AgentsData {
 const AgentGuard: ParentComponent = (props) => {
   const params = useParams<{ agentName: string }>();
 
-  const [data, { refetch }] = createResource(() => getAgents() as Promise<AgentsData>);
+  // Key the fetch on the agent param so the list is re-fetched whenever the
+  // viewed agent changes. AgentGuard stays mounted across `/harnesses/:agentName`
+  // navigations (only the param updates), so a source-less resource would keep
+  // serving the list captured on first mount. That stale list omits an agent
+  // created from the always-present sidebar while another agent is open, which
+  // left `setAgentPlatform(null)` below — making the post-create setup modal
+  // render its full harness picker instead of the harness the user just chose.
+  const [data, { refetch }] = createResource(
+    () => params.agentName,
+    () => getAgents() as Promise<AgentsData>,
+  );
 
   const agentExists = createMemo(() => {
     const decoded = decodeURIComponent(params.agentName);
@@ -46,7 +56,10 @@ const AgentGuard: ParentComponent = (props) => {
   });
 
   return (
-    <Show when={!data.loading} fallback={null}>
+    // Only blank on the very first load. Once a list has resolved, keep the
+    // children mounted while a param-change refetch is in flight so switching
+    // agents (and the post-create redirect) doesn't flash an empty page.
+    <Show when={!data.loading || data() !== undefined} fallback={null}>
       <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
         <Show when={data()?.agents}>
           <Show when={agentExists()} fallback={<NotFound />}>

--- a/packages/frontend/tests/components/AgentGuard.test.tsx
+++ b/packages/frontend/tests/components/AgentGuard.test.tsx
@@ -1,8 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 
+// Reactive agent param so tests can simulate navigating between agents while
+// AgentGuard stays mounted (the resource is keyed on this).
+const [agentNameParam, setAgentNameParam] = createSignal("test-agent");
 vi.mock("@solidjs/router", () => ({
-  useParams: () => ({ agentName: "test-agent" }),
+  useParams: () => ({
+    get agentName() {
+      return agentNameParam();
+    },
+  }),
   A: (props: any) => <a href={props.href}>{props.children}</a>,
 }));
 
@@ -44,6 +52,7 @@ describe("AgentGuard", () => {
     mockSetAgentDisplayName.mockClear();
     mockIsRecentlyCreated.mockReturnValue(false);
     mockClearRecentAgent.mockClear();
+    setAgentNameParam("test-agent");
   });
 
   it("renders children when agent exists", async () => {
@@ -107,5 +116,37 @@ describe("AgentGuard", () => {
     await vi.waitFor(() => {
       expect(mockClearRecentAgent).toHaveBeenCalledWith("test-agent");
     });
+  });
+
+  it("refetches the agent list when the viewed agent changes", async () => {
+    // First load only knows about test-agent; a second agent is created later
+    // (e.g. from the sidebar while this guard stays mounted) and must trigger a
+    // fresh fetch rather than reusing the stale first-mount list.
+    mockGetAgents
+      .mockResolvedValueOnce({ agents: [{ agent_name: "test-agent" }] })
+      .mockResolvedValueOnce({
+        agents: [{ agent_name: "test-agent" }, { agent_name: "new-agent" }],
+      });
+    mockIsRecentlyCreated.mockImplementation((name: string) => name === "new-agent");
+
+    render(() => (
+      <AgentGuard>
+        <div data-testid="child">Child content</div>
+      </AgentGuard>
+    ));
+    await vi.waitFor(() => {
+      expect(mockGetAgents).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("child")).toBeDefined();
+    });
+
+    setAgentNameParam("new-agent");
+
+    await vi.waitFor(() => {
+      expect(mockGetAgents).toHaveBeenCalledTimes(2);
+    });
+    // Children stay mounted through the in-flight refetch (no blank flash) and
+    // the freshly fetched list resolves the new agent.
+    expect(screen.getByTestId("child")).toBeDefined();
+    expect(mockClearRecentAgent).toHaveBeenCalledWith("new-agent");
   });
 });


### PR DESCRIPTION
## Problem

Creating a new agent (or app) shows the **Set up harness** modal. When the harness (an Agent or a Toolkit/SDK) was already chosen at creation time, the modal is supposed to show only that harness's connection snippet. Instead it renders the full **Agents / Toolkits** toggle plus the SDK list — making the user re-pick what they already picked.

![bug](https://github.com/user-attachments/assets/placeholder)

## Root cause

The modal's platform-filtering keys off `agentPlatform()`, populated by `AgentGuard`. `AgentGuard` fetched the agent list with a **source-less resource**:

```ts
const [data] = createResource(() => getAgents()); // no source → fetches once, never refetches
```

`AgentGuard` is bound to `/harnesses/:agentName` and stays mounted across navigations — only the param changes. Creating a new agent from the **always-present sidebar** button (while another agent is open) redirects to the new agent, but the resource keeps serving the list captured on first mount, which doesn't contain the just-created agent. `agentExists()` then falls through to `setAgentPlatform(null)`, and the modal shows its full harness picker.

(It works when you create from the Workspace page, because there `AgentGuard` mounts fresh — which is why it looked intermittent.)

## Fix

Key the resource on the agent param so the list refetches per agent, and keep children mounted during the in-flight refetch so switching agents doesn't flash an empty page:

```ts
const [data, { refetch }] = createResource(
  () => params.agentName,
  () => getAgents() as Promise<AgentsData>,
);
...
<Show when={!data.loading || data() !== undefined} fallback={null}>
```

Now the fresh list contains the new agent → its platform reaches the modal → only the chosen harness's snippet is shown. Also fixes the same latent staleness for the agent display name and the NotFound gate.

## Tests
- New `AgentGuard.test.tsx` case asserts the list refetches when the viewed agent changes and children stay mounted through the refetch.
- `AgentGuard.tsx`: 100% line + branch coverage; `tsc` and eslint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the post-create setup modal to show only the harness you selected when creating an agent. `AgentGuard` now refetches the agent list when the viewed agent changes and keeps content visible during refetch.

- **Bug Fixes**
  - Keyed the `getAgents` resource to `params.agentName` so new agents are included; prevents falling back to a null platform and the full Agents/Toolkits picker.
  - Kept children mounted while refetching to avoid a blank flash on redirects; also updates the display name and NotFound gate with fresh data.

<sup>Written for commit 9376f2942f5f90549130cc66d5424fb0f4548273. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

