### PR TITLE
feat: provider-grouped usage chart on the per-agent Overview (restore Seb's design)

### DIFF
--- a/.changeset/agent-provider-chart.md
+++ b/.changeset/agent-provider-chart.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+The per-agent Overview now breaks usage down by provider (chart + provider filter), matching the global Overview.

--- a/docs/superpowers/plans/2026-06-10-agent-provider-chart.md
+++ b/docs/superpowers/plans/2026-06-10-agent-provider-chart.md
@@ -1,0 +1,425 @@
+# Per-agent Provider Chart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore Seb's provider-grouped usage chart on the per-agent Overview: `ProviderChartCard` grouped by provider + a provider multiselect filter, scoped to the one agent.
+
+**Architecture:** Reuse `ProviderChartCard` + `MultiAgentTokenChart` (already used by the global Overview). Feed them three per-agent/per-provider timeseries (tokens/messages/cost). Add the one missing frontend API client fn (`getPerProviderCostTimeseries`); the backend endpoint already exists. Port Seb's provider-multiselect + filter/color logic from `AgentOverview.tsx` @ `fix/pr2061-migration-dedup-and-access` into the current `Overview.tsx`.
+
+**Tech Stack:** SolidJS, vitest. Worktree `/Users/guillaumegay/Documents/Projects/manifest/worktrees/dashboard-fixes`, branch `feat/agent-provider-chart` (off `fix/remove-subscription-savings` #2200). node_modules symlinked from `pr10-analytics-ui`.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-agent-provider-chart-design.md`
+
+**Verify:** `cd packages/frontend && npx vitest run <path>` ; `npx tsc --noEmit`.
+
+---
+
+### Task 1: add `getPerProviderCostTimeseries` to the API client
+
+**Files:**
+- Modify: `packages/frontend/src/services/api/analytics.ts` (after `getPerProviderMessageTimeseries`, ends line ~127)
+- Test: `packages/frontend/tests/services/api/analytics.test.ts` (the `agent-scoped per-provider timeseries` test, line ~134)
+
+- [ ] **Step 1: failing test.** In `analytics.test.ts`, extend the `fns` array in the `agent-scoped per-provider timeseries endpoints forward agent_name + range` test:
+
+```typescript
+    const fns: Array<[(a: string, r?: string) => unknown, string]> = [
+      [analytics.getPerProviderTimeseries, 'per-provider-timeseries'],
+      [analytics.getPerProviderMessageTimeseries, 'per-provider-message-timeseries'],
+      [analytics.getPerProviderCostTimeseries, 'per-provider-cost-timeseries'],
+    ];
+```
+
+- [ ] **Step 2: run, verify FAIL.**
+Run: `cd packages/frontend && npx vitest run tests/services/api/analytics.test.ts`
+Expected: FAIL — `getPerProviderCostTimeseries` is undefined.
+
+- [ ] **Step 3: implement.** In `analytics.ts`, immediately after the `getPerProviderMessageTimeseries` function (before `getRateLimits`):
+
+```typescript
+export function getPerProviderCostTimeseries(
+  agentName: string,
+  range = '24h',
+): PivotedTimeseries {
+  return fetchJson('/overview/per-provider-cost-timeseries', {
+    agent_name: agentName,
+    range,
+  }) as PivotedTimeseries;
+}
+```
+
+- [ ] **Step 4: run, verify PASS.** Same command. Expected: PASS.
+
+- [ ] **Step 5: commit.**
+
+```bash
+git add packages/frontend/src/services/api/analytics.ts packages/frontend/tests/services/api/analytics.test.ts
+git commit -m "feat(api): add per-agent per-provider cost timeseries client fn"
+```
+
+---
+
+### Task 2: render the provider-grouped chart on the per-agent Overview
+
+**Files:**
+- Modify: `packages/frontend/src/pages/Overview.tsx`
+- Test: `packages/frontend/tests/pages/Overview.test.tsx`
+
+This swaps `ChartCard` for `ProviderChartCard`, adds the provider multiselect, and wires three per-provider resources + filter/color memos (ported from Seb).
+
+- [ ] **Step 1: imports.** In `Overview.tsx`, replace the `ChartCard` import (line 12) and add the new deps. Change:
+
+```typescript
+import ChartCard from '../components/ChartCard.jsx';
+```
+to:
+```typescript
+import ProviderChartCard from '../components/ProviderChartCard.jsx';
+import { AGENT_COLORS } from '../components/MultiAgentTokenChart.jsx';
+import { PROVIDERS } from '../services/providers.js';
+```
+
+Add `For` and `onCleanup` to the `solid-js` import (line 3-11 block); add the three per-provider client fns to the `../services/api.js` import OR import from `../services/api/analytics.js`. **Check first** whether `getOverview` in `Overview.tsx` comes from `../services/api.js` (it does — line 23). The per-provider fns live in `../services/api/analytics.js`; add a new import line:
+
+```typescript
+import {
+  getPerProviderTimeseries,
+  getPerProviderMessageTimeseries,
+  getPerProviderCostTimeseries,
+} from '../services/api/analytics.js';
+```
+
+Add `import '../styles/charts.css';` after the existing `'../styles/overview.css'` import (ProviderChartCard/MultiAgentTokenChart need chart styles).
+
+- [ ] **Step 2: type for pivoted series.** After the `OverviewData` interface (line ~73), add:
+
+```typescript
+type PivotedTimeseries = {
+  agents: string[];
+  timeseries: Array<Record<string, number | string>>;
+};
+```
+
+- [ ] **Step 3: state + resources + memos.** Inside the component, after the `messageChartData` memo (line ~210), add the provider chart machinery (ported from Seb, adapted to use `params.agentName` and the existing `range()` signal). Note: the existing page already has `range()`/`activeView()`; reuse them — do NOT add a second range signal.
+
+```typescript
+  // ── Provider breakdown (per-agent, grouped by provider) ─────────────
+  const providerFilterKey = () => `agent-overview-providers:${params.agentName}`;
+  const loadSavedProviders = (): Set<string> => {
+    try {
+      const saved = sessionStorage.getItem(providerFilterKey());
+      if (saved) return new Set(JSON.parse(saved) as string[]);
+    } catch {
+      /* ignore */
+    }
+    return new Set();
+  };
+  const [selectedProviders, setSelectedProviders] = createSignal<Set<string>>(loadSavedProviders());
+  const [providerFilterOpen, setProviderFilterOpen] = createSignal(false);
+  let providerFilterRef: HTMLDivElement | undefined;
+  if (typeof document !== 'undefined') {
+    const onClickOutside = (e: MouseEvent) => {
+      if (providerFilterRef && !providerFilterRef.contains(e.target as Node))
+        setProviderFilterOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setProviderFilterOpen(false);
+    };
+    document.addEventListener('click', onClickOutside);
+    document.addEventListener('keydown', onKeyDown);
+    onCleanup(() => {
+      document.removeEventListener('click', onClickOutside);
+      document.removeEventListener('keydown', onKeyDown);
+    });
+  }
+
+  const tsKey = () => ({ range: range(), agent: params.agentName, _ping: messagePing() });
+  const [providerTokenTs] = createResource(tsKey, (p) =>
+    p.agent ? (getPerProviderTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>) : undefined,
+  );
+  const [providerMessageTs] = createResource(tsKey, (p) =>
+    p.agent
+      ? (getPerProviderMessageTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>)
+      : undefined,
+  );
+  const [providerCostTs] = createResource(tsKey, (p) =>
+    p.agent
+      ? (getPerProviderCostTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>)
+      : undefined,
+  );
+
+  const allProviders = createMemo(() => {
+    const set = new Set<string>([
+      ...(providerTokenTs()?.agents ?? []),
+      ...(providerMessageTs()?.agents ?? []),
+      ...(providerCostTs()?.agents ?? []),
+    ]);
+    return [...set].sort();
+  });
+
+  const providerColorMap = createMemo(() => {
+    const map: Record<string, string> = {};
+    const list = allProviders();
+    for (let i = 0; i < list.length; i++) map[list[i]!] = AGENT_COLORS[i % AGENT_COLORS.length]!;
+    return map;
+  });
+
+  const effectiveSelected = () => {
+    const sel = selectedProviders();
+    if (sel.size === 0 && allProviders().length > 0) return new Set(allProviders());
+    return sel;
+  };
+  const selectedProviderCount = () => effectiveSelected().size;
+
+  const toggleProvider = (provider: string) => {
+    const next = new Set(effectiveSelected());
+    if (next.has(provider)) next.delete(provider);
+    else next.add(provider);
+    setSelectedProviders(next);
+    try {
+      sessionStorage.setItem(providerFilterKey(), JSON.stringify([...next]));
+    } catch {
+      /* ignore */
+    }
+  };
+  const setAllProviders = (on: boolean) => {
+    const next = on ? new Set(allProviders()) : new Set<string>();
+    setSelectedProviders(next);
+    try {
+      sessionStorage.setItem(providerFilterKey(), JSON.stringify([...next]));
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const filterTs = (raw: PivotedTimeseries | undefined): PivotedTimeseries | undefined => {
+    if (!raw) return undefined;
+    const sel = effectiveSelected();
+    if (sel.size === 0) return raw;
+    return {
+      agents: raw.agents.filter((a) => sel.has(a)),
+      timeseries: raw.timeseries.map((row) => {
+        const out: Record<string, number | string> = {};
+        for (const [k, v] of Object.entries(row)) {
+          if (k === 'hour' || k === 'date' || sel.has(k)) out[k] = v;
+        }
+        return out;
+      }),
+    };
+  };
+  const filteredTokenTs = createMemo(() => filterTs(providerTokenTs()));
+  const filteredMessageTs = createMemo(() => filterTs(providerMessageTs()));
+  const filteredCostTs = createMemo(() => filterTs(providerCostTs()));
+
+  const providerDisplayName = (provId: string): string =>
+    PROVIDERS.find((p) => p.id === provId)?.name ?? provId;
+```
+
+- [ ] **Step 4: header — add the provider multiselect + right-align.** Replace the page-header block (lines 221-240) with the right-aligned version that adds the provider multiselect before the range select. (This also folds in the "range on the right" cosmetic.)
+
+```tsx
+      <div class="page-header" style="justify-content: flex-end;">
+        <div class="header-controls">
+          <Show when={showDashboard() && allProviders().length > 1}>
+            <div class="agent-filter-select" ref={providerFilterRef}>
+              <button
+                class="agent-filter-select__trigger"
+                onClick={() => setProviderFilterOpen(!providerFilterOpen())}
+                type="button"
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+                </svg>
+                {selectedProviderCount() === allProviders().length
+                  ? `All providers (${allProviders().length})`
+                  : `${selectedProviderCount()} of ${allProviders().length} providers`}
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="m6 9 6 6 6-6" />
+                </svg>
+              </button>
+              <Show when={providerFilterOpen()}>
+                <div class="agent-filter-select__dropdown">
+                  <div class="agent-filter-select__actions">
+                    <button
+                      class="agent-filter-select__action-btn"
+                      type="button"
+                      disabled={selectedProviderCount() === allProviders().length}
+                      onClick={() => setAllProviders(true)}
+                    >
+                      Select all
+                    </button>
+                    <button
+                      class="agent-filter-select__action-btn"
+                      type="button"
+                      disabled={selectedProviderCount() === 0}
+                      onClick={() => setAllProviders(false)}
+                    >
+                      Unselect all
+                    </button>
+                  </div>
+                  <For each={allProviders()}>
+                    {(provider) => {
+                      const isOn = () => effectiveSelected().has(provider);
+                      return (
+                        <button
+                          class="agent-filter-select__item"
+                          onClick={() => toggleProvider(provider)}
+                          type="button"
+                        >
+                          <span
+                            class="agent-filter-select__swatch"
+                            style={{ background: providerColorMap()[provider] }}
+                          />
+                          <span class="agent-filter-select__name">
+                            {providerDisplayName(provider)}
+                          </span>
+                          <span
+                            class="agent-filter-select__toggle"
+                            classList={{ 'agent-filter-select__toggle--on': isOn() }}
+                          >
+                            <span class="agent-filter-select__toggle-thumb" />
+                          </span>
+                        </button>
+                      );
+                    }}
+                  </For>
+                </div>
+              </Show>
+            </div>
+          </Show>
+          <Show when={showDashboard()}>
+            <Select
+              value={range()}
+              onChange={handleRangeChange}
+              options={[
+                { label: 'Last 24 hours', value: '24h' },
+                { label: 'Last 7 days', value: '7d' },
+                { label: 'Last 30 days', value: '30d' },
+              ]}
+            />
+          </Show>
+          <Show when={showEmptyState() && !setupCompleted()}>
+            <button class="btn btn--primary btn--sm" onClick={() => setSetupOpen(true)}>
+              Set up harness
+            </button>
+          </Show>
+        </div>
+      </div>
+```
+
+- [ ] **Step 5: swap ChartCard → ProviderChartCard.** Replace the `<ChartCard .../>` block (lines 307-320) with:
+
+```tsx
+                  <ProviderChartCard
+                    activeView={activeView()}
+                    onViewChange={setActiveView}
+                    costValue={d().summary?.cost_today?.value ?? 0}
+                    costTrendPct={d().summary?.cost_today?.trend_pct ?? 0}
+                    tokensValue={d().summary?.tokens_today?.value ?? 0}
+                    tokensTrendPct={d().summary?.tokens_today?.trend_pct ?? 0}
+                    messagesValue={d().summary?.messages?.value ?? 0}
+                    messagesTrendPct={d().summary?.messages?.trend_pct ?? 0}
+                    costInfoTooltip="Actual API key costs only. Subscription usage is not included."
+                    range={range()}
+                    agentTimeseries={filteredTokenTs() ?? undefined}
+                    agentMessageTimeseries={filteredMessageTs() ?? undefined}
+                    agentCostTimeseries={filteredCostTs() ?? undefined}
+                    colorMap={providerColorMap()}
+                  />
+```
+
+Note: `messageChartData` (the old `ChartCard` `messageChartData` prop source) is now unused by the chart — but verify it's not referenced elsewhere before deleting its memo. `grep -n messageChartData packages/frontend/src/pages/Overview.tsx`; if the only use was the ChartCard prop, delete the memo (lines 207-210) to avoid an unused-var lint error.
+
+- [ ] **Step 6: update Overview.test.tsx.** The test currently mocks `CostChart`/`TokenChart`/`SingleTokenChart` (ChartCard's children) and stripped the `api/analytics` mock during the savings removal. Now the page renders `ProviderChartCard` → `MultiAgentTokenChart`, and calls the three per-provider client fns. Add:
+
+```typescript
+const mockPerProvider = vi.fn(() => Promise.resolve({ agents: [], timeseries: [] }));
+vi.mock("../../src/services/api/analytics.js", () => ({
+  getPerProviderTimeseries: (...a: unknown[]) => mockPerProvider(...a),
+  getPerProviderMessageTimeseries: (...a: unknown[]) => mockPerProvider(...a),
+  getPerProviderCostTimeseries: (...a: unknown[]) => mockPerProvider(...a),
+}));
+vi.mock("../../src/components/MultiAgentTokenChart.jsx", () => ({
+  AGENT_COLORS: ['#111111', '#222222'],
+  default: (props: any) => (
+    <div data-testid="multi-agent-chart" data-series={(props.data?.agents ?? []).join(',')} />
+  ),
+}));
+```
+
+Keep the existing `CostChart`/`TokenChart`/`SingleTokenChart` mocks (harmless; no longer rendered). Then fix assertions that depended on ChartCard internals:
+- The test `switches chart view when stat header clicked` (clicks `.chart-card__stat--clickable` and expects `[data-testid="cost-chart"]`): ProviderChartCard reuses the same `.chart-card__stat--clickable` classes and Cost/Messages/Tokens order (Cost = index 0). Update it to assert the active stat class toggles instead of the old per-view chart testids — e.g. click `stats[0]` → expect `.chart-card__stat--active` contains "Cost"; click `stats[1]` → "Messages". (ProviderChartCard renders `multi-agent-chart` for whichever view; assert the active-stat label, not a per-view testid.)
+- Any assertion referencing `single-token-chart`/`cost-chart`/`token-chart` as the agent-overview chart must change to `multi-agent-chart` or the active-stat check.
+- Add a test: with `mockPerProvider` resolving `{ agents: ['openai','anthropic'], timeseries: [{hour:'1', openai:5, anthropic:3}] }`, the provider multiselect renders ("All providers (2)") and `multi-agent-chart` shows both series; clicking "Unselect all" then a single provider filters the series.
+
+Run iteratively: `cd packages/frontend && npx vitest run tests/pages/Overview.test.tsx` until green.
+
+- [ ] **Step 7: typecheck + format.**
+Run: `cd packages/frontend && npx tsc --noEmit && npx prettier --write src/pages/Overview.tsx src/services/api/analytics.ts tests/pages/Overview.test.tsx`
+Expected: clean.
+
+- [ ] **Step 8: commit.**
+
+```bash
+git add packages/frontend/src/pages/Overview.tsx packages/frontend/tests/pages/Overview.test.tsx
+git commit -m "feat(overview): provider-grouped usage chart on the per-agent overview"
+```
+
+---
+
+### Task 3: full verification + changeset + PR
+
+- [ ] **Step 1: full suites.**
+Run: `cd packages/frontend && npx tsc --noEmit && npx vitest run --coverage`
+Expected: all green; 100% line coverage on `Overview.tsx` and the new client fn. Add tests for any uncovered branch (e.g. the `setAllProviders(false)` path, the sessionStorage catch).
+
+- [ ] **Step 2: lint.** Run from repo root: `npm run lint` (expect 0 errors; warnings pre-exist).
+
+- [ ] **Step 3: grep guard.** `grep -n "ChartCard" packages/frontend/src/pages/Overview.tsx` → no match (now uses ProviderChartCard). Confirm `ChartCard` itself still has its other consumers: `grep -rln "import ChartCard" packages/frontend/src` → GlobalOverview, ConnectionDetail still present.
+
+- [ ] **Step 4: live check.** The dev server (`:3010`) hot-reloads. Confirm the agent Overview chart shows per-provider series + the "All providers (N)" filter on the right next to "Last 30 days". (Backend on `:3011`, login admin@manifest.build/manifest.)
+
+- [ ] **Step 5: changeset.**
+
+```bash
+# create .changeset/agent-provider-chart.md targeting "manifest", patch
+```
+Content: `The per-agent Overview now breaks usage down by provider (chart + provider filter), matching the global Overview.`
+
+- [ ] **Step 6: commit + push + PR.**
+
+```bash
+git add .changeset/agent-provider-chart.md
+git commit -m "chore: changeset for per-agent provider chart"
+git push -u origin feat/agent-provider-chart
+git push upstream fix/remove-subscription-savings   # base must be on upstream
+```
+PR base = `fix/remove-subscription-savings` (#2200), head = `guillaumegay13:feat/agent-provider-chart`.
+
+---
+
+## Self-review notes
+
+- Spec coverage: ProviderChartCard swap (Task 2 step 5), provider multiselect (step 4), three timeseries incl. new cost fn (Task 1 + step 3), color map + filter (step 3), range-on-right fold-in (step 4), no backend change, ChartCard kept. ✓
+- The cosmetic ChartCard reorder is intentionally NOT carried (moot — agent page uses ProviderChartCard now, already Cost-first). The stash on `fix/remove-subscription-savings` can be dropped after this lands.
+- ProviderChartCard prop names verified against `components/ProviderChartCard.tsx`: `activeView`, `onViewChange`, `messagesValue`, `messagesTrendPct`, `tokensValue`, `tokensTrendPct`, `costValue`, `costTrendPct`, `costInfoTooltip`, `range`, `agentTimeseries`, `agentMessageTimeseries`, `agentCostTimeseries`, `colorMap`.

--- a/docs/superpowers/specs/2026-06-10-agent-provider-chart-design.md
+++ b/docs/superpowers/specs/2026-06-10-agent-provider-chart-design.md
@@ -1,0 +1,101 @@
+# Per-agent Overview: provider-grouped usage chart (restore Seb's design)
+
+**Date:** 2026-06-10
+**Status:** Approved
+**Branch:** `feat/agent-provider-chart`, stacked on `fix/remove-subscription-savings` (#2200).
+
+## Problem
+
+The per-agent Overview (`packages/frontend/src/pages/Overview.tsx`, route
+`/harnesses/:agentName`) renders a single-series `ChartCard` (one line for the
+whole agent's cost/tokens/messages). The global Overview shows the same data
+**broken down by provider** via `ProviderChartCard` plus a provider filter.
+That provider breakdown existed on the per-agent page in Seb's #2061 design
+(`AgentOverview.tsx` at ref `fix/pr2061-migration-dedup-and-access`) and was
+dropped in the re-slice. Restore it.
+
+## Decision
+
+Replace the single-series `ChartCard` on the per-agent Overview with
+`ProviderChartCard` (the global Overview's component), grouped **by provider**,
+plus Seb's **provider multiselect** filter. Provider-only — no "By model"
+toggle (YAGNI; Seb didn't have one), no "By harness" (meaningless for one
+agent).
+
+## Design
+
+### Components (reuse, no new components)
+
+- **`ProviderChartCard`** (`components/ProviderChartCard.tsx`) — unchanged. It
+  already has the Cost / Messages / Token usage view toggle (Cost first) and
+  renders `MultiAgentTokenChart` for whatever series it's given. Feed it
+  provider-keyed series and it draws one line per provider.
+- **Provider multiselect** — Seb's header control: an "All providers (N) ▾"
+  dropdown with *Select all* / *Unselect all* and per-provider rows (color
+  swatch + display name + toggle), selection persisted in `sessionStorage` per
+  agent. Reuses the existing `agent-filter-select` CSS classes.
+
+### Header layout
+
+Page header right side: `[ provider multiselect ] [ Last 30 days ]`. The range
+`Select` stays on the right (the cosmetic "range on the right" move folds in
+here). The simple `ChartCard`'s old header (range-only) is replaced.
+
+### Data flow (mirrors global, scoped to the agent)
+
+Three resources keyed on `(agentName, range)`:
+- `getPerProviderTimeseries(agentName, range)` — tokens. **exists**
+- `getPerProviderMessageTimeseries(agentName, range)` — messages. **exists**
+- `getPerProviderCostTimeseries(agentName, range)` — cost. **MISSING from the
+  frontend API client; add it.** Backend endpoint
+  `GET /api/v1/overview/per-provider-cost-timeseries` (takes `agent_name`)
+  already exists (`overview.controller.ts`). Including cost is what makes the
+  page match global (Seb's version omitted cost).
+
+Each returns `{ agents: string[]; timeseries: Array<Record<string, number |
+string>> }` where `agents` is the list of provider series keys. Custom-provider
+keys already arrive resolved to display names (PR #2197 `PROVIDER_SERIES_KEY_EXPR`,
+in this stack's base).
+
+The page filters series to the selected providers (drop unselected columns from
+each timeseries row + the `agents` array) and builds a `providerColorMap` from
+the existing `AGENT_COLORS` palette (`MultiAgentTokenChart.tsx`), assigned over
+the full provider list so colors are stable as the filter changes.
+
+Summary stat values (the Cost/Messages/Tokens numbers above the chart) keep
+coming from the existing `/overview` endpoint response (`data().summary`).
+
+### Provider display names
+
+The series keys from the backend are already display-ready (built-in provider
+names + resolved custom names). The multiselect labels reuse the same keys, so
+no extra resolution is needed beyond what the timeseries returns. The full
+provider set = union of `agents` arrays across the three timeseries (so a
+provider that has cost but no tokens still appears).
+
+### What does NOT change
+
+- `ChartCard` component stays (still used by `GlobalOverview` and
+  `ConnectionDetail`). The earlier cosmetic ChartCard stat reorder is dropped —
+  moot now that the agent page uses `ProviderChartCard` (already Cost-first).
+- Recent Messages, Cost-by-model, setup modal, feedback, range smart-cascade —
+  all unchanged.
+- Backend — no change (endpoints already exist; only the frontend API client
+  gains one function).
+
+## Testing
+
+- `services/api/analytics.test.ts`: `getPerProviderCostTimeseries` forwards
+  `agent_name` + `range` to `/overview/per-provider-cost-timeseries`.
+- `Overview.test.tsx`: renders `ProviderChartCard` with provider series;
+  provider multiselect shows the providers, Select all / Unselect all toggles
+  the rendered series; range select present on the right; switching the
+  Cost/Messages/Tokens view renders the matching chart. Mock the three
+  per-provider timeseries API calls.
+- Full vitest + `tsc` clean, 100% patch coverage, one changeset.
+
+## Out of scope
+
+- A "By model" breakdown toggle.
+- Any backend change.
+- Touching the global Overview or Connection detail.

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -250,20 +250,17 @@ const Overview: Component = () => {
   }
 
   const tsKey = () => ({ range: range(), agent: params.agentName, _ping: messagePing() });
-  const [providerTokenTs] = createResource(tsKey, (p) =>
-    p.agent
-      ? (getPerProviderTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>)
-      : undefined,
+  const [providerTokenTs] = createResource(
+    tsKey,
+    (p) => getPerProviderTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
-  const [providerMessageTs] = createResource(tsKey, (p) =>
-    p.agent
-      ? (getPerProviderMessageTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>)
-      : undefined,
+  const [providerMessageTs] = createResource(
+    tsKey,
+    (p) => getPerProviderMessageTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
-  const [providerCostTs] = createResource(tsKey, (p) =>
-    p.agent
-      ? (getPerProviderCostTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>)
-      : undefined,
+  const [providerCostTs] = createResource(
+    tsKey,
+    (p) => getPerProviderCostTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
 
   const allProviders = createMemo(() => {

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -5,11 +5,14 @@ import {
   createMemo,
   createResource,
   createSignal,
+  For,
   on,
+  onCleanup,
   Show,
   type Component,
 } from 'solid-js';
-import ChartCard from '../components/ChartCard.jsx';
+import ProviderChartCard from '../components/ProviderChartCard.jsx';
+import { AGENT_COLORS } from '../components/MultiAgentTokenChart.jsx';
 import CostByModelTable from '../components/CostByModelTable.jsx';
 import ErrorState from '../components/ErrorState.jsx';
 import FeedbackModal from '../components/FeedbackModal.jsx';
@@ -20,7 +23,13 @@ import SetupModal from '../components/SetupModal.jsx';
 import { type MessageRow } from '../components/message-table-types.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import { agentPlatform, agentCategory } from '../services/agent-platform-store.js';
+import { PROVIDERS } from '../services/providers.js';
 import { getOverview, setMessageFeedback, clearMessageFeedback } from '../services/api.js';
+import {
+  getPerProviderTimeseries,
+  getPerProviderMessageTimeseries,
+  getPerProviderCostTimeseries,
+} from '../services/api/analytics.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { isRecentlyCreated, isSetupPending, clearSetupPending } from '../services/recent-agents.js';
 import { messagePing } from '../services/sse.js';
@@ -31,6 +40,7 @@ import {
   useOverviewRange,
 } from '../services/use-overview-range.js';
 import '../styles/overview.css';
+import '../styles/charts.css';
 
 interface OverviewData {
   summary: {
@@ -71,6 +81,11 @@ interface OverviewData {
   has_data?: boolean;
   has_providers?: boolean;
 }
+
+type PivotedTimeseries = {
+  agents: string[];
+  timeseries: Array<Record<string, number | string>>;
+};
 
 const Overview: Component = () => {
   const params = useParams<{ agentName: string }>();
@@ -204,10 +219,114 @@ const Overview: Component = () => {
     ),
   );
 
-  const messageChartData = createMemo(() => {
-    const src = data()?.message_usage;
-    return src?.map((d) => ({ time: d.hour ?? d.date ?? '', value: d.count })) ?? [];
+  // ── Provider breakdown (per-agent, grouped by provider) ─────────────
+  const providerFilterKey = () => `agent-overview-providers:${params.agentName}`;
+  const loadSavedProviders = (): Set<string> => {
+    try {
+      const saved = sessionStorage.getItem(providerFilterKey());
+      if (saved) return new Set(JSON.parse(saved) as string[]);
+    } catch {
+      /* ignore */
+    }
+    return new Set();
+  };
+  const [selectedProviders, setSelectedProviders] = createSignal<Set<string>>(loadSavedProviders());
+  const [providerFilterOpen, setProviderFilterOpen] = createSignal(false);
+  let providerFilterRef: HTMLDivElement | undefined;
+  if (typeof document !== 'undefined') {
+    const onClickOutside = (e: MouseEvent) => {
+      if (providerFilterRef && !providerFilterRef.contains(e.target as Node))
+        setProviderFilterOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setProviderFilterOpen(false);
+    };
+    document.addEventListener('click', onClickOutside);
+    document.addEventListener('keydown', onKeyDown);
+    onCleanup(() => {
+      document.removeEventListener('click', onClickOutside);
+      document.removeEventListener('keydown', onKeyDown);
+    });
+  }
+
+  const tsKey = () => ({ range: range(), agent: params.agentName, _ping: messagePing() });
+  const [providerTokenTs] = createResource(tsKey, (p) =>
+    p.agent
+      ? (getPerProviderTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>)
+      : undefined,
+  );
+  const [providerMessageTs] = createResource(tsKey, (p) =>
+    p.agent
+      ? (getPerProviderMessageTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>)
+      : undefined,
+  );
+  const [providerCostTs] = createResource(tsKey, (p) =>
+    p.agent
+      ? (getPerProviderCostTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>)
+      : undefined,
+  );
+
+  const allProviders = createMemo(() => {
+    const set = new Set<string>([
+      ...(providerTokenTs()?.agents ?? []),
+      ...(providerMessageTs()?.agents ?? []),
+      ...(providerCostTs()?.agents ?? []),
+    ]);
+    return [...set].sort();
   });
+
+  const providerColorMap = createMemo(() => {
+    const map: Record<string, string> = {};
+    const list = allProviders();
+    for (let i = 0; i < list.length; i++) map[list[i]!] = AGENT_COLORS[i % AGENT_COLORS.length]!;
+    return map;
+  });
+
+  const effectiveSelected = () => {
+    const sel = selectedProviders();
+    if (sel.size === 0 && allProviders().length > 0) return new Set(allProviders());
+    return sel;
+  };
+  const selectedProviderCount = () => effectiveSelected().size;
+
+  const persistProviders = (next: Set<string>) => {
+    setSelectedProviders(next);
+    try {
+      sessionStorage.setItem(providerFilterKey(), JSON.stringify([...next]));
+    } catch {
+      /* ignore */
+    }
+  };
+  const toggleProvider = (provider: string) => {
+    const next = new Set(effectiveSelected());
+    if (next.has(provider)) next.delete(provider);
+    else next.add(provider);
+    persistProviders(next);
+  };
+  const setAllProviders = (on: boolean) =>
+    persistProviders(on ? new Set(allProviders()) : new Set<string>());
+
+  const filterTs = (raw: PivotedTimeseries | undefined): PivotedTimeseries | undefined => {
+    if (!raw) return undefined;
+    const sel = effectiveSelected();
+    if (sel.size === 0) return raw;
+    return {
+      agents: raw.agents.filter((a) => sel.has(a)),
+      timeseries: raw.timeseries.map((row) => {
+        const out: Record<string, number | string> = {};
+        for (const [k, v] of Object.entries(row)) {
+          if (k === 'hour' || k === 'date' || sel.has(k)) out[k] = v;
+        }
+        return out;
+      }),
+    };
+  };
+  const filteredTokenTs = createMemo(() => filterTs(providerTokenTs()));
+  const filteredMessageTs = createMemo(() => filterTs(providerMessageTs()));
+  const filteredCostTs = createMemo(() => filterTs(providerCostTs()));
+
+  const providerDisplayName = (provId: string): string =>
+    PROVIDERS.find((p) => p.id === provId)?.name ?? provId;
 
   return (
     <div class="container--lg">
@@ -218,8 +337,95 @@ const Overview: Component = () => {
         name="description"
         content={`Monitor ${agentDisplayName() ?? decodeURIComponent(params.agentName)} performance — costs, tokens, and activity.`}
       />
-      <div class="page-header">
+      <div class="page-header" style="justify-content: flex-end;">
         <div class="header-controls">
+          <Show when={showDashboard() && allProviders().length > 1}>
+            <div class="agent-filter-select" ref={providerFilterRef}>
+              <button
+                class="agent-filter-select__trigger"
+                onClick={() => setProviderFilterOpen(!providerFilterOpen())}
+                type="button"
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+                </svg>
+                {selectedProviderCount() === allProviders().length
+                  ? `All providers (${allProviders().length})`
+                  : `${selectedProviderCount()} of ${allProviders().length} providers`}
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="m6 9 6 6 6-6" />
+                </svg>
+              </button>
+              <Show when={providerFilterOpen()}>
+                <div class="agent-filter-select__dropdown">
+                  <div class="agent-filter-select__actions">
+                    <button
+                      class="agent-filter-select__action-btn"
+                      type="button"
+                      disabled={selectedProviderCount() === allProviders().length}
+                      onClick={() => setAllProviders(true)}
+                    >
+                      Select all
+                    </button>
+                    <button
+                      class="agent-filter-select__action-btn"
+                      type="button"
+                      disabled={selectedProviderCount() === 0}
+                      onClick={() => setAllProviders(false)}
+                    >
+                      Unselect all
+                    </button>
+                  </div>
+                  <For each={allProviders()}>
+                    {(provider) => {
+                      const isOn = () => effectiveSelected().has(provider);
+                      return (
+                        <button
+                          class="agent-filter-select__item"
+                          onClick={() => toggleProvider(provider)}
+                          type="button"
+                        >
+                          <span
+                            class="agent-filter-select__swatch"
+                            style={{ background: providerColorMap()[provider] }}
+                          />
+                          <span class="agent-filter-select__name">
+                            {providerDisplayName(provider)}
+                          </span>
+                          <span
+                            class="agent-filter-select__toggle"
+                            classList={{ 'agent-filter-select__toggle--on': isOn() }}
+                          >
+                            <span class="agent-filter-select__toggle-thumb" />
+                          </span>
+                        </button>
+                      );
+                    }}
+                  </For>
+                </div>
+              </Show>
+            </div>
+          </Show>
           <Show when={showDashboard()}>
             <Select
               value={range()}
@@ -304,7 +510,7 @@ const Overview: Component = () => {
                       </p>
                     </div>
                   </Show>
-                  <ChartCard
+                  <ProviderChartCard
                     activeView={activeView()}
                     onViewChange={setActiveView}
                     costValue={d().summary?.cost_today?.value ?? 0}
@@ -313,10 +519,12 @@ const Overview: Component = () => {
                     tokensTrendPct={d().summary?.tokens_today?.trend_pct ?? 0}
                     messagesValue={d().summary?.messages?.value ?? 0}
                     messagesTrendPct={d().summary?.messages?.trend_pct ?? 0}
-                    costUsage={d().cost_usage}
-                    tokenUsage={d().token_usage}
-                    messageChartData={messageChartData()}
+                    costInfoTooltip="Actual API key costs only. Subscription usage is not included."
                     range={range()}
+                    agentTimeseries={filteredTokenTs() ?? undefined}
+                    agentMessageTimeseries={filteredMessageTs() ?? undefined}
+                    agentCostTimeseries={filteredCostTs() ?? undefined}
+                    colorMap={providerColorMap()}
                   />
 
                   {/* Recent Messages */}

--- a/packages/frontend/src/services/api/analytics.ts
+++ b/packages/frontend/src/services/api/analytics.ts
@@ -126,10 +126,7 @@ export function getPerProviderMessageTimeseries(
   }) as PivotedTimeseries;
 }
 
-export function getPerProviderCostTimeseries(
-  agentName: string,
-  range = '24h',
-): PivotedTimeseries {
+export function getPerProviderCostTimeseries(agentName: string, range = '24h'): PivotedTimeseries {
   return fetchJson('/overview/per-provider-cost-timeseries', {
     agent_name: agentName,
     range,

--- a/packages/frontend/src/services/api/analytics.ts
+++ b/packages/frontend/src/services/api/analytics.ts
@@ -126,6 +126,16 @@ export function getPerProviderMessageTimeseries(
   }) as PivotedTimeseries;
 }
 
+export function getPerProviderCostTimeseries(
+  agentName: string,
+  range = '24h',
+): PivotedTimeseries {
+  return fetchJson('/overview/per-provider-cost-timeseries', {
+    agent_name: agentName,
+    range,
+  }) as PivotedTimeseries;
+}
+
 export function getRateLimits() {
   return fetchJson('/rate-limits');
 }

--- a/packages/frontend/tests/pages/Overview-limits.test.tsx
+++ b/packages/frontend/tests/pages/Overview-limits.test.tsx
@@ -1,76 +1,108 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@solidjs/testing-library';
 
-let mockAgentName = "test-agent";
-vi.mock("@solidjs/router", () => ({
+let mockAgentName = 'test-agent';
+vi.mock('@solidjs/router', () => ({
   useParams: () => ({ agentName: mockAgentName }),
   useLocation: () => ({ pathname: `/harnesses/${mockAgentName}`, state: null }),
   useNavigate: () => vi.fn(),
-  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
+  A: (props: any) => (
+    <a href={props.href} class={props.class}>
+      {props.children}
+    </a>
+  ),
 }));
 
-vi.mock("@solidjs/meta", () => ({
+vi.mock('@solidjs/meta', () => ({
   Title: (props: any) => <title>{props.children}</title>,
   Meta: () => null,
 }));
 
 const mockGetOverview = vi.fn();
-vi.mock("../../src/services/api.js", () => ({
+vi.mock('../../src/services/api.js', () => ({
   getOverview: (...args: unknown[]) => mockGetOverview(...args),
   getCustomProviders: vi.fn().mockResolvedValue([]),
 }));
 
-
-vi.mock("../../src/services/toast-store.js", () => ({
+vi.mock('../../src/services/toast-store.js', () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
-vi.mock("../../src/services/sse.js", () => ({
+vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
   messagePing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
 }));
 
-vi.mock("../../src/services/formatters.js", () => ({
+vi.mock('../../src/services/formatters.js', () => ({
   formatCost: (v: number) => `$${v.toFixed(2)}`,
   formatNumber: (v: number) => String(v),
   formatStatus: (s: string) => s,
   formatTime: (t: string) => t,
 }));
 
-vi.mock("../../src/services/routing-utils.js", () => ({
+vi.mock('../../src/services/routing-utils.js', () => ({
   inferProviderFromModel: () => null,
-  inferProviderName: () => "",
+  inferProviderName: () => '',
   stripCustomPrefix: (m: string) => m,
 }));
 
-vi.mock("../../src/components/ProviderIcon.jsx", () => ({
-  providerIcon: () => null, customProviderLogo: () => null,
+vi.mock('../../src/components/ProviderIcon.jsx', () => ({
+  providerIcon: () => null,
+  customProviderLogo: () => null,
 }));
 
-vi.mock("../../src/components/CostChart.jsx", () => ({ default: () => <div data-testid="cost-chart" /> }));
-vi.mock("../../src/components/TokenChart.jsx", () => ({ default: () => <div data-testid="token-chart" /> }));
-vi.mock("../../src/components/SingleTokenChart.jsx", () => ({ default: () => <div data-testid="single-token-chart" /> }));
-vi.mock("../../src/components/SetupModal.jsx", () => ({
-  default: (props: any) => <div data-testid="setup-modal" data-open={props.open ? "true" : "false"} />,
+vi.mock('../../src/components/CostChart.jsx', () => ({
+  default: () => <div data-testid="cost-chart" />,
 }));
-vi.mock("../../src/components/InfoTooltip.jsx", () => ({ default: () => <span data-testid="info-tooltip" /> }));
-vi.mock("../../src/components/Select.jsx", () => ({
+vi.mock('../../src/components/TokenChart.jsx', () => ({
+  default: () => <div data-testid="token-chart" />,
+}));
+vi.mock('../../src/components/SingleTokenChart.jsx', () => ({
+  default: () => <div data-testid="single-token-chart" />,
+}));
+// The per-agent Overview now renders ProviderChartCard → MultiAgentTokenChart
+// (uPlot) and fetches per-provider timeseries; stub both so jsdom doesn't load
+// the real chart (which calls matchMedia).
+vi.mock('../../src/services/api/analytics.js', () => ({
+  getPerProviderTimeseries: () => Promise.resolve({ agents: [], timeseries: [] }),
+  getPerProviderMessageTimeseries: () => Promise.resolve({ agents: [], timeseries: [] }),
+  getPerProviderCostTimeseries: () => Promise.resolve({ agents: [], timeseries: [] }),
+}));
+vi.mock('../../src/components/MultiAgentTokenChart.jsx', () => ({
+  AGENT_COLORS: ['#111111', '#222222'],
+  default: () => <div data-testid="multi-agent-chart" />,
+}));
+vi.mock('../../src/components/SetupModal.jsx', () => ({
   default: (props: any) => (
-    <select data-testid="select" value={props.value} onChange={(e: any) => props.onChange(e.target.value)}>
-      {props.options?.map((o: any) => <option value={o.value}>{o.label}</option>)}
+    <div data-testid="setup-modal" data-open={props.open ? 'true' : 'false'} />
+  ),
+}));
+vi.mock('../../src/components/InfoTooltip.jsx', () => ({
+  default: () => <span data-testid="info-tooltip" />,
+}));
+vi.mock('../../src/components/Select.jsx', () => ({
+  default: (props: any) => (
+    <select
+      data-testid="select"
+      value={props.value}
+      onChange={(e: any) => props.onChange(e.target.value)}
+    >
+      {props.options?.map((o: any) => (
+        <option value={o.value}>{o.label}</option>
+      ))}
     </select>
   ),
 }));
 
-vi.mock("../../src/services/recent-agents.js", () => ({
+vi.mock('../../src/services/recent-agents.js', () => ({
   isRecentlyCreated: () => false,
   isSetupPending: () => false,
   clearSetupPending: vi.fn(),
 }));
 
-import Overview from "../../src/pages/Overview";
+import Overview from '../../src/pages/Overview';
 
 const overviewData = {
   summary: {
@@ -79,24 +111,34 @@ const overviewData = {
     messages: { value: 42, trend_pct: 8 },
     services_hit: { total: 3, healthy: 3, issues: 0 },
   },
-  token_usage: [{ hour: "2026-02-18 10:00:00", input_tokens: 1000, output_tokens: 500 }],
-  cost_usage: [{ hour: "2026-02-18 10:00:00", cost: 0.5 }],
-  message_usage: [{ hour: "2026-02-18 10:00:00", count: 5 }],
+  token_usage: [{ hour: '2026-02-18 10:00:00', input_tokens: 1000, output_tokens: 500 }],
+  cost_usage: [{ hour: '2026-02-18 10:00:00', cost: 0.5 }],
+  message_usage: [{ hour: '2026-02-18 10:00:00', count: 5 }],
   cost_by_model: [],
   recent_activity: [
-    { id: "msg-12345678", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "gpt-4o", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok" },
+    {
+      id: 'msg-12345678',
+      timestamp: '2026-02-18T10:00:00Z',
+      agent_name: 'test-agent',
+      model: 'gpt-4o',
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      cost: 0.01,
+      status: 'ok',
+    },
   ],
   has_data: true,
 };
 
-describe("Overview - trend badges and status display", () => {
+describe('Overview - trend badges and status display', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
-    mockAgentName = "test-agent";
+    mockAgentName = 'test-agent';
   });
 
-  it("does not render trend badge when trend_pct is 0", async () => {
+  it('does not render trend badge when trend_pct is 0', async () => {
     const zeroTrendData = {
       ...overviewData,
       summary: {
@@ -109,79 +151,83 @@ describe("Overview - trend badges and status display", () => {
     mockGetOverview.mockResolvedValue(zeroTrendData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("$3.50");
+      expect(container.textContent).toContain('$3.50');
     });
-    const trendBadges = container.querySelectorAll(".trend");
+    const trendBadges = container.querySelectorAll('.trend');
     expect(trendBadges.length).toBe(0);
   });
 
-  it("renders rate_limited status as a link to the limits page", async () => {
+  it('renders rate_limited status as a link to the limits page', async () => {
     const rateLimitedData = {
       ...overviewData,
-      recent_activity: [{
-        id: "msg-ratelimit1",
-        timestamp: "2026-02-18T10:00:00Z",
-        agent_name: "test-agent",
-        model: null,
-        input_tokens: 0,
-        output_tokens: 0,
-        total_tokens: null,
-        cost: null,
-        status: "rate_limited",
-      }],
+      recent_activity: [
+        {
+          id: 'msg-ratelimit1',
+          timestamp: '2026-02-18T10:00:00Z',
+          agent_name: 'test-agent',
+          model: null,
+          input_tokens: 0,
+          output_tokens: 0,
+          total_tokens: null,
+          cost: null,
+          status: 'rate_limited',
+        },
+      ],
     };
     mockGetOverview.mockResolvedValue(rateLimitedData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("rate_limited");
+      expect(container.textContent).toContain('rate_limited');
     });
     const link = container.querySelector('.status-badge--rate_limited a');
     expect(link).not.toBeNull();
-    expect(link?.getAttribute("href")).toContain("/limits");
+    expect(link?.getAttribute('href')).toContain('/limits');
   });
 
-  it("renders routing tier badge when routing_tier is set", async () => {
+  it('renders routing tier badge when routing_tier is set', async () => {
     const routedData = {
       ...overviewData,
-      recent_activity: [{
-        ...overviewData.recent_activity[0],
-        routing_tier: "complex",
-      }],
+      recent_activity: [
+        {
+          ...overviewData.recent_activity[0],
+          routing_tier: 'complex',
+        },
+      ],
     };
     mockGetOverview.mockResolvedValue(routedData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const tierBadge = container.querySelector(".tier-badge--complex");
+      const tierBadge = container.querySelector('.tier-badge--complex');
       expect(tierBadge).not.toBeNull();
-      expect(tierBadge?.textContent).toBe("complex");
+      expect(tierBadge?.textContent).toBe('complex');
     });
   });
 
-  it("renders negative cost trend with down-good class (inverted)", async () => {
+  it('renders the negative cost trend badge on the chart card', async () => {
+    // ProviderChartCard renders neutral trend badges (no inverted up-bad /
+    // down-good styling).
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const downTrend = container.querySelector(".trend--down-good");
-      expect(downTrend).not.toBeNull();
-      expect(downTrend?.textContent).toContain("-5%");
+      const badges = Array.from(container.querySelectorAll('.trend--neutral'));
+      expect(badges.some((b) => b.textContent?.includes('-5%'))).toBe(true);
     });
   });
 
-  it("renders positive token trend with up-bad class (inverted)", async () => {
+  it('renders the positive token trend badge on the chart card', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const upTrend = container.querySelector(".trend--up-bad");
-      expect(upTrend).not.toBeNull();
-      expect(upTrend?.textContent).toContain("+12%");
+      const badges = Array.from(container.querySelectorAll('.trend--neutral'));
+      expect(badges.some((b) => b.textContent?.includes('+12%'))).toBe(true);
     });
   });
 
-  it("renders status-specific class on status badge", async () => {
+  it('renders status-specific class on status badge', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.querySelector(".status-badge--ok")).not.toBeNull();
+      expect(container.querySelector('.status-badge--ok')).not.toBeNull();
     });
   });
 });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -89,6 +89,8 @@ vi.mock('../../src/components/MultiAgentTokenChart.jsx', () => ({
     <div
       data-testid="multi-agent-chart"
       data-series={((props.agents ?? []) as string[]).join(',')}
+      data-range={props.range}
+      data-colors={Object.keys(props.colorMap ?? {}).length}
     />
   ),
 }));
@@ -440,6 +442,13 @@ describe('Overview', () => {
       const active = container.querySelector('.chart-card__stat--active');
       expect(active?.textContent).toContain('Messages');
     });
+
+    fireEvent.click(stats[2]); // tokens — renders the token-view chart
+    await vi.waitFor(() => {
+      const active = container.querySelector('.chart-card__stat--active');
+      expect(active?.textContent).toContain('Token usage');
+      expect(container.querySelector('[data-testid="multi-agent-chart"]')).not.toBeNull();
+    });
   });
 
   it('renders the provider multiselect and filters chart series', async () => {
@@ -476,6 +485,63 @@ describe('Overview', () => {
     await vi.waitFor(() => {
       expect(container.textContent).toContain('All providers (2)');
     });
+  });
+
+  it('re-adds a provider when toggled back on, and closes the dropdown on Escape', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['anthropic', 'openai'],
+      timeseries: [{ hour: '1', anthropic: 3, openai: 5 }],
+    });
+    const { container, getByText } = render(() => <Overview />);
+    await vi.waitFor(() => expect(container.textContent).toContain('All providers (2)'));
+
+    fireEvent.click(container.querySelector('.agent-filter-select__trigger')!);
+    // Toggle anthropic off (delete branch), then on again (add branch).
+    fireEvent.click(getByText('Anthropic'));
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="multi-agent-chart"]')?.getAttribute('data-series'),
+      ).toBe('openai');
+    });
+    fireEvent.click(getByText('Anthropic'));
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="multi-agent-chart"]')?.getAttribute('data-series'),
+      ).toBe('anthropic,openai');
+    });
+
+    // Escape closes the open dropdown.
+    expect(container.querySelector('.agent-filter-select__dropdown')).not.toBeNull();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await vi.waitFor(() => {
+      expect(container.querySelector('.agent-filter-select__dropdown')).toBeNull();
+    });
+  });
+
+  it('survives sessionStorage failures when loading and persisting the provider filter', async () => {
+    // Corrupt saved value → load catch; setItem throwing → persist catch.
+    sessionStorage.setItem('agent-overview-providers:test-agent', 'not-json{');
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['anthropic', 'openai'],
+      timeseries: [{ hour: '1', anthropic: 3, openai: 5 }],
+    });
+    const { container, getByText } = render(() => <Overview />);
+    await vi.waitFor(() => expect(container.textContent).toContain('All providers (2)'));
+
+    // Toggling persists → setItem throws → caught, no crash, filter still applies.
+    fireEvent.click(container.querySelector('.agent-filter-select__trigger')!);
+    fireEvent.click(getByText('Anthropic'));
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="multi-agent-chart"]')?.getAttribute('data-series'),
+      ).toBe('openai');
+    });
+    setItemSpy.mockRestore();
   });
 
   it('shows View more link to messages page', async () => {

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -1,50 +1,53 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
 
-let mockAgentName = "test-agent";
+let mockAgentName = 'test-agent';
 let mockLocationState: any = null;
 const mockNavigate = vi.fn();
-vi.mock("@solidjs/router", () => ({
+vi.mock('@solidjs/router', () => ({
   useParams: () => ({ agentName: mockAgentName }),
   useLocation: () => ({ pathname: `/harnesses/${mockAgentName}`, state: mockLocationState }),
   useNavigate: () => mockNavigate,
-  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
+  A: (props: any) => (
+    <a href={props.href} class={props.class}>
+      {props.children}
+    </a>
+  ),
 }));
 
-vi.mock("@solidjs/meta", () => ({
+vi.mock('@solidjs/meta', () => ({
   Title: (props: any) => <title>{props.children}</title>,
-  Meta: (props: any) => <meta name={props.name ?? ""} content={props.content ?? ""} />,
+  Meta: (props: any) => <meta name={props.name ?? ''} content={props.content ?? ''} />,
 }));
 
 const mockGetOverview = vi.fn();
 const mockGetCustomProviders = vi.fn();
 const mockSetMessageFeedback = vi.fn();
 const mockClearMessageFeedback = vi.fn();
-vi.mock("../../src/services/api.js", () => ({
+vi.mock('../../src/services/api.js', () => ({
   getOverview: (...args: unknown[]) => mockGetOverview(...args),
   getCustomProviders: (...args: unknown[]) => mockGetCustomProviders(...args),
   setMessageFeedback: (...args: unknown[]) => mockSetMessageFeedback(...args),
   clearMessageFeedback: (...args: unknown[]) => mockClearMessageFeedback(...args),
 }));
 
-
-vi.mock("../../src/services/sse.js", () => ({
+vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
   messagePing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
 }));
 
-vi.mock("../../src/services/toast-store.js", () => ({
+vi.mock('../../src/services/toast-store.js', () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
-vi.mock("../../src/services/model-display.js", () => ({
-  getModelDisplayName: (slug: string) => slug.replace(/^custom:[^/]+\//, ""),
+vi.mock('../../src/services/model-display.js', () => ({
+  getModelDisplayName: (slug: string) => slug.replace(/^custom:[^/]+\//, ''),
   preloadModelDisplayNames: () => {},
 }));
 
-vi.mock("../../src/services/formatters.js", () => ({
+vi.mock('../../src/services/formatters.js', () => ({
   formatCost: (v: number) => `$${v.toFixed(2)}`,
   formatNumber: (v: number) => String(v),
   formatStatus: (s: string) => s,
@@ -54,57 +57,92 @@ vi.mock("../../src/services/formatters.js", () => ({
 }));
 
 const mockCheckIsSelfHosted = vi.fn(() => Promise.resolve(false));
-vi.mock("../../src/services/setup-status.js", () => ({
+vi.mock('../../src/services/setup-status.js', () => ({
   checkIsSelfHosted: () => mockCheckIsSelfHosted(),
 }));
 
-vi.mock("../../src/components/CostChart.jsx", () => ({
+vi.mock('../../src/components/CostChart.jsx', () => ({
   default: () => <div data-testid="cost-chart" />,
 }));
 
-vi.mock("../../src/components/TokenChart.jsx", () => ({
+vi.mock('../../src/components/TokenChart.jsx', () => ({
   default: () => <div data-testid="token-chart" />,
 }));
 
-vi.mock("../../src/components/SingleTokenChart.jsx", () => ({
+vi.mock('../../src/components/SingleTokenChart.jsx', () => ({
   default: () => <div data-testid="single-token-chart" />,
 }));
 
+// The per-agent Overview renders ProviderChartCard → MultiAgentTokenChart and
+// fetches three per-provider timeseries. Stub the chart to a marker exposing
+// its series, and the API to a controllable resolver.
+const mockPerProvider = vi.fn(() => Promise.resolve({ agents: [], timeseries: [] }));
+vi.mock('../../src/services/api/analytics.js', () => ({
+  getPerProviderTimeseries: (...a: unknown[]) => mockPerProvider(...a),
+  getPerProviderMessageTimeseries: (...a: unknown[]) => mockPerProvider(...a),
+  getPerProviderCostTimeseries: (...a: unknown[]) => mockPerProvider(...a),
+}));
 
-vi.mock("../../src/components/FeedbackModal.jsx", () => ({
+vi.mock('../../src/components/MultiAgentTokenChart.jsx', () => ({
+  AGENT_COLORS: ['#111111', '#222222', '#333333'],
   default: (props: any) => (
-    <div data-testid="feedback-modal" data-open={props.open ? "true" : "false"}>
-      <button data-testid="feedback-submit" onClick={() => props.onSubmit?.(['Too slow'], 'test')}>Submit</button>
-      <button data-testid="feedback-close" onClick={() => props.onClose?.()}>Close</button>
+    <div
+      data-testid="multi-agent-chart"
+      data-series={((props.agents ?? []) as string[]).join(',')}
+    />
+  ),
+}));
+
+vi.mock('../../src/components/FeedbackModal.jsx', () => ({
+  default: (props: any) => (
+    <div data-testid="feedback-modal" data-open={props.open ? 'true' : 'false'}>
+      <button data-testid="feedback-submit" onClick={() => props.onSubmit?.(['Too slow'], 'test')}>
+        Submit
+      </button>
+      <button data-testid="feedback-close" onClick={() => props.onClose?.()}>
+        Close
+      </button>
     </div>
   ),
 }));
 
-vi.mock("../../src/components/SetupModal.jsx", () => ({
+vi.mock('../../src/components/SetupModal.jsx', () => ({
   default: (props: any) => (
     <div
       data-testid="setup-modal"
-      data-open={props.open ? "true" : "false"}
-      data-agent={props.agentName ?? ""}
-      data-api-key={props.apiKey ?? ""}
-      data-platform={props.agentPlatform ?? ""}
-      data-category={props.agentCategory ?? ""}
+      data-open={props.open ? 'true' : 'false'}
+      data-agent={props.agentName ?? ''}
+      data-api-key={props.apiKey ?? ''}
+      data-platform={props.agentPlatform ?? ''}
+      data-category={props.agentCategory ?? ''}
     >
-      <button data-testid="setup-close" onClick={() => props.onClose?.()}>Close</button>
-      <button data-testid="setup-done" onClick={() => props.onDone?.()}>Done</button>
-      <button data-testid="setup-go-routing" onClick={() => props.onGoToRouting?.()}>Go to routing</button>
+      <button data-testid="setup-close" onClick={() => props.onClose?.()}>
+        Close
+      </button>
+      <button data-testid="setup-done" onClick={() => props.onDone?.()}>
+        Done
+      </button>
+      <button data-testid="setup-go-routing" onClick={() => props.onGoToRouting?.()}>
+        Go to routing
+      </button>
     </div>
   ),
 }));
 
-vi.mock("../../src/components/InfoTooltip.jsx", () => ({
+vi.mock('../../src/components/InfoTooltip.jsx', () => ({
   default: () => <span data-testid="info-tooltip" />,
 }));
 
-vi.mock("../../src/components/Select.jsx", () => ({
+vi.mock('../../src/components/Select.jsx', () => ({
   default: (props: any) => (
-    <select data-testid="select" value={props.value} onChange={(e: any) => props.onChange(e.target.value)}>
-      {props.options?.map((o: any) => <option value={o.value}>{o.label}</option>)}
+    <select
+      data-testid="select"
+      value={props.value}
+      onChange={(e: any) => props.onChange(e.target.value)}
+    >
+      {props.options?.map((o: any) => (
+        <option value={o.value}>{o.label}</option>
+      ))}
     </select>
   ),
 }));
@@ -112,13 +150,13 @@ vi.mock("../../src/components/Select.jsx", () => ({
 const mockIsRecentlyCreated = vi.fn(() => false);
 const mockIsSetupPending = vi.fn(() => false);
 const mockClearSetupPending = vi.fn();
-vi.mock("../../src/services/recent-agents.js", () => ({
+vi.mock('../../src/services/recent-agents.js', () => ({
   isRecentlyCreated: (...args: unknown[]) => mockIsRecentlyCreated(...args),
   isSetupPending: (...args: unknown[]) => mockIsSetupPending(...args),
   clearSetupPending: (...args: unknown[]) => mockClearSetupPending(...args),
 }));
 
-import Overview from "../../src/pages/Overview";
+import Overview from '../../src/pages/Overview';
 
 const overviewData = {
   summary: {
@@ -127,15 +165,31 @@ const overviewData = {
     messages: { value: 42, trend_pct: 8 },
     services_hit: { total: 3, healthy: 3, issues: 0 },
   },
-  token_usage: [{ hour: "2026-02-18 10:00:00", input_tokens: 1000, output_tokens: 500 }],
-  cost_usage: [{ hour: "2026-02-18 10:00:00", cost: 0.5 }],
-  message_usage: [{ hour: "2026-02-18 10:00:00", count: 5 }],
+  token_usage: [{ hour: '2026-02-18 10:00:00', input_tokens: 1000, output_tokens: 500 }],
+  cost_usage: [{ hour: '2026-02-18 10:00:00', cost: 0.5 }],
+  message_usage: [{ hour: '2026-02-18 10:00:00', count: 5 }],
   cost_by_model: [
-    { model: "gpt-4o", tokens: 30000, share_pct: 60, estimated_cost: 2.1, auth_type: "api_key" },
-    { model: "claude-3.5-sonnet", tokens: 20000, share_pct: 40, estimated_cost: 1.4, auth_type: "subscription" },
+    { model: 'gpt-4o', tokens: 30000, share_pct: 60, estimated_cost: 2.1, auth_type: 'api_key' },
+    {
+      model: 'claude-3.5-sonnet',
+      tokens: 20000,
+      share_pct: 40,
+      estimated_cost: 1.4,
+      auth_type: 'subscription',
+    },
   ],
   recent_activity: [
-    { id: "msg-12345678", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "gpt-4o", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok" },
+    {
+      id: 'msg-12345678',
+      timestamp: '2026-02-18T10:00:00Z',
+      agent_name: 'test-agent',
+      model: 'gpt-4o',
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      cost: 0.01,
+      status: 'ok',
+    },
   ],
   has_data: true,
 };
@@ -156,24 +210,26 @@ const emptyOverviewData = {
   has_providers: false,
 };
 
-describe("Overview", () => {
+describe('Overview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    sessionStorage.clear();
     mockIsRecentlyCreated.mockReturnValue(false);
     mockIsSetupPending.mockReturnValue(false);
-    mockAgentName = "test-agent";
+    mockAgentName = 'test-agent';
     mockLocationState = null;
     mockGetCustomProviders.mockResolvedValue([]);
+    mockPerProvider.mockResolvedValue({ agents: [], timeseries: [] });
   });
 
-  it("renders Overview heading with agent name", () => {
+  it('renders Overview heading with agent name', () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
-    expect(container.textContent).toContain("Overview");
+    expect(container.textContent).toContain('Overview');
   });
 
-  it("does not render duplicate agent-name H1 or breadcrumb subtitle (AgentDetail owns the H1)", () => {
+  it('does not render duplicate agent-name H1 or breadcrumb subtitle (AgentDetail owns the H1)', () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     // The breadcrumb "Real-time summary…" must no longer be rendered inside Overview,
@@ -183,51 +239,51 @@ describe("Overview", () => {
     expect(container.querySelector('h1')).toBeNull();
   });
 
-  it("shows loading skeleton while fetching", () => {
+  it('shows loading skeleton while fetching', () => {
     mockGetOverview.mockReturnValue(new Promise(() => {}));
     const { container } = render(() => <Overview />);
-    const skeletons = container.querySelectorAll(".skeleton");
+    const skeletons = container.querySelectorAll('.skeleton');
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it("keeps showing stale data during refetch instead of skeletons", async () => {
+  it('keeps showing stale data during refetch instead of skeletons', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("$3.50");
+      expect(container.textContent).toContain('$3.50');
     });
 
     // Trigger a refetch that never resolves
     mockGetOverview.mockReturnValue(new Promise(() => {}));
     const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
-    await fireEvent.change(select, { target: { value: "24h" } });
+    await fireEvent.change(select, { target: { value: '24h' } });
 
     // Should still show old data, not skeletons
-    expect(container.textContent).toContain("$3.50");
-    expect(container.querySelectorAll(".skeleton").length).toBe(0);
+    expect(container.textContent).toContain('$3.50');
+    expect(container.querySelectorAll('.skeleton').length).toBe(0);
   });
 
-  it("shows summary stats after data loads", async () => {
+  it('shows summary stats after data loads', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("$3.50");
-      expect(container.textContent).toContain("50000");
-      expect(container.textContent).toContain("42");
+      expect(container.textContent).toContain('$3.50');
+      expect(container.textContent).toContain('50000');
+      expect(container.textContent).toContain('42');
     });
   });
 
-  it("shows trend badges with percentages", async () => {
+  it('shows trend badges with percentages', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("+12%");
-      expect(container.textContent).toContain("-5%");
-      expect(container.textContent).toContain("+8%");
+      expect(container.textContent).toContain('+12%');
+      expect(container.textContent).toContain('-5%');
+      expect(container.textContent).toContain('+8%');
     });
   });
 
-  it("hides trend badges when metric values are zero", async () => {
+  it('hides trend badges when metric values are zero', async () => {
     const zeroData = {
       ...overviewData,
       summary: {
@@ -240,13 +296,13 @@ describe("Overview", () => {
     mockGetOverview.mockResolvedValue(zeroData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("$0.00");
-      const trends = container.querySelectorAll(".trend");
+      expect(container.textContent).toContain('$0.00');
+      const trends = container.querySelectorAll('.trend');
       expect(trends.length).toBe(0);
     });
   });
 
-  it("clamps absurdly large trend percentages", async () => {
+  it('clamps absurdly large trend percentages', async () => {
     const absurdData = {
       ...overviewData,
       summary: {
@@ -257,78 +313,90 @@ describe("Overview", () => {
     mockGetOverview.mockResolvedValue(absurdData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("+999%");
-      expect(container.textContent).not.toContain("5000000%");
+      expect(container.textContent).toContain('+999%');
+      expect(container.textContent).not.toContain('5000000%');
     });
   });
 
-  it("shows recent messages table", async () => {
+  it('shows recent messages table', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Recent Messages");
-      expect(container.textContent).toContain("msg-1234");
-      expect(container.textContent).toContain("gpt-4o");
+      expect(container.textContent).toContain('Recent Messages');
+      expect(container.textContent).toContain('msg-1234');
+      expect(container.textContent).toContain('gpt-4o');
     });
   });
 
-  it("shows cost by model table", async () => {
+  it('shows cost by model table', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Cost by Model");
-      expect(container.textContent).toContain("gpt-4o");
-      expect(container.textContent).toContain("claude-3.5-sonnet");
-      expect(container.textContent).toContain("60%");
+      expect(container.textContent).toContain('Cost by Model');
+      expect(container.textContent).toContain('gpt-4o');
+      expect(container.textContent).toContain('claude-3.5-sonnet');
+      expect(container.textContent).toContain('60%');
     });
   });
 
-  it("sorts cost by model rows by estimated_cost descending", async () => {
+  it('sorts cost by model rows by estimated_cost descending', async () => {
     const data = {
       ...overviewData,
       cost_by_model: [
-        { model: "claude-3.5-sonnet", tokens: 20000, share_pct: 40, estimated_cost: 1.4, auth_type: "subscription" },
-        { model: "gpt-4o", tokens: 30000, share_pct: 60, estimated_cost: 2.1, auth_type: "api_key" },
+        {
+          model: 'claude-3.5-sonnet',
+          tokens: 20000,
+          share_pct: 40,
+          estimated_cost: 1.4,
+          auth_type: 'subscription',
+        },
+        {
+          model: 'gpt-4o',
+          tokens: 30000,
+          share_pct: 60,
+          estimated_cost: 2.1,
+          auth_type: 'api_key',
+        },
       ],
     };
     mockGetOverview.mockResolvedValue(data);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const panels = container.querySelectorAll(".panel");
+      const panels = container.querySelectorAll('.panel');
       // Find the Cost by Model panel
-      const costPanel = Array.from(panels).find(p => p.textContent?.includes("Cost by Model"));
+      const costPanel = Array.from(panels).find((p) => p.textContent?.includes('Cost by Model'));
       expect(costPanel).toBeDefined();
-      const rows = costPanel!.querySelectorAll("tbody tr");
+      const rows = costPanel!.querySelectorAll('tbody tr');
       expect(rows.length).toBe(2);
       // gpt-4o ($2.1) should come before claude ($1.4) even though claude is first in data
-      expect(rows[0].textContent).toContain("gpt-4o");
-      expect(rows[1].textContent).toContain("claude-3.5-sonnet");
+      expect(rows[0].textContent).toContain('gpt-4o');
+      expect(rows[1].textContent).toContain('claude-3.5-sonnet');
     });
   });
 
-  it("renders auth badges on cost by model provider icons", async () => {
+  it('renders auth badges on cost by model provider icons', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const panels = container.querySelectorAll(".panel");
-      const costPanel = Array.from(panels).find(p => p.textContent?.includes("Cost by Model"));
+      const panels = container.querySelectorAll('.panel');
+      const costPanel = Array.from(panels).find((p) => p.textContent?.includes('Cost by Model'));
       expect(costPanel).toBeDefined();
-      const keyBadge = costPanel!.querySelector(".provider-auth-badge--key");
-      const subBadge = costPanel!.querySelector(".provider-auth-badge--sub");
+      const keyBadge = costPanel!.querySelector('.provider-auth-badge--key');
+      const subBadge = costPanel!.querySelector('.provider-auth-badge--sub');
       expect(keyBadge).not.toBeNull();
       expect(subBadge).not.toBeNull();
     });
   });
 
-  it("shows empty state for new agent with no data", async () => {
+  it('shows empty state for new agent with no data', async () => {
     mockGetOverview.mockResolvedValue(emptyOverviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("No activity yet");
+      expect(container.textContent).toContain('No activity yet');
     });
   });
 
-  it("calls getOverview on mount", async () => {
+  it('calls getOverview on mount', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     render(() => <Overview />);
     await vi.waitFor(() => {
@@ -336,105 +404,191 @@ describe("Overview", () => {
     });
   });
 
-  it("has clickable stat headers for cost, tokens and messages", async () => {
+  it('has clickable stat headers for cost, tokens and messages', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const clickable = container.querySelectorAll(".chart-card__stat--clickable");
+      const clickable = container.querySelectorAll('.chart-card__stat--clickable');
       expect(clickable.length).toBe(3);
     });
   });
 
-  it("switches chart view when stat header clicked", async () => {
+  it('switches chart view when stat header clicked', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['openai'],
+      timeseries: [{ hour: '1', openai: 5 }],
+    });
     const { container } = render(() => <Overview />);
+    // ProviderChartCard renders the multi-provider chart for every view; the
+    // active stat reflects the selection. Stat order is Cost / Messages / Tokens.
     await vi.waitFor(() => {
-      expect(container.querySelector('[data-testid="single-token-chart"]')).not.toBeNull();
+      expect(container.querySelector('[data-testid="multi-agent-chart"]')).not.toBeNull();
     });
 
-    // Click cost stat
-    const stats = container.querySelectorAll(".chart-card__stat--clickable");
-    fireEvent.click(stats[1]); // cost
+    const stats = container.querySelectorAll('.chart-card__stat--clickable');
+    expect(stats.length).toBe(3);
+
+    fireEvent.click(stats[0]); // cost
     await vi.waitFor(() => {
-      expect(container.querySelector('[data-testid="cost-chart"]')).not.toBeNull();
+      const active = container.querySelector('.chart-card__stat--active');
+      expect(active?.textContent).toContain('Cost');
     });
 
-    // Click tokens stat
-    fireEvent.click(stats[2]); // tokens
+    fireEvent.click(stats[1]); // messages
     await vi.waitFor(() => {
-      expect(container.querySelector('[data-testid="token-chart"]')).not.toBeNull();
+      const active = container.querySelector('.chart-card__stat--active');
+      expect(active?.textContent).toContain('Messages');
     });
   });
 
-  it("shows View more link to messages page", async () => {
+  it('renders the provider multiselect and filters chart series', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['anthropic', 'openai'],
+      timeseries: [{ hour: '1', anthropic: 3, openai: 5 }],
+    });
+    const { container, getByText } = render(() => <Overview />);
+
+    // Provider multiselect appears (2 providers) and the chart shows both series.
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('All providers (2)');
+      const chart = container.querySelector('[data-testid="multi-agent-chart"]');
+      expect(chart?.getAttribute('data-series')).toBe('anthropic,openai');
+    });
+
+    // No explicit selection means "all"; toggling a provider off filters it out.
+    fireEvent.click(container.querySelector('.agent-filter-select__trigger')!);
+    fireEvent.click(getByText('Anthropic'));
+    await vi.waitFor(() => {
+      const chart = container.querySelector('[data-testid="multi-agent-chart"]');
+      expect(chart?.getAttribute('data-series')).toBe('openai');
+    });
+    expect(container.textContent).toContain('1 of 2 providers');
+
+    // "Select all" restores every series; "Unselect all" resets to the all state.
+    fireEvent.click(getByText('Select all'));
+    await vi.waitFor(() => {
+      const chart = container.querySelector('[data-testid="multi-agent-chart"]');
+      expect(chart?.getAttribute('data-series')).toBe('anthropic,openai');
+    });
+    fireEvent.click(getByText('Unselect all'));
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('All providers (2)');
+    });
+  });
+
+  it('shows View more link to messages page', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
       const link = container.querySelector('a.view-more-link') as HTMLAnchorElement;
       expect(link).not.toBeNull();
-      expect(link.getAttribute("href")).toBe("/harnesses/test-agent/messages");
+      expect(link.getAttribute('href')).toBe('/harnesses/test-agent/messages');
     });
   });
 
-  describe("error tooltip", () => {
-    it("shows tooltip when error_message is present on a failed row", async () => {
+  describe('error tooltip', () => {
+    it('shows tooltip when error_message is present on a failed row', async () => {
       const dataWithError = {
         ...overviewData,
         recent_activity: [
-          { id: "msg-err12345", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "gpt-4o", input_tokens: 0, output_tokens: 0, total_tokens: 0, cost: 0, status: "error", error_message: "401 Unauthorized: invalid API key" },
+          {
+            id: 'msg-err12345',
+            timestamp: '2026-02-18T10:00:00Z',
+            agent_name: 'test-agent',
+            model: 'gpt-4o',
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            cost: 0,
+            status: 'error',
+            error_message: '401 Unauthorized: invalid API key',
+          },
         ],
       };
       mockGetOverview.mockResolvedValue(dataWithError);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        const tooltip = container.querySelector(".status-badge-tooltip");
+        const tooltip = container.querySelector('.status-badge-tooltip');
         expect(tooltip).not.toBeNull();
-        const bubble = container.querySelector(".status-badge-tooltip__bubble");
+        const bubble = container.querySelector('.status-badge-tooltip__bubble');
         expect(bubble).not.toBeNull();
-        expect(bubble!.textContent).toBe("401 Unauthorized: invalid API key");
+        expect(bubble!.textContent).toBe('401 Unauthorized: invalid API key');
       });
     });
 
-    it("does not show tooltip when error_message is absent", async () => {
+    it('does not show tooltip when error_message is absent', async () => {
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("msg-1234");
-        const tooltip = container.querySelector(".status-badge-tooltip");
+        expect(container.textContent).toContain('msg-1234');
+        const tooltip = container.querySelector('.status-badge-tooltip');
         expect(tooltip).toBeNull();
       });
     });
 
-    it("sets aria-label on the tooltip wrapper", async () => {
+    it('sets aria-label on the tooltip wrapper', async () => {
       const dataWithError = {
         ...overviewData,
         recent_activity: [
-          { id: "msg-err99999", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "gpt-4o", input_tokens: 0, output_tokens: 0, total_tokens: 0, cost: 0, status: "error", error_message: "timeout" },
+          {
+            id: 'msg-err99999',
+            timestamp: '2026-02-18T10:00:00Z',
+            agent_name: 'test-agent',
+            model: 'gpt-4o',
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            cost: 0,
+            status: 'error',
+            error_message: 'timeout',
+          },
         ],
       };
       mockGetOverview.mockResolvedValue(dataWithError);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        const tooltip = container.querySelector(".status-badge-tooltip");
-        expect(tooltip?.getAttribute("aria-label")).toBe("timeout");
+        const tooltip = container.querySelector('.status-badge-tooltip');
+        expect(tooltip?.getAttribute('aria-label')).toBe('timeout');
       });
     });
   });
 
-  describe("custom provider models", () => {
+  describe('custom provider models', () => {
     // The backend resolves the custom provider's name into each row
     // (`custom_provider_name`); the page no longer fetches the list itself.
     const customOverview = {
       ...overviewData,
       recent_activity: [
-        { id: "msg-cp1", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "custom:abc-123/my-llama", provider: "custom:abc-123", custom_provider_name: "Cerebras", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok" },
+        {
+          id: 'msg-cp1',
+          timestamp: '2026-02-18T10:00:00Z',
+          agent_name: 'test-agent',
+          model: 'custom:abc-123/my-llama',
+          provider: 'custom:abc-123',
+          custom_provider_name: 'Cerebras',
+          input_tokens: 100,
+          output_tokens: 50,
+          total_tokens: 150,
+          cost: 0.01,
+          status: 'ok',
+        },
       ],
       cost_by_model: [
-        { model: "custom:abc-123/my-llama", provider: "custom:abc-123", custom_provider_name: "Cerebras", tokens: 30000, share_pct: 100, estimated_cost: 2.1, auth_type: "api_key" },
+        {
+          model: 'custom:abc-123/my-llama',
+          provider: 'custom:abc-123',
+          custom_provider_name: 'Cerebras',
+          tokens: 30000,
+          share_pct: 100,
+          estimated_cost: 2.1,
+          auth_type: 'api_key',
+        },
       ],
     };
 
-    it("renders custom provider icon in recent messages", async () => {
+    it('renders custom provider icon in recent messages', async () => {
       mockGetOverview.mockResolvedValue(customOverview);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
@@ -443,16 +597,16 @@ describe("Overview", () => {
       });
     });
 
-    it("strips custom prefix from model name display", async () => {
+    it('strips custom prefix from model name display', async () => {
       mockGetOverview.mockResolvedValue(customOverview);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("my-llama");
-        expect(container.textContent).not.toContain("custom:abc-123/");
+        expect(container.textContent).toContain('my-llama');
+        expect(container.textContent).not.toContain('custom:abc-123/');
       });
     });
 
-    it("renders custom provider icon in cost by model table", async () => {
+    it('renders custom provider icon in cost by model table', async () => {
       mockGetOverview.mockResolvedValue(customOverview);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
@@ -462,63 +616,59 @@ describe("Overview", () => {
       });
     });
 
-    it("falls back to model prefix when custom provider was deleted", async () => {
+    it('falls back to model prefix when custom provider was deleted', async () => {
       const deletedProvider = {
         ...customOverview,
-        recent_activity: [
-          { ...customOverview.recent_activity[0], custom_provider_name: null },
-        ],
-        cost_by_model: [
-          { ...customOverview.cost_by_model[0], custom_provider_name: null },
-        ],
+        recent_activity: [{ ...customOverview.recent_activity[0], custom_provider_name: null }],
+        cost_by_model: [{ ...customOverview.cost_by_model[0], custom_provider_name: null }],
       };
       mockGetOverview.mockResolvedValue(deletedProvider);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("my-llama");
-        expect(container.textContent).not.toContain("custom:abc-123/");
+        expect(container.textContent).toContain('my-llama');
+        expect(container.textContent).not.toContain('custom:abc-123/');
       });
     });
   });
 
-  describe("setup modal callbacks", () => {
-    it("closes setup modal and sets dismissed flag", async () => {
+  describe('setup modal callbacks', () => {
+    it('closes setup modal and sets dismissed flag', async () => {
       mockGetOverview.mockResolvedValue(emptyOverviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const modal = container.querySelector('[data-testid="setup-modal"]');
-        expect(modal?.getAttribute("data-open")).toBe("true");
+        expect(modal?.getAttribute('data-open')).toBe('true');
       });
 
       const closeBtn = container.querySelector('[data-testid="setup-close"]') as HTMLButtonElement;
       fireEvent.click(closeBtn);
 
       await vi.waitFor(() => {
-        expect(localStorage.getItem("setup_dismissed_test-agent")).toBe("1");
+        expect(localStorage.getItem('setup_dismissed_test-agent')).toBe('1');
         const modal = container.querySelector('[data-testid="setup-modal"]');
-        expect(modal?.getAttribute("data-open")).toBe("false");
+        expect(modal?.getAttribute('data-open')).toBe('false');
       });
-      expect(mockClearSetupPending).toHaveBeenCalledWith("test-agent");
+      expect(mockClearSetupPending).toHaveBeenCalledWith('test-agent');
     });
 
-    it("marks setup as completed when onDone is called", async () => {
+    it('marks setup as completed when onDone is called', async () => {
       mockGetOverview.mockResolvedValue(emptyOverviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const modal = container.querySelector('[data-testid="setup-modal"]');
-        expect(modal?.getAttribute("data-open")).toBe("true");
+        expect(modal?.getAttribute('data-open')).toBe('true');
       });
 
       const doneBtn = container.querySelector('[data-testid="setup-done"]') as HTMLButtonElement;
       fireEvent.click(doneBtn);
 
       await vi.waitFor(() => {
-        expect(localStorage.getItem("setup_completed_test-agent")).toBe("1");
+        expect(localStorage.getItem('setup_completed_test-agent')).toBe('1');
       });
-      expect(mockClearSetupPending).toHaveBeenCalledWith("test-agent");
+      expect(mockClearSetupPending).toHaveBeenCalledWith('test-agent');
     });
 
-    it("opens the setup modal on mount when setup is pending (survives a refresh)", async () => {
+    it('opens the setup modal on mount when setup is pending (survives a refresh)', async () => {
       // has_data true → showEmptyState() is false, so the empty-state effect
       // does NOT open the modal. The persistent pending flag is the only thing
       // that opens it here, proving the gate survives a refresh.
@@ -531,14 +681,14 @@ describe("Overview", () => {
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const modal = container.querySelector('[data-testid="setup-modal"]');
-        expect(modal?.getAttribute("data-open")).toBe("true");
+        expect(modal?.getAttribute('data-open')).toBe('true');
       });
-      expect(mockIsSetupPending).toHaveBeenCalledWith("test-agent");
+      expect(mockIsSetupPending).toHaveBeenCalledWith('test-agent');
     });
 
-    it("keeps the setup modal closed on mount when pending but already dismissed", async () => {
+    it('keeps the setup modal closed on mount when pending but already dismissed', async () => {
       mockIsSetupPending.mockReturnValue(true);
-      localStorage.setItem("setup_dismissed_test-agent", "1");
+      localStorage.setItem('setup_dismissed_test-agent', '1');
       mockGetOverview.mockResolvedValue({
         ...overviewData,
         has_data: true,
@@ -549,12 +699,12 @@ describe("Overview", () => {
         expect(container.querySelector('[data-testid="setup-modal"]')).not.toBeNull();
       });
       const modal = container.querySelector('[data-testid="setup-modal"]');
-      expect(modal?.getAttribute("data-open")).toBe("false");
+      expect(modal?.getAttribute('data-open')).toBe('false');
     });
 
-    it("keeps the setup modal closed on mount when pending but already completed", async () => {
+    it('keeps the setup modal closed on mount when pending but already completed', async () => {
       mockIsSetupPending.mockReturnValue(true);
-      localStorage.setItem("setup_completed_test-agent", "1");
+      localStorage.setItem('setup_completed_test-agent', '1');
       mockGetOverview.mockResolvedValue({
         ...overviewData,
         has_data: true,
@@ -565,30 +715,30 @@ describe("Overview", () => {
         expect(container.querySelector('[data-testid="setup-modal"]')).not.toBeNull();
       });
       const modal = container.querySelector('[data-testid="setup-modal"]');
-      expect(modal?.getAttribute("data-open")).toBe("false");
+      expect(modal?.getAttribute('data-open')).toBe('false');
     });
   });
 
-  it("shows waiting banner when has_providers is true but has_data is false", async () => {
+  it('shows waiting banner when has_providers is true but has_data is false', async () => {
     mockGetOverview.mockResolvedValue({ ...emptyOverviewData, has_providers: true });
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("No activity yet");
+      expect(container.textContent).toContain('No activity yet');
       expect(container.querySelector('.waiting-banner')).not.toBeNull();
       expect(container.querySelector('.empty-state')).toBeNull();
     });
   });
 
-  it("shows dashboard with zeros when has_providers is true but has_data is false", async () => {
+  it('shows dashboard with zeros when has_providers is true but has_data is false', async () => {
     mockGetOverview.mockResolvedValue({ ...emptyOverviewData, has_providers: true });
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
       expect(container.querySelector('.chart-card__stat--clickable')).not.toBeNull();
-      expect(container.textContent).toContain("$0.00");
+      expect(container.textContent).toContain('$0.00');
     });
   });
 
-  it("shows full dashboard when has_data is true regardless of has_providers", async () => {
+  it('shows full dashboard when has_data is true regardless of has_providers', async () => {
     mockGetOverview.mockResolvedValue({ ...overviewData, has_data: true, has_providers: false });
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
@@ -597,7 +747,7 @@ describe("Overview", () => {
     });
   });
 
-  it("does not show waiting banner when has_data is true", async () => {
+  it('does not show waiting banner when has_data is true', async () => {
     mockGetOverview.mockResolvedValue({ ...overviewData, has_data: true, has_providers: true });
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
@@ -605,125 +755,123 @@ describe("Overview", () => {
     });
   });
 
-  it("shows Connect provider button when setupCompleted but no providers and no data", async () => {
-    localStorage.setItem("setup_completed_test-agent", "1");
+  it('shows Connect provider button when setupCompleted but no providers and no data', async () => {
+    localStorage.setItem('setup_completed_test-agent', '1');
     mockGetOverview.mockResolvedValue(emptyOverviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Connect provider");
-      expect(container.textContent).toContain("Connect a provider to start routing LLM calls");
-      expect(container.textContent).not.toContain("Enable routing");
+      expect(container.textContent).toContain('Connect provider');
+      expect(container.textContent).toContain('Connect a provider to start routing LLM calls');
+      expect(container.textContent).not.toContain('Enable routing');
       const btn = container.querySelector('.empty-state button.btn--primary');
       expect(btn).not.toBeNull();
     });
   });
 
-  it("navigates to routing with openProviders state when Connect provider clicked", async () => {
-    localStorage.setItem("setup_completed_test-agent", "1");
+  it('navigates to routing with openProviders state when Connect provider clicked', async () => {
+    localStorage.setItem('setup_completed_test-agent', '1');
     mockGetOverview.mockResolvedValue(emptyOverviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Connect provider");
+      expect(container.textContent).toContain('Connect provider');
     });
     const btn = container.querySelector('.empty-state button.btn--primary') as HTMLButtonElement;
     fireEvent.click(btn);
-    expect(mockNavigate).toHaveBeenCalledWith(
-      "/harnesses/test-agent/routing",
-      { state: { openProviders: true } },
-    );
+    expect(mockNavigate).toHaveBeenCalledWith('/harnesses/test-agent/routing', {
+      state: { openProviders: true },
+    });
   });
 
-  it("shows Set up harness button when not setupCompleted and no providers", async () => {
+  it('shows Set up harness button when not setupCompleted and no providers', async () => {
     mockGetOverview.mockResolvedValue(emptyOverviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Set up harness");
-      expect(container.textContent).not.toContain("Enable routing");
-      expect(container.textContent).not.toContain("Connect provider");
+      expect(container.textContent).toContain('Set up harness');
+      expect(container.textContent).not.toContain('Enable routing');
+      expect(container.textContent).not.toContain('Connect provider');
     });
   });
 
-  describe("SetupModal callbacks", () => {
-    it("sets localStorage and closes modal on onClose", async () => {
+  describe('SetupModal callbacks', () => {
+    it('sets localStorage and closes modal on onClose', async () => {
       mockGetOverview.mockResolvedValue(emptyOverviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const modal = container.querySelector('[data-testid="setup-modal"]');
-        expect(modal?.getAttribute("data-open")).toBe("true");
+        expect(modal?.getAttribute('data-open')).toBe('true');
       });
-      fireEvent.click(screen.getByTestId("setup-close"));
-      expect(localStorage.getItem("setup_dismissed_test-agent")).toBe("1");
+      fireEvent.click(screen.getByTestId('setup-close'));
+      expect(localStorage.getItem('setup_dismissed_test-agent')).toBe('1');
     });
 
-    it("sets localStorage on onDone", async () => {
+    it('sets localStorage on onDone', async () => {
       mockGetOverview.mockResolvedValue(emptyOverviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const modal = container.querySelector('[data-testid="setup-modal"]');
-        expect(modal?.getAttribute("data-open")).toBe("true");
+        expect(modal?.getAttribute('data-open')).toBe('true');
       });
-      fireEvent.click(screen.getByTestId("setup-done"));
-      expect(localStorage.getItem("setup_completed_test-agent")).toBe("1");
+      fireEvent.click(screen.getByTestId('setup-done'));
+      expect(localStorage.getItem('setup_completed_test-agent')).toBe('1');
     });
 
-    it("navigates to routing page on onGoToRouting", async () => {
+    it('navigates to routing page on onGoToRouting', async () => {
       mockGetOverview.mockResolvedValue(emptyOverviewData);
       render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(screen.getByTestId("setup-go-routing")).toBeDefined();
+        expect(screen.getByTestId('setup-go-routing')).toBeDefined();
       });
-      fireEvent.click(screen.getByTestId("setup-go-routing"));
-      expect(mockNavigate).toHaveBeenCalledWith(
-        "/harnesses/test-agent/routing",
-        { state: { openProviders: true } },
-      );
+      fireEvent.click(screen.getByTestId('setup-go-routing'));
+      expect(mockNavigate).toHaveBeenCalledWith('/harnesses/test-agent/routing', {
+        state: { openProviders: true },
+      });
     });
   });
 
-  describe("range persistence", () => {
-    it("persists range selection in localStorage", async () => {
+  describe('range persistence', () => {
+    it('persists range selection in localStorage', async () => {
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         expect(container.querySelector('[data-testid="select"]')).not.toBeNull();
       });
       const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
-      await fireEvent.change(select, { target: { value: "24h" } });
-      expect(localStorage.getItem("manifest_chart_range")).toBe("24h");
+      await fireEvent.change(select, { target: { value: '24h' } });
+      expect(localStorage.getItem('manifest_chart_range')).toBe('24h');
     });
 
-    it("reads persisted range from localStorage on mount", async () => {
-      localStorage.setItem("manifest_chart_range", "24h");
+    it('reads persisted range from localStorage on mount', async () => {
+      localStorage.setItem('manifest_chart_range', '24h');
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
-        expect(select.value).toBe("24h");
+        expect(select.value).toBe('24h');
       });
     });
 
-    it("defaults to 30d when no localStorage value", async () => {
+    it('defaults to 30d when no localStorage value', async () => {
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
-        expect(select.value).toBe("30d");
+        expect(select.value).toBe('30d');
       });
     });
 
-    it("ignores stale localStorage value and defaults to 30d", async () => {
-      localStorage.setItem("manifest_chart_range", "1h");
+    it('ignores stale localStorage value and defaults to 30d', async () => {
+      localStorage.setItem('manifest_chart_range', '1h');
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
-        expect(select.value).toBe("30d");
+        expect(select.value).toBe('30d');
       });
     });
   });
 
-  describe("smart default range", () => {
-    it("cascades to smaller range when data arrays are all empty", async () => {
+  describe('smart default range', () => {
+    it('cascades to smaller range when data arrays are all empty', async () => {
       const emptyUsageData = {
         ...overviewData,
         has_data: true,
@@ -736,12 +884,12 @@ describe("Overview", () => {
       await vi.waitFor(() => {
         // Cascades from 30d → 7d → 24h (all empty, lands at final range)
         const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
-        expect(select.value).toBe("24h");
+        expect(select.value).toBe('24h');
       });
     });
 
-    it("does not cascade when user has manually selected a range", async () => {
-      localStorage.setItem("manifest_chart_range", "30d");
+    it('does not cascade when user has manually selected a range', async () => {
+      localStorage.setItem('manifest_chart_range', '30d');
       const emptyUsageData = {
         ...overviewData,
         has_data: true,
@@ -753,23 +901,23 @@ describe("Overview", () => {
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
-        expect(select.value).toBe("30d");
+        expect(select.value).toBe('30d');
       });
     });
 
-    it("stays on current range when there is data", async () => {
+    it('stays on current range when there is data', async () => {
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
         const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
-        expect(select.value).toBe("30d");
+        expect(select.value).toBe('30d');
       });
     });
 
-    it("cascades when localStorage contains an invalid range (not treated as user selection)", async () => {
+    it('cascades when localStorage contains an invalid range (not treated as user selection)', async () => {
       // An invalid stored range must NOT lock userSelectedRange=true;
       // the smart-range cascade must still kick in.
-      localStorage.setItem("manifest_chart_range", "invalid");
+      localStorage.setItem('manifest_chart_range', 'invalid');
       const emptyUsageData = {
         ...overviewData,
         has_data: true,
@@ -782,38 +930,44 @@ describe("Overview", () => {
       await vi.waitFor(() => {
         // Cascade should run: all-empty data + invalid stored range → lands at 24h
         const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
-        expect(select.value).toBe("24h");
+        expect(select.value).toBe('24h');
       });
     });
   });
 
-  it("renders provider icon and auth badge in cost_by_model for known providers", async () => {
+  it('renders provider icon and auth badge in cost_by_model for known providers', async () => {
     const dataWithKnownModel = {
       ...overviewData,
       cost_by_model: [
-        { model: "gpt-4o", tokens: 30000, share_pct: 100, estimated_cost: 2.1, auth_type: "api_key" },
+        {
+          model: 'gpt-4o',
+          tokens: 30000,
+          share_pct: 100,
+          estimated_cost: 2.1,
+          auth_type: 'api_key',
+        },
       ],
     };
     mockGetOverview.mockResolvedValue(dataWithKnownModel);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const panels = container.querySelectorAll(".panel");
-      const costPanel = Array.from(panels).find(p => p.textContent?.includes("Cost by Model"));
+      const panels = container.querySelectorAll('.panel');
+      const costPanel = Array.from(panels).find((p) => p.textContent?.includes('Cost by Model'));
       expect(costPanel).toBeDefined();
       // Verify the provider icon SVG is rendered (aria-hidden, not role="img")
       const icon = costPanel!.querySelector('svg[aria-hidden="true"]');
       expect(icon).not.toBeNull();
       // Verify auth badge is rendered
-      const keyBadge = costPanel!.querySelector(".provider-auth-badge--key");
+      const keyBadge = costPanel!.querySelector('.provider-auth-badge--key');
       expect(keyBadge).not.toBeNull();
     });
   });
 
-  it("shows $0.00 cost for flat-fee subscription messages (cost null) in recent activity", async () => {
+  it('shows $0.00 cost for flat-fee subscription messages (cost null) in recent activity', async () => {
     const dataWithSub = {
       ...overviewData,
       recent_activity: [
-        { ...overviewData.recent_activity[0], auth_type: "subscription", cost: null },
+        { ...overviewData.recent_activity[0], auth_type: 'subscription', cost: null },
       ],
     };
     mockGetOverview.mockResolvedValue(dataWithSub);
@@ -821,233 +975,235 @@ describe("Overview", () => {
     await vi.waitFor(() => {
       const subCost = container.querySelector('[title="Included in subscription"]');
       expect(subCost).not.toBeNull();
-      expect(subCost!.textContent).toBe("$0.00");
+      expect(subCost!.textContent).toBe('$0.00');
     });
   });
 
-  it("renders the recorded cost for per-request subscriptions (e.g. OpenCode Go)", async () => {
+  it('renders the recorded cost for per-request subscriptions (e.g. OpenCode Go)', async () => {
     const dataWithPerRequestSub = {
       ...overviewData,
       recent_activity: [
-        { ...overviewData.recent_activity[0], auth_type: "subscription", cost: 0.013636 },
+        { ...overviewData.recent_activity[0], auth_type: 'subscription', cost: 0.013636 },
       ],
     };
     mockGetOverview.mockResolvedValue(dataWithPerRequestSub);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
       // Per-request subscription rows should show the real cost, not $0.00.
-      expect(container.textContent).toContain("$0.01");
+      expect(container.textContent).toContain('$0.01');
       const tooltip = container.querySelector('[title^="Per-request subscription cost:"]');
       expect(tooltip).not.toBeNull();
     });
   });
 
-  it("shows formatCost for non-subscription messages with cost in recent activity", async () => {
+  it('shows formatCost for non-subscription messages with cost in recent activity', async () => {
     const dataWithCost = {
       ...overviewData,
-      recent_activity: [
-        { ...overviewData.recent_activity[0], auth_type: null, cost: 0.05 },
-      ],
+      recent_activity: [{ ...overviewData.recent_activity[0], auth_type: null, cost: 0.05 }],
     };
     mockGetOverview.mockResolvedValue(dataWithCost);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("$0.05");
+      expect(container.textContent).toContain('$0.05');
     });
   });
 
-  it("renders subscription auth badge on provider icon in recent activity", async () => {
+  it('renders subscription auth badge on provider icon in recent activity', async () => {
     const dataWithSub = {
       ...overviewData,
       recent_activity: [
-        { ...overviewData.recent_activity[0], model: "claude-sonnet-4", auth_type: "subscription" },
+        { ...overviewData.recent_activity[0], model: 'claude-sonnet-4', auth_type: 'subscription' },
       ],
     };
     mockGetOverview.mockResolvedValue(dataWithSub);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".provider-auth-badge--sub");
+      const badge = container.querySelector('.provider-auth-badge--sub');
       expect(badge).not.toBeNull();
     });
   });
 
-  it("renders api_key auth badge when auth_type is api_key", async () => {
+  it('renders api_key auth badge when auth_type is api_key', async () => {
     const dataWithApiKey = {
       ...overviewData,
       recent_activity: [
-        { ...overviewData.recent_activity[0], model: "claude-sonnet-4", auth_type: "api_key" },
+        { ...overviewData.recent_activity[0], model: 'claude-sonnet-4', auth_type: 'api_key' },
       ],
-      cost_by_model: overviewData.cost_by_model.map(r => ({ ...r, auth_type: "api_key" })),
+      cost_by_model: overviewData.cost_by_model.map((r) => ({ ...r, auth_type: 'api_key' })),
     };
     mockGetOverview.mockResolvedValue(dataWithApiKey);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".provider-auth-badge--key");
+      const badge = container.querySelector('.provider-auth-badge--key');
       expect(badge).not.toBeNull();
-      const subBadge = container.querySelector(".provider-auth-badge--sub");
+      const subBadge = container.querySelector('.provider-auth-badge--sub');
       expect(subBadge).toBeNull();
     });
   });
 
-  it("renders fallback badge in recent activity when fallback_from_model is present", async () => {
+  it('renders fallback badge in recent activity when fallback_from_model is present', async () => {
     const dataWithFallback = {
       ...overviewData,
       recent_activity: [
-        { ...overviewData.recent_activity[0], fallback_from_model: "gpt-4o", fallback_index: 0 },
+        { ...overviewData.recent_activity[0], fallback_from_model: 'gpt-4o', fallback_index: 0 },
       ],
     };
     mockGetOverview.mockResolvedValue(dataWithFallback);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".tier-badge--fallback");
+      const badge = container.querySelector('.tier-badge--fallback');
       expect(badge).not.toBeNull();
-      expect(badge!.textContent).toBe("fallback");
+      expect(badge!.textContent).toBe('fallback');
     });
   });
 
-  it("does not render fallback badge in recent activity when fallback_from_model is absent", async () => {
+  it('does not render fallback badge in recent activity when fallback_from_model is absent', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("gpt-4o");
-      const badge = container.querySelector(".tier-badge--fallback");
+      expect(container.textContent).toContain('gpt-4o');
+      const badge = container.querySelector('.tier-badge--fallback');
       expect(badge).toBeNull();
     });
   });
 
-  it("renders fallback_error status with Handled badge in recent activity", async () => {
+  it('renders fallback_error status with Handled badge in recent activity', async () => {
     const dataWithHandled = {
       ...overviewData,
       recent_activity: [
         {
           ...overviewData.recent_activity[0],
-          status: "fallback_error",
-          model: "gemini-flash",
-          error_message: "Provider returned HTTP 429, routed to fallback",
+          status: 'fallback_error',
+          model: 'gemini-flash',
+          error_message: 'Provider returned HTTP 429, routed to fallback',
         },
       ],
     };
     mockGetOverview.mockResolvedValue(dataWithHandled);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".status-badge--fallback_error");
+      const badge = container.querySelector('.status-badge--fallback_error');
       expect(badge).not.toBeNull();
-      expect(badge!.textContent).toBe("fallback_error");
+      expect(badge!.textContent).toBe('fallback_error');
     });
   });
 
-  describe("feedback", () => {
-    it("calls setMessageFeedback with like when thumb up is clicked", async () => {
+  describe('feedback', () => {
+    it('calls setMessageFeedback with like when thumb up is clicked', async () => {
       mockSetMessageFeedback.mockResolvedValue(undefined);
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const likeBtn = container.querySelector(".feedback-btn") as HTMLElement;
+      const likeBtn = container.querySelector('.feedback-btn') as HTMLElement;
       fireEvent.click(likeBtn);
-      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "like" });
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith('msg-12345678', { rating: 'like' });
     });
 
-    it("calls setMessageFeedback with dislike and opens modal", async () => {
+    it('calls setMessageFeedback with dislike and opens modal', async () => {
       mockSetMessageFeedback.mockResolvedValue(undefined);
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      const dislikeBtn = container.querySelectorAll('.feedback-btn')[1] as HTMLElement;
       fireEvent.click(dislikeBtn);
-      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike" });
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith('msg-12345678', { rating: 'dislike' });
       const modal = container.querySelector('[data-testid="feedback-modal"]');
-      expect(modal?.getAttribute("data-open")).toBe("true");
+      expect(modal?.getAttribute('data-open')).toBe('true');
     });
 
-    it("calls clearMessageFeedback when active like is clicked", async () => {
+    it('calls clearMessageFeedback when active like is clicked', async () => {
       mockClearMessageFeedback.mockResolvedValue(undefined);
       const dataWithFeedback = {
         ...overviewData,
-        recent_activity: [{ ...overviewData.recent_activity[0], feedback_rating: "like" }],
+        recent_activity: [{ ...overviewData.recent_activity[0], feedback_rating: 'like' }],
       };
       mockGetOverview.mockResolvedValue(dataWithFeedback);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn--active-like')).not.toBeNull();
       });
-      const likeBtn = container.querySelector(".feedback-btn--active-like") as HTMLElement;
+      const likeBtn = container.querySelector('.feedback-btn--active-like') as HTMLElement;
       fireEvent.click(likeBtn);
-      expect(mockClearMessageFeedback).toHaveBeenCalledWith("msg-12345678");
+      expect(mockClearMessageFeedback).toHaveBeenCalledWith('msg-12345678');
     });
 
-    it("submits feedback details from modal", async () => {
+    it('submits feedback details from modal', async () => {
       mockSetMessageFeedback.mockResolvedValue(undefined);
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      const dislikeBtn = container.querySelectorAll('.feedback-btn')[1] as HTMLElement;
       fireEvent.click(dislikeBtn);
       const submitBtn = container.querySelector('[data-testid="feedback-submit"]') as HTMLElement;
       fireEvent.click(submitBtn);
-      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike", tags: ["Too slow"], details: "test" });
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith('msg-12345678', {
+        rating: 'dislike',
+        tags: ['Too slow'],
+        details: 'test',
+      });
     });
 
-    it("hides feedback column and modal in the self-hosted version", async () => {
+    it('hides feedback column and modal in the self-hosted version', async () => {
       mockCheckIsSelfHosted.mockResolvedValue(true);
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".data-table")).not.toBeNull();
+        expect(container.querySelector('.data-table')).not.toBeNull();
       });
-      expect(container.querySelector(".feedback-btn")).toBeNull();
+      expect(container.querySelector('.feedback-btn')).toBeNull();
       expect(container.querySelector('[data-testid="feedback-modal"]')).toBeNull();
       mockCheckIsSelfHosted.mockResolvedValue(false);
     });
 
-    it("reverts optimistic like on API error", async () => {
-      mockSetMessageFeedback.mockRejectedValue(new Error("fail"));
+    it('reverts optimistic like on API error', async () => {
+      mockSetMessageFeedback.mockRejectedValue(new Error('fail'));
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const likeBtn = container.querySelector(".feedback-btn") as HTMLElement;
+      const likeBtn = container.querySelector('.feedback-btn') as HTMLElement;
       fireEvent.click(likeBtn);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-like")).toBeNull();
+        expect(container.querySelector('.feedback-btn--active-like')).toBeNull();
       });
     });
 
-    it("reverts optimistic dislike on API error", async () => {
-      mockSetMessageFeedback.mockRejectedValue(new Error("fail"));
+    it('reverts optimistic dislike on API error', async () => {
+      mockSetMessageFeedback.mockRejectedValue(new Error('fail'));
       mockGetOverview.mockResolvedValue(overviewData);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      const dislikeBtn = container.querySelectorAll('.feedback-btn')[1] as HTMLElement;
       fireEvent.click(dislikeBtn);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-dislike")).toBeNull();
+        expect(container.querySelector('.feedback-btn--active-dislike')).toBeNull();
       });
     });
 
-    it("reverts optimistic clear on API error", async () => {
-      mockClearMessageFeedback.mockRejectedValue(new Error("fail"));
+    it('reverts optimistic clear on API error', async () => {
+      mockClearMessageFeedback.mockRejectedValue(new Error('fail'));
       const dataWithFeedback = {
         ...overviewData,
-        recent_activity: [{ ...overviewData.recent_activity[0], feedback_rating: "like" }],
+        recent_activity: [{ ...overviewData.recent_activity[0], feedback_rating: 'like' }],
       };
       mockGetOverview.mockResolvedValue(dataWithFeedback);
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn--active-like')).not.toBeNull();
       });
-      const likeBtn = container.querySelector(".feedback-btn--active-like") as HTMLElement;
+      const likeBtn = container.querySelector('.feedback-btn--active-like') as HTMLElement;
       fireEvent.click(likeBtn);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn--active-like')).not.toBeNull();
       });
     });
   });

--- a/packages/frontend/tests/services/api/analytics.test.ts
+++ b/packages/frontend/tests/services/api/analytics.test.ts
@@ -135,6 +135,7 @@ describe('analytics API client', () => {
     const fns: Array<[(a: string, r?: string) => unknown, string]> = [
       [analytics.getPerProviderTimeseries, 'per-provider-timeseries'],
       [analytics.getPerProviderMessageTimeseries, 'per-provider-message-timeseries'],
+      [analytics.getPerProviderCostTimeseries, 'per-provider-cost-timeseries'],
     ];
     for (const [fn, path] of fns) {
       const fetchMock = setupFetch({ agents: [], timeseries: [] });


### PR DESCRIPTION
## What

Restores the **provider breakdown** on the per-agent Overview (`/harnesses/:agentName`) that existed in Seb's #2061 design (`AgentOverview.tsx`) and was dropped in the re-slice. The agent's usage chart is now grouped **by provider**, matching the global Overview.

- Swaps the single-series `ChartCard` for **`ProviderChartCard`** (the same component the global Overview uses) — one line per provider, with the built-in Cost / Messages / Token usage view toggle (Cost first).
- Adds the **provider multiselect** filter in the header ("All providers (N) ▾" + Select all / Unselect all + per-provider color-swatch toggles), persisted in `sessionStorage` per agent. This is the "By Provider" control. It sits on the right next to "Last 30 days" (the range select is now right-aligned).
- Wires three per-agent/per-provider timeseries (tokens, messages, cost). The cost one was the only missing piece in the frontend API client — added `getPerProviderCostTimeseries(agentName, range)`; the backend endpoint `GET /overview/per-provider-cost-timeseries` already existed.

Provider-only (no By-model toggle, no By-harness — meaningless for a single agent). Custom-provider series already arrive resolved to display names from #2197 (underneath this stack). No backend changes.

## ⚠️ Follow-up: orphaned ChartCard

This was the **last consumer of `ChartCard`** (GlobalOverview and ConnectionDetail use `ProviderChartCard`). So `ChartCard.tsx` — and its lazy children `CostChart` / `TokenChart` / `SingleTokenChart` — are now **dead code**. I left them in place to keep this PR focused (they're still tested, CI-green). Recommend a small follow-up PR to delete the cluster + tests. Happy to fold the deletion in here if preferred.

## Stack

Stacked on #2200 (`fix/remove-subscription-savings`) ← #2199 ← #2198 ← #2197.

## Testing

- New client test: `getPerProviderCostTimeseries` forwards `agent_name` + `range`.
- Overview tests: ProviderChartCard renders provider series; multiselect shows providers and filters series (toggle off/on, Select all / Unselect all); range select on the right; view toggle (Cost/Messages/Tokens); sessionStorage load/persist failure paths; Escape closes the dropdown.
- Adapted `Overview-limits` chart assertions to ProviderChartCard's neutral trend badges + stubbed the uPlot chart.
- Full frontend suite green (191 files / 3,944 tests), `tsc` clean, lint 0 errors, **100% line coverage on `Overview.tsx`** and the new client fn.
- Spec + plan committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the provider breakdown on the per-agent Overview by replacing the single-series usage chart with a provider-grouped chart and adding a provider filter. Adds a frontend API method for per-agent per-provider cost timeseries; no backend changes.

- **New Features**
  - Replaced the single-series chart with a provider-grouped `ProviderChartCard` (one line per provider) with a Cost/Messages/Tokens toggle (Cost default).
  - Added a provider multiselect in the header (“All providers (N)” with Select all / Unselect all and per-provider toggles), persisted per agent in sessionStorage; range select is right-aligned.
  - Wired per-agent/per-provider timeseries for tokens, messages, and cost via `getPerProviderCostTimeseries(agentName, range)`.

- **Refactors**
  - The previous `ChartCard` is no longer used on this page and can be removed in a follow-up.

<sup>Written for commit bb2e557cb01e5b15d573cb74f8423371cd9cdb69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

