### PR TITLE
fix: Gemini adapter — unsupported schema keywords, parallel tool merge, and missing thought signatures

### DIFF
--- a/.changeset/silver-chairs-grab.md
+++ b/.changeset/silver-chairs-grab.md
@@ -2,12 +2,14 @@
 "manifest": patch
 ---
 
-fix: strip additional unsupported JSON Schema keywords from Gemini tool declarations
+fix: Gemini adapter — strip unsupported schema keywords and merge parallel tool responses
 
-Gemini's `function_declarations` parameter schema accepts only a restricted
-OpenAPI subset and hard-rejects unknown keywords with
-`Unknown name "<field>" ... Cannot find field`. The sanitizer now also strips
-`propertyNames`, `uniqueItems`, `multipleOf`, `contains`/`minContains`/`maxContains`,
-`prefixItems`, `additionalItems`, `readOnly`, `writeOnly`, `deprecated`, and the
-`$comment`/`$anchor`/`$dynamicRef`/`$dynamicAnchor`/`$vocabulary` meta-keywords,
-preventing 400 errors when tools carry these common JSON Schema fields.
+The Gemini adapter now strips additional JSON Schema keywords that Google's
+`function_declarations` parameter schema rejects (`propertyNames`,
+`uniqueItems`, `multipleOf`, `contains`/`minContains`/`maxContains`,
+`prefixItems`, `additionalItems`, `readOnly`, `writeOnly`, `deprecated`,
+and `$comment`/`$anchor`/`$dynamicRef`/`$dynamicAnchor`/`$vocabulary`).
+
+It also merges consecutive parallel tool responses into a single Gemini
+user turn, matching Google's requirement that N functionCall parts be
+answered by exactly N functionResponse parts in one turn.

--- a/.changeset/silver-chairs-grab.md
+++ b/.changeset/silver-chairs-grab.md
@@ -2,7 +2,7 @@
 "manifest": patch
 ---
 
-fix: Gemini adapter — strip unsupported schema keywords and merge parallel tool responses
+fix: Gemini adapter — strip unsupported schema keywords, merge parallel tool responses, and inject missing thought signatures
 
 The Gemini adapter now strips additional JSON Schema keywords that Google's
 `function_declarations` parameter schema rejects (`propertyNames`,
@@ -10,6 +10,11 @@ The Gemini adapter now strips additional JSON Schema keywords that Google's
 `prefixItems`, `additionalItems`, `readOnly`, `writeOnly`, `deprecated`,
 and `$comment`/`$anchor`/`$dynamicRef`/`$dynamicAnchor`/`$vocabulary`).
 
-It also merges consecutive parallel tool responses into a single Gemini
-user turn, matching Google's requirement that N functionCall parts be
-answered by exactly N functionResponse parts in one turn.
+It merges consecutive parallel tool responses into a single Gemini user turn,
+matching Google's requirement that N functionCall parts be answered by exactly
+N functionResponse parts in one turn.
+
+When a functionCall part has no `thought_signature` from the client or cache
+(e.g. after a fallback from another model), the adapter now injects the
+documented dummy signature so Gemini 3.x does not reject the request with
+"Function call is missing a thought_signature".

--- a/.changeset/silver-chairs-grab.md
+++ b/.changeset/silver-chairs-grab.md
@@ -1,0 +1,13 @@
+---
+"manifest": patch
+---
+
+fix: strip additional unsupported JSON Schema keywords from Gemini tool declarations
+
+Gemini's `function_declarations` parameter schema accepts only a restricted
+OpenAPI subset and hard-rejects unknown keywords with
+`Unknown name "<field>" ... Cannot find field`. The sanitizer now also strips
+`propertyNames`, `uniqueItems`, `multipleOf`, `contains`/`minContains`/`maxContains`,
+`prefixItems`, `additionalItems`, `readOnly`, `writeOnly`, `deprecated`, and the
+`$comment`/`$anchor`/`$dynamicRef`/`$dynamicAnchor`/`$vocabulary` meta-keywords,
+preventing 400 errors when tools carry these common JSON Schema fields.

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -2037,14 +2037,18 @@ describe('Google Adapter', () => {
         args: { q: 'cats' },
       });
 
-      // call_2 response resolved to `search` and keeps its id.
+      // call_2 and call_1 responses are merged into a single user turn with
+      // both functionResponse parts — Gemini requires N functionCall parts to be
+      // answered by exactly N functionResponse parts in one user turn.
+      expect(contents).toHaveLength(3);
+      expect(contents[2].role).toBe('user');
+      expect(contents[2].parts).toHaveLength(2);
       expect(contents[2].parts[0].functionResponse).toEqual({
         id: 'call_2',
         name: 'search',
         response: { result: '{"results":[]}' },
       });
-      // call_1 response resolved to `weather` and keeps its id.
-      expect(contents[3].parts[0].functionResponse).toEqual({
+      expect(contents[2].parts[1].functionResponse).toEqual({
         id: 'call_1',
         name: 'weather',
         response: { result: '{"temp":72}' },

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -203,6 +203,60 @@ describe('Google Adapter', () => {
       expect(props.config.properties).toEqual({ key: { type: 'string' } });
     });
 
+    it('strips additional Gemini-rejected JSON Schema keywords from tool parameters', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Validate config' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'validate_config',
+              parameters: {
+                type: 'object',
+                propertyNames: { pattern: '^[a-z_]+$' },
+                properties: {
+                  tags: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    uniqueItems: true,
+                    contains: { const: 'required' },
+                    minContains: 1,
+                    maxContains: 2,
+                    prefixItems: [{ type: 'string' }],
+                    additionalItems: false,
+                  },
+                  ratio: { type: 'number', multipleOf: 0.5 },
+                  metadata: {
+                    type: 'string',
+                    readOnly: true,
+                    writeOnly: false,
+                    deprecated: true,
+                    $comment: 'internal note',
+                    $anchor: 'Metadata',
+                    $dynamicRef: '#meta',
+                    $dynamicAnchor: 'Meta',
+                    $vocabulary: { 'https://json-schema.org/draft/2020-12/vocab/core': true },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-3.1-pro-preview');
+
+      const tools = result.tools as Array<{
+        functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+      }>;
+      const params = tools[0].functionDeclarations[0].parameters;
+      const props = params.properties as Record<string, Record<string, unknown>>;
+
+      expect(params).not.toHaveProperty('propertyNames');
+      expect(props.tags).toEqual({ type: 'array', items: { type: 'string' } });
+      expect(props.ratio).toEqual({ type: 'number' });
+      expect(props.metadata).toEqual({ type: 'string' });
+    });
+
     it('strips exclusive numeric bounds without removing same-named properties', () => {
       const body = {
         messages: [{ role: 'user', content: 'Set limits' }],

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -1135,7 +1135,7 @@ describe('Google Adapter', () => {
       expect(contents[0].parts[0].thoughtSignature).toBe('from_client');
     });
 
-    it('omits thoughtSignature when neither client nor cache provides one', () => {
+    it('injects a dummy thoughtSignature when neither client nor cache provides one', () => {
       const body = {
         messages: [
           {
@@ -1155,8 +1155,8 @@ describe('Google Adapter', () => {
       const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
       expect(contents[0].parts[0]).toEqual({
         functionCall: { id: 'call_1', name: 'noop', args: {} },
+        thoughtSignature: 'context_engineering_is_the_way_to_go',
       });
-      expect(contents[0].parts[0].thoughtSignature).toBeUndefined();
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -1135,6 +1135,29 @@ describe('Google Adapter', () => {
       expect(contents[0].parts[0].thoughtSignature).toBe('from_client');
     });
 
+    it('falls back to cache when client echoes an empty string', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'noop', arguments: '{}' },
+                thought_signature: '',
+              },
+            ],
+          },
+        ],
+      };
+      const lookup = jest.fn().mockReturnValue('cached_sig');
+      const result = toGoogleRequest(body, 'gemini-3-pro-preview', lookup);
+      const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
+      expect(contents[0].parts[0].thoughtSignature).toBe('cached_sig');
+    });
+
     it('injects a dummy thoughtSignature when neither client nor cache provides one', () => {
       const body = {
         messages: [

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -221,7 +221,14 @@ function messageToContent(
       const echoed = (tc as Record<string, unknown>).thought_signature;
       const cached = hasId && signatureLookup ? signatureLookup(tc.id) : null;
       const signature = typeof echoed === 'string' ? echoed : cached;
-      if (signature) part.thoughtSignature = signature;
+      // Gemini 3.x requires a thoughtSignature on every functionCall part.
+      // When the history comes from another model (fallback) or the cache has
+      // expired, inject the documented dummy signature so the request isn't
+      // rejected with "Function call is missing a thought_signature".
+      part.thoughtSignature =
+        typeof signature === 'string' && signature !== ''
+          ? signature
+          : 'context_engineering_is_the_way_to_go';
       parts.push(part);
     }
   }

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -50,7 +50,15 @@ const DATA_IMAGE_URL_RE = /^data:([^;,]+)(?:;[^,]*)?;base64,(.*)$/is;
  */
 const UNSUPPORTED_SCHEMA_FIELDS = new Set([
   'patternProperties',
+  'propertyNames',
   'additionalProperties',
+  'additionalItems',
+  'prefixItems',
+  'uniqueItems',
+  'multipleOf',
+  'contains',
+  'minContains',
+  'maxContains',
   '$schema',
   '$id',
   '$ref',
@@ -79,6 +87,14 @@ const UNSUPPORTED_SCHEMA_FIELDS = new Set([
   'title',
   'exclusiveMinimum',
   'exclusiveMaximum',
+  'readOnly',
+  'writeOnly',
+  'deprecated',
+  '$comment',
+  '$anchor',
+  '$dynamicRef',
+  '$dynamicAnchor',
+  '$vocabulary',
 ]);
 
 function sanitizeSchema(schema: unknown, isPropertiesMap = false): unknown {

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -294,7 +294,28 @@ export function toGoogleRequest(
     if (content) contents.push(content);
   }
 
-  const result: Record<string, unknown> = { contents };
+  // Merge consecutive user-role turns that contain only functionResponse parts
+  // into a single turn. Gemini requires that N functionCall parts in a model
+  // turn be answered by exactly N functionResponse parts in one user turn —
+  // separate turns trigger "number of function response parts is not equal".
+  const merged: GeminiContent[] = [];
+  for (const content of contents) {
+    const prev = merged[merged.length - 1];
+    const allFunctionResponses =
+      content.role === 'user' && content.parts.every((p) => p.functionResponse);
+    if (
+      allFunctionResponses &&
+      prev &&
+      prev.role === 'user' &&
+      prev.parts.every((p) => p.functionResponse)
+    ) {
+      prev.parts.push(...content.parts);
+    } else {
+      merged.push(content);
+    }
+  }
+
+  const result: Record<string, unknown> = { contents: merged };
 
   if (systemText) {
     result.systemInstruction = {

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -220,7 +220,7 @@ function messageToContent(
       // the Part level as `thoughtSignature`, not inside functionCall.
       const echoed = (tc as Record<string, unknown>).thought_signature;
       const cached = hasId && signatureLookup ? signatureLookup(tc.id) : null;
-      const signature = typeof echoed === 'string' ? echoed : cached;
+      const signature = typeof echoed === 'string' && echoed !== '' ? echoed : cached;
       // Gemini 3.x requires a thoughtSignature on every functionCall part.
       // When the history comes from another model (fallback) or the cache has
       // expired, inject the documented dummy signature so the request isn't


### PR DESCRIPTION
This PR fixes three distinct Gemini proxy failures observed in production.

### 1. Strip unsupported JSON Schema keywords
Gemini's `function_declarations` schema rejects several JSON Schema keywords that OpenAI and other providers accept. The adapter now strips `propertyNames`, `additionalItems`, `prefixItems`, `uniqueItems`, `multipleOf`, `contains`/`minContains`/`maxContains`, `readOnly`, `writeOnly`, `deprecated`, and `$comment`/`$anchor`/`$dynamicRef`/`$dynamicAnchor`/`$vocabulary` before sending tool declarations.

### 2. Merge parallel tool responses into one turn
OpenAI emits multiple `role: "tool"` messages for parallel tool calls. Gemini requires that N `functionCall` parts in a model turn be answered by exactly N `functionResponse` parts in **one** following user turn. Separate turns trigger a 400 error ("number of function response parts is not equal to the number of function call parts"). The adapter now merges consecutive user-role turns that contain only `functionResponse` parts into a single turn.

### 3. Inject dummy thoughtSignature for cross-model fallback
Gemini 3.x requires a `thoughtSignature` on every `functionCall` part. When the conversation history comes from another model (e.g. fallback from `qwen3.7-max`), neither the client echo nor the per-conversation cache has a signature. The adapter now injects the documented dummy signature `context_engineering_is_the_way_to_go` so Gemini 3.x does not reject the request with "Function call is missing a thought_signature".

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Gemini adapter errors by stripping unsupported schema keywords, merging parallel tool responses into one user turn, and always setting a valid `thoughtSignature` via cache or a dummy when missing. Prevents 400s from Google’s validator and keeps function calling working with fallbacks and parallel tools.

- Bug Fixes
  - Strip unsupported JSON Schema keywords from tool parameters before `function_declarations` (e.g., `propertyNames`, `uniqueItems`, `multipleOf`, `contains`/`minContains`/`maxContains`, `prefixItems`, `additionalItems`, `readOnly`, `writeOnly`, `deprecated`, `$comment`/`$anchor`/`$dynamicRef`/`$dynamicAnchor`/`$vocabulary`).
  - Merge consecutive user turns that contain only `functionResponse` parts into a single turn to satisfy Gemini’s “N calls -> N responses in one turn” rule.
  - Treat empty echoed `thought_signature` as absent and prefer cache; if none, inject `context_engineering_is_the_way_to_go` to meet Gemini 3.x requirements and support cross-model fallback.

<sup>Written for commit fe7abedcdbc10030232498fa9c961184d501b794. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

