### PR TITLE
fix: custom providers display like built-in providers (no more literal "custom:" prefix)

### DIFF
--- a/.changeset/custom-provider-display.md
+++ b/.changeset/custom-provider-display.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Custom providers now display their name and models consistently across Messages, Overview, graphs and cost tables — the literal "custom:" prefix is gone and names resolve on global pages too (the backend resolves them, so deleted providers degrade gracefully).

--- a/docs/superpowers/plans/2026-06-10-custom-provider-display.md
+++ b/docs/superpowers/plans/2026-06-10-custom-provider-display.md
@@ -1,0 +1,904 @@
+# Custom Provider Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve custom provider display names at the backend query layer and render custom-provider rows exactly like built-in provider rows (icon + tooltip carry the provider; text is just the model id; no literal `custom:` anywhere).
+
+**Architecture:** Messages store `model = custom:<uuid>/<model>` and `provider = custom:<uuid>`. Today three frontend pages each fetch the custom-providers list (agent-scoped endpoint) to resolve `uuid → name`, which breaks on global pages. This plan moves resolution into the backend: a `LEFT JOIN custom_providers` in the shared message-row projection helper (new `custom_provider_name` column), in `getCostByModel`, and a SQL `CASE` that resolves per-provider timeseries series keys. The global providers endpoint gains a `display_name` per group. The frontend then deletes all three duplicated lookups and the `customProviderName` prop chain.
+
+**Tech Stack:** NestJS 11 + TypeORM 0.3 (QueryBuilder, no raw SQL strings outside helpers), SolidJS + vitest frontend, Jest backend. Repo demands **100% line/patch coverage**.
+
+**Worktree:** `/Users/guillaumegay/Documents/Projects/manifest/worktrees/custom-provider-display`, branch `fix/custom-provider-display`, base `feat/analytics-ui`. `node_modules` is a symlink to the main checkout's — do not `npm install`.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-custom-provider-display-design.md`
+
+**Verification commands** (run from the worktree root unless stated):
+- Backend unit: `cd packages/backend && npx jest <path> --silent`
+- Frontend unit: `cd packages/frontend && npx vitest run <path>`
+- Typecheck: `cd packages/<pkg> && npx tsc --noEmit -p tsconfig.json` (frontend: `npx tsc --noEmit`)
+
+**Key existing facts (verified against this branch):**
+- `selectMessageRowColumns(qb, costExpr)` + pinned `MESSAGE_ROW_SELECT_ALIASES` live in `packages/backend/src/analytics/services/query-helpers.ts:160-216`. Spec pin test: `query-helpers.spec.ts:296-362`.
+- Call sites: `getRecentActivity()` (`timeseries-queries.service.ts:123-142`) and `getMessages()` (`messages-query.service.ts:60`). The count query is built from `baseQb.clone()` BEFORE the helper runs, so the join only lands on the data query — no count skew.
+- `custom_providers` entity: `packages/backend/src/entities/custom-provider.entity.ts` — `id` is a **varchar** PK (no cast needed), has `user_id`, `name`. Already registered in `analytics.module.ts` `forFeature` (line 51) and in `test/helpers.ts` entities (line 74).
+- `CustomProviderService.list(userId)` exists (used in `routing/model.controller.ts:98`); `CustomProviderModule` exports it and `routing.module.ts` imports the module — `UserProvidersController` (declared in `routing.module.ts:57`) can inject it.
+- Frontend: `stripCustomPrefix()` (`services/routing-utils.ts:174-177`) strips `custom:<uuid>/` safely (uuid contains no `/`). `getModelDisplayName()` does NOT strip the custom prefix (PROVIDERS has no `custom` def → `getModelLabel` is skipped → returns input verbatim), so custom rows must call `stripCustomPrefix` explicitly.
+- `customProviderLogo(name, size, baseUrl?, modelName?)` in `components/ProviderIcon.tsx:651`.
+
+---
+
+### Task 1: Backend — `custom_provider_name` in the shared message-row projection
+
+**Files:**
+- Modify: `packages/backend/src/analytics/services/query-helpers.ts`
+- Test: `packages/backend/src/analytics/services/query-helpers.spec.ts`
+
+- [ ] **Step 1: Extend the pinned spec (failing first)**
+
+In `query-helpers.spec.ts`, inside `describe('selectMessageRowColumns')`, the `makeMockQb` (lines 297-311) needs a `leftJoin` mock. Replace the factory with:
+
+```typescript
+  function makeMockQb() {
+    const selectCalls: Array<[string, string]> = [];
+    const addSelectCalls: Array<[string, string]> = [];
+    const leftJoinCalls: Array<[unknown, string, string]> = [];
+    const qb = {
+      select: jest.fn().mockImplementation((expr: string, alias: string) => {
+        selectCalls.push([expr, alias]);
+        return qb;
+      }),
+      addSelect: jest.fn().mockImplementation((expr: string, alias: string) => {
+        addSelectCalls.push([expr, alias]);
+        return qb;
+      }),
+      leftJoin: jest
+        .fn()
+        .mockImplementation((entity: unknown, alias: string, condition: string) => {
+          leftJoinCalls.push([entity, alias, condition]);
+          return qb;
+        }),
+    };
+    return { qb: qb as unknown as SelectQueryBuilder<never>, selectCalls, addSelectCalls, leftJoinCalls };
+  }
+```
+
+Add two tests at the end of the same describe block:
+
+```typescript
+  it('left-joins custom_providers and projects custom_provider_name', () => {
+    const { qb, addSelectCalls, leftJoinCalls } = makeMockQb();
+    selectMessageRowColumns(qb, 'cost');
+
+    expect(leftJoinCalls).toHaveLength(1);
+    const [entity, alias, condition] = leftJoinCalls[0]!;
+    expect(entity).toBe(CustomProvider);
+    expect(alias).toBe('cp');
+    expect(condition).toBe(CUSTOM_PROVIDER_JOIN_CONDITION);
+
+    const nameCall = addSelectCalls.find(([, a]) => a === 'custom_provider_name');
+    expect(nameCall).toEqual(['cp.name', 'custom_provider_name']);
+  });
+
+  it('keys the join on the custom:-prefixed provider id', () => {
+    expect(CUSTOM_PROVIDER_JOIN_CONDITION).toBe("at.provider = 'custom:' || cp.id");
+  });
+```
+
+Add to the imports at the top of the spec (extend the existing `./query-helpers` import list with `CUSTOM_PROVIDER_JOIN_CONDITION`, and add a new entity import):
+
+```typescript
+import { CustomProvider } from '../../entities/custom-provider.entity';
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/backend && npx jest src/analytics/services/query-helpers.spec.ts --silent`
+Expected: FAIL — `CUSTOM_PROVIDER_JOIN_CONDITION` not exported; alias-pin test also fails once the alias array changes (next step makes both pass together).
+
+- [ ] **Step 3: Implement in `query-helpers.ts`**
+
+Add the entity import at the top:
+
+```typescript
+import { CustomProvider } from '../../entities/custom-provider.entity';
+```
+
+Add the exported constants right above `MESSAGE_ROW_SELECT_ALIASES`:
+
+```typescript
+/**
+ * Join `custom_providers` to resolve a custom provider's display name from a
+ * stored `at.provider` of the form `custom:<uuid>`. `cp.id` is a varchar PK,
+ * so plain string concatenation matches without casts. Built-in providers
+ * never match (their provider ids carry no `custom:` prefix) and resolve to a
+ * NULL `cp.name`.
+ */
+export const CUSTOM_PROVIDER_JOIN_CONDITION = "at.provider = 'custom:' || cp.id";
+
+/**
+ * Series key for per-provider aggregates: custom providers surface their
+ * display name (or a stable fallback when the provider was deleted), built-in
+ * providers keep their id. Requires the `cp` join above.
+ */
+export const PROVIDER_SERIES_KEY_EXPR =
+  "CASE WHEN at.provider LIKE 'custom:%' THEN COALESCE(cp.name, 'Deleted provider') ELSE at.provider END";
+```
+
+Append `'custom_provider_name'` to `MESSAGE_ROW_SELECT_ALIASES` (after `'recorded'`).
+
+In `selectMessageRowColumns`, add the join before the select chain and the new column at the end:
+
+```typescript
+export function selectMessageRowColumns<T extends ObjectLiteral>(
+  qb: SelectQueryBuilder<T>,
+  costExpr: string,
+): SelectQueryBuilder<T> {
+  return qb
+    .leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
+    .select('at.id', 'id')
+    /* ...existing addSelect chain unchanged... */
+    .addSelect('at.recorded', 'recorded')
+    .addSelect('cp.name', 'custom_provider_name');
+}
+```
+
+Note for the alias-pin test (`projects exactly the columns declared in MESSAGE_ROW_SELECT_ALIASES`, line 313): it derives expectations from the array, so it passes automatically once the array and the chain agree.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/backend && npx jest src/analytics/services/query-helpers.spec.ts --silent`
+Expected: PASS (all suites in the file).
+
+- [ ] **Step 5: Check the two call-site specs still pass** (their mocks must already tolerate `leftJoin` — `timeseries-queries.service.spec.ts` mock has `leftJoin: jest.fn().mockReturnThis()` at line 50/68; `messages-query.service.spec.ts` needs checking — if its mock qb lacks `leftJoin`, add `leftJoin: jest.fn().mockReturnThis(),` to the mock factory; also note `getRecentActivity` specs asserting `leftJoin).not.toHaveBeenCalled()` at lines 469/528 of the timeseries spec — those assertions are about OTHER methods (`getTimeseries`/`getActiveSkills`); if any assertion covering `getRecentActivity` expects no join, flip it to expect the `cp` join.)
+
+Run: `cd packages/backend && npx jest src/analytics/services/timeseries-queries.service.spec.ts src/analytics/services/messages-query.service.spec.ts --silent`
+Expected: PASS after the described mock fixes only.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/backend/src/analytics/services/query-helpers.ts packages/backend/src/analytics/services/query-helpers.spec.ts packages/backend/src/analytics/services/timeseries-queries.service.spec.ts packages/backend/src/analytics/services/messages-query.service.spec.ts
+git commit -m "feat(analytics): resolve custom provider name in shared message-row projection"
+```
+
+---
+
+### Task 2: Backend — `getCostByModel` carries `custom_provider_name`
+
+**Files:**
+- Modify: `packages/backend/src/analytics/services/timeseries-queries.service.ts:144-182`
+- Test: `packages/backend/src/analytics/services/timeseries-queries.service.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In the timeseries spec, find the existing `getCostByModel` tests and add:
+
+```typescript
+    it('getCostByModel resolves the custom provider display name', async () => {
+      mockTurnQb.getRawMany.mockResolvedValue([
+        {
+          model: 'custom:u1/gpt-oss-120b',
+          display_name: 'custom:u1/gpt-oss-120b',
+          tokens: '10',
+          estimated_cost: '0.5',
+          auth_type: 'api_key',
+          provider: 'custom:u1',
+          custom_provider_name: 'MyLLM',
+        },
+      ]);
+      const out = await service.getCostByModel('24h', 'u1');
+      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith(
+        CustomProvider,
+        'cp',
+        CUSTOM_PROVIDER_JOIN_CONDITION,
+      );
+      expect(mockTurnQb.addSelect).toHaveBeenCalledWith('cp.name', 'custom_provider_name');
+      expect(mockTurnQb.addGroupBy).toHaveBeenCalledWith('cp.name');
+      expect(out[0]).toMatchObject({
+        provider: 'custom:u1',
+        custom_provider_name: 'MyLLM',
+      });
+    });
+
+    it('getCostByModel returns null custom_provider_name for built-in and deleted providers', async () => {
+      mockTurnQb.getRawMany.mockResolvedValue([
+        { model: 'gpt-4o', tokens: '5', estimated_cost: '0.1', auth_type: null, provider: 'openai', custom_provider_name: null },
+      ]);
+      const out = await service.getCostByModel('24h', 'u1');
+      expect(out[0]!.custom_provider_name).toBeNull();
+    });
+```
+
+Add the imports to the spec's import block:
+
+```typescript
+import { CUSTOM_PROVIDER_JOIN_CONDITION } from './query-helpers';
+import { CustomProvider } from '../../entities/custom-provider.entity';
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/backend && npx jest src/analytics/services/timeseries-queries.service.spec.ts -t "getCostByModel" --silent`
+Expected: FAIL (no join, no `custom_provider_name` key).
+
+- [ ] **Step 3: Implement**
+
+In `getCostByModel` (`timeseries-queries.service.ts`), import `CUSTOM_PROVIDER_JOIN_CONDITION` (extend the existing `./query-helpers` import) and `CustomProvider` from `../../entities/custom-provider.entity`. Change the query:
+
+```typescript
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
+      .select("COALESCE(at.model, 'unknown')", 'model')
+      .addSelect('at.model', 'display_name')
+      .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
+      .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'estimated_cost')
+      .addSelect('at.auth_type', 'auth_type')
+      .addSelect('at.provider', 'provider')
+      .addSelect('cp.name', 'custom_provider_name')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.model IS NOT NULL')
+      .andWhere("at.model != ''");
+```
+
+Add `.addGroupBy('cp.name')` after the existing `.addGroupBy('at.provider')`, and extend the mapped return object with:
+
+```typescript
+      custom_provider_name: r['custom_provider_name'] ? String(r['custom_provider_name']) : null,
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/backend && npx jest src/analytics/services/timeseries-queries.service.spec.ts --silent`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/backend/src/analytics/services/timeseries-queries.service.ts packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+git commit -m "feat(analytics): cost-by-model rows carry resolved custom provider name"
+```
+
+---
+
+### Task 3: Backend — per-provider timeseries series keys resolve custom names
+
+**Files:**
+- Modify: `packages/backend/src/analytics/services/timeseries-queries.service.ts` — `getPerProviderTimeseries` (413-447), `getPerProviderMessageTimeseries` (449-482), `getPerProviderCostTimeseries` (555-586)
+- Test: `packages/backend/src/analytics/services/timeseries-queries.service.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+The existing per-provider tests assert `leftJoin).not.toHaveBeenCalled()` (spec lines 610, 656, 687) — **flip those three assertions** to:
+
+```typescript
+      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith(
+        CustomProvider,
+        'cp',
+        CUSTOM_PROVIDER_JOIN_CONDITION,
+      );
+```
+
+Add a new test next to `getPerProviderTimeseries filters by agentName and pivots tokens` (line 584):
+
+```typescript
+    it('getPerProviderTimeseries resolves custom series keys via the CASE expression', async () => {
+      mockTurnQb.getRawMany.mockResolvedValue([
+        { hour: '2026-06-10T10', provider: 'MyLLM', tokens: '7' },
+        { hour: '2026-06-10T10', provider: 'openai', tokens: '3' },
+      ]);
+      const out = await service.getPerProviderTimeseries('24h', 'u1', true);
+      expect(mockTurnQb.addSelect).toHaveBeenCalledWith(PROVIDER_SERIES_KEY_EXPR, 'provider');
+      expect(mockTurnQb.addGroupBy).toHaveBeenCalledWith(PROVIDER_SERIES_KEY_EXPR);
+      expect(out.agents).toEqual(['MyLLM', 'openai']);
+    });
+```
+
+Extend the spec's `./query-helpers` import with `PROVIDER_SERIES_KEY_EXPR`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/backend && npx jest src/analytics/services/timeseries-queries.service.spec.ts -t "PerProvider" --silent`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement (apply identically to all three methods)**
+
+Extend the service's `./query-helpers` import with `PROVIDER_SERIES_KEY_EXPR` and `CUSTOM_PROVIDER_JOIN_CONDITION` (Task 2 already imported `CustomProvider`). In each of the three methods, change the query builder:
+
+```typescript
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
+      .select(bucketExpr, bucketAlias)
+      .addSelect(PROVIDER_SERIES_KEY_EXPR, 'provider')
+      /* the metric addSelect stays as-is per method: tokens / messages / cost */
+```
+
+and change the grouping from `.addGroupBy('at.provider')` to `.addGroupBy(PROVIDER_SERIES_KEY_EXPR)`. Everything else (cutoff, `at.provider IS NOT NULL`, `excludeSystemAgents`, tenant filter, live-agent filter, pivot call) stays identical.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/backend && npx jest src/analytics/services/timeseries-queries.service.spec.ts --silent`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/backend/src/analytics/services/timeseries-queries.service.ts packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+git commit -m "feat(analytics): per-provider chart series resolve custom provider names"
+```
+
+---
+
+### Task 4: Backend — Messages provider-filter labels (`provider_labels`)
+
+**Files:**
+- Modify: `packages/backend/src/analytics/services/messages-query.service.ts`
+- Test: `packages/backend/src/analytics/services/messages-query.service.spec.ts`
+
+The Messages page provider dropdown gets its option ids from `getMessages().providers` — custom entries are raw `custom:<uuid>` and render verbatim. Return a label map alongside.
+
+- [ ] **Step 1: Write the failing test**
+
+In `messages-query.service.spec.ts`, locate the module/mock setup and register a mock for the new repository (mirror how the `AgentMessage` repo mock is provided; the CustomProvider repo only needs `find`):
+
+```typescript
+        {
+          provide: getRepositoryToken(CustomProvider),
+          useValue: { find: jest.fn().mockResolvedValue([]) },
+        },
+```
+
+with import `import { CustomProvider } from '../../entities/custom-provider.entity';`. Add a test:
+
+```typescript
+    it('returns provider_labels mapping custom provider ids to display names', async () => {
+      // distinct models/providers query returns a custom provider id
+      /* arrange the existing distinct-models mock so providers includes 'custom:u-1' */
+      customProviderRepo.find.mockResolvedValue([{ id: 'u-1', name: 'MyLLM' }]);
+      const out = await service.getMessages({ userId: 'u1', limit: 10 });
+      expect(customProviderRepo.find).toHaveBeenCalledWith({ where: { id: In(['u-1']) } });
+      expect(out.provider_labels).toEqual({ 'custom:u-1': 'MyLLM' });
+    });
+
+    it('omits provider_labels entries when no custom providers are stored', async () => {
+      const out = await service.getMessages({ userId: 'u1', limit: 10 });
+      expect(out.provider_labels).toEqual({});
+    });
+```
+
+(Adapt the arrange step to the spec's existing distinct-models mock helper — the row shape is `{ model, provider }`; make one row carry `provider: 'custom:u-1'`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/backend && npx jest src/analytics/services/messages-query.service.spec.ts --silent`
+Expected: FAIL (service has no CustomProvider dependency / no `provider_labels`).
+
+- [ ] **Step 3: Implement**
+
+In `messages-query.service.ts`:
+
+```typescript
+import { Brackets, In, Repository, SelectQueryBuilder } from 'typeorm';
+import { CustomProvider } from '../../entities/custom-provider.entity';
+```
+
+Constructor gains:
+
+```typescript
+    @InjectRepository(CustomProvider)
+    private readonly customProviderRepo: Repository<CustomProvider>,
+```
+
+In `getMessages`, after `const providers = this.deriveProviders(...)`:
+
+```typescript
+    const providerLabels = await this.resolveCustomProviderLabels(providers);
+
+    return {
+      items,
+      next_cursor: nextCursor,
+      total_count: totalCount,
+      providers,
+      provider_labels: providerLabels,
+    };
+```
+
+New private method:
+
+```typescript
+  /**
+   * Map `custom:<uuid>` provider ids to their display names so the Messages
+   * filter dropdown can label them. Deleted providers simply have no entry
+   * and fall back to the raw id in the UI.
+   */
+  private async resolveCustomProviderLabels(
+    providers: string[],
+  ): Promise<Record<string, string>> {
+    const uuids = providers
+      .filter((p) => p.startsWith('custom:'))
+      .map((p) => p.slice('custom:'.length));
+    if (uuids.length === 0) return {};
+    const rows = await this.customProviderRepo.find({ where: { id: In(uuids) } });
+    return Object.fromEntries(rows.map((cp) => [`custom:${cp.id}`, cp.name]));
+  }
+```
+
+`CustomProvider` is already in `analytics.module.ts` `forFeature` — no module change.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/backend && npx jest src/analytics/services/messages-query.service.spec.ts --silent`
+Expected: PASS.
+
+- [ ] **Step 5: Check the messages e2e suite (it asserts response shapes)**
+
+Run: `cd packages/backend && npx jest --config ./test/jest-e2e.json messages --silent` (requires the dev Postgres container per CLAUDE.md; if no DB is available locally, defer to CI and note it)
+Expected: PASS — additive field.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/backend/src/analytics/services/messages-query.service.ts packages/backend/src/analytics/services/messages-query.service.spec.ts
+git commit -m "feat(analytics): messages endpoint labels custom providers for the filter dropdown"
+```
+
+---
+
+### Task 5: Backend — global providers endpoint gains `display_name`
+
+**Files:**
+- Modify: `packages/backend/src/routing/user-providers.controller.ts`
+- Test: its spec (`packages/backend/src/routing/user-providers.controller.spec.ts` — locate with `ls packages/backend/src/routing/*user-providers*`)
+
+- [ ] **Step 1: Write the failing test**
+
+In the controller spec, add a `CustomProviderService` mock provider (`{ list: jest.fn().mockResolvedValue([]) }`) to the testing module, and a test:
+
+```typescript
+  it('resolves display_name for custom provider groups', async () => {
+    providerRepo.find.mockResolvedValue([
+      makeProvider({ provider: 'custom:u-9', auth_type: 'api_key' }),
+    ]);
+    customProviderService.list.mockResolvedValue([{ id: 'u-9', name: 'MyLLM' }]);
+    const res = await controller.listProviders(user);
+    expect(res.providers[0]).toMatchObject({ provider: 'custom:u-9', display_name: 'MyLLM' });
+  });
+
+  it('returns null display_name for built-in groups and deleted custom providers', async () => {
+    providerRepo.find.mockResolvedValue([
+      makeProvider({ provider: 'openai', auth_type: 'api_key' }),
+      makeProvider({ provider: 'custom:gone', auth_type: 'api_key' }),
+    ]);
+    customProviderService.list.mockResolvedValue([]);
+    const res = await controller.listProviders(user);
+    expect(res.providers.find((p) => p.provider === 'openai')!.display_name).toBeNull();
+    expect(res.providers.find((p) => p.provider === 'custom:gone')!.display_name).toBeNull();
+  });
+```
+
+(Reuse the spec's existing provider-row factory; if none exists, build the minimal `UserProvider` literal the controller reads: `id, provider, auth_type, label, key_prefix, priority, connected_at, models_fetched_at, cached_models, is_active`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/backend && npx jest src/routing/user-providers.controller --silent`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `user-providers.controller.ts`, inject the service:
+
+```typescript
+import { CustomProviderService } from './custom-provider/custom-provider.service';
+```
+
+(constructor): `private readonly customProviderService: CustomProviderService,`
+
+In `listProviders`, before building `result`:
+
+```typescript
+    const customProviders = await this.customProviderService.list(user.id);
+    const customNameById = new Map(customProviders.map((cp) => [cp.id, cp.name]));
+```
+
+and extend the mapped group object:
+
+```typescript
+        display_name: g.provider.startsWith('custom:')
+          ? (customNameById.get(g.provider.slice('custom:'.length)) ?? null)
+          : null,
+```
+
+Check the import path/type of `CustomProviderService.list` return (see `routing/model.controller.ts:98` for usage) and that `routing.module.ts` already provides it via `CustomProviderModule` (it does — line 46).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/backend && npx jest src/routing/user-providers.controller --silent`
+Expected: PASS.
+
+- [ ] **Step 5: Backend-wide check + commit**
+
+Run: `cd packages/backend && npx tsc --noEmit -p tsconfig.json && npx jest --silent`
+Expected: clean compile, all unit suites green.
+
+```bash
+git add packages/backend/src/routing/user-providers.controller.ts packages/backend/src/routing/user-providers.controller.spec.ts
+git commit -m "feat(providers): global providers endpoint resolves custom display names"
+```
+
+---
+
+### Task 6: Frontend — `ModelCell` renders custom rows like built-in rows
+
+**Files:**
+- Modify: `packages/frontend/src/components/message-table-types.ts` (MessageRow)
+- Modify: `packages/frontend/src/components/message-table-cells.tsx` (`ModelCell`, `CellRenderContext`, `renderCell`)
+- Modify: `packages/frontend/src/components/MessageTable.tsx` (drop the prop)
+- Test: `packages/frontend/tests/components/message-table-cells.test.tsx`, `packages/frontend/tests/components/MessageTable.test.tsx`
+
+- [ ] **Step 1: Add the field to `MessageRow`** (`message-table-types.ts`, after `provider`):
+
+```typescript
+  custom_provider_name?: string | null;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`message-table-cells.test.tsx` — `ModelCell` is currently called as `ModelCell(row, noCustom)`. The new signature drops the callback: `ModelCell(row)`. Update the two existing calls (lines 128, 137) and add:
+
+```typescript
+  it('renders a custom row with just the model text and the provider name in the tooltip', () => {
+    const row = makeRow({
+      model: 'custom:u-1/openai/gpt-oss-120b',
+      provider: 'custom:u-1',
+      custom_provider_name: 'MyLLM',
+    });
+    const { container } = render(() => (
+      <table><tbody><tr>{ModelCell(row)}</tr></tbody></table>
+    ));
+    expect(container.textContent).toContain('openai/gpt-oss-120b');
+    expect(container.textContent).not.toContain('custom:');
+    expect(container.textContent).not.toContain('Custom');
+    expect(container.querySelector('[title="MyLLM"]')).toBeTruthy();
+  });
+
+  it('falls back to a letter avatar from the model when the custom provider was deleted', () => {
+    const row = makeRow({
+      model: 'custom:gone/my-model',
+      provider: 'custom:gone',
+      custom_provider_name: null,
+    });
+    const { container } = render(() => (
+      <table><tbody><tr>{ModelCell(row)}</tr></tbody></table>
+    ));
+    expect(container.textContent).toContain('my-model');
+    expect(container.textContent).not.toContain('custom:');
+    const avatar = container.querySelector('.provider-card__logo-letter');
+    expect(avatar?.textContent).toBe('M');
+  });
+```
+
+(Use the file's existing row factory; if it's named differently than `makeRow`, follow the local convention.)
+
+`MessageTable.test.tsx` — delete the `customProviderName={noopProvider}` prop from every `<MessageTable …>` render (the `noopProvider` const too), and update the custom-avatar regression test (line 398-420): rows now need `custom_provider_name` instead of relying on the callback; assertions that previously expected `custom:Custom/my-model` text must expect `my-model`.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cd packages/frontend && npx vitest run tests/components/message-table-cells.test.tsx tests/components/MessageTable.test.tsx`
+Expected: FAIL (signature mismatch).
+
+- [ ] **Step 4: Implement**
+
+`message-table-cells.tsx` — new `ModelCell` (replaces lines 234-318's header and custom branch; badge/fallback tail unchanged):
+
+```typescript
+export function ModelCell(item: MessageRow, onOpenRecording?: (id: string) => void): JSX.Element {
+  const provId = resolveMessageProvider(item);
+  const provName = resolveMessageProviderName(item);
+  // Custom providers are identified by either the literal 'custom' (from
+  // inferProviderFromModel on a `custom:...` model name) or by a stored
+  // provider column of the form `custom:<uuid>` (from resolveProviderId,
+  // which returns custom-prefixed IDs unchanged). Their display name arrives
+  // pre-resolved from the backend as `custom_provider_name` (null when the
+  // provider was deleted).
+  const isCustomProvider = provId === 'custom' || provId?.startsWith('custom:') === true;
+  return (
+    <td style={MONO_XS}>
+      <span style="display: inline-flex; align-items: center; gap: 4px;">
+        {item.model && isCustomProvider ? (
+          (() => {
+            const customName = item.custom_provider_name ?? undefined;
+            const logo = customProviderLogo(customName ?? '', 16, undefined, item.model ?? undefined);
+            if (logo) return logo;
+            const letter = (customName ?? stripCustomPrefix(item.model!)).charAt(0).toUpperCase();
+            return (
+              <span
+                class="provider-card__logo-letter"
+                title={customName}
+                style={{
+                  background: customProviderColor(customName ?? ''),
+                  width: '16px',
+                  height: '16px',
+                  'font-size': '9px',
+                  'flex-shrink': '0',
+                  'border-radius': '50%',
+                }}
+              >
+                {letter}
+              </span>
+            );
+          })()
+        ) : provId ? (
+          /* built-in branch unchanged */
+        ) : null}
+        {item.model
+          ? item.model.startsWith('custom:')
+            ? stripCustomPrefix(item.model)
+            : getModelDisplayName(item.model)
+          : '—'}
+        {/* tier badge / fallback badge tail unchanged */}
+      </span>
+    </td>
+  );
+}
+```
+
+`CellRenderContext` (line 454-462): delete the `customProviderName: (model: string) => string | undefined;` member. `renderCell` case `'model'` (line 483): `return ModelCell(item, ctx.onOpenRecording);`.
+
+`MessageTable.tsx`: delete `customProviderName` from `MessageTableProps` (line 10) and from both `ctx` literals (lines 70, 141).
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd packages/frontend && npx vitest run tests/components/message-table-cells.test.tsx tests/components/MessageTable.test.tsx`
+Expected: PASS. (Typecheck will still fail at page call sites — fixed in Task 8; do not run tsc yet.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/components/message-table-types.ts packages/frontend/src/components/message-table-cells.tsx packages/frontend/src/components/MessageTable.tsx packages/frontend/tests/components/message-table-cells.test.tsx packages/frontend/tests/components/MessageTable.test.tsx
+git commit -m "feat(frontend): ModelCell renders custom providers like built-in providers"
+```
+
+---
+
+### Task 7: Frontend — `CostByModelTable` reads the backend-resolved name
+
+**Files:**
+- Modify: `packages/frontend/src/components/CostByModelTable.tsx`
+- Test: `packages/frontend/tests/components/CostByModelTable.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Rewrite the custom-provider tests (current lines ~75-110). The component no longer takes `customProviderName`; rows carry the name:
+
+```typescript
+  it('renders a custom row with the stripped model text and tooltip from the row', () => {
+    const { container } = render(() => (
+      <CostByModelTable
+        rows={[row({ model: 'custom:abc123/gpt-custom', provider: 'custom:abc123', custom_provider_name: 'My Provider' })]}
+      />
+    ));
+    expect(container.textContent).toContain('gpt-custom');
+    expect(container.textContent).not.toContain('custom:');
+    expect(container.querySelector('[title="My Provider"]')).toBeTruthy();
+  });
+
+  it('falls back to a letter avatar when the custom provider was deleted', () => {
+    const { container } = render(() => (
+      <CostByModelTable
+        rows={[row({ model: 'custom:abc/my-model', provider: 'custom:abc', custom_provider_name: null, auth_type: null })]}
+      />
+    ));
+    // stripCustomPrefix('custom:abc/my-model') → 'my-model' → first letter "M".
+    expect(container.querySelector('.provider-card__logo-letter')?.textContent).toBe('M');
+    expect(container.textContent).toContain('my-model');
+    expect(container.textContent).not.toContain('Custom');
+  });
+```
+
+Remove `customProviderName` from every other render in the file and from the `row` factory's prop expectations.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/frontend && npx vitest run tests/components/CostByModelTable.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`CostByModelTable.tsx`:
+- `CostByModelRow` gains `custom_provider_name?: string | null;`
+- `CostByModelTableProps` loses `customProviderName` (interface becomes `{ rows: CostByModelRow[] }`).
+- In the icon IIFE (lines 72-118): replace `const provName = props.customProviderName(row.model);` with `const provName = row.custom_provider_name ?? undefined;` (keep the rest of the custom branch as-is).
+- Text expression (lines 119-123) becomes:
+
+```typescript
+                    {row.model
+                      ? row.model.startsWith('custom:')
+                        ? stripCustomPrefix(row.model)
+                        : row.display_name || getModelDisplayName(row.model)
+                      : row.model}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/frontend && npx vitest run tests/components/CostByModelTable.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/components/CostByModelTable.tsx packages/frontend/tests/components/CostByModelTable.test.tsx
+git commit -m "feat(frontend): CostByModelTable reads backend-resolved custom provider name"
+```
+
+---
+
+### Task 8: Frontend — pages drop the duplicated lookups
+
+**Files:**
+- Modify: `packages/frontend/src/pages/Overview.tsx` (lines 120-130, 384-402)
+- Modify: `packages/frontend/src/pages/MessageLog.tsx` (lines 27, 54, 158-161, 180-186, 310-321, 574-578)
+- Test: `packages/frontend/tests/pages/Overview.test.tsx`, `packages/frontend/tests/pages/MessageLog.test.tsx` (exact names: `ls packages/frontend/tests/pages/ | grep -i 'overview\|message'`)
+
+- [ ] **Step 1: Overview.tsx**
+
+Delete the `customProviders` resource (lines 120-123) and `customProviderName` function (lines 125-130); remove `getCustomProviders` and `CustomProviderData` from imports **if** no other use remains in the file (verify with grep before deleting the import). Remove `customProviderName={customProviderName}` from the `<MessageTable>` (line 392) and `<CostByModelTable>` (line 401) usages.
+
+- [ ] **Step 2: MessageLog.tsx**
+
+- Delete the `customProviders` resource (158-161) and `customProviderName` (180-186); prune now-unused imports (`getCustomProviders`, `CustomProviderData`) if unreferenced elsewhere in the file.
+- Remove `customProviderName={customProviderName}` from `<MessageTable>` (line 578).
+- `MessagesData` interface (~line 54): add `provider_labels?: Record<string, string>;`
+- `providerDisplayName` (lines 310-313) becomes:
+
+```typescript
+  const providerDisplayName = (id: string): string => {
+    const prov = PROVIDERS.find((p) => p.id === id);
+    if (prov) return prov.name;
+    return data()?.provider_labels?.[id] ?? id;
+  };
+```
+
+- [ ] **Step 3: Update page tests**
+
+Run the two page suites; fix failures mechanically: remove mocks of `getCustomProviders` that exist solely for the deleted resources, and update any fixture rows/assertions that relied on the `custom:`-prefixed display (now expect the stripped model text). If `MessageLog` tests cover the provider dropdown, add a case: with `provider_labels: { 'custom:u-1': 'MyLLM' }` and providers `['custom:u-1']`, the option label is `MyLLM`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/frontend && npx vitest run tests/pages/Overview.test.tsx tests/pages/MessageLog.test.tsx` (adjust to the actual file names)
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/pages/Overview.tsx packages/frontend/src/pages/MessageLog.tsx packages/frontend/tests/pages/
+git commit -m "refactor(frontend): drop per-page custom provider name lookups"
+```
+
+---
+
+### Task 9: Frontend — GlobalOverview uses backend-resolved names
+
+**Files:**
+- Modify: `packages/frontend/src/pages/GlobalOverview.tsx`
+- Test: `packages/frontend/tests/pages/GlobalOverview.test.tsx` (verify exact name)
+
+- [ ] **Step 1: Types and dead code**
+
+- `ProviderGroup` (line 42): add `display_name?: string | null;`
+- `CostByModelRow` (line 55): add `custom_provider_name?: string | null;`
+- Delete the first-agent hack: `firstAgent` (line 194), the `customProviderData` resource (195-198), and `resolveCustomName` (199-204). Prune `getCustomProviders` (and `getAgents` ONLY if its sole use was `firstAgent` — it is also used for the agents list; check before touching) from imports.
+
+- [ ] **Step 2: Replace usages**
+
+- `connList` (line 655): `const customName = g.display_name ?? null;` (replaces `resolveCustomName(g.provider)`).
+- Provider connections table (lines 1131-1136): `const customName = isCustom ? (group.display_name ?? null) : null;` — rest unchanged.
+- Cost-by-model panel (lines 1042-1051): make the row render custom-aware:
+
+```tsx
+                        <div style="display: flex; align-items: center; gap: 6px;">
+                          {(() => {
+                            const isCustom = row.provider?.startsWith('custom:') === true;
+                            if (isCustom) {
+                              const name = row.custom_provider_name ?? undefined;
+                              return (
+                                customProviderLogo(name ?? '', 16, undefined, row.model) ?? (
+                                  <span
+                                    class="provider-card__logo-letter"
+                                    title={name}
+                                    style={{
+                                      background: customProviderColor(name ?? ''),
+                                      width: '16px',
+                                      height: '16px',
+                                      'font-size': '9px',
+                                      'flex-shrink': '0',
+                                      'border-radius': '50%',
+                                    }}
+                                  >
+                                    {(name ?? stripCustomPrefix(row.model)).charAt(0).toUpperCase()}
+                                  </span>
+                                )
+                              );
+                            }
+                            return row.provider ? (
+                              <span style="position: relative; flex-shrink: 0; display: flex; align-items: center;">
+                                {providerIcon(row.provider, 16)}
+                                {authBadgeFor(row.auth_type, 12)}
+                              </span>
+                            ) : null;
+                          })()}
+                          <span style="font-weight: 500; color: hsl(var(--foreground));">
+                            {row.model.startsWith('custom:')
+                              ? stripCustomPrefix(row.model)
+                              : row.display_name || row.model}
+                          </span>
+                        </div>
+```
+
+Add `stripCustomPrefix` to the file's `routing-utils` import if missing. (`CostByModelRow.auth_type` — confirm the field exists on the interface at line 55-…; pass `null` if absent.)
+
+- [ ] **Step 3: Update GlobalOverview tests**
+
+Run the suite; mechanically: drop `getCustomProviders` mocks tied to the deleted resource, add `display_name` to provider-group fixtures used by custom-provider assertions, and add one assertion that a custom cost-by-model row renders the stripped model with no `custom:` substring.
+
+- [ ] **Step 4: Run to verify pass + frontend-wide check**
+
+Run: `cd packages/frontend && npx vitest run tests/pages/GlobalOverview.test.tsx && npx tsc --noEmit`
+Expected: PASS; compile clean (this is the first point where the whole frontend should typecheck again).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/pages/GlobalOverview.tsx packages/frontend/tests/pages/
+git commit -m "feat(frontend): GlobalOverview reads backend-resolved custom provider names"
+```
+
+---
+
+### Task 10: Full verification, coverage, changeset
+
+- [ ] **Step 1: Full test runs**
+
+```bash
+cd packages/backend && npx tsc --noEmit -p tsconfig.json && npx jest --coverage --silent
+cd ../frontend && npx tsc --noEmit && npx vitest run --coverage
+cd ../shared && npx jest --coverage --silent
+```
+
+Expected: all green, **100% line coverage** on every touched file (repo policy). If any new line is uncovered, add the missing test before proceeding.
+
+- [ ] **Step 2: Lint**
+
+Run: `npx eslint packages/backend/src packages/frontend/src --max-warnings 0` (from repo root; match the repo's lint script if it differs — check `package.json`).
+Expected: clean.
+
+- [ ] **Step 3: Grep guard — no orphaned references**
+
+```bash
+grep -rn "customProviderName" packages/frontend/src && echo "LEAK" || echo "clean"
+```
+
+Expected: `clean` (the only allowed survivors are unrelated locals in `ModelPickerModal`/`FallbackList` — those components have their own agent-scoped maps and are out of scope; if the grep hits them, confirm they are the pre-existing routing-config code paths and leave them).
+
+- [ ] **Step 4: Changeset**
+
+```bash
+npx changeset add --empty   # then replace: create .changeset/<name>.md targeting "manifest", patch
+```
+
+Write a real changeset (patch, package `manifest`): `Custom providers now display their name and models consistently across Messages, Overview, graphs and cost tables — no more literal "custom:" prefix.`
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add .changeset
+git commit -m "chore: changeset for custom provider display fix"
+```
+
+---
+
+## Out of scope (do not touch)
+
+- `ModelPickerModal`, `FallbackList`, routing config UI — already correct, agent-scoped.
+- The small "custom" type chip after the provider name in GlobalOverview's provider-connections table (line 1166-1170) — it is a provider-type tag, not a name prefix; flag it in the PR description for the user to decide.
+- Removing the now-redundant agent-scoped `GET :agentName/custom-providers` consumers elsewhere — separate cleanup.

--- a/docs/superpowers/specs/2026-06-10-custom-provider-display-design.md
+++ b/docs/superpowers/specs/2026-06-10-custom-provider-display-design.md
@@ -57,8 +57,8 @@ and over write-time denormalization, which goes stale on rename.)
 - Per-provider timeseries (token + message variants, agent-scoped and global):
   series keys of the form `custom:<uuid>` are resolved to the provider's name
   in the pivoted output, so chart legends arrive pre-resolved. Unresolvable
-  uuids (deleted provider) keep a stable fallback label derived from the model
-  (never the literal `custom:<uuid>`).
+  uuids (deleted provider) get the stable fallback label `Deleted provider` —
+  never the literal `custom:<uuid>`.
 - The pinned alias test `query-helpers.spec.ts` is updated to include
   `custom_provider_name`.
 

--- a/docs/superpowers/specs/2026-06-10-custom-provider-display-design.md
+++ b/docs/superpowers/specs/2026-06-10-custom-provider-display-design.md
@@ -1,0 +1,116 @@
+# Custom provider display: resolve names in the backend, render like built-in providers
+
+**Date:** 2026-06-10
+**Branch:** `fix/custom-provider-display` (based on `feat/analytics-ui`)
+**Status:** Approved
+
+## Problem
+
+Messages store the model as `custom:<uuid>/<model>` and the provider as
+`custom:<uuid>`. The dashboard resolves the custom provider's display name by
+fetching the custom-providers list in the frontend and matching the uuid. This
+breaks in three ways:
+
+1. **Global Messages page** (`MessageLog.tsx`): the `customProviders` resource
+   is keyed on `params.agentName`. In global mode there is no agent name, the
+   resource never fetches, and every custom row falls back to the placeholder
+   name `Custom`.
+2. **GlobalOverview** (`GlobalOverview.tsx`): works around the agent-scoped
+   endpoint by fetching custom providers via the *first agent's* name — a
+   fragile hack (empty agent list → no names).
+3. **Hardcoded literal** at `message-table-cells.tsx` (ModelCell) and
+   `CostByModelTable.tsx`: the display string is
+   `` `custom:${name ?? 'Custom'}/${model}` `` — so even when the lookup
+   succeeds the UI shows `custom:MyLLM/openai/gpt-oss-120b`.
+
+The name resolution is duplicated in three pages (`Overview.tsx`,
+`MessageLog.tsx`, `GlobalOverview.tsx`) and threaded as a prop through
+`MessageTable` — every new view must remember to wire it, which is exactly how
+the global views broke.
+
+Note: `stripCustomPrefix()` (`routing-utils.ts`) already parses
+`custom:<uuid>/` unambiguously — uuids contain no slash, so model ids with
+slashes (`openai/gpt-oss-120b`) survive intact. No "split at last slash"
+heuristics are needed; the bug is purely name resolution + display formatting.
+
+## Decision
+
+**Resolve the custom provider name at the backend query layer** and render
+custom rows exactly like built-in provider rows. (Chosen over a
+frontend-global lookup store, which keeps the wire-it-everywhere failure mode,
+and over write-time denormalization, which goes stale on rename.)
+
+## Design
+
+### 1. Backend — resolve names in analytics responses
+
+- `selectMessageRowColumns()` in
+  `packages/backend/src/analytics/services/query-helpers.ts` gains a
+  `LEFT JOIN custom_providers cp ON at.provider = 'custom:' || cp.id::text`
+  and a new alias `custom_provider_name` (`cp.name`). NULL for built-in
+  providers and for deleted custom providers. Both call sites (Messages log
+  `getMessages()`, Overview Recent Messages `getRecentActivity()`) inherit the
+  column via the shared-projection contract. The join is added by the helper
+  (or a sibling helper called alongside it) so call sites cannot forget it.
+- `getCostByModel()` in `timeseries-queries.service.ts`: same join; rows carry
+  `custom_provider_name`.
+- Per-provider timeseries (token + message variants, agent-scoped and global):
+  series keys of the form `custom:<uuid>` are resolved to the provider's name
+  in the pivoted output, so chart legends arrive pre-resolved. Unresolvable
+  uuids (deleted provider) keep a stable fallback label derived from the model
+  (never the literal `custom:<uuid>`).
+- The pinned alias test `query-helpers.spec.ts` is updated to include
+  `custom_provider_name`.
+
+### 2. Frontend — render custom rows like built-in rows
+
+- `ModelCell` (`message-table-cells.tsx`): text is just
+  `stripCustomPrefix(item.model)`; the icon is the custom provider logo or
+  letter avatar with the provider name in the tooltip — identical structure to
+  built-in rows. The `` `custom:${…}` `` literal is deleted.
+- `CostByModelTable.tsx`: same treatment, reads the backend-resolved name from
+  the row.
+- Remove the `customProviderName` prop chain entirely: the three duplicated
+  lookup implementations (`Overview.tsx`, `MessageLog.tsx`,
+  `GlobalOverview.tsx` incl. the first-agent hack and `resolveCustomName`) and
+  the prop threading through `MessageTable`. Components read
+  `item.custom_provider_name`.
+- Routing config UI (`ModelPickerModal`, `FallbackList`) is untouched — it has
+  agent context and already displays correctly.
+
+### 3. The generic display rule
+
+Applies everywhere (messages, recent messages, overviews, graphs, cost
+tables), agent-scoped or global:
+
+- **Text** = raw model id (`stripCustomPrefix(model)`), always — same as
+  built-in rows showing `gpt-4o`, not `OpenAI/gpt-4o`.
+- **Provider identity** = icon + tooltip from the backend-resolved name.
+- **Deleted provider fallback**: NULL name → letter avatar from the model's
+  first character; no crash, no `Custom` placeholder text.
+- The word "custom" never appears in any rendered string.
+
+### 4. Tests
+
+- Backend: updated pinned alias spec; unit/e2e asserting
+  `custom_provider_name` resolves for a live custom provider and is NULL for a
+  deleted one; timeseries/cost-by-model assertions for resolved series keys.
+- Frontend: vitest asserting a custom row renders without the `custom:`
+  literal, with the raw model text and resolved tooltip; fallback rendering
+  when `custom_provider_name` is null.
+- 100% patch coverage per repo policy.
+
+### 5. PR placement
+
+New PR, branch `fix/custom-provider-display`, base **`feat/analytics-ui`**
+(deepest real PR tip on the main fork; the integration branch #2174 is
+preview-only/do-not-merge so it cannot be the base). Base branch must exist on
+`upstream` (it does — the capstone targets it).
+
+## Out of scope
+
+- Provider modal changes (tracked separately, spec TBD).
+- Routing config UI changes.
+- Renaming/migrating the agent-scoped `GET :agentName/custom-providers`
+  endpoint — it becomes unused by these views but removal is a separate
+  cleanup.

--- a/packages/backend/src/analytics/services/messages-query.service.cost-filter.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.cost-filter.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Brackets } from 'typeorm';
 import { MessagesQueryService } from './messages-query.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
+import { CustomProvider } from '../../entities/custom-provider.entity';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 
 /**
@@ -76,6 +77,10 @@ describe('MessagesQueryService — cost filter edge cases', () => {
         {
           provide: getRepositoryToken(AgentMessage),
           useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQb) },
+        },
+        {
+          provide: getRepositoryToken(CustomProvider),
+          useValue: { find: jest.fn().mockResolvedValue([]) },
         },
         {
           provide: TenantCacheService,

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -1,8 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Brackets } from 'typeorm';
+import { Brackets, In } from 'typeorm';
 import { MessagesQueryService } from './messages-query.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
+import { CustomProvider } from '../../entities/custom-provider.entity';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 
 describe('MessagesQueryService', () => {
@@ -10,11 +11,13 @@ describe('MessagesQueryService', () => {
   let mockGetRawOne: jest.Mock;
   let mockGetRawMany: jest.Mock;
   let mockTenantResolve: jest.Mock;
+  let mockCustomProviderFind: jest.Mock;
 
   beforeEach(async () => {
     mockGetRawOne = jest.fn().mockResolvedValue({ total: 0 });
     mockGetRawMany = jest.fn().mockResolvedValue([]);
     mockTenantResolve = jest.fn().mockResolvedValue('tenant-123');
+    mockCustomProviderFind = jest.fn().mockResolvedValue([]);
 
     const mockQb: Record<string, jest.Mock> = {
       select: jest.fn(),
@@ -65,6 +68,10 @@ describe('MessagesQueryService', () => {
           useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQb) },
         },
         {
+          provide: getRepositoryToken(CustomProvider),
+          useValue: { find: mockCustomProviderFind },
+        },
+        {
           provide: TenantCacheService,
           useValue: { resolve: mockTenantResolve },
         },
@@ -102,6 +109,31 @@ describe('MessagesQueryService', () => {
     expect(result.items[0]).toHaveProperty('cache_read_tokens', 500);
     expect(result.items[0]).toHaveProperty('cache_creation_tokens', 100);
     expect(result.items[0]).toHaveProperty('duration_ms', 1200);
+  });
+
+  it('returns provider_labels mapping custom provider ids to display names', async () => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 1 });
+    mockGetRawMany.mockResolvedValueOnce([
+      { id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'custom:u-1/m', cost: 0 },
+    ]);
+    mockGetRawMany.mockResolvedValueOnce([{ model: 'custom:u-1/m', provider: 'custom:u-1' }]);
+    mockCustomProviderFind.mockResolvedValueOnce([{ id: 'u-1', name: 'MyLLM' }]);
+
+    const result = await service.getMessages({ range: '24h', userId: 'labels-user', limit: 10 });
+
+    expect(mockCustomProviderFind).toHaveBeenCalledWith({ where: { id: In(['u-1']) } });
+    expect(result.provider_labels).toEqual({ 'custom:u-1': 'MyLLM' });
+  });
+
+  it('returns empty provider_labels without querying when no custom providers appear', async () => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 0 });
+    mockGetRawMany.mockResolvedValueOnce([]);
+    mockGetRawMany.mockResolvedValueOnce([{ model: 'gpt-4o', provider: 'openai' }]);
+
+    const result = await service.getMessages({ range: '24h', userId: 'no-labels-user', limit: 10 });
+
+    expect(mockCustomProviderFind).not.toHaveBeenCalled();
+    expect(result.provider_labels).toEqual({});
   });
 
   it('returns paginated messages with total count and providers list', async () => {

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Brackets, Repository, SelectQueryBuilder } from 'typeorm';
+import { Brackets, In, Repository, SelectQueryBuilder } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
+import { CustomProvider } from '../../entities/custom-provider.entity';
 import { rangeToInterval } from '../../common/utils/range.util';
 import { addTenantFilter, formatTimestamp, selectMessageRowColumns } from './query-helpers';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
@@ -31,6 +32,8 @@ export class MessagesQueryService {
   constructor(
     @InjectRepository(AgentMessage)
     private readonly turnRepo: Repository<AgentMessage>,
+    @InjectRepository(CustomProvider)
+    private readonly customProviderRepo: Repository<CustomProvider>,
     private readonly tenantCache: TenantCacheService,
   ) {}
 
@@ -91,13 +94,31 @@ export class MessagesQueryService {
     const lastItem = items[items.length - 1] as Record<string, unknown> | undefined;
     const nextCursor = hasMore && lastItem ? this.encodeCursor(lastItem) : null;
     const providers = this.deriveProviders(distinctRows.models, distinctRows.providers);
+    const providerLabels = await this.resolveCustomProviderLabels(providers);
 
     return {
       items,
       next_cursor: nextCursor,
       total_count: totalCount,
       providers,
+      provider_labels: providerLabels,
     };
+  }
+
+  /**
+   * Map `custom:<uuid>` provider ids to their display names so the Messages
+   * filter dropdown can label them. Deleted providers simply have no entry
+   * and fall back to the raw id in the UI.
+   */
+  private async resolveCustomProviderLabels(
+    providers: string[],
+  ): Promise<Record<string, string>> {
+    const uuids = providers
+      .filter((p) => p.startsWith('custom:'))
+      .map((p) => p.slice('custom:'.length));
+    if (uuids.length === 0) return {};
+    const rows = await this.customProviderRepo.find({ where: { id: In(uuids) } });
+    return Object.fromEntries(rows.map((cp) => [`custom:${cp.id}`, cp.name]));
   }
 
   private async buildBaseMessageQuery(

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -110,9 +110,7 @@ export class MessagesQueryService {
    * filter dropdown can label them. Deleted providers simply have no entry
    * and fall back to the raw id in the UI.
    */
-  private async resolveCustomProviderLabels(
-    providers: string[],
-  ): Promise<Record<string, string>> {
+  private async resolveCustomProviderLabels(providers: string[]): Promise<Record<string, string>> {
     const uuids = providers
       .filter((p) => p.startsWith('custom:'))
       .map((p) => p.slice('custom:'.length));

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -6,11 +6,14 @@ import {
   selectMessageRowColumns,
   excludeSystemAgents,
   EXCLUDE_SYSTEM_AGENTS_PREDICATE,
+  CUSTOM_PROVIDER_JOIN_CONDITION,
+  PROVIDER_SERIES_KEY_EXPR,
   filterByKeyLabel,
   filterByLiveAgentName,
   MESSAGE_ROW_SELECT_ALIASES,
 } from './query-helpers';
 import { SelectQueryBuilder } from 'typeorm';
+import { CustomProvider } from '../../entities/custom-provider.entity';
 
 describe('computeTrend', () => {
   it('returns positive trend when current exceeds previous', () => {
@@ -297,6 +300,7 @@ describe('selectMessageRowColumns', () => {
   function makeMockQb() {
     const selectCalls: Array<[string, string]> = [];
     const addSelectCalls: Array<[string, string]> = [];
+    const leftJoinCalls: Array<[unknown, string, string]> = [];
     const qb = {
       select: jest.fn().mockImplementation((expr: string, alias: string) => {
         selectCalls.push([expr, alias]);
@@ -306,8 +310,19 @@ describe('selectMessageRowColumns', () => {
         addSelectCalls.push([expr, alias]);
         return qb;
       }),
+      leftJoin: jest
+        .fn()
+        .mockImplementation((entity: unknown, alias: string, condition: string) => {
+          leftJoinCalls.push([entity, alias, condition]);
+          return qb;
+        }),
     };
-    return { qb: qb as unknown as SelectQueryBuilder<never>, selectCalls, addSelectCalls };
+    return {
+      qb: qb as unknown as SelectQueryBuilder<never>,
+      selectCalls,
+      addSelectCalls,
+      leftJoinCalls,
+    };
   }
 
   it('projects exactly the columns declared in MESSAGE_ROW_SELECT_ALIASES', () => {
@@ -358,5 +373,29 @@ describe('selectMessageRowColumns', () => {
     const { qb } = makeMockQb();
     const result = selectMessageRowColumns(qb, 'cost');
     expect(result).toBe(qb);
+  });
+
+  it('left-joins custom_providers and projects custom_provider_name', () => {
+    const { qb, addSelectCalls, leftJoinCalls } = makeMockQb();
+    selectMessageRowColumns(qb, 'cost');
+
+    expect(leftJoinCalls).toHaveLength(1);
+    const [entity, alias, condition] = leftJoinCalls[0]!;
+    expect(entity).toBe(CustomProvider);
+    expect(alias).toBe('cp');
+    expect(condition).toBe(CUSTOM_PROVIDER_JOIN_CONDITION);
+
+    const nameCall = addSelectCalls.find(([, a]) => a === 'custom_provider_name');
+    expect(nameCall).toEqual(['cp.name', 'custom_provider_name']);
+  });
+
+  it('keys the join on the custom:-prefixed provider id', () => {
+    expect(CUSTOM_PROVIDER_JOIN_CONDITION).toBe("at.provider = 'custom:' || cp.id");
+  });
+
+  it('resolves custom series keys to the provider name with a deleted-provider fallback', () => {
+    expect(PROVIDER_SERIES_KEY_EXPR).toBe(
+      "CASE WHEN at.provider LIKE 'custom:%' THEN COALESCE(cp.name, 'Deleted provider') ELSE at.provider END",
+    );
   });
 });

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -1,4 +1,5 @@
 import { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+import { CustomProvider } from '../../entities/custom-provider.entity';
 
 export interface MetricWithTrend {
   value: number;
@@ -157,6 +158,23 @@ export function filterByKeyLabel<T extends ObjectLiteral>(
  * `costExpr` (e.g. `sqlCastFloat(sqlSanitizeCost('at.cost_usd'))`) so the
  * shared helper stays agnostic to how each call site sanitises cost.
  */
+/**
+ * Join `custom_providers` to resolve a custom provider's display name from a
+ * stored `at.provider` of the form `custom:<uuid>`. `cp.id` is a varchar PK,
+ * so plain string concatenation matches without casts. Built-in providers
+ * never match (their provider ids carry no `custom:` prefix) and resolve to a
+ * NULL `cp.name`.
+ */
+export const CUSTOM_PROVIDER_JOIN_CONDITION = "at.provider = 'custom:' || cp.id";
+
+/**
+ * Series key for per-provider aggregates: custom providers surface their
+ * display name (or a stable fallback when the provider was deleted), built-in
+ * providers keep their id. Requires the `cp` join above.
+ */
+export const PROVIDER_SERIES_KEY_EXPR =
+  "CASE WHEN at.provider LIKE 'custom:%' THEN COALESCE(cp.name, 'Deleted provider') ELSE at.provider END";
+
 export const MESSAGE_ROW_SELECT_ALIASES = [
   'id',
   'timestamp',
@@ -182,6 +200,7 @@ export const MESSAGE_ROW_SELECT_ALIASES = [
   'header_tier_color',
   'provider_key_label',
   'recorded',
+  'custom_provider_name',
 ] as const;
 
 export function selectMessageRowColumns<T extends ObjectLiteral>(
@@ -189,6 +208,7 @@ export function selectMessageRowColumns<T extends ObjectLiteral>(
   costExpr: string,
 ): SelectQueryBuilder<T> {
   return qb
+    .leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
     .select('at.id', 'id')
     .addSelect('at.timestamp', 'timestamp')
     .addSelect('at.agent_name', 'agent_name')
@@ -212,5 +232,6 @@ export function selectMessageRowColumns<T extends ObjectLiteral>(
     .addSelect('at.header_tier_name', 'header_tier_name')
     .addSelect('at.header_tier_color', 'header_tier_color')
     .addSelect('at.provider_key_label', 'provider_key_label')
-    .addSelect('at.recorded', 'recorded');
+    .addSelect('at.recorded', 'recorded')
+    .addSelect('cp.name', 'custom_provider_name');
 }

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -4,7 +4,13 @@ import { TimeseriesQueriesService } from './timeseries-queries.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { Agent } from '../../entities/agent.entity';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
-import { MESSAGE_ROW_SELECT_ALIASES, EXCLUDE_SYSTEM_AGENTS_PREDICATE } from './query-helpers';
+import {
+  MESSAGE_ROW_SELECT_ALIASES,
+  EXCLUDE_SYSTEM_AGENTS_PREDICATE,
+  CUSTOM_PROVIDER_JOIN_CONDITION,
+  PROVIDER_SERIES_KEY_EXPR,
+} from './query-helpers';
+import { CustomProvider } from '../../entities/custom-provider.entity';
 
 describe('TimeseriesQueriesService', () => {
   let service: TimeseriesQueriesService;
@@ -196,6 +202,49 @@ describe('TimeseriesQueriesService', () => {
       expect(result[0].share_pct).toBe(0);
       expect(result[0].auth_type).toBeNull();
       expect(result[0].provider).toBeNull();
+    });
+
+    it('resolves the custom provider display name', async () => {
+      mockGetRawMany.mockResolvedValue([
+        {
+          model: 'custom:u-1/gpt-oss-120b',
+          display_name: 'custom:u-1/gpt-oss-120b',
+          tokens: 10,
+          estimated_cost: 0.5,
+          auth_type: 'api_key',
+          provider: 'custom:u-1',
+          custom_provider_name: 'MyLLM',
+        },
+      ]);
+
+      const result = await service.getCostByModel('7d', 'u1');
+      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith(
+        CustomProvider,
+        'cp',
+        CUSTOM_PROVIDER_JOIN_CONDITION,
+      );
+      expect(mockTurnQb.addSelect).toHaveBeenCalledWith('cp.name', 'custom_provider_name');
+      expect(mockTurnQb.addGroupBy).toHaveBeenCalledWith('cp.name');
+      expect(result[0]).toMatchObject({
+        provider: 'custom:u-1',
+        custom_provider_name: 'MyLLM',
+      });
+    });
+
+    it('returns null custom_provider_name for built-in and deleted custom providers', async () => {
+      mockGetRawMany.mockResolvedValue([
+        {
+          model: 'gpt-4o',
+          tokens: 5,
+          estimated_cost: 0.1,
+          auth_type: null,
+          provider: 'openai',
+          custom_provider_name: null,
+        },
+      ]);
+
+      const result = await service.getCostByModel('7d', 'u1');
+      expect(result[0].custom_provider_name).toBeNull();
     });
   });
 
@@ -607,7 +656,40 @@ describe('TimeseriesQueriesService', () => {
       // Playground (is_system) usage must be excluded from per-provider totals,
       // via the same NOT EXISTS semi-join as the per-agent endpoints (no join).
       expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
-      expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
+      // Custom provider names resolve via the cp join (built-ins join to NULL).
+      expect(mockTurnQb.leftJoin).toHaveBeenCalledWith(
+        CustomProvider,
+        'cp',
+        CUSTOM_PROVIDER_JOIN_CONDITION,
+      );
+    });
+
+    it('resolves custom series keys via the CASE expression in all per-provider pivots', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { hour: '01', provider: 'MyLLM', tokens: 7 },
+        { hour: '01', provider: 'openai', tokens: 3 },
+      ]);
+      const out = await service.getPerProviderTimeseries('24h', 'u1', true);
+      expect(mockTurnQb.addSelect).toHaveBeenCalledWith(PROVIDER_SERIES_KEY_EXPR, 'provider');
+      expect(mockTurnQb.addGroupBy).toHaveBeenCalledWith(PROVIDER_SERIES_KEY_EXPR);
+      expect(out.agents).toEqual(['MyLLM', 'openai']);
+
+      for (const call of [
+        () => service.getPerProviderMessageTimeseries('24h', 'u1', true),
+        () => service.getPerProviderCostTimeseries('24h', 'u1', true),
+      ]) {
+        mockTurnQb.addSelect.mockClear();
+        mockTurnQb.addGroupBy.mockClear();
+        mockTurnQb.leftJoin.mockClear();
+        await call();
+        expect(mockTurnQb.leftJoin).toHaveBeenCalledWith(
+          CustomProvider,
+          'cp',
+          CUSTOM_PROVIDER_JOIN_CONDITION,
+        );
+        expect(mockTurnQb.addSelect).toHaveBeenCalledWith(PROVIDER_SERIES_KEY_EXPR, 'provider');
+        expect(mockTurnQb.addGroupBy).toHaveBeenCalledWith(PROVIDER_SERIES_KEY_EXPR);
+      }
     });
 
     it('getPerModelTimeseries scopes to the live agent id when an agent is given', async () => {

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -10,7 +10,10 @@ import {
   excludeSystemAgents,
   filterByKeyLabel,
   filterByLiveAgentName,
+  CUSTOM_PROVIDER_JOIN_CONDITION,
+  PROVIDER_SERIES_KEY_EXPR,
 } from './query-helpers';
+import { CustomProvider } from '../../entities/custom-provider.entity';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import {
   computeCutoff,
@@ -148,12 +151,14 @@ export class TimeseriesQueriesService {
 
     const qb = this.turnRepo
       .createQueryBuilder('at')
+      .leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
       .select("COALESCE(at.model, 'unknown')", 'model')
       .addSelect('at.model', 'display_name')
       .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
       .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'estimated_cost')
       .addSelect('at.auth_type', 'auth_type')
       .addSelect('at.provider', 'provider')
+      .addSelect('cp.name', 'custom_provider_name')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL')
       .andWhere("at.model != ''");
@@ -162,6 +167,7 @@ export class TimeseriesQueriesService {
       .groupBy('at.model')
       .addGroupBy('at.auth_type')
       .addGroupBy('at.provider')
+      .addGroupBy('cp.name')
       .orderBy('tokens', 'DESC')
       .getRawMany();
 
@@ -178,6 +184,7 @@ export class TimeseriesQueriesService {
       estimated_cost: Number(r['estimated_cost'] ?? 0),
       auth_type: r['auth_type'] ? String(r['auth_type']) : null,
       provider: r['provider'] ? String(r['provider']) : null,
+      custom_provider_name: r['custom_provider_name'] ? String(r['custom_provider_name']) : null,
     }));
   }
 
@@ -424,8 +431,9 @@ export class TimeseriesQueriesService {
 
     const qb = this.turnRepo
       .createQueryBuilder('at')
+      .leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
       .select(bucketExpr, bucketAlias)
-      .addSelect('at.provider', 'provider')
+      .addSelect(PROVIDER_SERIES_KEY_EXPR, 'provider')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
@@ -439,7 +447,7 @@ export class TimeseriesQueriesService {
 
     const rows = await qb
       .groupBy(bucketAlias)
-      .addGroupBy('at.provider')
+      .addGroupBy(PROVIDER_SERIES_KEY_EXPR)
       .orderBy(bucketAlias, 'ASC')
       .getRawMany();
 
@@ -460,8 +468,9 @@ export class TimeseriesQueriesService {
 
     const qb = this.turnRepo
       .createQueryBuilder('at')
+      .leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
       .select(bucketExpr, bucketAlias)
-      .addSelect('at.provider', 'provider')
+      .addSelect(PROVIDER_SERIES_KEY_EXPR, 'provider')
       .addSelect('COUNT(*)', 'messages')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
@@ -474,7 +483,7 @@ export class TimeseriesQueriesService {
 
     const rows = await qb
       .groupBy(bucketAlias)
-      .addGroupBy('at.provider')
+      .addGroupBy(PROVIDER_SERIES_KEY_EXPR)
       .orderBy(bucketAlias, 'ASC')
       .getRawMany();
 
@@ -566,8 +575,9 @@ export class TimeseriesQueriesService {
     const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
     const qb = this.turnRepo
       .createQueryBuilder('at')
+      .leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
       .select(bucketExpr, bucketAlias)
-      .addSelect('at.provider', 'provider')
+      .addSelect(PROVIDER_SERIES_KEY_EXPR, 'provider')
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
@@ -579,7 +589,7 @@ export class TimeseriesQueriesService {
     if (agentName) filterByLiveAgentName(qb, agentName, userId, tenantId);
     const rows = await qb
       .groupBy(bucketAlias)
-      .addGroupBy('at.provider')
+      .addGroupBy(PROVIDER_SERIES_KEY_EXPR)
       .orderBy(bucketAlias, 'ASC')
       .getRawMany();
     return pivotByKey(rows, bucketAlias, 'provider', 'cost');

--- a/packages/backend/src/routing/user-providers.controller.spec.ts
+++ b/packages/backend/src/routing/user-providers.controller.spec.ts
@@ -36,6 +36,7 @@ describe('UserProvidersController', () => {
       {} as never,
       { findOne: jest.fn().mockResolvedValue(null) } as never,
       { getAll: jest.fn().mockReturnValue([]) } as never,
+      { list: jest.fn().mockResolvedValue([]) } as never,
     );
 
     const result = await controller.listProviders({ id: 'user-1' } as never);
@@ -67,6 +68,7 @@ describe('UserProvidersController', () => {
       {} as never,
       { findOne: jest.fn().mockResolvedValue(null) } as never,
       { getAll: jest.fn().mockReturnValue([]) } as never,
+      { list: jest.fn().mockResolvedValue([]) } as never,
     );
 
     const result = await controller.listProviders({ id: 'user-1' } as never);
@@ -103,6 +105,7 @@ describe('UserProvidersController', () => {
       {} as never,
       { findOne: jest.fn().mockResolvedValue(null) } as never,
       { getAll: jest.fn().mockReturnValue([]) } as never,
+      { list: jest.fn().mockResolvedValue([]) } as never,
     );
 
     const result = await controller.listProviders({ id: 'user-1' } as never);
@@ -126,6 +129,7 @@ describe('UserProvidersController', () => {
           { provider: 'Anthropic', model_name: 'claude-3-5-sonnet' },
         ]),
       } as never,
+      { list: jest.fn().mockResolvedValue([]) } as never,
     );
 
     const result = await controller.listProviders({ id: 'user-1' } as never);
@@ -165,6 +169,7 @@ describe('UserProvidersController', () => {
       messageRepo as never,
       { findOne: jest.fn().mockResolvedValue({ id: tenantId }) } as never,
       { getAll: jest.fn().mockReturnValue([]) } as never,
+      { list: jest.fn().mockResolvedValue([]) } as never,
     );
 
     const result = await controller.listProviders({ id: 'user-1' } as never);
@@ -173,5 +178,54 @@ describe('UserProvidersController', () => {
     expect(result.providers[0].consumption_messages).toBe(10);
     expect(result.providers[0].consumption_cost).toBe(0.05);
     expect(result.providers[0].last_used_at).toBe('2026-01-15T00:00:00.000Z');
+  });
+
+  it('resolves display_name for custom provider groups', async () => {
+    const providerRepo = {
+      find: jest
+        .fn()
+        .mockResolvedValue([{ ...makeProvider('p1', 'Default'), provider: 'custom:u-9' }]),
+    };
+    const customProviderService = {
+      list: jest.fn().mockResolvedValue([{ id: 'u-9', name: 'MyLLM' }]),
+    };
+    const controller = new UserProvidersController(
+      providerRepo as never,
+      {} as never,
+      { findOne: jest.fn().mockResolvedValue(null) } as never,
+      { getAll: jest.fn().mockReturnValue([]) } as never,
+      customProviderService as never,
+    );
+
+    const result = await controller.listProviders({ id: 'user-1' } as never);
+
+    expect(customProviderService.list).toHaveBeenCalledWith('user-1');
+    expect(result.providers[0]).toMatchObject({
+      provider: 'custom:u-9',
+      display_name: 'MyLLM',
+    });
+  });
+
+  it('returns null display_name for built-in groups and deleted custom providers', async () => {
+    const providerRepo = {
+      find: jest
+        .fn()
+        .mockResolvedValue([
+          makeProvider('p1', 'Default'),
+          { ...makeProvider('p2', 'Gone'), provider: 'custom:gone' },
+        ]),
+    };
+    const controller = new UserProvidersController(
+      providerRepo as never,
+      {} as never,
+      { findOne: jest.fn().mockResolvedValue(null) } as never,
+      { getAll: jest.fn().mockReturnValue([]) } as never,
+      { list: jest.fn().mockResolvedValue([]) } as never,
+    );
+
+    const result = await controller.listProviders({ id: 'user-1' } as never);
+
+    expect(result.providers.find((p) => p.provider === 'openai')!.display_name).toBeNull();
+    expect(result.providers.find((p) => p.provider === 'custom:gone')!.display_name).toBeNull();
   });
 });

--- a/packages/backend/src/routing/user-providers.controller.ts
+++ b/packages/backend/src/routing/user-providers.controller.ts
@@ -7,6 +7,7 @@ import { UserProvider } from '../entities/user-provider.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { Tenant } from '../entities/tenant.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
+import { CustomProviderService } from './custom-provider/custom-provider.service';
 
 /**
  * User-level provider management endpoints.
@@ -22,6 +23,7 @@ export class UserProvidersController {
     @InjectRepository(Tenant)
     private readonly tenantRepo: Repository<Tenant>,
     private readonly pricingCache: ModelPricingCacheService,
+    private readonly customProviderService: CustomProviderService,
   ) {}
 
   /**
@@ -175,6 +177,10 @@ export class UserProvidersController {
       }
     }
 
+    // Resolve custom provider display names (provider key = `custom:<uuid>`).
+    const customProviders = await this.customProviderService.list(user.id);
+    const customNameById = new Map(customProviders.map((cp) => [cp.id, cp.name]));
+
     const result = Array.from(grouped.values()).map((g) => {
       const cons = consumption.get(`${g.provider}::${g.auth_type}`) ?? {
         tokens: 0,
@@ -185,6 +191,9 @@ export class UserProvidersController {
       return {
         provider: g.provider,
         auth_type: g.auth_type,
+        display_name: g.provider.startsWith('custom:')
+          ? (customNameById.get(g.provider.slice('custom:'.length)) ?? null)
+          : null,
         connection_count: g.connections.length,
         connections: g.connections,
         total_models: g.total_models,

--- a/packages/frontend/src/components/CostByModelTable.tsx
+++ b/packages/frontend/src/components/CostByModelTable.tsx
@@ -19,11 +19,11 @@ interface CostByModelRow {
   estimated_cost: number;
   auth_type: string | null;
   provider?: string | null;
+  custom_provider_name?: string | null;
 }
 
 interface CostByModelTableProps {
   rows: CostByModelRow[];
-  customProviderName: (model: string) => string | undefined;
 }
 
 function resolveRowProvider(row: CostByModelRow): string | undefined {
@@ -74,7 +74,7 @@ const CostByModelTable: Component<CostByModelTableProps> = (props) => {
                       const isCustom =
                         provId === 'custom' || provId?.startsWith('custom:') === true;
                       if (row.model && isCustom) {
-                        const provName = props.customProviderName(row.model);
+                        const provName = row.custom_provider_name ?? undefined;
                         const logo = customProviderLogo(
                           provName ?? '',
                           16,
@@ -118,7 +118,7 @@ const CostByModelTable: Component<CostByModelTableProps> = (props) => {
                     })()}
                     {row.model
                       ? row.model.startsWith('custom:')
-                        ? `custom:${props.customProviderName(row.model) ?? 'Custom'}/${stripCustomPrefix(row.model)}`
+                        ? stripCustomPrefix(row.model)
                         : row.display_name || getModelDisplayName(row.model)
                       : row.model}
                   </span>

--- a/packages/frontend/src/components/MessageTable.tsx
+++ b/packages/frontend/src/components/MessageTable.tsx
@@ -7,7 +7,6 @@ export interface MessageTableProps {
   items: MessageRow[];
   columns: MessageColumnKey[];
   agentName?: string;
-  customProviderName: (model: string) => string | undefined;
   onFallbackErrorClick?: (model: string) => void;
   onFeedbackLike?: (id: string) => void;
   onFeedbackDislike?: (id: string) => void;
@@ -67,7 +66,6 @@ function ExpandableRow(props: {
   const colSpan = () => props.columns.length + 1;
   const ctx = {
     agentName: props.tableProps.agentName,
-    customProviderName: props.tableProps.customProviderName,
     onFallbackErrorClick: props.tableProps.onFallbackErrorClick,
     onFeedbackLike: props.tableProps.onFeedbackLike,
     onFeedbackDislike: props.tableProps.onFeedbackDislike,
@@ -138,7 +136,6 @@ function PlainRow(props: {
 }): JSX.Element {
   const ctx = {
     agentName: props.tableProps.agentName,
-    customProviderName: props.tableProps.customProviderName,
     onFallbackErrorClick: props.tableProps.onFallbackErrorClick,
     onFeedbackLike: props.tableProps.onFeedbackLike,
     onFeedbackDislike: props.tableProps.onFeedbackDislike,

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -231,24 +231,22 @@ function resolveMessageProviderName(item: MessageRow): string | undefined {
   );
 }
 
-export function ModelCell(
-  item: MessageRow,
-  customProviderName: (m: string) => string | undefined,
-  onOpenRecording?: (id: string) => void,
-): JSX.Element {
+export function ModelCell(item: MessageRow, onOpenRecording?: (id: string) => void): JSX.Element {
   const provId = resolveMessageProvider(item);
   const provName = resolveMessageProviderName(item);
   // Custom providers are identified by either the literal 'custom' (from
   // inferProviderFromModel on a `custom:...` model name) or by a stored
   // provider column of the form `custom:<uuid>` (from resolveProviderId,
-  // which returns custom-prefixed IDs unchanged).
+  // which returns custom-prefixed IDs unchanged). Their display name arrives
+  // pre-resolved from the backend as `custom_provider_name` (null when the
+  // provider was deleted).
   const isCustomProvider = provId === 'custom' || provId?.startsWith('custom:') === true;
   return (
     <td style={MONO_XS}>
       <span style="display: inline-flex; align-items: center; gap: 4px;">
         {item.model && isCustomProvider ? (
           (() => {
-            const customName = customProviderName(item.model!);
+            const customName = item.custom_provider_name ?? undefined;
             const logo = customProviderLogo(
               customName ?? '',
               16,
@@ -287,7 +285,7 @@ export function ModelCell(
         ) : null}
         {item.model
           ? item.model.startsWith('custom:')
-            ? `custom:${customProviderName(item.model) ?? 'Custom'}/${stripCustomPrefix(item.model)}`
+            ? stripCustomPrefix(item.model)
             : getModelDisplayName(item.model)
           : '\u2014'}
         {item.header_tier_name ? (
@@ -453,7 +451,6 @@ export function FeedbackCell(
 
 export interface CellRenderContext {
   agentName?: string;
-  customProviderName: (model: string) => string | undefined;
   onFallbackErrorClick?: (model: string) => void;
   onFeedbackLike?: (id: string) => void;
   onFeedbackDislike?: (id: string) => void;
@@ -480,7 +477,7 @@ export function renderCell(
     case 'output':
       return SmallTokenCell(item.output_tokens);
     case 'model':
-      return ModelCell(item, ctx.customProviderName, ctx.onOpenRecording);
+      return ModelCell(item, ctx.onOpenRecording);
     case 'cache':
       return CacheCell(item);
     case 'duration':

--- a/packages/frontend/src/components/message-table-types.ts
+++ b/packages/frontend/src/components/message-table-types.ts
@@ -4,6 +4,7 @@ export interface MessageRow {
   agent_name: string | null;
   model: string | null;
   provider?: string | null;
+  custom_provider_name?: string | null;
   display_name?: string | null;
   routing_tier?: string;
   routing_reason?: string;

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -12,9 +12,10 @@ import {
   type Component,
 } from 'solid-js';
 import AddAgentModal from '../components/AddAgentModal.jsx';
-import { getAgents, getCustomProviders, getGlobalProviders } from '../services/api.js';
+import { getAgents, getGlobalProviders } from '../services/api.js';
 import { customProviderColor } from '../services/formatters.js';
 import { customProviderLogo } from '../components/ProviderIcon.jsx';
+import { stripCustomPrefix } from '../services/routing-utils.js';
 import {
   getOverview,
   getGlobalPerAgentTimeseries,
@@ -42,6 +43,8 @@ import '../styles/analytics-overview.css';
 interface ProviderGroup {
   provider: string;
   auth_type: string;
+  /** Backend-resolved name for `custom:<uuid>` groups; null for built-ins. */
+  display_name?: string | null;
   connection_count: number;
   connections: Array<{ id: string; label: string; is_active: boolean }>;
   total_models: number;
@@ -60,6 +63,7 @@ interface CostByModelRow {
   estimated_cost: number;
   auth_type: string | null;
   provider: string | null;
+  custom_provider_name?: string | null;
 }
 
 interface RecentActivityRow {
@@ -189,19 +193,6 @@ const GlobalOverview: Component = () => {
       }
     },
   );
-
-  // Custom providers for name resolution
-  const firstAgent = () => ((agents() ?? []) as AgentRow[])[0]?.agent_name ?? '';
-  const [customProviderData] = createResource(
-    () => firstAgent(),
-    (name) => (name ? getCustomProviders(name).catch(() => []) : Promise.resolve([])),
-  );
-  const resolveCustomName = (providerId: string) => {
-    if (!providerId.startsWith('custom:')) return null;
-    const uuid = providerId.replace('custom:', '');
-    const cp = (customProviderData() ?? []).find((c: any) => c.id === uuid);
-    return cp ? (cp as any).name : null;
-  };
 
   type TSResult = { agents: string[]; timeseries: Array<Record<string, number | string>> };
   const tokenFetcher = (range: string, group: string): Promise<TSResult> => {
@@ -652,7 +643,7 @@ const GlobalOverview: Component = () => {
             for (const g of groups) {
               for (const c of g.connections.slice(0, 5 - items.length)) {
                 const prov = PROVIDERS.find((p) => p.id === g.provider);
-                const customName = resolveCustomName(g.provider);
+                const customName = g.display_name ?? null;
                 const isCustom = g.provider.startsWith('custom:');
                 items.push({
                   id: c.id,
@@ -1040,14 +1031,40 @@ const GlobalOverview: Component = () => {
                     <tr>
                       <td>
                         <div style="display: flex; align-items: center; gap: 6px;">
-                          <Show when={row.provider}>
-                            <span style="position: relative; flex-shrink: 0; display: flex; align-items: center;">
-                              {providerIcon(row.provider!, 16)}
-                              {authBadgeFor(row.auth_type, 12)}
-                            </span>
-                          </Show>
+                          {(() => {
+                            const isCustom = row.provider?.startsWith('custom:') === true;
+                            if (isCustom) {
+                              const name = row.custom_provider_name ?? undefined;
+                              return (
+                                customProviderLogo(name ?? '', 16, undefined, row.model) ?? (
+                                  <span
+                                    class="provider-card__logo-letter"
+                                    title={name}
+                                    style={{
+                                      background: customProviderColor(name ?? ''),
+                                      width: '16px',
+                                      height: '16px',
+                                      'font-size': '9px',
+                                      'flex-shrink': '0',
+                                      'border-radius': '50%',
+                                    }}
+                                  >
+                                    {(name ?? stripCustomPrefix(row.model)).charAt(0).toUpperCase()}
+                                  </span>
+                                )
+                              );
+                            }
+                            return row.provider ? (
+                              <span style="position: relative; flex-shrink: 0; display: flex; align-items: center;">
+                                {providerIcon(row.provider, 16)}
+                                {authBadgeFor(row.auth_type, 12)}
+                              </span>
+                            ) : null;
+                          })()}
                           <span style="font-weight: 500; color: hsl(var(--foreground));">
-                            {row.display_name || row.model}
+                            {row.model.startsWith('custom:')
+                              ? stripCustomPrefix(row.model)
+                              : row.display_name || row.model}
                           </span>
                         </div>
                       </td>
@@ -1129,9 +1146,7 @@ const GlobalOverview: Component = () => {
                           <div style="display: flex; align-items: center; gap: 8px;">
                             {(() => {
                               const isCustom = group.provider.startsWith('custom:');
-                              const customName = isCustom
-                                ? resolveCustomName(group.provider)
-                                : null;
+                              const customName = isCustom ? (group.display_name ?? null) : null;
                               const prov = PROVIDERS.find((p) => p.id === group.provider);
                               const displayName = prov?.name ?? customName ?? group.provider;
                               return (

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -24,14 +24,12 @@ import { agentDisplayName } from '../services/agent-display-name.js';
 import { agentPlatform, agentCategory } from '../services/agent-platform-store.js';
 import {
   getAgents,
-  getCustomProviders,
   getSpecificityAssignments,
   getMessages,
   getRoutingStatus,
   listHeaderTiers,
   setMessageFeedback,
   clearMessageFeedback,
-  type CustomProviderData,
 } from '../services/api.js';
 import { createCursorPagination } from '../services/cursor-pagination.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
@@ -52,6 +50,7 @@ interface MessagesData {
   next_cursor: string | null;
   total_count: number;
   providers: string[];
+  provider_labels?: Record<string, string>;
 }
 
 const SPECIFICITY_FILTER_PREFIX = 'specificity:';
@@ -155,11 +154,6 @@ const MessageLog: Component = () => {
     setFeedbackModalOpen(false);
   };
 
-  const [customProviders] = createResource(
-    () => params.agentName,
-    (name) => getCustomProviders(decodeURIComponent(name)),
-  );
-
   const [routingStatus] = createResource(
     () => params.agentName,
     (name) => getRoutingStatus(decodeURIComponent(name)),
@@ -176,14 +170,6 @@ const MessageLog: Component = () => {
   );
 
   const hasProviders = () => routingStatus()?.enabled === true;
-
-  /** Map custom:<uuid> → provider display name */
-  const customProviderName = (model: string): string | undefined => {
-    const match = model.match(/^custom:([^/]+)\//);
-    if (!match) return undefined;
-    const id = match[1];
-    return customProviders()?.find((cp: CustomProviderData) => cp.id === id)?.name;
-  };
 
   const pager = createCursorPagination(50);
 
@@ -309,7 +295,10 @@ const MessageLog: Component = () => {
   /** Resolve provider ID to display name */
   const providerDisplayName = (id: string): string => {
     const prov = PROVIDERS.find((p) => p.id === id);
-    return prov?.name ?? id;
+    if (prov) return prov.name;
+    // Custom providers arrive as `custom:<uuid>` — the backend ships a label
+    // map alongside the provider list so the dropdown can show their names.
+    return data()?.provider_labels?.[id] ?? id;
   };
 
   const providerOptions = createMemo(() => [
@@ -575,7 +564,6 @@ const MessageLog: Component = () => {
                   items={displayedItems()}
                   columns={columns()}
                   agentName={params.agentName}
-                  customProviderName={customProviderName}
                   onFallbackErrorClick={scrollToFallbackSuccess}
                   onFeedbackLike={isSelfHosted() ? undefined : handleFeedbackLike}
                   onFeedbackDislike={isSelfHosted() ? undefined : handleFeedbackDislike}

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -377,9 +377,7 @@ const Overview: Component = () => {
                       />
                     </div>
 
-                    <CostByModelTable
-                      rows={d().cost_by_model ?? []}
-                    />
+                    <CostByModelTable rows={d().cost_by_model ?? []} />
                   </>
                 );
               }}

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -20,13 +20,7 @@ import SetupModal from '../components/SetupModal.jsx';
 import { type MessageRow } from '../components/message-table-types.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import { agentPlatform, agentCategory } from '../services/agent-platform-store.js';
-import {
-  getCustomProviders,
-  getOverview,
-  setMessageFeedback,
-  clearMessageFeedback,
-  type CustomProviderData,
-} from '../services/api.js';
+import { getOverview, setMessageFeedback, clearMessageFeedback } from '../services/api.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { isRecentlyCreated, isSetupPending, clearSetupPending } from '../services/recent-agents.js';
 import { messagePing } from '../services/sse.js';
@@ -117,18 +111,6 @@ const Overview: Component = () => {
   const [setupCompleted, setSetupCompleted] = createSignal(
     !!localStorage.getItem(`setup_completed_${params.agentName}`),
   );
-  const [customProviders] = createResource(
-    () => params.agentName,
-    (name) => getCustomProviders(decodeURIComponent(name)),
-  );
-
-  const customProviderName = (model: string): string | undefined => {
-    const match = model.match(/^custom:([^/]+)\//);
-    if (!match) return undefined;
-    const id = match[1];
-    return customProviders()?.find((cp: CustomProviderData) => cp.id === id)?.name;
-  };
-
   const [feedbackModalOpen, setFeedbackModalOpen] = createSignal(false);
   const [feedbackMessageId, setFeedbackMessageId] = createSignal('');
   const [feedbackOverrides, setFeedbackOverrides] = createSignal<Record<string, string | null>>({});
@@ -389,7 +371,6 @@ const Overview: Component = () => {
                         }
                         columns={columns()}
                         agentName={params.agentName}
-                        customProviderName={customProviderName}
                         onFeedbackLike={isSelfHosted() ? undefined : handleFeedbackLike}
                         onFeedbackDislike={isSelfHosted() ? undefined : handleFeedbackDislike}
                         onFeedbackClear={isSelfHosted() ? undefined : handleFeedbackClear}
@@ -398,7 +379,6 @@ const Overview: Component = () => {
 
                     <CostByModelTable
                       rows={d().cost_by_model ?? []}
-                      customProviderName={customProviderName}
                     />
                   </>
                 );

--- a/packages/frontend/tests/components/CostByModelTable.test.tsx
+++ b/packages/frontend/tests/components/CostByModelTable.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render } from '@solidjs/testing-library';
 import CostByModelTable from '../../src/components/CostByModelTable';
 
@@ -16,7 +16,7 @@ function row(overrides: Record<string, unknown> = {}) {
 describe('CostByModelTable', () => {
   it('renders a header row with Model/Tokens/% of total/Cost', () => {
     const { container } = render(() => (
-      <CostByModelTable rows={[]} customProviderName={() => undefined} />
+      <CostByModelTable rows={[]} />
     ));
     const headers = Array.from(container.querySelectorAll('th')).map((h) => h.textContent?.trim());
     expect(headers).toEqual(['Model', 'Tokens', '% of total', 'Cost']);
@@ -30,7 +30,6 @@ describe('CostByModelTable', () => {
           row({ model: 'pricey', estimated_cost: 5 }),
           row({ model: 'mid', estimated_cost: 2 }),
         ]}
-        customProviderName={() => undefined}
       />
     ));
     const firstCells = Array.from(container.querySelectorAll('tbody tr td:first-child')).map(
@@ -44,7 +43,7 @@ describe('CostByModelTable', () => {
 
   it('formats tokens and rounds the share percentage', () => {
     const { container } = render(() => (
-      <CostByModelTable rows={[row({ tokens: 12345, share_pct: 42.6 })]} customProviderName={() => undefined} />
+      <CostByModelTable rows={[row({ tokens: 12345, share_pct: 42.6 })]} />
     ));
     expect(container.textContent).toContain('12.3k');
     expect(container.textContent).toContain('43%');
@@ -54,7 +53,6 @@ describe('CostByModelTable', () => {
     const { container } = render(() => (
       <CostByModelTable
         rows={[row({ estimated_cost: 0 })]}
-        customProviderName={() => undefined}
       />
     ));
     const costCell = container.querySelector('tbody tr td:nth-child(4)');
@@ -67,52 +65,58 @@ describe('CostByModelTable', () => {
 
   it('adds a tooltip with the full cost for sub-penny amounts', () => {
     const { container } = render(() => (
-      <CostByModelTable rows={[row({ estimated_cost: 0.00123 })]} customProviderName={() => undefined} />
+      <CostByModelTable rows={[row({ estimated_cost: 0.00123 })]} />
     ));
     const costCell = container.querySelector('tbody tr td:nth-child(4)');
     expect(costCell?.getAttribute('title')).toBe('$0.001230');
   });
 
-  it('renders a custom-provider letter badge when no logo is registered', () => {
-    const customProviderName = vi.fn(() => 'My Provider');
+  it('renders a custom-provider letter badge and the stripped model text', () => {
     const { container } = render(() => (
       <CostByModelTable
         rows={[
           row({
             model: 'custom:abc123/gpt-custom',
+            provider: 'custom:abc123',
+            custom_provider_name: 'My Provider',
             auth_type: null,
           }),
         ]}
-        customProviderName={customProviderName}
       />
     ));
     const letterBadge = container.querySelector('.provider-card__logo-letter');
     expect(letterBadge).not.toBeNull();
     expect(letterBadge?.textContent).toBe('M');
-    // Full cell text should include the namespaced custom model name.
-    expect(container.textContent).toContain('custom:My Provider/gpt-custom');
-    // The component must call customProviderName with the row's model name.
-    expect(customProviderName).toHaveBeenCalledWith('custom:abc123/gpt-custom');
+    expect(letterBadge?.getAttribute('title')).toBe('My Provider');
+    // Just the raw model — no `custom:` prefix, no provider-name echo.
+    expect(container.textContent).toContain('gpt-custom');
+    expect(container.textContent).not.toContain('custom:');
   });
 
-  it('falls back to the stripped custom prefix when the provider name lookup returns nothing', () => {
+  it('falls back to the stripped custom prefix when the provider was deleted', () => {
     const { container } = render(() => (
       <CostByModelTable
-        rows={[row({ model: 'custom:abc/my-model', auth_type: null })]}
-        customProviderName={() => undefined}
+        rows={[
+          row({
+            model: 'custom:abc/my-model',
+            provider: 'custom:abc',
+            custom_provider_name: null,
+            auth_type: null,
+          }),
+        ]}
       />
     ));
     const letterBadge = container.querySelector('.provider-card__logo-letter');
     // stripCustomPrefix('custom:abc/my-model') → 'my-model' → first letter "M".
     expect(letterBadge?.textContent).toBe('M');
-    expect(container.textContent).toContain('custom:Custom/my-model');
+    expect(container.textContent).toContain('my-model');
+    expect(container.textContent).not.toContain('Custom');
   });
 
   it('renders a provider icon + auth badge for recognised model prefixes', () => {
     const { container } = render(() => (
       <CostByModelTable
         rows={[row({ model: 'claude-opus-4', auth_type: 'subscription' })]}
-        customProviderName={() => undefined}
       />
     ));
     const providerCell = container.querySelector('tbody tr td');
@@ -127,7 +131,6 @@ describe('CostByModelTable', () => {
     const { container } = render(() => (
       <CostByModelTable
         rows={[row({ model: 'minimax-chat', provider: 'ollama', auth_type: 'api_key' })]}
-        customProviderName={() => undefined}
       />
     ));
     const providerSpan = container.querySelector('tbody tr td span[title]');
@@ -138,7 +141,6 @@ describe('CostByModelTable', () => {
     const { container } = render(() => (
       <CostByModelTable
         rows={[row({ model: 'claude-opus-4', provider: null, auth_type: 'api_key' })]}
-        customProviderName={() => undefined}
       />
     ));
     const providerSpan = container.querySelector('tbody tr td span[title]');
@@ -167,7 +169,6 @@ describe('CostByModelTable', () => {
       const { container } = render(() => (
         <CostByModelTable
           rows={[row({ share_pct: 0 })]}
-          customProviderName={() => undefined}
         />
       ));
       expect(barWidthStyle(container)).toContain('width: 0%');
@@ -178,7 +179,6 @@ describe('CostByModelTable', () => {
       const { container } = render(() => (
         <CostByModelTable
           rows={[row({ share_pct: -1 })]}
-          customProviderName={() => undefined}
         />
       ));
       // The text label uses Math.round, so "-1%" is shown verbatim.
@@ -193,7 +193,6 @@ describe('CostByModelTable', () => {
       const { container } = render(() => (
         <CostByModelTable
           rows={[row({ share_pct: 150 })]}
-          customProviderName={() => undefined}
         />
       ));
       expect(shareCellOf(container)?.textContent).toContain('150%');
@@ -206,7 +205,6 @@ describe('CostByModelTable', () => {
       const { container } = render(() => (
         <CostByModelTable
           rows={[row({ share_pct: NaN })]}
-          customProviderName={() => undefined}
         />
       ));
       // Math.round(NaN) is NaN — rendered as "NaN%". The component must
@@ -221,7 +219,6 @@ describe('CostByModelTable', () => {
       const { container } = render(() => (
         <CostByModelTable
           rows={[row({ estimated_cost: -0.5 })]}
-          customProviderName={() => undefined}
         />
       ));
       const cell = costCellOf(container);
@@ -234,7 +231,6 @@ describe('CostByModelTable', () => {
       const { container } = render(() => (
         <CostByModelTable
           rows={[row({ estimated_cost: NaN })]}
-          customProviderName={() => undefined}
         />
       ));
       const cell = costCellOf(container);
@@ -252,7 +248,6 @@ describe('CostByModelTable', () => {
       const { container } = render(() => (
         <CostByModelTable
           rows={[row({ estimated_cost: Infinity })]}
-          customProviderName={() => undefined}
         />
       ));
       const cell = costCellOf(container);

--- a/packages/frontend/tests/components/MessageTable.test.tsx
+++ b/packages/frontend/tests/components/MessageTable.test.tsx
@@ -102,7 +102,6 @@ function makeRow(overrides: Partial<MessageRow> = {}): MessageRow {
   };
 }
 
-const noopProvider = () => undefined;
 
 describe('MessageTable', () => {
   describe('column configuration', () => {
@@ -112,7 +111,6 @@ describe('MessageTable', () => {
           items={[]}
           columns={COMPACT_COLUMNS}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const headers = container.querySelectorAll('th');
@@ -132,7 +130,6 @@ describe('MessageTable', () => {
           items={[]}
           columns={DETAILED_COLUMNS}
           agentName="agent-1"
-          customProviderName={noopProvider}
           showHeaderTooltips
         />
       ));
@@ -157,7 +154,6 @@ describe('MessageTable', () => {
           items={[]}
           columns={COMPACT_COLUMNS}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const tokensHeader = container.querySelectorAll('th')[6]!; // 'totalTokens' is at index 6 in COMPACT_COLUMNS
@@ -171,7 +167,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={DETAILED_COLUMNS}
           agentName="agent-1"
-          customProviderName={noopProvider}
           showHeaderTooltips
         />
       ));
@@ -188,7 +183,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('2026-02-16 10:00:00');
@@ -200,7 +194,6 @@ describe('MessageTable', () => {
           items={[makeRow({ id: 'e83a3049-xxxx' })]}
           columns={['message']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('e83a3049');
@@ -212,7 +205,6 @@ describe('MessageTable', () => {
           items={[makeRow({ routing_reason: 'heartbeat' })]}
           columns={['message']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const heartbeat = container.querySelector('[title="Heartbeat"]');
@@ -226,7 +218,6 @@ describe('MessageTable', () => {
           items={[makeRow({ cost: 1.5 })]}
           columns={['cost']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('$1.50');
@@ -238,7 +229,6 @@ describe('MessageTable', () => {
           items={[makeRow({ auth_type: 'subscription', cost: null })]}
           columns={['cost']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('$0.00');
@@ -251,7 +241,6 @@ describe('MessageTable', () => {
           items={[makeRow({ auth_type: 'subscription', cost: 0.013636 })]}
           columns={['cost']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('$0.01');
@@ -266,7 +255,6 @@ describe('MessageTable', () => {
           items={[makeRow({ cost: null })]}
           columns={['cost']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('\u2014');
@@ -278,7 +266,6 @@ describe('MessageTable', () => {
           items={[makeRow({ total_tokens: 1500 })]}
           columns={['totalTokens']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('1500');
@@ -290,7 +277,6 @@ describe('MessageTable', () => {
           items={[makeRow({ input_tokens: 200, output_tokens: 80 })]}
           columns={['input', 'output']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('200');
@@ -303,7 +289,6 @@ describe('MessageTable', () => {
           items={[makeRow({ cache_read_tokens: 500, cache_creation_tokens: 100 })]}
           columns={['cache']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('Read: 500');
@@ -316,7 +301,6 @@ describe('MessageTable', () => {
           items={[makeRow({ cache_read_tokens: 0, cache_creation_tokens: 0 })]}
           columns={['cache']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('\u2014');
@@ -328,7 +312,6 @@ describe('MessageTable', () => {
           items={[makeRow({ duration_ms: 450 })]}
           columns={['duration']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('450ms');
@@ -342,7 +325,6 @@ describe('MessageTable', () => {
           items={[makeRow({ model: 'gpt-4o' })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.querySelector('[data-testid="icon-openai"]')).not.toBeNull();
@@ -355,7 +337,6 @@ describe('MessageTable', () => {
           items={[makeRow({ model: 'gpt-4o', display_name: 'GPT-4o' })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       // getModelDisplayName is mocked to strip custom prefix; for gpt-4o it returns as-is
@@ -372,7 +353,6 @@ describe('MessageTable', () => {
           ]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       // All three rows should render the ollama-cloud icon, not ollama (colon
@@ -389,7 +369,6 @@ describe('MessageTable', () => {
           items={[makeRow({ model: 'gpt-4o', provider: null })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.querySelector('[data-testid="icon-openai"]')).not.toBeNull();
@@ -403,24 +382,31 @@ describe('MessageTable', () => {
       // does not equal 'custom', so the custom branch would be skipped.
       const { container } = render(() => (
         <MessageTable
-          items={[makeRow({ model: 'custom:abc/my-model', provider: 'custom:abc' })]}
+          items={[
+            makeRow({
+              model: 'custom:abc/my-model',
+              provider: 'custom:abc',
+              custom_provider_name: 'MyProvider',
+            }),
+          ]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={() => 'MyProvider'}
         />
       ));
       const avatar = container.querySelector('.provider-card__logo-letter');
       expect(avatar).not.toBeNull();
       expect(avatar!.textContent).toBe('M');
+      // The text shows just the raw model — no `custom:` prefix, no name echo.
+      expect(container.textContent).toContain('my-model');
+      expect(container.textContent).not.toContain('custom:');
     });
 
     it('renders custom provider letter avatar', () => {
       const { container } = render(() => (
         <MessageTable
-          items={[makeRow({ model: 'custom:abc/my-model' })]}
+          items={[makeRow({ model: 'custom:abc/my-model', custom_provider_name: 'MyProvider' })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={() => 'MyProvider'}
         />
       ));
       const avatar = container.querySelector('.provider-card__logo-letter');
@@ -434,7 +420,6 @@ describe('MessageTable', () => {
           items={[makeRow({ model: null })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('\u2014');
@@ -446,7 +431,6 @@ describe('MessageTable', () => {
           items={[makeRow({ routing_tier: 'fast' })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const badge = container.querySelector('.tier-badge--fast');
@@ -465,7 +449,6 @@ describe('MessageTable', () => {
           ]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const specBadge = container.querySelector('.tier-badge--specificity');
@@ -482,7 +465,6 @@ describe('MessageTable', () => {
           items={[makeRow({ fallback_from_model: 'claude-opus-4-6' })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const badge = container.querySelector('.tier-badge--fallback');
@@ -498,7 +480,6 @@ describe('MessageTable', () => {
           items={[makeRow({ status: 'ok' })]}
           columns={['status']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.querySelector('.status-badge--ok')).not.toBeNull();
@@ -510,7 +491,6 @@ describe('MessageTable', () => {
           items={[makeRow({ status: 'rate_limited' })]}
           columns={['status']}
           agentName="my-agent"
-          customProviderName={noopProvider}
         />
       ));
       const link = container.querySelector('a');
@@ -524,7 +504,6 @@ describe('MessageTable', () => {
           items={[makeRow({ status: 'error', error_message: 'timeout' })]}
           columns={['status']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const tooltip = container.querySelector('.status-badge-tooltip');
@@ -538,7 +517,6 @@ describe('MessageTable', () => {
           items={[makeRow({ status: 'fallback_error', error_message: 'rate limited' })]}
           columns={['status']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const badge = container.querySelector('.status-badge--fallback_error');
@@ -555,7 +533,6 @@ describe('MessageTable', () => {
           ]}
           columns={['status']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const badges = container.querySelectorAll('.status-badge--fallback_error');
@@ -575,7 +552,6 @@ describe('MessageTable', () => {
           items={[makeRow({ status: 'fallback_error', error_message: 'err', model: 'gpt-4o' })]}
           columns={['status']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           onFallbackErrorClick={handler}
         />
       ));
@@ -592,7 +568,6 @@ describe('MessageTable', () => {
           items={[makeRow({ id: 'test-id-123' })]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           rowIdPrefix="msg-"
         />
       ));
@@ -606,7 +581,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const bodyRow = container.querySelector('tbody tr');
@@ -621,7 +595,6 @@ describe('MessageTable', () => {
           items={[makeRow(), makeRow({ id: 'row-2' })]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           expandable
         />
       ));
@@ -635,7 +608,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.querySelector('.msg-detail__chevron-btn')).toBeNull();
@@ -648,7 +620,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           expandable
         />
       ));
@@ -664,7 +635,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           expandable
         />
       ));
@@ -681,7 +651,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           expandable
         />
       ));
@@ -697,7 +666,6 @@ describe('MessageTable', () => {
           items={[makeRow({ id: 'specific-msg-id' })]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           expandable
         />
       ));
@@ -714,7 +682,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={['date']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           expandable
         />
       ));
@@ -734,7 +701,6 @@ describe('MessageTable', () => {
           items={[row]}
           columns={COMPACT_COLUMNS}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const { container: detailed } = render(() => (
@@ -742,7 +708,6 @@ describe('MessageTable', () => {
           items={[row]}
           columns={DETAILED_COLUMNS}
           agentName="agent-1"
-          customProviderName={noopProvider}
           showHeaderTooltips
         />
       ));
@@ -763,7 +728,6 @@ describe('MessageTable', () => {
           items={[row]}
           columns={COMPACT_COLUMNS}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const { container: detailed } = render(() => (
@@ -771,7 +735,6 @@ describe('MessageTable', () => {
           items={[row]}
           columns={DETAILED_COLUMNS}
           agentName="agent-1"
-          customProviderName={noopProvider}
           showHeaderTooltips
         />
       ));
@@ -789,7 +752,6 @@ describe('MessageTable', () => {
           items={[makeRow({ duration_ms: 300 })]}
           columns={['date', 'cost', 'totalTokens', 'duration', 'status']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       const headers = container.querySelectorAll('th');
@@ -809,7 +771,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={['feedback']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           onFeedbackLike={vi.fn()}
           onFeedbackDislike={vi.fn()}
           onFeedbackClear={vi.fn()}
@@ -826,7 +787,6 @@ describe('MessageTable', () => {
           items={[makeRow({ id: 'msg-like-test' })]}
           columns={['feedback']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           onFeedbackLike={handler}
           onFeedbackDislike={vi.fn()}
           onFeedbackClear={vi.fn()}
@@ -844,7 +804,6 @@ describe('MessageTable', () => {
           items={[makeRow({ id: 'msg-dislike-test' })]}
           columns={['feedback']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           onFeedbackLike={vi.fn()}
           onFeedbackDislike={handler}
           onFeedbackClear={vi.fn()}
@@ -862,7 +821,6 @@ describe('MessageTable', () => {
           items={[makeRow({ id: 'msg-clear-test', feedback_rating: 'like' })]}
           columns={['feedback']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           onFeedbackLike={vi.fn()}
           onFeedbackDislike={vi.fn()}
           onFeedbackClear={handler}
@@ -881,7 +839,6 @@ describe('MessageTable', () => {
           items={[makeRow({ id: 'msg-clear-test', feedback_rating: 'dislike' })]}
           columns={['feedback']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           onFeedbackLike={vi.fn()}
           onFeedbackDislike={vi.fn()}
           onFeedbackClear={handler}
@@ -899,7 +856,6 @@ describe('MessageTable', () => {
           items={[makeRow({ feedback_rating: 'like' })]}
           columns={['feedback']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.querySelector('.feedback-btn--active-like')).not.toBeNull();
@@ -912,7 +868,6 @@ describe('MessageTable', () => {
           items={[makeRow({ feedback_rating: 'dislike' })]}
           columns={['feedback']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.querySelector('.feedback-btn--active-dislike')).not.toBeNull();
@@ -925,7 +880,6 @@ describe('MessageTable', () => {
           items={[makeRow()]}
           columns={['feedback']}
           agentName="agent-1"
-          customProviderName={noopProvider}
         />
       ));
       expect(container.querySelector('.feedback-btn--active-like')).toBeNull();
@@ -941,7 +895,6 @@ describe('MessageTable', () => {
           items={[makeRow({ recorded: true })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           onOpenRecording={onOpen}
           expandable
         />
@@ -960,7 +913,6 @@ describe('MessageTable', () => {
           items={[makeRow({ recorded: false })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           onOpenRecording={vi.fn()}
           expandable
         />
@@ -975,7 +927,6 @@ describe('MessageTable', () => {
           items={[makeRow({ recorded: true })]}
           columns={['model']}
           agentName="agent-1"
-          customProviderName={noopProvider}
           expandable
         />
       ));
@@ -990,7 +941,6 @@ describe('MessageTable', () => {
         <MessageTable
           items={[makeRow({ agent_name: 'my-agent' })]}
           columns={['agent', 'date']}
-          customProviderName={noopProvider}
         />
       ));
       const headers = container.querySelectorAll('th');
@@ -1003,7 +953,6 @@ describe('MessageTable', () => {
         <MessageTable
           items={[makeRow({ agent_name: 'my-agent' })]}
           columns={['agent']}
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('my-agent');
@@ -1014,7 +963,6 @@ describe('MessageTable', () => {
         <MessageTable
           items={[makeRow({ agent_name: null })]}
           columns={['agent']}
-          customProviderName={noopProvider}
         />
       ));
       expect(container.textContent).toContain('—');
@@ -1025,7 +973,6 @@ describe('MessageTable', () => {
         <MessageTable
           items={[makeRow()]}
           columns={['date', 'status']}
-          customProviderName={noopProvider}
         />
       ));
       expect(container.querySelector('.data-table')).not.toBeNull();

--- a/packages/frontend/tests/components/message-table-cells.test.tsx
+++ b/packages/frontend/tests/components/message-table-cells.test.tsx
@@ -18,10 +18,12 @@ vi.mock('../../src/services/formatters.js', () => ({
 }));
 
 vi.mock('../../src/services/routing-utils.js', () => ({
-  inferProviderFromModel: () => null,
+  // Mirror the real helpers' custom-provider behavior so ModelCell's custom
+  // branch is exercised; non-custom inputs behave exactly as before.
+  inferProviderFromModel: (m: string) => (m.startsWith('custom:') ? 'custom' : null),
   inferProviderName: (m: string) => m,
-  resolveProviderId: () => undefined,
-  stripCustomPrefix: (m: string) => m,
+  resolveProviderId: (p: string) => (p.startsWith('custom:') ? p : undefined),
+  stripCustomPrefix: (m: string) => m.replace(/^custom:[^/]+\//, ''),
 }));
 
 vi.mock('../../src/services/model-display.js', () => ({
@@ -118,14 +120,12 @@ describe('StatusCell without agentName (global mode)', () => {
 });
 
 describe('ModelCell', () => {
-  const noCustom = () => undefined;
-
   it('renders header tier badge when header_tier_name is set', () => {
     const row = baseRow({
       header_tier_name: 'My Custom Tier',
       header_tier_color: 'rose',
     });
-    const { container } = render(() => <table><tbody><tr>{ModelCell(row, noCustom)}</tr></tbody></table>);
+    const { container } = render(() => <table><tbody><tr>{ModelCell(row)}</tr></tbody></table>);
     const badge = container.querySelector('.tier-badge--custom');
     expect(badge).not.toBeNull();
     expect(badge!.textContent).toBe('My Custom Tier');
@@ -134,9 +134,36 @@ describe('ModelCell', () => {
 
   it('uses indigo as default header tier color', () => {
     const row = baseRow({ header_tier_name: 'Tier A' });
-    const { container } = render(() => <table><tbody><tr>{ModelCell(row, noCustom)}</tr></tbody></table>);
+    const { container } = render(() => <table><tbody><tr>{ModelCell(row)}</tr></tbody></table>);
     const badge = container.querySelector('.tier-badge--custom');
     expect(badge).not.toBeNull();
     expect(badge!.className).toContain('tier-color--indigo');
+  });
+
+  it('renders a custom row with just the model text and the provider name in the tooltip', () => {
+    const row = baseRow({
+      model: 'custom:u-1/openai/gpt-oss-120b',
+      provider: 'custom:u-1',
+      custom_provider_name: 'MyLLM',
+    });
+    const { container } = render(() => <table><tbody><tr>{ModelCell(row)}</tr></tbody></table>);
+    expect(container.textContent).toContain('openai/gpt-oss-120b');
+    expect(container.textContent).not.toContain('custom:');
+    expect(container.textContent).not.toContain('Custom');
+    expect(container.querySelector('[title="MyLLM"]')).not.toBeNull();
+  });
+
+  it('falls back to a letter avatar from the model when the custom provider was deleted', () => {
+    const row = baseRow({
+      model: 'custom:gone/my-model',
+      provider: 'custom:gone',
+      custom_provider_name: null,
+    });
+    const { container } = render(() => <table><tbody><tr>{ModelCell(row)}</tr></tbody></table>);
+    expect(container.textContent).toContain('my-model');
+    expect(container.textContent).not.toContain('custom:');
+    const avatar = container.querySelector('.provider-card__logo-letter');
+    expect(avatar).not.toBeNull();
+    expect(avatar!.textContent).toBe('M');
   });
 });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -602,17 +602,20 @@ describe("MessageLog", () => {
   });
 
   describe("custom provider models", () => {
+    // The backend resolves the custom provider's name into each row
+    // (`custom_provider_name`) and ships a `provider_labels` map for the
+    // filter dropdown; the page no longer fetches the list itself.
     const customMessagesData = {
       items: [
-        { id: "msg-cp1", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "custom:abc-123/my-llama", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok", cache_read_tokens: null, cache_creation_tokens: null, duration_ms: 800 },
+        { id: "msg-cp1", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "custom:abc-123/my-llama", provider: "custom:abc-123", custom_provider_name: "Cerebras", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok", cache_read_tokens: null, cache_creation_tokens: null, duration_ms: 800 },
       ],
       next_cursor: null,
       total_count: 1,
-      providers: ["custom"],
+      providers: ["custom:abc-123"],
+      provider_labels: { "custom:abc-123": "Cerebras" },
     };
 
     it("renders custom provider icon in message rows", async () => {
-      mockGetCustomProviders.mockResolvedValue([{ id: "abc-123", name: "Cerebras" }]);
       mockGetMessages.mockResolvedValue(customMessagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -622,7 +625,6 @@ describe("MessageLog", () => {
     });
 
     it("strips custom prefix from model name display", async () => {
-      mockGetCustomProviders.mockResolvedValue([{ id: "abc-123", name: "Cerebras" }]);
       mockGetMessages.mockResolvedValue(customMessagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -631,12 +633,25 @@ describe("MessageLog", () => {
       });
     });
 
-    it("falls back to model prefix when custom provider not found", async () => {
-      mockGetCustomProviders.mockResolvedValue([]);
+    it("labels the provider filter option with the custom provider name", async () => {
       mockGetMessages.mockResolvedValue(customMessagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
+        expect(container.textContent).toContain("Cerebras");
+      });
+    });
+
+    it("falls back to model prefix when custom provider was deleted", async () => {
+      const deletedProvider = {
+        ...customMessagesData,
+        items: [{ ...customMessagesData.items[0], custom_provider_name: null }],
+        provider_labels: {},
+      };
+      mockGetMessages.mockResolvedValue(deletedProvider);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
         expect(container.textContent).toContain("my-llama");
+        expect(container.textContent).not.toContain("custom:abc-123/");
       });
     });
   });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -431,18 +431,19 @@ describe("Overview", () => {
   });
 
   describe("custom provider models", () => {
+    // The backend resolves the custom provider's name into each row
+    // (`custom_provider_name`); the page no longer fetches the list itself.
     const customOverview = {
       ...overviewData,
       recent_activity: [
-        { id: "msg-cp1", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "custom:abc-123/my-llama", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok" },
+        { id: "msg-cp1", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "custom:abc-123/my-llama", provider: "custom:abc-123", custom_provider_name: "Cerebras", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok" },
       ],
       cost_by_model: [
-        { model: "custom:abc-123/my-llama", tokens: 30000, share_pct: 100, estimated_cost: 2.1, auth_type: "api_key" },
+        { model: "custom:abc-123/my-llama", provider: "custom:abc-123", custom_provider_name: "Cerebras", tokens: 30000, share_pct: 100, estimated_cost: 2.1, auth_type: "api_key" },
       ],
     };
 
     it("renders custom provider icon in recent messages", async () => {
-      mockGetCustomProviders.mockResolvedValue([{ id: "abc-123", name: "Cerebras" }]);
       mockGetOverview.mockResolvedValue(customOverview);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
@@ -452,7 +453,6 @@ describe("Overview", () => {
     });
 
     it("strips custom prefix from model name display", async () => {
-      mockGetCustomProviders.mockResolvedValue([{ id: "abc-123", name: "Cerebras" }]);
       mockGetOverview.mockResolvedValue(customOverview);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
@@ -462,7 +462,6 @@ describe("Overview", () => {
     });
 
     it("renders custom provider icon in cost by model table", async () => {
-      mockGetCustomProviders.mockResolvedValue([{ id: "abc-123", name: "Cerebras" }]);
       mockGetOverview.mockResolvedValue(customOverview);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
@@ -472,12 +471,21 @@ describe("Overview", () => {
       });
     });
 
-    it("falls back to model prefix when custom provider not found", async () => {
-      mockGetCustomProviders.mockResolvedValue([]);
-      mockGetOverview.mockResolvedValue(customOverview);
+    it("falls back to model prefix when custom provider was deleted", async () => {
+      const deletedProvider = {
+        ...customOverview,
+        recent_activity: [
+          { ...customOverview.recent_activity[0], custom_provider_name: null },
+        ],
+        cost_by_model: [
+          { ...customOverview.cost_by_model[0], custom_provider_name: null },
+        ],
+      };
+      mockGetOverview.mockResolvedValue(deletedProvider);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         expect(container.textContent).toContain("my-llama");
+        expect(container.textContent).not.toContain("custom:abc-123/");
       });
     });
   });

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -215,6 +215,10 @@ vi.mock('../../src/services/connection-breadcrumb-store.js', () => ({
 vi.mock('manifest-shared', () => ({
   platformIcon: () => 'robot',
   PLATFORM_LABELS: { codex: 'Codex' },
+  // routing-utils (imported by GlobalOverview for stripCustomPrefix) reads
+  // these at module scope.
+  SHARED_PROVIDERS: [],
+  inferProviderFromModel: (m: string) => (m.startsWith('custom:') ? 'custom' : null),
 }));
 
 import GlobalOverview from '../../src/pages/GlobalOverview';
@@ -237,6 +241,39 @@ const overviewResponse = {
       estimated_cost: 1.23,
       auth_type: 'api_key',
       provider: 'openai',
+    },
+    {
+      // Custom provider row with a backend-resolved name → letter avatar +
+      // stripped model text (the literal `custom:` prefix must never render).
+      model: 'custom:cp-1/llama-local',
+      display_name: 'custom:cp-1/llama-local',
+      tokens: 300,
+      share_pct: 19,
+      estimated_cost: 0.44,
+      auth_type: 'api_key',
+      provider: 'custom:cp-1',
+      custom_provider_name: 'Custom Provider',
+    },
+    {
+      // Deleted custom provider (NULL name) → letter falls back to the model.
+      model: 'custom:cp-gone/zeta-model',
+      display_name: 'custom:cp-gone/zeta-model',
+      tokens: 100,
+      share_pct: 6,
+      estimated_cost: 0.1,
+      auth_type: 'api_key',
+      provider: 'custom:cp-gone',
+      custom_provider_name: null,
+    },
+    {
+      // Legacy row with no stored provider → no icon, plain display name.
+      model: 'orphan-model',
+      display_name: 'Orphan Model',
+      tokens: 10,
+      share_pct: 1,
+      estimated_cost: 0.01,
+      auth_type: null,
+      provider: null,
     },
   ],
   recent_activity: [
@@ -316,6 +353,8 @@ const providersResponse = {
     {
       provider: 'custom:cp-1',
       auth_type: 'api_key',
+      // Backend-resolved custom provider name (LEFT JOIN on custom_providers).
+      display_name: 'Custom Provider',
       connection_count: 1,
       connections: [{ id: 'conn-custom', label: 'My custom key', is_active: true }],
       total_models: 2,
@@ -328,6 +367,7 @@ const providersResponse = {
     {
       provider: 'custom:cp-2',
       auth_type: 'subscription',
+      display_name: 'Sub Custom',
       connection_count: 1,
       connections: [{ id: 'conn-custom-sub', label: 'Default', is_active: true }],
       total_models: 1,
@@ -495,6 +535,13 @@ describe('GlobalOverview (analytics)', () => {
     await waitFor(() => expect(screen.getAllByText('Custom Provider').length).toBeGreaterThan(0));
     // model usage + provider connection rows render
     expect(screen.getByText('GPT-5')).toBeDefined();
+    // custom cost-by-model rows show the stripped model text (no `custom:`),
+    // with a letter avatar from the provider name — or from the model when
+    // the provider was deleted (NULL custom_provider_name).
+    expect(screen.getByText('llama-local')).toBeDefined();
+    expect(screen.getByText('zeta-model')).toBeDefined();
+    expect(container.textContent).not.toContain('custom:cp-1/');
+    expect(container.textContent).not.toContain('custom:cp-gone/');
 
     fireEvent.click(screen.getByText('Messages chart'));
     expect(screen.getByTestId('provider-chart-card').getAttribute('data-active-view')).toBe(


### PR DESCRIPTION
## Problem

Messages store the model as `custom:<uuid>/<model>` and the provider as `custom:<uuid>`. The dashboard resolved the custom provider's display name **in the frontend**, by fetching the agent-scoped custom-providers list and matching the uuid. This broke in three ways:

1. **Global Messages page** — the lookup resource was keyed on `params.agentName`; in global mode it never fetched, so every custom row showed the placeholder `Custom`.
2. **GlobalOverview** — worked around the agent-scoped endpoint by fetching custom providers via the *first agent's* name (fragile: empty agent list → no names), and the cost-by-model panel showed the raw `custom:<uuid>/model` string.
3. **Hardcoded literal** — even when the lookup succeeded, `ModelCell` and `CostByModelTable` rendered `` `custom:${name}/${model}` ``, e.g. `custom:MyLLM/openai/gpt-oss-120b`.

The same lookup was duplicated in three pages and threaded as a prop through `MessageTable` — every new view had to remember to wire it, which is exactly how the global views broke.

## Fix: resolve the name in the backend, render like built-in providers

**Backend** (names resolve once, at the query layer):
- `selectMessageRowColumns()` gains a `LEFT JOIN custom_providers` and a new pinned alias `custom_provider_name` — both call sites (Messages log, Overview Recent Messages) inherit it via the shared-projection contract.
- `getCostByModel()` carries `custom_provider_name` per row.
- Per-provider timeseries (tokens/messages/cost) resolve series keys in SQL: `custom:<uuid>` → provider name (deleted providers get the stable `Deleted provider` label) — chart legends arrive pre-resolved, agent-scoped *and* global.
- `getMessages()` ships a `provider_labels` map so the provider filter dropdown can label `custom:<uuid>` options.
- `GET /api/v1/providers` resolves a `display_name` per custom group.

**Frontend** (renders custom rows exactly like built-in rows):
- Text is just the raw model (`stripCustomPrefix`), identical to how OpenAI rows show `gpt-4o` — the provider identity lives in the logo/letter avatar + tooltip. The word "custom" never renders as part of a name.
- Deleted provider (NULL name) → letter avatar from the model's first character; no crash, no `Custom` placeholder.
- The whole `customProviderName` prop chain is deleted: three duplicated page lookups, the `MessageTable`/`ModelCell`/`CostByModelTable` props, and GlobalOverview's first-agent hack.
- Routing config UI (`ModelPickerModal`, `FallbackList`) untouched — it already displayed correctly.

No `/`-splitting heuristics were needed: `custom:<uuid>/` parses unambiguously (uuids contain no slash), so model ids like `openai/gpt-oss-120b` survive intact.

## Notes for review

- **Left as-is**: the small "custom" type chip *after* the provider name in GlobalOverview's provider-connections table — it's a provider-type tag, not a name prefix. Happy to drop it too if wanted.
- The agent-scoped `GET :agentName/custom-providers` endpoint is now unused by these views; removal is a separate cleanup.
- Base is `feat/analytics-ui` (deepest tip of the global-providers stack that contains the affected code).

## Testing

- Backend: 339 suites / 6363 tests green; new unit tests for the join + alias pin, cost-by-model resolution, series-key CASE, `provider_labels`, and `display_name` (incl. deleted-provider NULL paths).
- Frontend: 194 files / 3967 tests green, `tsc --noEmit` clean; component + page tests assert custom rows render the stripped model with no `custom:` substring, resolved tooltips, and letter-avatar fallbacks. 100% line coverage on touched files; patch coverage 100%.
- Spec + implementation plan committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Custom providers now render like built‑in providers. Names resolve in the backend, the literal "custom:" prefix is gone, and global pages show correct labels.

- **Bug Fixes**
  - Resolve names via a backend join; expose `custom_provider_name` in message rows, cost-by-model, and per-provider timeseries (deleted providers show a stable fallback).
  - Ship a `provider_labels` map and resolve names in `/api/v1/providers`, fixing global Message Log and GlobalOverview (no more "Custom" placeholders).
  - Frontend renders only the model text (stripped); provider identity stays in the icon/tooltip.

- **Refactors**
  - Removed duplicated frontend lookups and the `customProviderName` prop across pages and tables.
  - Simplified `ModelCell` and `CostByModelTable` to use backend-resolved names with safe letter-avatar fallbacks.
  - Tests updated for the join, series keys, labels, and UI rendering paths.

<sup>Written for commit ae4ece668a2ad192241e1f2fa787156a32e939f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

