### PR TITLE
ci: show column name before type in schema diagram

### DIFF
--- a/.github/scripts/db-diagram/__fixtures__/expected-comment.md
+++ b/.github/scripts/db-diagram/__fixtures__/expected-comment.md
@@ -19,32 +19,32 @@ Showing only changed tables. 🟢 added, 🟡 modified, 🔴 removed. Changed co
 ```mermaid
 erDiagram
     agent_api_keys["🟡 agent_api_keys (modified)"] {
-        varchar id PK
-        varchar agent_id FK "🟡 FK added"
-        varchar_64_ key
+        id varchar PK
+        agent_id varchar FK "🟡 FK added"
+        key varchar_64_
     }
     agents["🟡 agents (modified)"] {
-        varchar id PK
-        varchar name "🟡 modified"
-        varchar tenant_id FK
-        varchar_255_ display_name "🟢 added"
-        boolean legacy_flag "🔴 removed"
+        id varchar PK
+        name varchar "🟡 modified"
+        tenant_id varchar FK
+        display_name varchar_255_ "🟢 added"
+        legacy_flag boolean "🔴 removed"
     }
     legacy_metrics["🔴 legacy_metrics (removed)"] {
-        varchar id PK
-        integer value
+        id varchar PK
+        value integer
     }
     provider_keys["🟡 provider_keys (modified)"] {
-        varchar id PK
-        varchar agent_id "🟡 FK removed"
-        varchar region PK "🟡 PK changed"
+        id varchar PK
+        agent_id varchar "🟡 FK removed"
+        region varchar PK "🟡 PK changed"
     }
     routing_tiers["🟢 routing_tiers (added)"] {
-        uuid id PK
-        varchar agent_id FK
-        varchar tier
-        varchar model
-        numeric_15_6_ max_cost
+        id uuid PK
+        agent_id varchar FK
+        tier varchar
+        model varchar
+        max_cost numeric_15_6_
     }
     agent_api_keys }o--|| agents : "agent_id"
     routing_tiers }o--|| agents : "agent_id"

--- a/.github/scripts/db-diagram/render-diagram.cjs
+++ b/.github/scripts/db-diagram/render-diagram.cjs
@@ -166,12 +166,12 @@ function buildMermaid(headSnap, baseSnap, added, modMap, dropped) {
             pkChangedCols,
           })
         : '';
-      lines.push(`        ${safeType} ${col.name}${pk}${fk}${note}`);
+      lines.push(`        ${col.name} ${safeType}${pk}${fk}${note}`);
     }
     // Columns removed by this PR no longer exist in the head snapshot, so render
     // them as trailing rows (with their pre-drop type) flagged 🔴 removed.
     for (const c of droppedCols) {
-      lines.push(`        ${sanitizeMermaidType(c.type)} ${c.column} "🔴 removed"`);
+      lines.push(`        ${c.column} ${sanitizeMermaidType(c.type)} "🔴 removed"`);
     }
     lines.push('    }');
     rendered.add(name);


### PR DESCRIPTION
### 💭 Why
The schema-diagram comment on migration PRs listed each column as `type name`, which reads backwards from SQL DDL and from the detailed list right below it. Column name first scans better.

### ✨ What changed
- Mermaid ER rows now emit `name type` instead of `type name`.
- Regenerated the golden fixture so the smoke test matches.

### 📝 Notes
PK/FK badges and the inline 🟢/🟡/🔴 change annotations are unchanged. Affects only the generated PR comment, nothing in the shipped image.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the schema diagram in migration PR comments to list columns as "name type" instead of "type name" for better readability and to match SQL DDL. Adjusted the Mermaid renderer and updated the fixture; PK/FK badges and change annotations are unchanged, and only the comment output is affected.

<sup>Written for commit 2607b9ff4a8a3d9e94c8a4468efc8d9e1e2310f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

