### PR TITLE
fix: strip context_management and signed thinking blocks from Anthropic proxy requests

### DIFF
--- a/.changeset/modern-wombats-accept.md
+++ b/.changeset/modern-wombats-accept.md
@@ -2,4 +2,12 @@
 "manifest": patch
 ---
 
-fix: strip `context_management` from Anthropic proxy requests to prevent `invalid_request_error`
+fix: strip `context_management` and signed thinking blocks from Anthropic proxy requests
+
+Strips `context_management` from Anthropic Messages proxy requests to prevent
+`invalid_request_error` when the compaction beta header isn't sent.
+
+When routing to a different Anthropic model than the client requested, removes
+signed `thinking` and `redacted_thinking` blocks from prior assistant turns
+whose signatures are only valid for the original model, preventing
+`Invalid signature in thinking block` upstream rejections.

--- a/.changeset/modern-wombats-accept.md
+++ b/.changeset/modern-wombats-accept.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: strip `context_management` from Anthropic proxy requests to prevent `invalid_request_error`

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -2319,6 +2319,88 @@ describe('Anthropic Adapter', () => {
         messages: [{ role: 'user', content: 'hi' }],
       });
     });
+
+    describe('stripThinkingBlocks', () => {
+      it('removes thinking and redacted_thinking blocks from assistant messages', () => {
+        const result = applyAnthropicMessagesMutations(
+          {
+            model: 'claude-sonnet-4-20250514',
+            max_tokens: 1024,
+            thinking: { type: 'enabled', budget_tokens: 4096 },
+            messages: [
+              { role: 'user', content: 'hello' },
+              {
+                role: 'assistant',
+                content: [
+                  { type: 'thinking', thinking: 'reasoning', signature: 'sig_abc' },
+                  { type: 'redacted_thinking', data: 'opaque' },
+                  { type: 'tool_use', id: 'toolu_1', name: 'foo', input: {} },
+                ],
+              },
+              {
+                role: 'user',
+                content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok' }],
+              },
+            ],
+          },
+          { stripThinkingBlocks: true },
+        );
+        expect(result).not.toHaveProperty('thinking');
+        const messages = result.messages as Array<Record<string, unknown>>;
+        // Assistant message should only have tool_use, no thinking blocks
+        const assistantContent = messages[1].content as Array<Record<string, unknown>>;
+        expect(assistantContent).toEqual([
+          { type: 'tool_use', id: 'toolu_1', name: 'foo', input: {} },
+        ]);
+        // User messages should be untouched
+        expect(messages[0]).toEqual({ role: 'user', content: 'hello' });
+      });
+
+      it('does not strip thinking blocks when stripThinkingBlocks is false/omitted', () => {
+        const result = applyAnthropicMessagesMutations({
+          model: 'claude-sonnet-4-20250514',
+          max_tokens: 1024,
+          thinking: { type: 'enabled', budget_tokens: 4096 },
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                { type: 'thinking', thinking: 'reasoning', signature: 'sig_abc' },
+                { type: 'tool_use', id: 'toolu_1', name: 'foo', input: {} },
+              ],
+            },
+          ],
+        });
+        expect(result).toHaveProperty('thinking');
+        const messages = result.messages as Array<Record<string, unknown>>;
+        const content = messages[0].content as Array<Record<string, unknown>>;
+        expect(content).toHaveLength(2);
+        expect(content[0].type).toBe('thinking');
+      });
+
+      it('does not mutate the original body', () => {
+        const body = {
+          model: 'claude-sonnet-4-20250514',
+          max_tokens: 1024,
+          thinking: { type: 'enabled', budget_tokens: 4096 },
+          messages: [
+            {
+              role: 'assistant' as const,
+              content: [
+                { type: 'thinking', thinking: 'r', signature: 's' },
+                { type: 'text', text: 'hi' },
+              ],
+            },
+          ],
+        };
+        applyAnthropicMessagesMutations(body, { stripThinkingBlocks: true });
+        // Original body should still have thinking blocks and thinking param
+        expect(body.thinking).toEqual({ type: 'enabled', budget_tokens: 4096 });
+        const originalContent = body.messages[0].content as Array<Record<string, unknown>>;
+        expect(originalContent).toHaveLength(2);
+        expect(originalContent[0].type).toBe('thinking');
+      });
+    });
   });
 
   describe('extractThinkingBlocksFromMessagesResponse', () => {

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -2304,6 +2304,21 @@ describe('Anthropic Adapter', () => {
         tool_choice: { type: 'auto' },
       });
     });
+
+    it('strips context_management (compaction field that requires a beta header)', () => {
+      const result = applyAnthropicMessagesMutations({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: 'hi' }],
+        context_management: { edits: [{ type: 'compact_20260112' }] },
+      });
+      expect(result).not.toHaveProperty('context_management');
+      expect(result).toMatchObject({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+    });
   });
 
   describe('extractThinkingBlocksFromMessagesResponse', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -426,6 +426,93 @@ describe('ProviderClient', () => {
       expect((anthropicBody.tools[1] as Record<string, unknown>).cache_control).toBeUndefined();
     });
 
+    it('strips thinking blocks when Anthropic Messages passthrough routes to a different model', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const anthropicBody = {
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: 1024,
+        thinking: { type: 'enabled', budget_tokens: 4096 },
+        messages: [
+          { role: 'user', content: 'hello' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'reasoning', signature: 'sig_abc' },
+              { type: 'redacted_thinking', data: 'opaque' },
+              { type: 'tool_use', id: 'toolu_1', name: 'foo', input: {} },
+            ],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok' }],
+          },
+        ],
+      };
+
+      // Route to a different model than the one in the request body
+      await client.forward({
+        provider: 'anthropic',
+        apiKey: 'sk-ant-test',
+        model: 'claude-opus-4-8',
+        body: anthropicBody,
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      // Top-level thinking should be stripped
+      expect(sent).not.toHaveProperty('thinking');
+      // Assistant message should have thinking blocks removed
+      const assistantContent = sent.messages[1].content;
+      expect(assistantContent).toEqual([
+        { type: 'tool_use', id: 'toolu_1', name: 'foo', input: {} },
+      ]);
+      // Model should be the routed-to model
+      expect(sent.model).toBe('claude-opus-4-8');
+      // Original body should not be mutated
+      expect(anthropicBody.thinking).toEqual({ type: 'enabled', budget_tokens: 4096 });
+      const origContent = (anthropicBody.messages[1] as Record<string, unknown>).content as Array<
+        Record<string, unknown>
+      >;
+      expect(origContent).toHaveLength(3);
+    });
+
+    it('preserves thinking blocks when Anthropic Messages passthrough routes to the same model', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const anthropicBody = {
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: 1024,
+        thinking: { type: 'enabled', budget_tokens: 4096 },
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'reasoning', signature: 'sig_abc' },
+              { type: 'tool_use', id: 'toolu_1', name: 'foo', input: {} },
+            ],
+          },
+        ],
+      };
+
+      // Same model as the request body
+      await client.forward({
+        provider: 'anthropic',
+        apiKey: 'sk-ant-test',
+        model: 'claude-sonnet-4-5-20250929',
+        body: anthropicBody,
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      // Thinking blocks should survive when model hasn't changed
+      expect(sent.thinking).toEqual({ type: 'enabled', budget_tokens: 4096 });
+      expect(sent.messages[0].content).toHaveLength(2);
+      expect(sent.messages[0].content[0].type).toBe('thinking');
+    });
+
     it('still uses toAnthropicRequest for chat_completions inbound forwarded to an Anthropic upstream', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -346,12 +346,26 @@ export function extractThinkingBlocksFromMessagesResponse(
  * - Replay cached extended-thinking blocks at the head of assistant turns
  *   whose first content block is a `tool_use`.
  */
+/**
+ * Fields that clients may send on the Anthropic Messages API but that Anthropic
+ * rejects as "extra inputs not permitted" when the required beta header is
+ * absent.  `context_management` is a valid Anthropic parameter for compaction
+ * (beta `compact-2026-01-12`), but Manifest does not forward that beta header,
+ * so the field must be stripped before forwarding.
+ */
+const ANTHROPIC_UNSUPPORTED_FIELDS = new Set(['context_management']);
+
 export function applyAnthropicMessagesMutations(
   body: Record<string, unknown>,
   options?: AnthropicRequestOptions,
 ): Record<string, unknown> {
   const shouldCache = options?.injectCacheControl !== false;
   const result: Record<string, unknown> = { ...body };
+
+  // Strip fields that Anthropic rejects under the standard version header.
+  for (const key of ANTHROPIC_UNSUPPORTED_FIELDS) {
+    delete result[key];
+  }
 
   // Normalize `system` to a content-block array so cache_control + identity
   // injection have a uniform target. Anthropic accepts either a bare string

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -244,6 +244,13 @@ export interface AnthropicRequestOptions {
   injectSubscriptionIdentity?: boolean;
   /** Lookup for re-injecting cached extended-thinking blocks. */
   thinkingLookup?: ThinkingBlockLookup;
+  /**
+   * Strip signed thinking blocks from native Messages payloads. Anthropic
+   * validates thinking signatures against the model that produced them, so
+   * forwarding a native Messages conversation to a different routed model can
+   * otherwise fail with `Invalid signature in thinking block`.
+   */
+  stripThinkingBlocks?: boolean;
 }
 
 export function toAnthropicRequest(
@@ -365,6 +372,24 @@ export function applyAnthropicMessagesMutations(
   // Strip fields that Anthropic rejects under the standard version header.
   for (const key of ANTHROPIC_UNSUPPORTED_FIELDS) {
     delete result[key];
+  }
+
+  // When routing to a different Anthropic model than the client requested,
+  // signed thinking blocks from prior turns carry signatures that are only
+  // valid for the original model.  Remove them so the upstream doesn't reject
+  // with `Invalid signature in thinking block`.  Also remove the top-level
+  // `thinking` parameter so Anthropic doesn't require signed blocks in
+  // previous assistant turns.
+  if (options?.stripThinkingBlocks && Array.isArray(result.messages)) {
+    result.messages = (result.messages as Array<Record<string, unknown>>).map((m) => {
+      if (m.role !== 'assistant' || !Array.isArray(m.content)) return m;
+      const content = m.content as ContentBlock[];
+      const filtered = content.filter(
+        (b) => b.type !== 'thinking' && b.type !== 'redacted_thinking',
+      );
+      return filtered.length === content.length ? m : { ...m, content: filtered };
+    });
+    delete result.thinking;
   }
 
   // Normalize `system` to a content-block array so cache_control + identity

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -368,6 +368,10 @@ export class ProviderClient {
     if (endpoint.format === 'anthropic') {
       const isSubscription = authType === 'subscription';
       const injectSubscriptionIdentity = isSubscription && !endpoint.skipSubscriptionIdentity;
+      const inboundModel =
+        typeof body.model === 'string' ? stripVendorPrefix(body.model) : undefined;
+      const stripThinkingBlocks =
+        ctx.apiMode === 'messages' && !!inboundModel && inboundModel !== bareModel;
       // When the inbound request is already Anthropic Messages
       // (`POST /v1/messages`) and the resolved upstream is also Anthropic,
       // skip the OpenAI translation round-trip and apply only the additive
@@ -382,7 +386,8 @@ export class ProviderClient {
           ? applyAnthropicMessagesMutations(body, {
               injectCacheControl: !isSubscription,
               injectSubscriptionIdentity,
-              thinkingLookup: ctx.thinkingLookup,
+              thinkingLookup: stripThinkingBlocks ? undefined : ctx.thinkingLookup,
+              stripThinkingBlocks,
             })
           : toAnthropicRequest(requestSource, bareModel, {
               injectCacheControl: !isSubscription,


### PR DESCRIPTION
fix: strip `context_management` and signed thinking blocks from Anthropic proxy requests

**Problem 1 — `context_management` strip**

Clients sending requests via `POST /v1/messages` (Anthropic Messages API format) may include a `context_management` field — a legitimate Anthropic parameter for compaction that requires the `compact-2026-01-12` beta header. Manifest forwards this field to Anthropic unchanged, but sends `anthropic-version: 2023-06-01` without the compaction beta header, causing Anthropic to reject the request:

```json
{"type":"error","error":{"type":"invalid_request_error","message":"context_management: Extra inputs are not permitted"}}
```

**Fix 1**

Strips `context_management` from the outbound request body in `applyAnthropicMessagesMutations()`, the passthrough function used when both inbound and upstream are Anthropic Messages format. Follows the existing `OPENAI_ONLY_FIELDS` pattern: a `Set` of known-problematic field names that gets deleted from the spread result.

**Problem 2 — signed thinking blocks on model mismatch**

When Manifest routes an Anthropic Messages request to a model different from the one the client originally requested, signed `thinking` and `redacted_thinking` blocks from prior assistant turns carry signatures that are only valid for the original model. The upstream rejects with:

```json
{"type":"error","error":{"type":"invalid_request_error","message":"Invalid signature in thinking block"}}
```

**Fix 2**

Removes `thinking` and `redacted_thinking` content blocks from assistant messages and drops the top-level `thinking` parameter when the `stripThinkingBlocks` option is set — which happens automatically when the inbound model differs from the resolved upstream model.

**Testing**

- Added test: verifies `context_management` is stripped while other Anthropic-native fields (`top_k`, `stop_sequences`, `thinking`, `metadata`, `tool_choice`) pass through untouched.
- Added tests for `stripThinkingBlocks`: removes blocks, respects the flag, does not mutate the original body.
- All 134 existing anthropic-adapter tests pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Anthropic proxy failures by stripping `context_management` when the compaction beta header isn’t sent and removing signed `thinking` blocks when routing to a different model. This stops upstream `invalid_request_error` and signature validation errors.

- **Bug Fixes**
  - For Anthropic Messages passthrough, delete `context_management` before forwarding.
  - When inbound and routed models differ, remove `thinking`/`redacted_thinking` blocks from assistant messages and drop the top-level `thinking` param.

<sup>Written for commit f79dab486b4cbd5b89bfbc3ac9fc83d468940b2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

