### PR TITLE
fix: restore prompt-cache hits for openai-subscription

### DIFF
--- a/.changeset/codex-subscription-cache-affinity.md
+++ b/.changeset/codex-subscription-cache-affinity.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Restore prompt-cache hits on the ChatGPT subscription backend: send the session affinity headers the Codex CLI sends (`session-id`/`thread-id`, `x-codex-turn-state` replay, stable `prompt_cache_key`), and forward the caller's `prompt_cache_key` on OpenAI /responses conversions

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-request.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-request.spec.ts
@@ -191,4 +191,36 @@ describe('ChatGPT Adapter – toResponsesRequest', () => {
     expect(result.instructions).toBe('You are a helpful assistant.');
     expect(result.input).toEqual([{ role: 'user', content: [{ type: 'input_text', text: 'Hi' }] }]);
   });
+
+  describe('prompt_cache_key forwarding', () => {
+    const body = {
+      messages: [{ role: 'user', content: 'Hi' }],
+      prompt_cache_key: 'conv-1',
+    };
+
+    it('forwards prompt_cache_key when opted in', () => {
+      const result = toResponsesRequest(body, 'gpt-5', { forwardPromptCacheKey: true });
+
+      expect(result.prompt_cache_key).toBe('conv-1');
+    });
+
+    it('drops prompt_cache_key by default', () => {
+      const result = toResponsesRequest(body, 'gpt-5');
+
+      expect(result).not.toHaveProperty('prompt_cache_key');
+    });
+
+    it.each([[undefined], [''], [42]])(
+      'ignores a %p prompt_cache_key even when opted in',
+      (key) => {
+        const result = toResponsesRequest(
+          { messages: body.messages, prompt_cache_key: key },
+          'gpt-5',
+          { forwardPromptCacheKey: true },
+        );
+
+        expect(result).not.toHaveProperty('prompt_cache_key');
+      },
+    );
+  });
 });

--- a/packages/backend/src/routing/proxy/__tests__/codex-session-affinity.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/codex-session-affinity.spec.ts
@@ -70,6 +70,33 @@ describe('CodexSessionAffinity', () => {
       expect(headers).not.toHaveProperty('x-codex-turn-state');
     });
 
+    it('treats an over-long prompt_cache_key as absent to cap per-key memory', () => {
+      const longKey = 'x'.repeat(513);
+      const body: Record<string, unknown> = { prompt_cache_key: longKey };
+      const otherLongKey: Record<string, unknown> = { prompt_cache_key: 'y'.repeat(600) };
+
+      const first = affinity.prepare('token', body);
+      const second = affinity.prepare('token', otherLongKey);
+
+      // The giant key is never echoed back to the upstream…
+      expect(body.prompt_cache_key).toMatch(UUID_RE);
+      expect(body.prompt_cache_key).not.toBe(longKey);
+      // …and distinct over-long keys collapse onto the single per-token session
+      // (storeKey is just the token), so they cannot amplify the cache.
+      expect(first.storeKey).toBe(second.storeKey);
+      expect(first.headers['session-id']).toBe(second.headers['session-id']);
+    });
+
+    it('accepts a prompt_cache_key at the length boundary', () => {
+      const maxKey = 'x'.repeat(512);
+      const body: Record<string, unknown> = { prompt_cache_key: maxKey };
+
+      const { storeKey } = affinity.prepare('token', body);
+
+      expect(body.prompt_cache_key).toBe(maxKey);
+      expect(storeKey).toContain(maxKey);
+    });
+
     it('rotates session ids after the TTL', () => {
       const before = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
 

--- a/packages/backend/src/routing/proxy/__tests__/codex-session-affinity.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/codex-session-affinity.spec.ts
@@ -1,0 +1,192 @@
+import { CodexSessionAffinity } from '../codex-session-affinity';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function okResponseWithTurnState(token: string): Response {
+  return new Response('{}', { status: 200, headers: { 'x-codex-turn-state': token } });
+}
+
+describe('CodexSessionAffinity', () => {
+  let affinity: CodexSessionAffinity;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    affinity = new CodexSessionAffinity();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('prepare', () => {
+    it('derives UUID-shaped session-id and thread-id headers', () => {
+      const { headers } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(headers['session-id']).toMatch(UUID_RE);
+      expect(headers['thread-id']).toMatch(UUID_RE);
+      expect(headers['session-id']).not.toBe(headers['thread-id']);
+    });
+
+    it('is deterministic for the same token + cache key, distinct otherwise', () => {
+      const a = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      const b = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      const otherConversation = affinity.prepare('token', { prompt_cache_key: 'conv-2' });
+      const otherToken = affinity.prepare('token-2', { prompt_cache_key: 'conv-1' });
+
+      expect(a.headers).toEqual(b.headers);
+      expect(a.storeKey).toBe(b.storeKey);
+      expect(otherConversation.headers['session-id']).not.toBe(a.headers['session-id']);
+      expect(otherToken.headers['session-id']).not.toBe(a.headers['session-id']);
+    });
+
+    it('keeps a caller-supplied prompt_cache_key untouched', () => {
+      const body: Record<string, unknown> = { prompt_cache_key: 'caller-key' };
+
+      affinity.prepare('token', body);
+
+      expect(body.prompt_cache_key).toBe('caller-key');
+    });
+
+    it.each([[undefined], [''], [42]])(
+      'injects a stable per-token default when prompt_cache_key is %p',
+      (callerKey) => {
+        const body: Record<string, unknown> = { prompt_cache_key: callerKey };
+        const bodyAgain: Record<string, unknown> = { prompt_cache_key: callerKey };
+        const otherToken: Record<string, unknown> = { prompt_cache_key: callerKey };
+
+        affinity.prepare('token', body);
+        affinity.prepare('token', bodyAgain);
+        affinity.prepare('token-2', otherToken);
+
+        expect(body.prompt_cache_key).toMatch(UUID_RE);
+        expect(bodyAgain.prompt_cache_key).toBe(body.prompt_cache_key);
+        expect(otherToken.prompt_cache_key).not.toBe(body.prompt_cache_key);
+      },
+    );
+
+    it('omits x-codex-turn-state when nothing has been captured', () => {
+      const { headers } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(headers).not.toHaveProperty('x-codex-turn-state');
+    });
+  });
+
+  describe('capture + replay', () => {
+    it('replays the captured turn-state token on the next request for the same session', () => {
+      const first = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      affinity.capture(first.storeKey, okResponseWithTurnState('turn-abc'));
+
+      const second = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(second.headers['x-codex-turn-state']).toBe('turn-abc');
+    });
+
+    it('scopes turn-state to the session it was captured for', () => {
+      const first = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      affinity.capture(first.storeKey, okResponseWithTurnState('turn-abc'));
+
+      const other = affinity.prepare('token', { prompt_cache_key: 'conv-2' });
+
+      expect(other.headers).not.toHaveProperty('x-codex-turn-state');
+    });
+
+    it('overwrites the stored token with the most recent one', () => {
+      const { storeKey } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      affinity.capture(storeKey, okResponseWithTurnState('turn-1'));
+      affinity.capture(storeKey, okResponseWithTurnState('turn-2'));
+
+      const next = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(next.headers['x-codex-turn-state']).toBe('turn-2');
+    });
+
+    it('ignores responses without a turn-state header', () => {
+      const { storeKey } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      affinity.capture(storeKey, new Response('{}', { status: 200 }));
+
+      const next = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(next.headers).not.toHaveProperty('x-codex-turn-state');
+    });
+
+    it('evicts the stored token when the upstream rejects a request', () => {
+      const { storeKey } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      affinity.capture(storeKey, okResponseWithTurnState('turn-abc'));
+      affinity.capture(storeKey, new Response('{}', { status: 400 }));
+
+      const next = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(next.headers).not.toHaveProperty('x-codex-turn-state');
+    });
+
+    it('expires tokens after the TTL', () => {
+      const { storeKey } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      affinity.capture(storeKey, okResponseWithTurnState('turn-abc'));
+
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+      const next = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(next.headers).not.toHaveProperty('x-codex-turn-state');
+    });
+
+    it('slides the TTL while the session stays active', () => {
+      const { storeKey } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      affinity.capture(storeKey, okResponseWithTurnState('turn-abc'));
+
+      jest.advanceTimersByTime(4 * 60 * 1000);
+      expect(
+        affinity.prepare('token', { prompt_cache_key: 'conv-1' }).headers['x-codex-turn-state'],
+      ).toBe('turn-abc');
+
+      // 8 minutes after capture — would be expired without the refresh above.
+      jest.advanceTimersByTime(4 * 60 * 1000);
+      expect(
+        affinity.prepare('token', { prompt_cache_key: 'conv-1' }).headers['x-codex-turn-state'],
+      ).toBe('turn-abc');
+    });
+
+    it('sweeps expired entries during capture', () => {
+      const expired = affinity.prepare('token', { prompt_cache_key: 'conv-expired' });
+      affinity.capture(expired.storeKey, okResponseWithTurnState('turn-old'));
+
+      jest.advanceTimersByTime(6 * 60 * 1000);
+      const fresh = affinity.prepare('token', { prompt_cache_key: 'conv-fresh' });
+      affinity.capture(fresh.storeKey, okResponseWithTurnState('turn-new'));
+
+      expect(
+        affinity.prepare('token', { prompt_cache_key: 'conv-fresh' }).headers['x-codex-turn-state'],
+      ).toBe('turn-new');
+      expect(
+        affinity.prepare('token', { prompt_cache_key: 'conv-expired' }).headers,
+      ).not.toHaveProperty('x-codex-turn-state');
+    });
+
+    it('evicts the oldest entry at capacity, but never for an already-stored session', () => {
+      const first = affinity.prepare('token', { prompt_cache_key: 'conv-0' });
+      affinity.capture(first.storeKey, okResponseWithTurnState('turn-0'));
+      for (let i = 1; i < 10_000; i++) {
+        affinity.capture(`store-key-${i}`, okResponseWithTurnState(`turn-${i}`));
+      }
+
+      // Re-capturing an existing session at capacity must not evict anything.
+      affinity.capture(first.storeKey, okResponseWithTurnState('turn-0-updated'));
+      expect(
+        affinity.prepare('token', { prompt_cache_key: 'conv-0' }).headers['x-codex-turn-state'],
+      ).toBe('turn-0-updated');
+
+      // A new session at capacity evicts the oldest entry (store-key-1 — the
+      // re-capture above moved conv-0 to the back of the recency order).
+      const overflow = affinity.prepare('token', { prompt_cache_key: 'conv-overflow' });
+      affinity.capture(overflow.storeKey, okResponseWithTurnState('turn-overflow'));
+
+      expect(
+        affinity.prepare('token', { prompt_cache_key: 'conv-overflow' }).headers[
+          'x-codex-turn-state'
+        ],
+      ).toBe('turn-overflow');
+      expect(
+        affinity.prepare('token', { prompt_cache_key: 'conv-0' }).headers['x-codex-turn-state'],
+      ).toBe('turn-0-updated');
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/codex-session-affinity.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/codex-session-affinity.spec.ts
@@ -19,7 +19,7 @@ describe('CodexSessionAffinity', () => {
   });
 
   describe('prepare', () => {
-    it('derives UUID-shaped session-id and thread-id headers', () => {
+    it('issues UUID-shaped session-id and thread-id headers', () => {
       const { headers } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
 
       expect(headers['session-id']).toMatch(UUID_RE);
@@ -27,7 +27,7 @@ describe('CodexSessionAffinity', () => {
       expect(headers['session-id']).not.toBe(headers['thread-id']);
     });
 
-    it('is deterministic for the same token + cache key, distinct otherwise', () => {
+    it('reuses the same ids for the same token + cache key, distinct otherwise', () => {
       const a = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
       const b = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
       const otherConversation = affinity.prepare('token', { prompt_cache_key: 'conv-2' });
@@ -69,6 +69,43 @@ describe('CodexSessionAffinity', () => {
 
       expect(headers).not.toHaveProperty('x-codex-turn-state');
     });
+
+    it('rotates session ids after the TTL', () => {
+      const before = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+      const after = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(after.headers['session-id']).not.toBe(before.headers['session-id']);
+    });
+
+    it('rotates an expired session in place when no sweep has run yet', () => {
+      const before = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      // A sweep 4m30s in leaves conv-1 alive and resets the cleanup clock…
+      jest.advanceTimersByTime(4 * 60 * 1000 + 30 * 1000);
+      affinity.prepare('token', { prompt_cache_key: 'conv-other' });
+
+      // …so 40s later conv-1 is expired but still in the map, and prepare()
+      // must replace it rather than reuse it.
+      jest.advanceTimersByTime(40 * 1000);
+      const after = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(after.headers['session-id']).not.toBe(before.headers['session-id']);
+    });
+
+    it('slides the TTL while the session stays active', () => {
+      const before = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      jest.advanceTimersByTime(4 * 60 * 1000);
+      affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      // 8 minutes after creation — would have rotated without the refresh above.
+      jest.advanceTimersByTime(4 * 60 * 1000);
+      const after = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+
+      expect(after.headers['session-id']).toBe(before.headers['session-id']);
+    });
   });
 
   describe('capture + replay', () => {
@@ -109,14 +146,15 @@ describe('CodexSessionAffinity', () => {
       expect(next.headers).not.toHaveProperty('x-codex-turn-state');
     });
 
-    it('evicts the stored token when the upstream rejects a request', () => {
-      const { storeKey } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
-      affinity.capture(storeKey, okResponseWithTurnState('turn-abc'));
-      affinity.capture(storeKey, new Response('{}', { status: 400 }));
+    it('drops the stored token but keeps the session when the upstream rejects a request', () => {
+      const first = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
+      affinity.capture(first.storeKey, okResponseWithTurnState('turn-abc'));
+      affinity.capture(first.storeKey, new Response('{}', { status: 400 }));
 
       const next = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
 
       expect(next.headers).not.toHaveProperty('x-codex-turn-state');
+      expect(next.headers['session-id']).toBe(first.headers['session-id']);
     });
 
     it('expires tokens after the TTL', () => {
@@ -129,64 +167,37 @@ describe('CodexSessionAffinity', () => {
       expect(next.headers).not.toHaveProperty('x-codex-turn-state');
     });
 
-    it('slides the TTL while the session stays active', () => {
-      const { storeKey } = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
-      affinity.capture(storeKey, okResponseWithTurnState('turn-abc'));
+    it('is a no-op when the session has been swept before the response arrived', () => {
+      const stale = affinity.prepare('token', { prompt_cache_key: 'conv-stale' });
 
-      jest.advanceTimersByTime(4 * 60 * 1000);
-      expect(
-        affinity.prepare('token', { prompt_cache_key: 'conv-1' }).headers['x-codex-turn-state'],
-      ).toBe('turn-abc');
-
-      // 8 minutes after capture — would be expired without the refresh above.
-      jest.advanceTimersByTime(4 * 60 * 1000);
-      expect(
-        affinity.prepare('token', { prompt_cache_key: 'conv-1' }).headers['x-codex-turn-state'],
-      ).toBe('turn-abc');
-    });
-
-    it('sweeps expired entries during capture', () => {
-      const expired = affinity.prepare('token', { prompt_cache_key: 'conv-expired' });
-      affinity.capture(expired.storeKey, okResponseWithTurnState('turn-old'));
-
+      // The sweep during this prepare() removes the expired conv-stale session.
       jest.advanceTimersByTime(6 * 60 * 1000);
-      const fresh = affinity.prepare('token', { prompt_cache_key: 'conv-fresh' });
-      affinity.capture(fresh.storeKey, okResponseWithTurnState('turn-new'));
+      affinity.prepare('token', { prompt_cache_key: 'conv-other' });
 
-      expect(
-        affinity.prepare('token', { prompt_cache_key: 'conv-fresh' }).headers['x-codex-turn-state'],
-      ).toBe('turn-new');
-      expect(
-        affinity.prepare('token', { prompt_cache_key: 'conv-expired' }).headers,
-      ).not.toHaveProperty('x-codex-turn-state');
+      affinity.capture(stale.storeKey, okResponseWithTurnState('turn-late'));
+      const next = affinity.prepare('token', { prompt_cache_key: 'conv-stale' });
+
+      expect(next.headers).not.toHaveProperty('x-codex-turn-state');
     });
+  });
 
-    it('evicts the oldest entry at capacity, but never for an already-stored session', () => {
-      const first = affinity.prepare('token', { prompt_cache_key: 'conv-0' });
-      affinity.capture(first.storeKey, okResponseWithTurnState('turn-0'));
-      for (let i = 1; i < 10_000; i++) {
-        affinity.capture(`store-key-${i}`, okResponseWithTurnState(`turn-${i}`));
+  describe('capacity', () => {
+    it('evicts the oldest session at capacity, preserving recently used ones', () => {
+      const first = affinity.prepare('token-0', {});
+      const second = affinity.prepare('token-1', {});
+      for (let i = 2; i < 10_000; i++) {
+        affinity.prepare(`token-${i}`, {});
       }
 
-      // Re-capturing an existing session at capacity must not evict anything.
-      affinity.capture(first.storeKey, okResponseWithTurnState('turn-0-updated'));
-      expect(
-        affinity.prepare('token', { prompt_cache_key: 'conv-0' }).headers['x-codex-turn-state'],
-      ).toBe('turn-0-updated');
+      // Touching token-0 at capacity must not evict anything, and moves it to
+      // the back of the recency order…
+      expect(affinity.prepare('token-0', {}).headers).toEqual(first.headers);
 
-      // A new session at capacity evicts the oldest entry (store-key-1 — the
-      // re-capture above moved conv-0 to the back of the recency order).
-      const overflow = affinity.prepare('token', { prompt_cache_key: 'conv-overflow' });
-      affinity.capture(overflow.storeKey, okResponseWithTurnState('turn-overflow'));
+      // …so a brand-new session evicts token-1 (now the oldest), not token-0.
+      affinity.prepare('token-overflow', {});
 
-      expect(
-        affinity.prepare('token', { prompt_cache_key: 'conv-overflow' }).headers[
-          'x-codex-turn-state'
-        ],
-      ).toBe('turn-overflow');
-      expect(
-        affinity.prepare('token', { prompt_cache_key: 'conv-0' }).headers['x-codex-turn-state'],
-      ).toBe('turn-0-updated');
+      expect(affinity.prepare('token-1', {}).headers).not.toEqual(second.headers);
+      expect(affinity.prepare('token-0', {}).headers).toEqual(first.headers);
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
@@ -319,6 +319,22 @@ describe('ProviderClient — Codex prompt-cache affinity (openai-subscription)',
     expect(sentBody.prompt_cache_key).toMatch(UUID_RE);
   });
 
+  it('keeps affinity headers authoritative over caller-supplied extraHeaders', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      ...subscriptionOpts,
+      extraHeaders: { 'session-id': 'attacker-override', 'x-observability': 'keep-me' },
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    // Routing-critical affinity header wins…
+    expect(sentHeaders['session-id']).toMatch(UUID_RE);
+    expect(sentHeaders['session-id']).not.toBe('attacker-override');
+    // …while non-conflicting extraHeaders still pass through.
+    expect(sentHeaders['x-observability']).toBe('keep-me');
+  });
+
   it('uses an injected CodexSessionAffinity instance when provided', async () => {
     const affinity = new CodexSessionAffinity();
     const prepareSpy = jest.spyOn(affinity, 'prepare');

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
@@ -9,6 +9,9 @@
 // fails loudly.
 
 import { ProviderClient } from '../provider-client';
+import { CodexSessionAffinity } from '../codex-session-affinity';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 const mockFetch = jest.fn();
 (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
@@ -209,7 +212,121 @@ describe('ProviderClient — strict header contract on auth-critical paths', () 
     // rejects non-Codex shaped requests).
     expect(typeof sentHeaders['user-agent']).toBe('string');
     expect(sentHeaders['user-agent'].length).toBeGreaterThan(0);
+    // Prompt-cache affinity headers the Codex backend needs for cache hits.
+    expect(sentHeaders['session-id']).toMatch(UUID_RE);
+    expect(sentHeaders['thread-id']).toMatch(UUID_RE);
     expect(sentHeaders).not.toHaveProperty('x-api-key');
     expect(sentHeaders).not.toHaveProperty('anthropic-version');
+  });
+});
+
+describe('ProviderClient — Codex prompt-cache affinity (openai-subscription)', () => {
+  let client: ProviderClient;
+
+  beforeEach(() => {
+    client = new ProviderClient();
+    mockFetch.mockReset();
+  });
+
+  const subscriptionOpts = {
+    provider: 'openai',
+    apiKey: 'oauth-token',
+    model: 'gpt-5',
+    body,
+    stream: false,
+    authType: 'subscription',
+  } as const;
+
+  it('sends deterministic session-id/thread-id headers across requests', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({ ...subscriptionOpts });
+    await client.forward({ ...subscriptionOpts });
+
+    const first = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    const second = mockFetch.mock.calls[1][1].headers as Record<string, string>;
+    expect(first['session-id']).toMatch(UUID_RE);
+    expect(first['session-id']).toBe(second['session-id']);
+    expect(first['thread-id']).toBe(second['thread-id']);
+  });
+
+  it('injects a stable default prompt_cache_key into the outgoing body', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({ ...subscriptionOpts });
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(sentBody.prompt_cache_key).toMatch(UUID_RE);
+  });
+
+  it('keeps the caller-supplied prompt_cache_key on the Chat Completions path', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      ...subscriptionOpts,
+      body: { ...body, prompt_cache_key: 'caller-conv-1' },
+    });
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(sentBody.prompt_cache_key).toBe('caller-conv-1');
+  });
+
+  it('forwards the caller prompt_cache_key on the api-key /responses conversion path', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'openai',
+      apiKey: 'sk-test',
+      model: 'o1-pro',
+      body: { ...body, prompt_cache_key: 'caller-conv-1' },
+      stream: false,
+    });
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(sentBody.prompt_cache_key).toBe('caller-conv-1');
+    // Affinity headers stay subscription-only; the API-key path needs none.
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(sentHeaders).not.toHaveProperty('session-id');
+  });
+
+  it('replays the x-codex-turn-state token captured from the previous response', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('{}', { status: 200, headers: { 'x-codex-turn-state': 'turn-abc' } }),
+    );
+    mockFetch.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    await client.forward({ ...subscriptionOpts });
+    await client.forward({ ...subscriptionOpts });
+
+    const first = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    const second = mockFetch.mock.calls[1][1].headers as Record<string, string>;
+    expect(first).not.toHaveProperty('x-codex-turn-state');
+    expect(second['x-codex-turn-state']).toBe('turn-abc');
+  });
+
+  it('applies affinity on the native Responses API path too', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      ...subscriptionOpts,
+      apiMode: 'responses',
+      body: { input: 'Hello', instructions: 'You are helpful.' },
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(sentHeaders['session-id']).toMatch(UUID_RE);
+    expect(sentBody.prompt_cache_key).toMatch(UUID_RE);
+  });
+
+  it('uses an injected CodexSessionAffinity instance when provided', async () => {
+    const affinity = new CodexSessionAffinity();
+    const prepareSpy = jest.spyOn(affinity, 'prepare');
+    const injected = new ProviderClient(undefined, undefined, affinity);
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await injected.forward({ ...subscriptionOpts });
+
+    expect(prepareSpy).toHaveBeenCalledWith('oauth-token', expect.any(Object));
   });
 });

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -41,6 +41,13 @@ export interface ToResponsesRequestOptions {
    */
   mapMaxOutputTokens?: boolean;
   /**
+   * Forward the caller's `prompt_cache_key` so same-prefix requests keep
+   * their prompt-cache affinity. Opt-in per endpoint: OpenAI's /responses
+   * endpoints accept the field, other Responses-shaped backends may reject
+   * unknown parameters.
+   */
+  forwardPromptCacheKey?: boolean;
+  /**
    * Explicit upstream streaming mode. Omit to preserve the historical
    * ChatGPT-subscription behavior, which expects SSE collection.
    */
@@ -99,6 +106,14 @@ export function toResponsesRequest(
     if (typeof maxOutputTokens === 'number') {
       request.max_output_tokens = maxOutputTokens;
     }
+  }
+
+  if (
+    options.forwardPromptCacheKey &&
+    typeof body.prompt_cache_key === 'string' &&
+    body.prompt_cache_key
+  ) {
+    request.prompt_cache_key = body.prompt_cache_key;
   }
 
   if (isObjectRecord(body.reasoning)) {

--- a/packages/backend/src/routing/proxy/codex-session-affinity.ts
+++ b/packages/backend/src/routing/proxy/codex-session-affinity.ts
@@ -5,6 +5,10 @@ import { Injectable } from '@nestjs/common';
 const SESSION_TTL_MS = 5 * 60 * 1000; // matches the OpenAI prompt-cache idle window
 const CLEANUP_INTERVAL_MS = 60 * 1000;
 const MAX_ENTRIES = 10_000;
+// Legitimate prompt_cache_key values are short identifiers; an over-long one is
+// treated as absent so a caller can't amplify memory by storing huge unique
+// keys (MAX_ENTRIES bounds the count, this bounds each key's size).
+const MAX_CACHE_KEY_LEN = 512;
 
 interface CodexSession {
   sessionId: string;
@@ -64,7 +68,10 @@ export class CodexSessionAffinity {
    */
   prepare(apiKey: string, requestBody: Record<string, unknown>): CodexAffinityRequest {
     const callerKey = requestBody.prompt_cache_key;
-    const cacheKey = typeof callerKey === 'string' && callerKey ? callerKey : null;
+    const cacheKey =
+      typeof callerKey === 'string' && callerKey && callerKey.length <= MAX_CACHE_KEY_LEN
+        ? callerKey
+        : null;
     const storeKey = cacheKey ? `${apiKey}\u0000${cacheKey}` : apiKey;
 
     const session = this.getOrCreateSession(storeKey, cacheKey);

--- a/packages/backend/src/routing/proxy/codex-session-affinity.ts
+++ b/packages/backend/src/routing/proxy/codex-session-affinity.ts
@@ -1,0 +1,139 @@
+import { createHash } from 'crypto';
+
+import { Injectable } from '@nestjs/common';
+
+const TURN_STATE_TTL_MS = 5 * 60 * 1000; // matches the OpenAI prompt-cache idle window
+const CLEANUP_INTERVAL_MS = 60 * 1000;
+const MAX_ENTRIES = 10_000;
+
+interface CachedTurnState {
+  token: string;
+  expiresAt: number;
+}
+
+export interface CodexAffinityRequest {
+  /** Headers to merge into the upstream request. */
+  headers: Record<string, string>;
+  /** Key under which `capture()` stores the response's turn-state token. */
+  storeKey: string;
+}
+
+/**
+ * Prompt-cache affinity for the ChatGPT subscription backend
+ * (`chatgpt.com/backend-api/codex/responses`).
+ *
+ * The Codex backend only serves prompt-cache hits when consecutive requests
+ * land on the same shard. The real Codex CLI achieves that by (1) sending
+ * stable `session-id` / `thread-id` headers, (2) defaulting the body's
+ * `prompt_cache_key` to its thread id, and (3) replaying the
+ * `x-codex-turn-state` sticky-routing token returned by each response on the
+ * next request. Manifest sent none of these, so every request landed on an
+ * arbitrary shard and `cached_tokens` was always 0 — agentic tool loops
+ * re-paid their full prompt prefix on every step (mnfst/manifest#2217).
+ *
+ * This service closes that gap:
+ * - `prepare()` derives deterministic session/thread ids from the
+ *   subscription token + the caller's `prompt_cache_key` (injecting a stable
+ *   per-token default when the caller sent none, exactly like the CLI), and
+ *   attaches the last seen turn-state token if one is cached.
+ * - `capture()` stores the response's turn-state token for the next request,
+ *   and drops it on upstream errors so a poisoned token can't wedge a session.
+ *
+ * Turn-state is cached in-memory with a sliding TTL. The CLI scopes the token
+ * to a single turn, but a proxy cannot see turn boundaries; the TTL matches
+ * the prompt-cache idle window, so the token only outlives a turn while the
+ * cache it routes to is still warm. Tokens are per-instance — in a
+ * multi-replica deployment each replica converges on its own affinity, which
+ * degrades to today's behavior at worst.
+ */
+@Injectable()
+export class CodexSessionAffinity {
+  private readonly turnStates = new Map<string, CachedTurnState>();
+  private lastCleanup = Date.now();
+
+  /**
+   * Derive affinity headers for an outgoing Codex-backend request and inject
+   * a stable `prompt_cache_key` into `requestBody` when the caller sent none.
+   */
+  prepare(apiKey: string, requestBody: Record<string, unknown>): CodexAffinityRequest {
+    const callerKey = requestBody.prompt_cache_key;
+    const cacheKey =
+      typeof callerKey === 'string' && callerKey
+        ? callerKey
+        : deriveStableId('prompt-cache-key', apiKey);
+    requestBody.prompt_cache_key = cacheKey;
+
+    const storeKey = sha256(`${apiKey}\u0000${cacheKey}`);
+    const headers: Record<string, string> = {
+      'session-id': deriveStableId('session-id', apiKey, cacheKey),
+      'thread-id': deriveStableId('thread-id', apiKey, cacheKey),
+    };
+    const turnState = this.retrieve(storeKey);
+    if (turnState) headers['x-codex-turn-state'] = turnState;
+
+    return { headers, storeKey };
+  }
+
+  /**
+   * Store the response's sticky-routing token for the next request in this
+   * session, or evict the cached one when the upstream rejected the request.
+   */
+  capture(storeKey: string, response: Response): void {
+    if (!response.ok) {
+      this.turnStates.delete(storeKey);
+      return;
+    }
+    const token = response.headers.get('x-codex-turn-state');
+    if (!token) return;
+    this.maybeCleanup();
+    if (this.turnStates.size >= MAX_ENTRIES && !this.turnStates.has(storeKey)) {
+      const oldest = this.turnStates.keys().next().value as string;
+      this.turnStates.delete(oldest);
+    }
+    // Delete-then-set keeps Map insertion order ≈ recency for the eviction above.
+    this.turnStates.delete(storeKey);
+    this.turnStates.set(storeKey, { token, expiresAt: Date.now() + TURN_STATE_TTL_MS });
+  }
+
+  private retrieve(storeKey: string): string | null {
+    const entry = this.turnStates.get(storeKey);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.turnStates.delete(storeKey);
+      return null;
+    }
+    // Sliding expiry: an active tool loop keeps its affinity alive.
+    entry.expiresAt = Date.now() + TURN_STATE_TTL_MS;
+    return entry.token;
+  }
+
+  /** Lazily evict expired entries to avoid unbounded growth. */
+  private maybeCleanup(): void {
+    const now = Date.now();
+    if (now - this.lastCleanup < CLEANUP_INTERVAL_MS) return;
+    this.lastCleanup = now;
+    for (const [key, entry] of this.turnStates) {
+      if (now > entry.expiresAt) this.turnStates.delete(key);
+    }
+  }
+}
+
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+/**
+ * Deterministic UUID-shaped id from a purpose + the inputs that scope it.
+ * The Codex backend expects UUID-formatted session/thread ids; hashing keeps
+ * them stable across requests (and across restarts) without storing state.
+ */
+function deriveStableId(purpose: string, ...parts: string[]): string {
+  const digest = createHash('sha256')
+    .update(`manifest-codex-affinity:${purpose}:${parts.join('\u0000')}`)
+    .digest();
+  const bytes = Buffer.from(digest.subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/backend/src/routing/proxy/codex-session-affinity.ts
+++ b/packages/backend/src/routing/proxy/codex-session-affinity.ts
@@ -1,13 +1,16 @@
-import { createHash } from 'crypto';
+import { randomUUID } from 'crypto';
 
 import { Injectable } from '@nestjs/common';
 
-const TURN_STATE_TTL_MS = 5 * 60 * 1000; // matches the OpenAI prompt-cache idle window
+const SESSION_TTL_MS = 5 * 60 * 1000; // matches the OpenAI prompt-cache idle window
 const CLEANUP_INTERVAL_MS = 60 * 1000;
 const MAX_ENTRIES = 10_000;
 
-interface CachedTurnState {
-  token: string;
+interface CodexSession {
+  sessionId: string;
+  threadId: string;
+  promptCacheKey: string;
+  turnState?: string;
   expiresAt: number;
 }
 
@@ -32,79 +35,93 @@ export interface CodexAffinityRequest {
  * re-paid their full prompt prefix on every step (mnfst/manifest#2217).
  *
  * This service closes that gap:
- * - `prepare()` derives deterministic session/thread ids from the
- *   subscription token + the caller's `prompt_cache_key` (injecting a stable
- *   per-token default when the caller sent none, exactly like the CLI), and
- *   attaches the last seen turn-state token if one is cached.
+ * - `prepare()` resolves a session for the subscription token + the caller's
+ *   `prompt_cache_key` (injecting a stable default when the caller sent none,
+ *   exactly like the CLI) and attaches its ids plus the last seen turn-state
+ *   token.
  * - `capture()` stores the response's turn-state token for the next request,
  *   and drops it on upstream errors so a poisoned token can't wedge a session.
  *
- * Turn-state is cached in-memory with a sliding TTL. The CLI scopes the token
- * to a single turn, but a proxy cannot see turn boundaries; the TTL matches
- * the prompt-cache idle window, so the token only outlives a turn while the
- * cache it routes to is still warm. Tokens are per-instance — in a
- * multi-replica deployment each replica converges on its own affinity, which
- * degrades to today's behavior at worst.
+ * Session ids are random, never derived from the credential — the token is
+ * only used as an in-memory map key and never flows into any hash or header.
+ * Sessions live in-memory with a sliding TTL: ids only need to outlive the
+ * upstream prompt cache they pin (minutes), so losing them on restart or
+ * expiry just means one cold-cache request, which is today's behavior on
+ * every request. The CLI scopes turn-state to a single turn, but a proxy
+ * cannot see turn boundaries; the TTL bounds how far a token can outlive its
+ * turn to the window where the cache it routes to is still warm. Tokens are
+ * per-instance — in a multi-replica deployment each replica converges on its
+ * own affinity, which degrades to today's behavior at worst.
  */
 @Injectable()
 export class CodexSessionAffinity {
-  private readonly turnStates = new Map<string, CachedTurnState>();
+  private readonly sessions = new Map<string, CodexSession>();
   private lastCleanup = Date.now();
 
   /**
-   * Derive affinity headers for an outgoing Codex-backend request and inject
+   * Resolve affinity headers for an outgoing Codex-backend request and inject
    * a stable `prompt_cache_key` into `requestBody` when the caller sent none.
    */
   prepare(apiKey: string, requestBody: Record<string, unknown>): CodexAffinityRequest {
     const callerKey = requestBody.prompt_cache_key;
-    const cacheKey =
-      typeof callerKey === 'string' && callerKey
-        ? callerKey
-        : deriveStableId('prompt-cache-key', apiKey);
-    requestBody.prompt_cache_key = cacheKey;
+    const cacheKey = typeof callerKey === 'string' && callerKey ? callerKey : null;
+    const storeKey = cacheKey ? `${apiKey}\u0000${cacheKey}` : apiKey;
 
-    const storeKey = sha256(`${apiKey}\u0000${cacheKey}`);
+    const session = this.getOrCreateSession(storeKey, cacheKey);
+    requestBody.prompt_cache_key = session.promptCacheKey;
+
     const headers: Record<string, string> = {
-      'session-id': deriveStableId('session-id', apiKey, cacheKey),
-      'thread-id': deriveStableId('thread-id', apiKey, cacheKey),
+      'session-id': session.sessionId,
+      'thread-id': session.threadId,
     };
-    const turnState = this.retrieve(storeKey);
-    if (turnState) headers['x-codex-turn-state'] = turnState;
+    if (session.turnState) headers['x-codex-turn-state'] = session.turnState;
 
     return { headers, storeKey };
   }
 
   /**
    * Store the response's sticky-routing token for the next request in this
-   * session, or evict the cached one when the upstream rejected the request.
+   * session, or evict the stale one when the upstream rejected the request.
    */
   capture(storeKey: string, response: Response): void {
+    const session = this.sessions.get(storeKey);
+    // The session can be gone when a request outlives the TTL; the next
+    // prepare() starts a fresh one, so there is nothing to record here.
+    if (!session) return;
     if (!response.ok) {
-      this.turnStates.delete(storeKey);
+      delete session.turnState;
       return;
     }
     const token = response.headers.get('x-codex-turn-state');
     if (!token) return;
-    this.maybeCleanup();
-    if (this.turnStates.size >= MAX_ENTRIES && !this.turnStates.has(storeKey)) {
-      const oldest = this.turnStates.keys().next().value as string;
-      this.turnStates.delete(oldest);
-    }
-    // Delete-then-set keeps Map insertion order ≈ recency for the eviction above.
-    this.turnStates.delete(storeKey);
-    this.turnStates.set(storeKey, { token, expiresAt: Date.now() + TURN_STATE_TTL_MS });
+    session.turnState = token;
+    session.expiresAt = Date.now() + SESSION_TTL_MS;
   }
 
-  private retrieve(storeKey: string): string | null {
-    const entry = this.turnStates.get(storeKey);
-    if (!entry) return null;
-    if (Date.now() > entry.expiresAt) {
-      this.turnStates.delete(storeKey);
-      return null;
+  private getOrCreateSession(storeKey: string, callerCacheKey: string | null): CodexSession {
+    this.maybeCleanup();
+    const existing = this.sessions.get(storeKey);
+    if (existing && Date.now() <= existing.expiresAt) {
+      // Sliding expiry: an active tool loop keeps its affinity alive.
+      existing.expiresAt = Date.now() + SESSION_TTL_MS;
+      // Delete-then-set keeps Map insertion order ≈ recency for the eviction below.
+      this.sessions.delete(storeKey);
+      this.sessions.set(storeKey, existing);
+      return existing;
     }
-    // Sliding expiry: an active tool loop keeps its affinity alive.
-    entry.expiresAt = Date.now() + TURN_STATE_TTL_MS;
-    return entry.token;
+    if (existing) this.sessions.delete(storeKey);
+    if (this.sessions.size >= MAX_ENTRIES) {
+      const oldest = this.sessions.keys().next().value as string;
+      this.sessions.delete(oldest);
+    }
+    const session: CodexSession = {
+      sessionId: randomUUID(),
+      threadId: randomUUID(),
+      promptCacheKey: callerCacheKey ?? randomUUID(),
+      expiresAt: Date.now() + SESSION_TTL_MS,
+    };
+    this.sessions.set(storeKey, session);
+    return session;
   }
 
   /** Lazily evict expired entries to avoid unbounded growth. */
@@ -112,28 +129,8 @@ export class CodexSessionAffinity {
     const now = Date.now();
     if (now - this.lastCleanup < CLEANUP_INTERVAL_MS) return;
     this.lastCleanup = now;
-    for (const [key, entry] of this.turnStates) {
-      if (now > entry.expiresAt) this.turnStates.delete(key);
+    for (const [key, session] of this.sessions) {
+      if (now > session.expiresAt) this.sessions.delete(key);
     }
   }
-}
-
-function sha256(input: string): string {
-  return createHash('sha256').update(input).digest('hex');
-}
-
-/**
- * Deterministic UUID-shaped id from a purpose + the inputs that scope it.
- * The Codex backend expects UUID-formatted session/thread ids; hashing keeps
- * them stable across requests (and across restarts) without storing state.
- */
-function deriveStableId(purpose: string, ...parts: string[]): string {
-  const digest = createHash('sha256')
-    .update(`manifest-codex-affinity:${purpose}:${parts.join('\u0000')}`)
-    .digest();
-  const bytes = Buffer.from(digest.subarray(0, 16));
-  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
-  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
-  const hex = bytes.toString('hex');
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -23,6 +23,7 @@ import {
   createReasoningContentStreamTransformer as reasoningContentStreamTransformer,
 } from './provider-client-converters';
 import { ForwardOptions } from './proxy-types';
+import { CodexSessionAffinity } from './codex-session-affinity';
 import { toNativeResponsesRequest } from './responses-adapter';
 import { forwardKiroChat } from './kiro-adapter';
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
@@ -83,13 +84,18 @@ function stripModelPrefix(model: string, endpointKey: string): string {
 @Injectable()
 export class ProviderClient {
   private readonly logger = new Logger(ProviderClient.name);
+  private readonly codexAffinity: CodexSessionAffinity;
 
   constructor(
     @Optional()
     private readonly opencodeGoCatalog?: OpencodeGoCatalogService,
     @Optional()
     private readonly modelRegistry?: ProviderModelRegistryService,
-  ) {}
+    @Optional()
+    codexAffinity?: CodexSessionAffinity,
+  ) {
+    this.codexAffinity = codexAffinity ?? new CodexSessionAffinity();
+  }
 
   async forward(opts: ForwardOptions): Promise<ForwardResult> {
     const {
@@ -154,7 +160,14 @@ export class ProviderClient {
       providerResource: opts.providerResource,
     });
 
-    const finalHeaders = extraHeaders ? { ...headers, ...extraHeaders } : headers;
+    // The Codex backend only serves prompt-cache hits with session affinity
+    // headers the real Codex CLI sends — see CodexSessionAffinity.
+    const affinity =
+      endpointKey === 'openai-subscription'
+        ? this.codexAffinity.prepare(apiKey, requestBody)
+        : undefined;
+    const finalHeaders =
+      affinity || extraHeaders ? { ...headers, ...affinity?.headers, ...extraHeaders } : headers;
 
     this.logger.debug(`Forwarding to ${endpointKey}: ${url.replace(/key=[^&]+/, 'key=***')}`);
 
@@ -171,13 +184,15 @@ export class ProviderClient {
       }
     }
 
-    return this.executeFetch(url, finalHeaders, requestBody, signal, {
+    const result = await this.executeFetch(url, finalHeaders, requestBody, signal, {
       isGoogle,
       isAnthropic,
       isChatGpt,
       isResponses,
       isCodeAssist,
     });
+    if (affinity) this.codexAffinity.capture(affinity.storeKey, result.response);
+    return result;
   }
 
   private async resolveEndpoint(
@@ -423,6 +438,10 @@ export class ProviderClient {
                 endpointKey === 'openai-responses' ||
                 endpointKey === 'copilot-responses' ||
                 endpointKey === 'xai-responses',
+              // Only OpenAI's /responses endpoints are known to accept
+              // prompt_cache_key; other Responses-shaped backends may 400.
+              forwardPromptCacheKey:
+                endpointKey === 'openai-subscription' || endpointKey === 'openai-responses',
             });
       // Force upstream streaming for copilot-responses so the SSE collector in
       // handleNonStreamResponse stays the single source of truth. Without this,

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -166,8 +166,10 @@ export class ProviderClient {
       endpointKey === 'openai-subscription'
         ? this.codexAffinity.prepare(apiKey, requestBody)
         : undefined;
+    // Affinity headers are routing-critical and must win over caller-supplied
+    // extraHeaders (provider-side observability hints), so they spread last.
     const finalHeaders =
-      affinity || extraHeaders ? { ...headers, ...affinity?.headers, ...extraHeaders } : headers;
+      affinity || extraHeaders ? { ...headers, ...extraHeaders, ...affinity?.headers } : headers;
 
     this.logger.debug(`Forwarding to ${endpointKey}: ${url.replace(/key=[^&]+/, 'key=***')}`);
 

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -26,6 +26,7 @@ import { CopilotTokenService } from './copilot-token.service';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { ReasoningContentCache } from './reasoning-content-cache';
+import { CodexSessionAffinity } from './codex-session-affinity';
 import { ProxyExceptionFilter } from './proxy-exception.filter';
 
 @Module({
@@ -59,6 +60,7 @@ import { ProxyExceptionFilter } from './proxy-exception.filter';
     ThoughtSignatureCache,
     ThinkingBlockCache,
     ReasoningContentCache,
+    CodexSessionAffinity,
     ProxyExceptionFilter,
     MessageRecordingService,
   ],


### PR DESCRIPTION
### ✨ What changed
- New `CodexSessionAffinity`: sends `session-id`/`thread-id` headers, injects a stable `prompt_cache_key` when missing, replays `x-codex-turn-state`.
- `ProviderClient.forward()` applies affinity only on `openai-subscription` (chat + native responses paths).
- `toResponsesRequest` gains opt-in `forwardPromptCacheKey`, enabled for `openai-subscription` and `openai-responses` only.

### 💭 Why
Codex's backend (`chatgpt.com/backend-api/codex/responses`) only serves cache hits when consecutive requests hit the same shard. The real CLI pins that affinity via session/thread headers, a default `prompt_cache_key`, and a replayed turn-state token. Manifest sent none of these, so every subscription request landed on a random shard and re-paid the full prefix. See #2217.

### 👤 For users
ChatGPT subscription routing now gets prompt-cache hits in tool loops, cutting repeated-prefix latency and subscription quota.

### 📝 Notes
- Fixes #2217.
- Turn-state is per-instance; in multi-replica deploys each replica converges on its own affinity, degrading to today's behavior at worst.
- Credential is only an in-memory map key, never hashed or sent. 5-min sliding TTL, 10k-entry cap, turn-state dropped on non-2xx.
- New `codex-session-affinity.spec.ts` (16 tests, 100% coverage) plus header and request-conversion tests. Full backend suite green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore prompt-cache hits for ChatGPT subscription by sending Codex session-affinity headers and preserving `prompt_cache_key` where supported. This cuts repeated prefix latency and subscription usage in tool loops. Fixes #2217.

- Bug Fixes
  - Added `CodexSessionAffinity`: sets `session-id`/`thread-id`, injects a stable per-session `prompt_cache_key` when missing, and replays `x-codex-turn-state`. Uses random memoized IDs (credential never hashed or sent), 5‑min sliding TTL with 10k cap; caps caller `prompt_cache_key` at 512 chars (longer treated as absent) to avoid memory amplification; drops turn-state on non‑2xx, keeps session IDs stable across errors, and ignores late responses after session sweep.
  - Applied only to `openai-subscription` (chat and native responses). `toResponsesRequest` adds `forwardPromptCacheKey`; enabled for `openai-subscription` and `openai-responses` only. Affinity headers are authoritative and override caller `extraHeaders`.

<sup>Written for commit e6e6e650e4c16cb3d45ea7e7570f218242d7054a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->