### PR TITLE
fix: Gemini adapter — strip unsupported schema keywords and merge parallel tool responses

### DIFF
--- a/.changeset/silver-chairs-grab.md
+++ b/.changeset/silver-chairs-grab.md
@@ -2,12 +2,14 @@
 "manifest": patch
 ---
 
-fix: strip additional unsupported JSON Schema keywords from Gemini tool declarations
+fix: Gemini adapter — strip unsupported schema keywords and merge parallel tool responses
 
-Gemini's `function_declarations` parameter schema accepts only a restricted
-OpenAPI subset and hard-rejects unknown keywords with
-`Unknown name "<field>" ... Cannot find field`. The sanitizer now also strips
-`propertyNames`, `uniqueItems`, `multipleOf`, `contains`/`minContains`/`maxContains`,
-`prefixItems`, `additionalItems`, `readOnly`, `writeOnly`, `deprecated`, and the
-`$comment`/`$anchor`/`$dynamicRef`/`$dynamicAnchor`/`$vocabulary` meta-keywords,
-preventing 400 errors when tools carry these common JSON Schema fields.
+The Gemini adapter now strips additional JSON Schema keywords that Google's
+`function_declarations` parameter schema rejects (`propertyNames`,
+`uniqueItems`, `multipleOf`, `contains`/`minContains`/`maxContains`,
+`prefixItems`, `additionalItems`, `readOnly`, `writeOnly`, `deprecated`,
+and `$comment`/`$anchor`/`$dynamicRef`/`$dynamicAnchor`/`$vocabulary`).
+
+It also merges consecutive parallel tool responses into a single Gemini
+user turn, matching Google's requirement that N functionCall parts be
+answered by exactly N functionResponse parts in one turn.

--- a/.changeset/silver-chairs-grab.md
+++ b/.changeset/silver-chairs-grab.md
@@ -1,0 +1,13 @@
+---
+"manifest": patch
+---
+
+fix: strip additional unsupported JSON Schema keywords from Gemini tool declarations
+
+Gemini's `function_declarations` parameter schema accepts only a restricted
+OpenAPI subset and hard-rejects unknown keywords with
+`Unknown name "<field>" ... Cannot find field`. The sanitizer now also strips
+`propertyNames`, `uniqueItems`, `multipleOf`, `contains`/`minContains`/`maxContains`,
+`prefixItems`, `additionalItems`, `readOnly`, `writeOnly`, `deprecated`, and the
+`$comment`/`$anchor`/`$dynamicRef`/`$dynamicAnchor`/`$vocabulary` meta-keywords,
+preventing 400 errors when tools carry these common JSON Schema fields.

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -2037,14 +2037,18 @@ describe('Google Adapter', () => {
         args: { q: 'cats' },
       });
 
-      // call_2 response resolved to `search` and keeps its id.
+      // call_2 and call_1 responses are merged into a single user turn with
+      // both functionResponse parts — Gemini requires N functionCall parts to be
+      // answered by exactly N functionResponse parts in one user turn.
+      expect(contents).toHaveLength(3);
+      expect(contents[2].role).toBe('user');
+      expect(contents[2].parts).toHaveLength(2);
       expect(contents[2].parts[0].functionResponse).toEqual({
         id: 'call_2',
         name: 'search',
         response: { result: '{"results":[]}' },
       });
-      // call_1 response resolved to `weather` and keeps its id.
-      expect(contents[3].parts[0].functionResponse).toEqual({
+      expect(contents[2].parts[1].functionResponse).toEqual({
         id: 'call_1',
         name: 'weather',
         response: { result: '{"temp":72}' },

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -203,6 +203,60 @@ describe('Google Adapter', () => {
       expect(props.config.properties).toEqual({ key: { type: 'string' } });
     });
 
+    it('strips additional Gemini-rejected JSON Schema keywords from tool parameters', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Validate config' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'validate_config',
+              parameters: {
+                type: 'object',
+                propertyNames: { pattern: '^[a-z_]+$' },
+                properties: {
+                  tags: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    uniqueItems: true,
+                    contains: { const: 'required' },
+                    minContains: 1,
+                    maxContains: 2,
+                    prefixItems: [{ type: 'string' }],
+                    additionalItems: false,
+                  },
+                  ratio: { type: 'number', multipleOf: 0.5 },
+                  metadata: {
+                    type: 'string',
+                    readOnly: true,
+                    writeOnly: false,
+                    deprecated: true,
+                    $comment: 'internal note',
+                    $anchor: 'Metadata',
+                    $dynamicRef: '#meta',
+                    $dynamicAnchor: 'Meta',
+                    $vocabulary: { 'https://json-schema.org/draft/2020-12/vocab/core': true },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-3.1-pro-preview');
+
+      const tools = result.tools as Array<{
+        functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+      }>;
+      const params = tools[0].functionDeclarations[0].parameters;
+      const props = params.properties as Record<string, Record<string, unknown>>;
+
+      expect(params).not.toHaveProperty('propertyNames');
+      expect(props.tags).toEqual({ type: 'array', items: { type: 'string' } });
+      expect(props.ratio).toEqual({ type: 'number' });
+      expect(props.metadata).toEqual({ type: 'string' });
+    });
+
     it('strips exclusive numeric bounds without removing same-named properties', () => {
       const body = {
         messages: [{ role: 'user', content: 'Set limits' }],

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -50,7 +50,15 @@ const DATA_IMAGE_URL_RE = /^data:([^;,]+)(?:;[^,]*)?;base64,(.*)$/is;
  */
 const UNSUPPORTED_SCHEMA_FIELDS = new Set([
   'patternProperties',
+  'propertyNames',
   'additionalProperties',
+  'additionalItems',
+  'prefixItems',
+  'uniqueItems',
+  'multipleOf',
+  'contains',
+  'minContains',
+  'maxContains',
   '$schema',
   '$id',
   '$ref',
@@ -79,6 +87,14 @@ const UNSUPPORTED_SCHEMA_FIELDS = new Set([
   'title',
   'exclusiveMinimum',
   'exclusiveMaximum',
+  'readOnly',
+  'writeOnly',
+  'deprecated',
+  '$comment',
+  '$anchor',
+  '$dynamicRef',
+  '$dynamicAnchor',
+  '$vocabulary',
 ]);
 
 function sanitizeSchema(schema: unknown, isPropertiesMap = false): unknown {

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -294,7 +294,28 @@ export function toGoogleRequest(
     if (content) contents.push(content);
   }
 
-  const result: Record<string, unknown> = { contents };
+  // Merge consecutive user-role turns that contain only functionResponse parts
+  // into a single turn. Gemini requires that N functionCall parts in a model
+  // turn be answered by exactly N functionResponse parts in one user turn —
+  // separate turns trigger "number of function response parts is not equal".
+  const merged: GeminiContent[] = [];
+  for (const content of contents) {
+    const prev = merged[merged.length - 1];
+    const allFunctionResponses =
+      content.role === 'user' && content.parts.every((p) => p.functionResponse);
+    if (
+      allFunctionResponses &&
+      prev &&
+      prev.role === 'user' &&
+      prev.parts.every((p) => p.functionResponse)
+    ) {
+      prev.parts.push(...content.parts);
+    } else {
+      merged.push(content);
+    }
+  }
+
+  const result: Record<string, unknown> = { contents: merged };
 
   if (systemText) {
     result.systemInstruction = {


### PR DESCRIPTION
## Problems

### 1. Unsupported JSON Schema keywords

Gemini's `function_declarations` parameter schema uses a restricted OpenAPI subset. Its request validator hard-rejects any unknown field name with:

```
Unknown name "propertyNames" at 'request.tools[0].function_declarations[1].parameters.properties[1].value': Cannot find field
```

This is HTTP 400 `INVALID_ARGUMENT` — any tool definition that carries a common JSON Schema keyword outside Gemini's closed allow-list causes the entire request to fail.

PR #2147 (`09a73799a`) added `sanitizeSchema()` / `UNSUPPORTED_SCHEMA_FIELDS` to strip a first batch of unsupported keywords, but several commonly-encountered ones still leak through.

### 2. Parallel tool responses not merged

OpenAI clients represent parallel tool results as one assistant message with multiple `tool_calls` followed by one `role: "tool"` message per result. The adapter previously converted each `role: "tool"` message into its own Gemini user turn containing a single `functionResponse` part.

Gemini requires the N `functionCall` parts from a model turn to be answered by **exactly N `functionResponse` parts in one user turn**. Separate turns trigger:

```
Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn.
```

## Fixes

### Commit 1: Strip additional unsupported JSON Schema keywords

Extend `UNSUPPORTED_SCHEMA_FIELDS` with the remaining keywords Gemini's `Schema` object does not accept:

- **Container constraints**: `propertyNames`, `uniqueItems`, `additionalItems`, `prefixItems`
- **Numeric**: `multipleOf`
- **Array contains**: `contains`, `minContains`, `maxContains`
- **Schema metadata**: `readOnly`, `writeOnly`, `deprecated`
- **JSON Schema meta-keywords**: `$comment`, `$anchor`, `$dynamicRef`, `$dynamicAnchor`, `$vocabulary`

### Commit 2: Merge parallel tool responses into one turn

After building the `contents` array, collapse consecutive `user`-role turns that contain only `functionResponse` parts into a single turn. Sequential tool-call cycles (assistant → tool → assistant → tool) remain separate because the intervening `model` turn prevents merging.

## Testing

- **Commit 1**: One new test exercises every added keyword in a single tool definition (92 total tests, all passing).
- **Commit 2**: Existing parallel-tool-response test updated to assert the merged single-turn structure. Sequential tool-call test unchanged — confirms merging doesn't over-collapse.

## Files changed

| File | Change |
|------|--------|
| `packages/backend/src/routing/proxy/google-adapter.ts` | 16 entries added to `UNSUPPORTED_SCHEMA_FIELDS`; parallel-response merge loop added |
| `packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts` | 1 new schema-keyword test; parallel-response test updated for merged structure |
| `.changeset/silver-chairs-grab.md` | patch changeset |

🤖 Generated with [Claude Code](https://claude.com/claude-code)