### PR TITLE
revert: show column type before name in schema diagram

### DIFF
--- a/.github/scripts/db-diagram/__fixtures__/expected-comment.md
+++ b/.github/scripts/db-diagram/__fixtures__/expected-comment.md
@@ -19,32 +19,32 @@ Showing only changed tables. 🟢 added, 🟡 modified, 🔴 removed. Changed co
 ```mermaid
 erDiagram
     agent_api_keys["🟡 agent_api_keys (modified)"] {
-        id varchar PK
-        agent_id varchar FK "🟡 FK added"
-        key varchar_64_
+        varchar id PK
+        varchar agent_id FK "🟡 FK added"
+        varchar_64_ key
     }
     agents["🟡 agents (modified)"] {
-        id varchar PK
-        name varchar "🟡 modified"
-        tenant_id varchar FK
-        display_name varchar_255_ "🟢 added"
-        legacy_flag boolean "🔴 removed"
+        varchar id PK
+        varchar name "🟡 modified"
+        varchar tenant_id FK
+        varchar_255_ display_name "🟢 added"
+        boolean legacy_flag "🔴 removed"
     }
     legacy_metrics["🔴 legacy_metrics (removed)"] {
-        id varchar PK
-        value integer
+        varchar id PK
+        integer value
     }
     provider_keys["🟡 provider_keys (modified)"] {
-        id varchar PK
-        agent_id varchar "🟡 FK removed"
-        region varchar PK "🟡 PK changed"
+        varchar id PK
+        varchar agent_id "🟡 FK removed"
+        varchar region PK "🟡 PK changed"
     }
     routing_tiers["🟢 routing_tiers (added)"] {
-        id uuid PK
-        agent_id varchar FK
-        tier varchar
-        model varchar
-        max_cost numeric_15_6_
+        uuid id PK
+        varchar agent_id FK
+        varchar tier
+        varchar model
+        numeric_15_6_ max_cost
     }
     agent_api_keys }o--|| agents : "agent_id"
     routing_tiers }o--|| agents : "agent_id"

--- a/.github/scripts/db-diagram/render-diagram.cjs
+++ b/.github/scripts/db-diagram/render-diagram.cjs
@@ -166,12 +166,12 @@ function buildMermaid(headSnap, baseSnap, added, modMap, dropped) {
             pkChangedCols,
           })
         : '';
-      lines.push(`        ${col.name} ${safeType}${pk}${fk}${note}`);
+      lines.push(`        ${safeType} ${col.name}${pk}${fk}${note}`);
     }
     // Columns removed by this PR no longer exist in the head snapshot, so render
     // them as trailing rows (with their pre-drop type) flagged 🔴 removed.
     for (const c of droppedCols) {
-      lines.push(`        ${c.column} ${sanitizeMermaidType(c.type)} "🔴 removed"`);
+      lines.push(`        ${sanitizeMermaidType(c.type)} ${c.column} "🔴 removed"`);
     }
     lines.push('    }');
     rendered.add(name);


### PR DESCRIPTION
### 💭 Why
The previous "type name" column order in the schema-diagram PR comment read better for our review flow. #2211 flipped it to "name type"; this reverts that.

### ✨ What changed
- Mermaid ER rows emit `type name` again instead of `name type`.
- Regenerated the golden fixture so the smoke test matches.

### 📝 Notes
Reverts #2211. CI-only change: affects the generated PR comment, nothing in the shipped image. PK/FK badges and change annotations unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the DB schema Mermaid diagram column order to show type before name in PR comments for better readability. Updates the renderer and expected fixture; CI-only change with no impact on the shipped image.

<sup>Written for commit 02d858d5f582fbe259455be9798089bfc004b549. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

