### PR TITLE
fix: hide Local providers (tab, page, overview card) in cloud

### DIFF
--- a/.changeset/hide-local-in-cloud.md
+++ b/.changeset/hide-local-in-cloud.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Local providers (sidebar tab, page and overview card) are hidden on cloud — they only apply to self-hosted installs.

--- a/packages/frontend/node_modules
+++ b/packages/frontend/node_modules
@@ -1,0 +1,1 @@
+/Users/guillaumegay/Documents/Projects/manifest/worktrees/pr10-analytics-ui/packages/frontend/node_modules

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { A, useLocation } from '@solidjs/router';
 import { Show, For, createSignal, createResource, type Component } from 'solid-js';
 import { useAgentName } from '../services/routing.js';
 import { getAgents } from '../services/api.js';
+import { checkIsSelfHosted } from '../services/setup-status.js';
 import { agentPing } from '../services/sse.js';
 import { platformIcon } from 'manifest-shared';
 import AddAgentModal from './AddAgentModal.jsx';
@@ -35,6 +36,9 @@ const Sidebar: Component<SidebarProps> = (props) => {
   const getAgentName = useAgentName();
   const [agentsCollapsed, setAgentsCollapsed] = createSignal(false);
   const [addModalOpen, setAddModalOpen] = createSignal(false);
+  // Local providers only exist on self-hosted installs — a cloud backend
+  // can't reach the user's localhost, so the Local entry is hidden there.
+  const [selfHosted] = createResource(checkIsSelfHosted);
 
   // Harness list for the in-nav switcher. Refetches whenever the agent SSE ping
   // fires (create/delete/rename). Uses the DEFAULT getAgents() — system agents
@@ -104,14 +108,16 @@ const Sidebar: Component<SidebarProps> = (props) => {
       >
         BYOK
       </A>
-      <A
-        href="/providers/local"
-        class="sidebar__link"
-        classList={{ active: isGlobalActive('/providers/local') }}
-        aria-current={isGlobalActive('/providers/local') ? 'page' : undefined}
-      >
-        Local
-      </A>
+      <Show when={selfHosted()}>
+        <A
+          href="/providers/local"
+          class="sidebar__link"
+          classList={{ active: isGlobalActive('/providers/local') }}
+          aria-current={isGlobalActive('/providers/local') ? 'page' : undefined}
+        >
+          Local
+        </A>
+      </Show>
 
       {/* Harnesses — collapsible section with a + create button.
           The collapse toggle and the create button are sibling buttons (never

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -13,6 +13,7 @@ import {
 } from 'solid-js';
 import AddAgentModal from '../components/AddAgentModal.jsx';
 import { getAgents, getGlobalProviders } from '../services/api.js';
+import { checkIsSelfHosted } from '../services/setup-status.js';
 import { customProviderColor } from '../services/formatters.js';
 import { customProviderLogo } from '../components/ProviderIcon.jsx';
 import { stripCustomPrefix } from '../services/routing-utils.js';
@@ -163,6 +164,10 @@ const GlobalOverview: Component = () => {
 
   // ── Chart view state ─────────────────────────────────────────────────
   const [chartView, setChartView] = createSignal<'messages' | 'tokens' | 'cost'>('tokens');
+
+  // Local providers only exist on self-hosted installs; cloud hides the
+  // Local stat card and drops the stats grid to three columns.
+  const [selfHosted] = createResource(checkIsSelfHosted);
 
   // ── Data resources (5 parallel) ──────────────────────────────────────
   const [overview] = createResource(
@@ -662,7 +667,7 @@ const GlobalOverview: Component = () => {
           return (
             <div
               class="overview-stats"
-              style="grid-template-columns: repeat(4, 1fr); align-items: stretch;"
+              style={`grid-template-columns: repeat(${selfHosted() ? 4 : 3}, 1fr); align-items: stretch;`}
             >
               <div class="overview-stat-card" style={cardStyle}>
                 <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;">
@@ -788,68 +793,70 @@ const GlobalOverview: Component = () => {
                   </A>
                 </div>
               </div>
-              <div class="overview-stat-card" style={cardStyle}>
-                <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;">
-                  <span class="overview-stat-card__label">Local</span>
-                  <A
-                    href="/providers/local?add=true"
-                    class="btn btn--outline btn--sm"
-                    style="font-size: var(--font-size-xs); padding: 2px 10px; height: 24px; text-decoration: none;"
-                  >
-                    + Add
-                  </A>
-                </div>
-                <span class="overview-stat-card__value" style="margin-bottom: 12px;">
-                  {totalConns(local())}
-                </span>
-                <div style="display: flex; flex-direction: column; gap: 6px; flex: 1;">
-                  <For each={connList(local())}>
-                    {(item) => (
-                      <A
-                        href={`/providers/connections/${item.id}`}
-                        style="display: flex; align-items: center; gap: 8px; text-decoration: none; font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));"
-                      >
-                        <span style="flex-shrink: 0; display: flex; align-items: center;">
-                          {providerIcon(item.icon, 14) ?? customProviderLogo(item.name, 14) ?? (
-                            <span
-                              style={{
-                                display: 'inline-flex',
-                                'align-items': 'center',
-                                'justify-content': 'center',
-                                width: '14px',
-                                height: '14px',
-                                'border-radius': '3px',
-                                'font-size': '9px',
-                                'font-weight': '600',
-                                color: 'white',
-                                background: customProviderColor(item.name),
-                              }}
-                            >
-                              {item.name.charAt(0).toUpperCase()}
-                            </span>
-                          )}
-                        </span>
-                        <span style="font-weight: 500; color: hsl(var(--foreground));">
-                          {item.name}
-                        </span>
-                        <Show when={item.isCustom}>
-                          <span style="font-size: 10px; font-weight: 500; color: hsl(var(--muted-foreground)); background: hsl(var(--muted)); padding: 1px 6px; border-radius: var(--radius-sm);">
-                            custom
+              <Show when={selfHosted()}>
+                <div class="overview-stat-card" style={cardStyle}>
+                  <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;">
+                    <span class="overview-stat-card__label">Local</span>
+                    <A
+                      href="/providers/local?add=true"
+                      class="btn btn--outline btn--sm"
+                      style="font-size: var(--font-size-xs); padding: 2px 10px; height: 24px; text-decoration: none;"
+                    >
+                      + Add
+                    </A>
+                  </div>
+                  <span class="overview-stat-card__value" style="margin-bottom: 12px;">
+                    {totalConns(local())}
+                  </span>
+                  <div style="display: flex; flex-direction: column; gap: 6px; flex: 1;">
+                    <For each={connList(local())}>
+                      {(item) => (
+                        <A
+                          href={`/providers/connections/${item.id}`}
+                          style="display: flex; align-items: center; gap: 8px; text-decoration: none; font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));"
+                        >
+                          <span style="flex-shrink: 0; display: flex; align-items: center;">
+                            {providerIcon(item.icon, 14) ?? customProviderLogo(item.name, 14) ?? (
+                              <span
+                                style={{
+                                  display: 'inline-flex',
+                                  'align-items': 'center',
+                                  'justify-content': 'center',
+                                  width: '14px',
+                                  height: '14px',
+                                  'border-radius': '3px',
+                                  'font-size': '9px',
+                                  'font-weight': '600',
+                                  color: 'white',
+                                  background: customProviderColor(item.name),
+                                }}
+                              >
+                                {item.name.charAt(0).toUpperCase()}
+                              </span>
+                            )}
                           </span>
-                        </Show>
-                        <Show when={item.label !== 'Default'}>
-                          <span>{item.label}</span>
-                        </Show>
-                      </A>
-                    )}
-                  </For>
+                          <span style="font-weight: 500; color: hsl(var(--foreground));">
+                            {item.name}
+                          </span>
+                          <Show when={item.isCustom}>
+                            <span style="font-size: 10px; font-weight: 500; color: hsl(var(--muted-foreground)); background: hsl(var(--muted)); padding: 1px 6px; border-radius: var(--radius-sm);">
+                              custom
+                            </span>
+                          </Show>
+                          <Show when={item.label !== 'Default'}>
+                            <span>{item.label}</span>
+                          </Show>
+                        </A>
+                      )}
+                    </For>
+                  </div>
+                  <div style="display: flex; justify-content: flex-end; margin-top: 12px;">
+                    <A href="/providers/local" class="view-more-link">
+                      View more
+                    </A>
+                  </div>
                 </div>
-                <div style="display: flex; justify-content: flex-end; margin-top: 12px;">
-                  <A href="/providers/local" class="view-more-link">
-                    View more
-                  </A>
-                </div>
-              </div>
+              </Show>
               <div class="overview-stat-card" style={cardStyle}>
                 <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;">
                   <span class="overview-stat-card__label">Harnesses</span>

--- a/packages/frontend/src/pages/providers/Local.tsx
+++ b/packages/frontend/src/pages/providers/Local.tsx
@@ -1,6 +1,23 @@
-import type { Component } from 'solid-js';
+import { Navigate } from '@solidjs/router';
+import { createResource, Show, type Component } from 'solid-js';
 import ProviderConnectionsPage from './ProviderConnectionsPage.jsx';
+import { checkIsSelfHosted } from '../../services/setup-status.js';
 
-const LocalProviders: Component = () => <ProviderConnectionsPage kind="local" />;
+/**
+ * Local providers (Ollama, LM Studio) only exist on self-hosted installs — a
+ * cloud backend can't reach the user's localhost. In cloud the route redirects
+ * to BYOK instead of showing an unusable page. Nothing renders until the
+ * self-hosted check resolves so the page never flashes before a redirect.
+ */
+const LocalProviders: Component = () => {
+  const [selfHosted] = createResource(checkIsSelfHosted);
+  return (
+    <Show when={selfHosted() !== undefined}>
+      <Show when={selfHosted()} fallback={<Navigate href="/providers/byok" />}>
+        <ProviderConnectionsPage kind="local" />
+      </Show>
+    </Show>
+  );
+};
 
 export default LocalProviders;

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -39,6 +39,14 @@ vi.mock("../../src/services/sse.js", () => ({
   agentPing: () => 0,
 }));
 
+// Local providers only exist on self-hosted installs; the Sidebar hides the
+// Local nav entry in cloud. Default to self-hosted so the legacy link
+// assertions keep applying; cloud tests flip the flag.
+let mockIsSelfHosted = true;
+vi.mock("../../src/services/setup-status.js", () => ({
+  checkIsSelfHosted: () => Promise.resolve(mockIsSelfHosted),
+}));
+
 // Stub the create-harness modal so the Sidebar test stays isolated from the
 // modal's own dependency tree; we only assert that the + button opens it.
 const mockAddModal = vi.fn();
@@ -80,6 +88,7 @@ const SAMPLE_AGENTS = [
 beforeEach(() => {
   vi.clearAllMocks();
   mockPathname = "/overview";
+  mockIsSelfHosted = true;
   mockGetAgents.mockResolvedValue({ agents: SAMPLE_AGENTS });
 });
 
@@ -94,12 +103,22 @@ describe("Sidebar — global nav links", () => {
     expect(screen.getByText("Messages")).toBeDefined();
   });
 
-  it("renders provider section links", () => {
+  it("renders provider section links (Local resolves async, self-hosted)", async () => {
     render(() => <Sidebar />);
     expect(screen.getByText("PROVIDERS")).toBeDefined();
     expect(screen.getByText("Subscriptions")).toBeDefined();
     expect(screen.getByText("BYOK")).toBeDefined();
-    expect(screen.getByText("Local")).toBeDefined();
+    await waitFor(() => expect(screen.getByText("Local")).toBeDefined());
+  });
+
+  it("hides the Local link in cloud", async () => {
+    mockIsSelfHosted = false;
+    const { container } = render(() => <Sidebar />);
+    // Wait for the self-hosted resource to settle (BYOK is always present).
+    await waitFor(() => expect(screen.getByText("BYOK")).toBeDefined());
+    await Promise.resolve();
+    expect(container.querySelector('a[href="/providers/local"]')).toBeNull();
+    expect(container.textContent).not.toContain("Local");
   });
 
   it("renders the HARNESSES section label", () => {
@@ -120,18 +139,23 @@ describe("Sidebar — global nav links", () => {
     expect(container.textContent).not.toContain("RESOURCES");
   });
 
-  it("global links point to global routes", () => {
+  it("global links point to global routes", async () => {
     const { container } = render(() => <Sidebar />);
     expect(container.querySelector('a[href="/overview"]')).not.toBeNull();
     expect(container.querySelector('a[href="/messages"]')).not.toBeNull();
     expect(container.querySelector('a[href="/providers/subscriptions"]')).not.toBeNull();
     expect(container.querySelector('a[href="/providers/byok"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/providers/local"]')).not.toBeNull();
+    await waitFor(() =>
+      expect(container.querySelector('a[href="/providers/local"]')).not.toBeNull(),
+    );
     expect(container.querySelector('a[href="/playground"]')).not.toBeNull();
   });
 
-  it("keeps exactly the expected sidebar__link set (no static Harnesses link)", () => {
+  it("keeps exactly the expected sidebar__link set (no static Harnesses link)", async () => {
     const { container } = render(() => <Sidebar />);
+    await waitFor(() =>
+      expect(container.querySelector('a[href="/providers/local"]')).not.toBeNull(),
+    );
     const links = Array.from(container.querySelectorAll("a.sidebar__link")).map((a) =>
       a.getAttribute("href"),
     );
@@ -177,11 +201,13 @@ describe("Sidebar — global nav active state", () => {
     expect(link?.getAttribute("aria-current")).toBe("page");
   });
 
-  it("marks Local active on /providers/local", () => {
+  it("marks Local active on /providers/local", async () => {
     mockPathname = "/providers/local";
     const { container } = render(() => <Sidebar />);
-    const link = container.querySelector('a[href="/providers/local"]');
-    expect(link?.getAttribute("aria-current")).toBe("page");
+    await waitFor(() => {
+      const link = container.querySelector('a[href="/providers/local"]');
+      expect(link?.getAttribute("aria-current")).toBe("page");
+    });
   });
 
   it("marks Playground active on /playground", () => {

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -221,6 +221,14 @@ vi.mock('manifest-shared', () => ({
   inferProviderFromModel: (m: string) => (m.startsWith('custom:') ? 'custom' : null),
 }));
 
+// Local providers only exist on self-hosted installs; GlobalOverview hides
+// the Local stat card in cloud. Default to self-hosted so the dashboard
+// tests keep covering the card; cloud tests flip the flag.
+let mockIsSelfHosted = true;
+vi.mock('../../src/services/setup-status.js', () => ({
+  checkIsSelfHosted: () => Promise.resolve(mockIsSelfHosted),
+}));
+
 import GlobalOverview from '../../src/pages/GlobalOverview';
 import ConnectionDetail from '../../src/pages/providers/ConnectionDetail';
 
@@ -490,6 +498,7 @@ beforeEach(() => {
   sessionStorage.clear();
   routerState.navigate.mockReset();
   routerState.params = { connectionId: 'conn-openai' };
+  mockIsSelfHosted = true;
 
   apiMocks.getAgents.mockResolvedValue(agentsResponse);
   apiMocks.getCustomProviders.mockResolvedValue([
@@ -520,6 +529,34 @@ afterEach(() => {
 });
 
 describe('GlobalOverview (analytics)', () => {
+  it('shows the Local stat card with a 4-column grid when self-hosted', async () => {
+    const { container } = render(() => <GlobalOverview />);
+    await waitFor(() => {
+      const labels = Array.from(container.querySelectorAll('.overview-stat-card__label')).map(
+        (el) => el.textContent,
+      );
+      expect(labels).toContain('Local');
+    });
+    expect(container.querySelector('.overview-stats')?.getAttribute('style')).toContain(
+      'repeat(4, 1fr)',
+    );
+  });
+
+  it('hides the Local stat card and drops to a 3-column grid in cloud', async () => {
+    mockIsSelfHosted = false;
+    const { container } = render(() => <GlobalOverview />);
+    await waitFor(() => {
+      expect(container.querySelector('.overview-stats')?.getAttribute('style')).toContain(
+        'repeat(3, 1fr)',
+      );
+    });
+    const labels = Array.from(container.querySelectorAll('.overview-stat-card__label')).map(
+      (el) => el.textContent,
+    );
+    expect(labels).not.toContain('Local');
+    expect(labels).toContain('Subscriptions');
+  });
+
   it('renders the dashboard with harness and provider data', async () => {
     const { container } = render(() => <GlobalOverview />);
 

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -11,6 +11,14 @@ const mockProviderSelectModal = vi.fn();
 
 vi.mock('@solidjs/router', () => ({
   useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+  Navigate: (props: { href: string }) => <div data-testid="navigate" data-href={props.href} />,
+}));
+
+// The Local providers page only exists on self-hosted installs; cloud
+// redirects to BYOK. Default to self-hosted so the page tests apply.
+let mockIsSelfHosted = true;
+vi.mock('../../src/services/setup-status.js', () => ({
+  checkIsSelfHosted: () => Promise.resolve(mockIsSelfHosted),
 }));
 
 vi.mock('@solidjs/meta', () => ({
@@ -120,6 +128,7 @@ describe('provider pages', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = {};
+    mockIsSelfHosted = true;
     mockGetGlobalProviders.mockResolvedValue(globalProvidersResponse);
     mockGetAgents.mockResolvedValue({ agents: [{ agent_name: 'demo-agent' }] });
     mockGetAgentProviders.mockResolvedValue([{ id: 'route-provider' }]);
@@ -208,6 +217,18 @@ describe('provider pages', () => {
       expect(screen.getByText('My Local Providers')).toBeDefined();
       expect(screen.getAllByText('Ollama').length).toBeGreaterThan(0);
     });
+  });
+
+  it('redirects the local providers page to BYOK in cloud', async () => {
+    mockIsSelfHosted = false;
+    const { container } = render(() => <LocalProviders />);
+
+    await waitFor(() => {
+      const navigate = container.querySelector('[data-testid="navigate"]');
+      expect(navigate).not.toBeNull();
+      expect(navigate?.getAttribute('data-href')).toBe('/providers/byok');
+    });
+    expect(container.textContent).not.toContain('Local Providers');
   });
 
   it('auto-opens the modal from add=true and clears the query param', async () => {


### PR DESCRIPTION
## Problem

Local providers (Ollama, LM Studio) only make sense on self-hosted installs — a cloud backend can't reach the user's localhost. Yet cloud still showed the sidebar **Local** tab, the `/providers/local` page, and the **Local** stat card on the global overview.

## Fix

Gate every local surface behind the existing `checkIsSelfHosted()` (same pattern the Messages log already uses for feedback columns). In cloud:

- **Sidebar**: the Local nav entry is not rendered.
- **Route**: `/providers/local` redirects to `/providers/byok` (nothing renders until the check resolves, so no flash).
- **GlobalOverview**: the Local stat card is gone and the stats grid drops from 4 to 3 columns.

The connect-provider modal's Local tab was **already** gated (`ProviderSelectContent.tsx` wraps it in `<Show when={isSelfHosted()}>`), so with these three closures cloud users have no path to local providers — and hence no local models in pickers. Self-hosted behavior is unchanged.

## Stack

Stacked on #2198 (`fix/agent-messages-filter-redirect`) ← #2197. Next: remove Subscription Savings.

## Testing

- Sidebar: Local hidden in cloud / visible + active-state self-hosted.
- Local page: cloud redirect to BYOK, self-hosted renders.
- GlobalOverview: card + grid assertions for both modes.
- Full frontend suite green (194 files / 3,975 tests), `tsc` clean, 100% line coverage on all three touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide Local providers in cloud by gating all Local surfaces behind `checkIsSelfHosted()`. Cloud users no longer see or reach Local providers; self-hosted behavior is unchanged.

- **Bug Fixes**
  - Sidebar: hide the Local link when not self-hosted.
  - Route: `/providers/local` redirects to `/providers/byok` in cloud, with no flash while the check resolves.
  - GlobalOverview: hide the Local stat card in cloud and switch the grid to 3 columns.
  - Tests updated to cover both self-hosted and cloud paths.

<sup>Written for commit c312bc23d4ce7929d55af4f67a09a1fbd7af564b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

