### PR TITLE
fix: apply agent filter when redirecting from a harness's Messages "View more"

### DIFF
--- a/.changeset/agent-messages-filter-redirect.md
+++ b/.changeset/agent-messages-filter-redirect.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+"View more" on a harness's recent messages now opens the global Messages log pre-filtered to that harness.

--- a/docs/superpowers/plans/2026-06-10-dashboard-fixes.md
+++ b/docs/superpowers/plans/2026-06-10-dashboard-fixes.md
@@ -1,0 +1,204 @@
+# Dashboard Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Three stacked PRs: (A) agent Messages "View more" carries the agent filter, (B) Local tab/models hidden in cloud, (C) Subscription Savings fully removed.
+
+**Architecture:** Stack on `fix/custom-provider-display` (#2197). PR A = query-param redirect + `MessageLog` seeding. PR B = `checkIsSelfHosted()` gating on Sidebar/route/GlobalOverview (the provider-select modal is ALREADY gated — verified `ProviderSelectContent.tsx:393` wraps the Local tab button in `<Show when={isSelfHosted()}>`). PR C = delete savings UI + backend endpoints; keep `baseline-cost.ts` (verified consumer: `routing/proxy/proxy-message-recorder.ts`) and the `baseline_cost_usd` column.
+
+**Tech Stack:** SolidJS (`@solidjs/router` `useSearchParams`), NestJS, vitest/jest. 100% patch coverage. Worktree: `/Users/guillaumegay/Documents/Projects/manifest/worktrees/dashboard-fixes` (node_modules symlinked from `pr10-analytics-ui`).
+
+---
+
+## PR A — branch `fix/agent-messages-filter-redirect`
+
+### Task A1: redirect carries the agent + MessageLog seeds the filter
+
+**Files:**
+- Modify: `packages/frontend/src/pages/AgentMessagesRedirect.tsx`
+- Modify: `packages/frontend/src/pages/MessageLog.tsx:77` (agentFilter init)
+- Test: `packages/frontend/tests/pages/AgentRedirects.test.tsx` (existing redirect tests), `packages/frontend/tests/pages/MessageLog.test.tsx`
+
+- [ ] **Step 1: failing tests.** In `AgentRedirects.test.tsx`, find the existing `AgentMessagesRedirect` test and update/add: the redirect target must be `/messages?agent=my%20agent` for route param `my agent`. In `MessageLog.test.tsx`, add a test in global mode (no `agentName` route param) mounting with search param `?agent=demo-agent` asserting the harness filter Select value is `demo-agent` and `getMessages` is called with `agent_name: 'demo-agent'`. (Follow the file's existing router-mocking convention — check how `useParams` is mocked and extend the same mock factory with `useSearchParams`.)
+
+- [ ] **Step 2: run, verify FAIL.**
+Run: `cd packages/frontend && npx vitest run tests/pages/AgentRedirects.test.tsx tests/pages/MessageLog.test.tsx`
+
+- [ ] **Step 3: implement.**
+
+`AgentMessagesRedirect.tsx` (whole file):
+
+```tsx
+import { Navigate, useParams } from '@solidjs/router';
+import type { Component } from 'solid-js';
+
+/**
+ * Redirects /harnesses/:agentName/messages → /messages?agent=<name> so the
+ * global message log opens pre-filtered to the harness the user came from.
+ */
+const AgentMessagesRedirect: Component = () => {
+  const params = useParams<{ agentName: string }>();
+  return (
+    <Navigate
+      href={`/messages?agent=${encodeURIComponent(decodeURIComponent(params.agentName))}`}
+    />
+  );
+};
+
+export default AgentMessagesRedirect;
+```
+
+`MessageLog.tsx`: import `useSearchParams` from `@solidjs/router` (extend the existing import on line 2) and seed the filter:
+
+```tsx
+  const [searchParams] = useSearchParams<{ agent?: string }>();
+  // Seed from ?agent= (set by AgentMessagesRedirect) so "View more" on a
+  // harness overview lands pre-filtered; only meaningful in global mode.
+  const [agentFilter, setAgentFilter] = createSignal(
+    !params.agentName && typeof searchParams.agent === 'string' ? searchParams.agent : '',
+  );
+```
+
+- [ ] **Step 4: run, verify PASS** (same command), plus `npx tsc --noEmit`.
+
+- [ ] **Step 5: changeset + commit.** Changeset (patch, `manifest`): `"View more" on a harness's recent messages now opens the global Messages log pre-filtered to that harness.` Then:
+
+```bash
+git add packages/frontend/src/pages/AgentMessagesRedirect.tsx packages/frontend/src/pages/MessageLog.tsx packages/frontend/tests/pages/AgentRedirects.test.tsx packages/frontend/tests/pages/MessageLog.test.tsx .changeset/
+git commit -m "fix(messages): carry agent filter through the messages redirect"
+```
+
+- [ ] **Step 6: push + PR** to `mnfst/manifest`, base `fix/custom-provider-display`... **NO** — cross-repo PRs need the base on upstream. Base on the SAME branch name pushed to upstream? #2197's head is on the fork. GitHub stacked PRs across forks can't base on a fork branch. **Resolution:** push `fix/custom-provider-display` is already on origin (fork) — so base PR A on `feat/analytics-ui` (upstream) and note in the body it stacks on #2197 (diff shows both until #2197 merges), OR push the base branch to upstream. Decide at execution: prefer pushing `fix/custom-provider-display` to upstream (memory: "Cross-repo PR base branches must be pushed to upstream first") and base PR A on it.
+
+---
+
+## PR B — branch `fix/hide-local-in-cloud` (off PR A)
+
+### Task B1: Sidebar + route + GlobalOverview gating
+
+**Files:**
+- Modify: `packages/frontend/src/components/Sidebar.tsx` (Local link, lines ~107-114)
+- Modify: `packages/frontend/src/pages/providers/Local.tsx` (route guard)
+- Modify: `packages/frontend/src/pages/GlobalOverview.tsx` (Local stat card ~791-851 + grid line 665)
+- Test: `packages/frontend/tests/components/Sidebar.test.tsx`, `packages/frontend/tests/pages/ProviderPages.test.tsx` (or wherever Local.tsx is covered — `grep -rln "providers/Local" packages/frontend/tests`), `packages/frontend/tests/pages/ProviderOverviewPages.test.tsx`
+
+- [ ] **Step 1: failing tests.**
+  - Sidebar: with `checkIsSelfHosted` mocked → `false` (cloud), the link `href="/providers/local"` is absent; mocked → `true`, present. (Check how Sidebar tests mock services; add a `vi.mock` for `setup-status.js` if absent.)
+  - Local page: in cloud, rendering `<LocalProviders/>` navigates to `/providers/byok`; self-hosted renders the connections page.
+  - GlobalOverview: in cloud, no "Local" stat card text and the stats grid style contains `repeat(3, 1fr)`; self-hosted keeps 4 columns and the card.
+
+- [ ] **Step 2: run, verify FAIL.**
+
+- [ ] **Step 3: implement.**
+
+`Sidebar.tsx`: add near the top of the component:
+
+```tsx
+  const [selfHosted] = createResource(checkIsSelfHosted);
+```
+
+(import `checkIsSelfHosted` from `../services/setup-status.js`; `createResource` already imported). Wrap the Local `<A>` block:
+
+```tsx
+      <Show when={selfHosted()}>
+        <A
+          href="/providers/local"
+          class="sidebar__link"
+          classList={{ active: isGlobalActive('/providers/local') }}
+          aria-current={isGlobalActive('/providers/local') ? 'page' : undefined}
+        >
+          Local
+        </A>
+      </Show>
+```
+
+`pages/providers/Local.tsx` (whole file — currently a one-line wrapper):
+
+```tsx
+import { Navigate } from '@solidjs/router';
+import { createResource, Show, type Component } from 'solid-js';
+import ProviderConnectionsPage from './ProviderConnectionsPage.jsx';
+import { checkIsSelfHosted } from '../../services/setup-status.js';
+
+/**
+ * Local providers (Ollama, LM Studio) only exist on self-hosted installs —
+ * a cloud backend can't reach the user's localhost. In cloud the route
+ * redirects to BYOK instead of showing an unusable page.
+ */
+const Local: Component = () => {
+  const [selfHosted] = createResource(checkIsSelfHosted);
+  return (
+    <Show when={selfHosted.loading === false && selfHosted() === false} fallback={
+      <Show when={selfHosted()}>
+        <ProviderConnectionsPage kind="local" />
+      </Show>
+    }>
+      <Navigate href="/providers/byok" />
+    </Show>
+  );
+};
+
+export default Local;
+```
+
+(Adapt to the actual current file shape; preserve any props it passes today.)
+
+`GlobalOverview.tsx`: add a `selfHosted` resource (same one-liner as Sidebar; `checkIsSelfHosted` may already be imported — check), make the grid conditional:
+
+```tsx
+              style={`grid-template-columns: repeat(${selfHosted() ? 4 : 3}, 1fr); align-items: stretch;`}
+```
+
+and wrap the whole Local stat card `<div class="overview-stat-card" …>` (the one whose label is `Local`) in `<Show when={selfHosted()}>…</Show>`.
+
+- [ ] **Step 4: run, verify PASS** + `npx tsc --noEmit` + full `npx vitest run` for regressions.
+
+- [ ] **Step 5: changeset + commit + push + PR** (base = PR A's branch on upstream). Changeset: `Local providers (tab, page, overview card) are hidden on cloud — they only apply to self-hosted installs.`
+
+```bash
+git add packages/frontend/src/components/Sidebar.tsx packages/frontend/src/pages/providers/Local.tsx packages/frontend/src/pages/GlobalOverview.tsx packages/frontend/tests .changeset/
+git commit -m "fix(providers): hide local tab, route and overview card in cloud"
+```
+
+---
+
+## PR C — branch `fix/remove-subscription-savings` (off PR B)
+
+### Task C1: frontend removal
+
+**Files:**
+- Delete: `packages/frontend/src/components/SavingsCard.tsx`, `SavingsExplainer.tsx`, `SavingsChart.tsx`, `packages/frontend/src/styles/savings.css`, `packages/frontend/tests/components/SavingsCard.test.tsx`, `SavingsExplainer.test.tsx`
+- Modify: `packages/frontend/src/components/ChartCard.tsx` (drop `'savings'` from `ActiveView` line 15, the `SavingsChart` lazy import line 11, `SavingsTimeseriesRow` import, the Savings stat block ~lines 100-117, the savings render block ~167-180, and the 4 savings props from `ChartCardProps`)
+- Modify: `packages/frontend/src/pages/Overview.tsx` (imports lines 33-36 keep `overview.css` only; signals 92-100: `activeView` union loses `'savings'`, delete `explainerOpen`/`savedCost`/`savedPct`/`savingsTimeseries`; delete the `SavingsExplainer` mount 225-228 — unwrap the `<Show when={!explainerOpen()}>` wrapper; delete ChartCard savings props 335-352 incl. the `SavingsCard` mount)
+- Modify: `packages/frontend/src/services/api/analytics.ts` (delete `SavingsData`, `getSavings`, `getBaselineCandidates` + `BaselineCandidateData` if savings-only, `SavingsTimeseriesRow`, `getSavingsTimeseries`)
+- Test: update `tests/components/ChartCard.test.tsx`, `tests/pages/Overview.test.tsx`, `tests/services/` analytics API tests (grep for `getSavings`)
+
+- [ ] **Step 1:** delete files, strip references per list above. Grep guard: `grep -rni "savings" packages/frontend/src` → no hits (except none).
+- [ ] **Step 2:** update tests: remove savings cases from ChartCard/Overview tests; run `npx vitest run` + `npx tsc --noEmit` until green.
+- [ ] **Step 3: commit** `refactor(frontend): remove subscription savings UI`.
+
+### Task C2: backend removal
+
+**Files:**
+- Delete: `packages/backend/src/analytics/controllers/savings.controller.ts` + `.spec.ts`, `packages/backend/src/analytics/services/savings-query.service.ts` + `.spec.ts`, `packages/backend/src/common/dto/savings-query.dto.ts` + `.spec.ts`
+- Modify: `packages/backend/src/analytics/analytics.module.ts` (remove imports lines 36-37, `SavingsController` line 72, `SavingsQueryService` line 87)
+- Keep: `packages/backend/src/common/utils/baseline-cost.ts` + spec (consumer: `routing/proxy/proxy-message-recorder.ts`)
+
+- [ ] **Step 1:** delete + deregister. Grep guard: `grep -rn "Savings" packages/backend/src --include="*.ts" | grep -v baseline` → empty. If `baseline-cost.ts` exports anything ONLY savings used (`pickMostExpensiveRoutedModel`, `collectRoutedModelIds`, `getBaselineCandidates` helpers), check `proxy-message-recorder.ts` usage and prune unused exports + their spec blocks (keep what the recorder uses).
+- [ ] **Step 2:** `npx jest --silent` + `npx tsc --noEmit -p tsconfig.json` green. Also grep e2e: `grep -rn "savings" packages/backend/test` and fix/remove.
+- [ ] **Step 3: changeset + commit + push + PR** (base = PR B's branch on upstream). Changeset (minor? UI feature removal → patch per repo habit; use patch): `Removed the Subscription Savings card, chart and API endpoints.`
+
+```bash
+git commit -m "refactor: remove subscription savings backend endpoints"
+```
+
+### Task C3: full verification
+
+- [ ] backend `npx jest --coverage --silent` green; frontend `npx vitest run --coverage` green; both `tsc` clean; lint clean; grep guards empty.
+
+---
+
+## Self-review notes
+
+- Spec coverage: A→Task A1, B→Task B1 (modal already gated — documented), C→C1+C2. ✓
+- PR bases: push each branch to upstream so the next can target it (memory rule). At PR-creation time for A: push `fix/custom-provider-display` to upstream and base A on it; B bases on A's upstream branch; C on B's.

--- a/docs/superpowers/specs/2026-06-10-dashboard-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-10-dashboard-fixes-design.md
@@ -1,0 +1,74 @@
+# Dashboard fixes: agent-filter redirect, local-in-cloud gating, savings removal
+
+**Date:** 2026-06-10
+**Status:** Approved
+**Shape:** Three stacked PRs on top of `fix/custom-provider-display` (#2197):
+`fix/agent-messages-filter-redirect` → `fix/hide-local-in-cloud` → `fix/remove-subscription-savings`.
+
+## PR A — Agent Messages "View more" applies the agent filter
+
+**Problem.** The agent Overview's Recent Messages "View more" link goes to
+`/harnesses/:agentName/messages`, which `AgentMessagesRedirect`
+(`packages/frontend/src/pages/AgentMessagesRedirect.tsx`) rewrites to plain
+`/messages` — the agent is dropped and the global log shows all harnesses.
+
+**Fix.** Carry the agent as a query param:
+
+- `AgentMessagesRedirect` navigates to
+  `/messages?agent=<encodeURIComponent(params.agentName)>`.
+- `MessageLog.tsx` seeds the `agentFilter` signal from the `agent` search
+  param (global mode only — when `params.agentName` is set the route itself
+  scopes the query). The harness dropdown arrives pre-selected; changing or
+  clearing it behaves exactly as today. Deep-linkable, refresh-safe; no
+  router state.
+
+## PR B — Local tab and models hidden in cloud
+
+Cloud (hosted) installs cannot reach a user's localhost, so local providers
+(Ollama, LM Studio) are meaningless there. Gate every "local" surface behind
+the existing `checkIsSelfHosted()` (`services/setup-status.ts`), the same
+pattern `MessageLog` uses for feedback columns. In **cloud**:
+
+- **Sidebar** (`components/Sidebar.tsx:108`): the Local nav entry is not
+  rendered.
+- **Route**: `/providers/local` redirects to `/providers/byok`.
+- **GlobalOverview**: the Local stat card is not rendered; the stats grid
+  drops from `repeat(4, 1fr)` to `repeat(3, 1fr)`.
+- **Provider-select modal / pickers**: `localOnly` provider tiles are hidden
+  so local providers cannot be connected; with no local connections, local
+  models never reach model pickers.
+
+Self-hosted behavior is unchanged. No backend change (the backend already
+exposes `isSelfHosted` via setup status; cloud users simply have no UI path
+to create local connections — defense-in-depth API rejection is out of
+scope).
+
+## PR C — Remove Subscription Savings (full removal)
+
+**Frontend — delete:** `components/SavingsCard.tsx`,
+`components/SavingsExplainer.tsx`, `components/SavingsChart.tsx`,
+`styles/savings.css`; the `'savings'` member of `ChartCard`'s `ActiveView`
+union plus its tab and render branches; the savings signals
+(`activeView`'s savings arm, `savedCost`, `savedPct`, `savingsTimeseries`),
+imports, mounts, and ChartCard props in `pages/Overview.tsx`;
+`getSavings`/`getSavingsTimeseries` in `services/api/analytics.ts`; all
+their tests.
+
+**Backend — delete:** `analytics/controllers/savings.controller.ts`
+(`GET /api/v1/savings`, `/savings/timeseries`, `/savings/baseline-candidates`),
+`analytics/services/savings-query.service.ts`,
+`common/dto/savings-query.dto.ts`, their spec files, and module
+registrations.
+
+**Kept:** `common/utils/baseline-cost.ts`, the
+`agent_messages.baseline_cost_usd` column, and its ingest-side precompute —
+no migration, nothing breaks. Exception: if inspection shows savings was
+baseline-cost's only consumer (no ingest-side usage), delete it too. Removal
+of the column is a separate cleanup if ever wanted.
+
+## Testing (each PR)
+
+Unit tests pinning the new behavior (redirect preserves the agent; local
+surfaces hidden in cloud and visible self-hosted; no savings references
+remain), full jest/vitest suites green, `tsc --noEmit` clean, 100% patch
+coverage, one changeset per PR.

--- a/packages/frontend/src/pages/AgentMessagesRedirect.tsx
+++ b/packages/frontend/src/pages/AgentMessagesRedirect.tsx
@@ -1,10 +1,18 @@
-import { Navigate } from '@solidjs/router';
+import { Navigate, useParams } from '@solidjs/router';
 import type { Component } from 'solid-js';
 
 /**
- * Redirects /harnesses/:agentName/messages → /messages (global message log).
- * Keeps backward-compat now that messages has a global home from PR1.
+ * Redirects /harnesses/:agentName/messages → /messages?agent=<name> so the
+ * global message log opens pre-filtered to the harness the user came from
+ * (e.g. via a Recent Messages "View more" link).
  */
-const AgentMessagesRedirect: Component = () => <Navigate href="/messages" />;
+const AgentMessagesRedirect: Component = () => {
+  const params = useParams<{ agentName: string }>();
+  return (
+    <Navigate
+      href={`/messages?agent=${encodeURIComponent(decodeURIComponent(params.agentName))}`}
+    />
+  );
+};
 
 export default AgentMessagesRedirect;

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -1,5 +1,5 @@
 import { Meta, Title } from '@solidjs/meta';
-import { A, useNavigate, useParams } from '@solidjs/router';
+import { A, useNavigate, useParams, useSearchParams } from '@solidjs/router';
 import {
   createEffect,
   createMemo,
@@ -74,7 +74,13 @@ const MessageLog: Component = () => {
     const at = base.indexOf('model');
     return [...base.slice(0, at), 'agent' as const, ...base.slice(at)];
   };
-  const [agentFilter, setAgentFilter] = createSignal('');
+  const [searchParams] = useSearchParams<{ agent?: string }>();
+  // Seed from ?agent= (set by AgentMessagesRedirect) so "View more" on a
+  // harness overview lands pre-filtered; only meaningful in global mode —
+  // when the route itself carries an agent, that param scopes the query.
+  const [agentFilter, setAgentFilter] = createSignal(
+    !params.agentName && typeof searchParams.agent === 'string' ? searchParams.agent : '',
+  );
   const [agentList] = createResource(
     () => !params.agentName,
     async (isGlobal) => {

--- a/packages/frontend/tests/pages/AgentRedirects.test.tsx
+++ b/packages/frontend/tests/pages/AgentRedirects.test.tsx
@@ -33,10 +33,28 @@ describe("AgentLimitsRedirect", () => {
 });
 
 describe("AgentMessagesRedirect", () => {
-  it("redirects /harnesses/:name/messages to global /messages", () => {
+  beforeEach(() => {
+    mockParams.agentName = "demo-agent";
+  });
+
+  it("redirects /harnesses/:name/messages to global /messages pre-filtered to the agent", () => {
     const { container } = render(() => <AgentMessagesRedirect />);
     const navigate = container.querySelector('[data-testid="navigate"]');
     expect(navigate).not.toBeNull();
-    expect(navigate?.getAttribute("data-href")).toBe("/messages");
+    expect(navigate?.getAttribute("data-href")).toBe("/messages?agent=demo-agent");
+  });
+
+  it("encodes agent names with special characters correctly", () => {
+    mockParams.agentName = "my agent";
+    const { container } = render(() => <AgentMessagesRedirect />);
+    const navigate = container.querySelector('[data-testid="navigate"]');
+    expect(navigate?.getAttribute("data-href")).toBe("/messages?agent=my%20agent");
+  });
+
+  it("normalizes an already-encoded route param instead of double-encoding", () => {
+    mockParams.agentName = "my%20agent";
+    const { container } = render(() => <AgentMessagesRedirect />);
+    const navigate = container.querySelector('[data-testid="navigate"]');
+    expect(navigate?.getAttribute("data-href")).toBe("/messages?agent=my%20agent");
   });
 });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@solidjs/testing-library";
 
 let mockAgentName = "test-agent";
+let mockSearchParams: { agent?: string } = {};
 const mockNavigate = vi.fn();
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: mockAgentName }),
   useNavigate: () => mockNavigate,
+  useSearchParams: () => [mockSearchParams, vi.fn()],
   A: (props: any) => <a href={props.href} style={props.style} class={props.class}>{props.children}</a>,
 }));
 
@@ -134,6 +136,7 @@ describe("MessageLog", () => {
     vi.clearAllMocks();
     localStorage.clear();
     mockAgentName = "test-agent";
+    mockSearchParams = {};
     mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "agent-alpha" }, { agent_name: "agent-beta" }] });
     mockGetCustomProviders.mockResolvedValue([]);
     mockGetSpecificityAssignments.mockResolvedValue([]);
@@ -1327,6 +1330,28 @@ describe("MessageLog", () => {
       render(() => <MessageLog />);
       await vi.waitFor(() => {
         expect(mockGetAgents).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it("seeds the agent filter from the ?agent= search param (View more redirect)", async () => {
+      mockAgentName = "";
+      mockSearchParams = { agent: "agent-beta" };
+      mockGetMessages.mockResolvedValue(messagesData);
+      render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        const lastCall = mockGetMessages.mock.calls.at(-1)![0] as Record<string, string>;
+        expect(lastCall.agent_name).toBe("agent-beta");
+      });
+    });
+
+    it("ignores the ?agent= search param in agent-scoped mode (route param wins)", async () => {
+      // mockAgentName is "test-agent" from beforeEach
+      mockSearchParams = { agent: "agent-beta" };
+      mockGetMessages.mockResolvedValue(messagesData);
+      render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        const lastCall = mockGetMessages.mock.calls.at(-1)![0] as Record<string, string>;
+        expect(lastCall.agent_name).toBe("test-agent");
       });
     });
 


### PR DESCRIPTION
## Problem

The agent Overview's Recent Messages "View more" link points at `/harnesses/:agentName/messages`, but `AgentMessagesRedirect` rewrites that to plain `/messages` — the agent is dropped, so the global log opens unfiltered across all harnesses.

## Fix

Carry the agent as a query param:

- `AgentMessagesRedirect` now navigates to `/messages?agent=<encoded name>` (normalizes already-encoded route params, no double-encoding).
- `MessageLog` seeds its `agentFilter` signal from the `agent` search param in global mode, so the harness dropdown arrives pre-selected and the first query is already scoped. Changing or clearing the filter behaves exactly as before; agent-scoped routes ignore the param (the route param wins). Deep-linkable and refresh-safe — no router state.

## Stack

Stacked on #2197 (`fix/custom-provider-display`), part of a 3-PR dashboard-fix batch (next: hide Local in cloud, remove Subscription Savings).

## Testing

- Redirect tests: encoded target, special characters, no double-encoding.
- MessageLog tests: `?agent=` seeds the filter and the `getMessages` call in global mode; route param wins in agent-scoped mode.
- Full frontend suite green (194 files / 3,971 tests), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the harness “View more” link so the global Messages log opens pre-filtered to that agent. Handles special characters and avoids double-encoding.

- **Bug Fixes**
  - `AgentMessagesRedirect` now redirects to `/messages?agent=<encoded name>`.
  - `MessageLog` seeds its agent filter from the `?agent=` search param in global mode; agent-scoped routes ignore it.

<sup>Written for commit 64c79eda318e754d8d9214689bc01d9a1b67612d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

