### PR TITLE
fix: strip context_management from Anthropic proxy requests

### DIFF
--- a/.changeset/modern-wombats-accept.md
+++ b/.changeset/modern-wombats-accept.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: strip `context_management` from Anthropic proxy requests to prevent `invalid_request_error`

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -2304,6 +2304,21 @@ describe('Anthropic Adapter', () => {
         tool_choice: { type: 'auto' },
       });
     });
+
+    it('strips context_management (compaction field that requires a beta header)', () => {
+      const result = applyAnthropicMessagesMutations({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: 'hi' }],
+        context_management: { edits: [{ type: 'compact_20260112' }] },
+      });
+      expect(result).not.toHaveProperty('context_management');
+      expect(result).toMatchObject({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+    });
   });
 
   describe('extractThinkingBlocksFromMessagesResponse', () => {

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -346,12 +346,26 @@ export function extractThinkingBlocksFromMessagesResponse(
  * - Replay cached extended-thinking blocks at the head of assistant turns
  *   whose first content block is a `tool_use`.
  */
+/**
+ * Fields that clients may send on the Anthropic Messages API but that Anthropic
+ * rejects as "extra inputs not permitted" when the required beta header is
+ * absent.  `context_management` is a valid Anthropic parameter for compaction
+ * (beta `compact-2026-01-12`), but Manifest does not forward that beta header,
+ * so the field must be stripped before forwarding.
+ */
+const ANTHROPIC_UNSUPPORTED_FIELDS = new Set(['context_management']);
+
 export function applyAnthropicMessagesMutations(
   body: Record<string, unknown>,
   options?: AnthropicRequestOptions,
 ): Record<string, unknown> {
   const shouldCache = options?.injectCacheControl !== false;
   const result: Record<string, unknown> = { ...body };
+
+  // Strip fields that Anthropic rejects under the standard version header.
+  for (const key of ANTHROPIC_UNSUPPORTED_FIELDS) {
+    delete result[key];
+  }
 
   // Normalize `system` to a content-block array so cache_control + identity
   // injection have a uniform target. Anthropic accepts either a bare string


### PR DESCRIPTION
  fix: strip context_management from Anthropic proxy requests

  Problem

  Clients sending requests via POST /v1/messages (Anthropic Messages API format) may include a context_management field — a legitimate Anthropic parameter for compaction that requires the compact-2026-01-12 beta header. Manifest forwards this field to Anthropic unchanged, but sends anthropic-version: 2023-06-01 without the compaction beta header, causing Anthropic to reject the request:

  `{"type":"error","error":{"type":"invalid_request_error","message":"context_management: Extra inputs are not permitted"}}`

  Fix

  Strips context_management from the outbound request body in applyAnthropicMessagesMutations(), the passthrough function used when both inbound and upstream are Anthropic Messages format. Follows the existing OPENAI_ONLY_FIELDS pattern from provider-client-converters.ts: a Set of known-problematic field names that gets deleted from the spread result.

  Testing

  - Added test: verifies context_management is stripped while other Anthropic-native fields (top_k, stop_sequences, thinking, metadata, tool_choice) pass through untouched.
  - All 131 existing anthropic-adapter tests pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips `context_management` from Anthropic Messages proxy requests to prevent Anthropic rejecting requests with invalid_request_error when the compaction beta header isn’t sent. This unblocks clients that include Anthropic-native payloads and avoids 400s.

- **Bug Fixes**
  - Remove `context_management` in `applyAnthropicMessagesMutations()` via an `ANTHROPIC_UNSUPPORTED_FIELDS` set.
  - Preserve other Anthropic fields (`top_k`, `stop_sequences`, `thinking`, `metadata`, `tool_choice`).
  - Add test to confirm removal and unchanged pass-through for other fields.

<sup>Written for commit ecdbe21d10b7290f9ffb2cd00f20c0e08c7b8e64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

