### PR TITLE
feat: add TokenRouter as an OpenAI-compatible API-key provider

### DIFF
--- a/.changeset/tokenrouter-provider.md
+++ b/.changeset/tokenrouter-provider.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add TokenRouter as an OpenAI-compatible API-key provider. Users can generate a key at tokenrouter.com, point Manifest at it, and route requests through the gateway to upstream models (GPT-4o, Claude, Gemini, Llama, etc.).

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -39,6 +39,7 @@ describe('ProviderModelFetcherService', () => {
       'anthropic',
       'gemini',
       'openrouter',
+      'tokenrouter',
       'ollama',
       'ollama-cloud',
       'copilot',
@@ -1660,6 +1661,62 @@ describe('ProviderModelFetcherService', () => {
       });
 
       const result = await service.fetch('openrouter', '');
+      expect(result).toEqual([]);
+    });
+  });
+
+  /* ── TokenRouter provider ── */
+
+  describe('tokenrouter provider', () => {
+    it('fetches the TokenRouter catalog with bearer auth and preserves vendor-prefixed model ids', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 'groq/llama-3.3-70b-versatile',
+              object: 'model',
+              created: 1730000000,
+              owned_by: 'groq',
+            },
+            {
+              id: 'openai/gpt-4o',
+              object: 'model',
+              created: 1730000001,
+              owned_by: 'openai',
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('tokenrouter', 'tk-router-key');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.tokenrouter.com/v1/models',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer tk-router-key' },
+        }),
+      );
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'groq/llama-3.3-70b-versatile',
+          provider: 'tokenrouter',
+        }),
+        expect.objectContaining({
+          id: 'openai/gpt-4o',
+          provider: 'tokenrouter',
+        }),
+      ]);
+    });
+
+    it('returns [] when the TokenRouter catalog data field is missing', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const result = await service.fetch('tokenrouter', 'tk-router-key');
+
       expect(result).toEqual([]);
     });
   });

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -37,6 +37,7 @@ const QWEN_TOKEN_PLAN_MODELS_URL =
   'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models';
 const QWEN_TOKEN_PLAN_CONTEXT_WINDOW = 991000;
 const KILO_GATEWAY_BASE = 'https://api.kilo.ai/api/gateway';
+const TOKENROUTER_MODELS_URL = 'https://api.tokenrouter.com/v1/models';
 const FIREWORKS_MODELS_URL = 'https://api.fireworks.ai/v1/accounts/fireworks/models';
 const FIREWORKS_MODELS_PAGE_SIZE = 200;
 const FIREWORKS_MODELS_MAX_PAGES = 20;
@@ -655,6 +656,15 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     endpoint: 'https://openrouter.ai/api/v1/models',
     buildHeaders: () => ({}),
     parse: parseOpenRouter,
+  },
+  tokenrouter: {
+    // TokenRouter's /v1/models returns the same `{ data: [{ id, ... }] }`
+    // shape as OpenAI-compatible providers. Each entry already carries a
+    // `vendor/model` id, so we preserve it verbatim and let the proxy
+    // forward it to the gateway as-is.
+    endpoint: TOKENROUTER_MODELS_URL,
+    buildHeaders: bearerHeaders,
+    parse: parseOpenAI,
   },
   ollama: {
     endpoint: `${OLLAMA_HOST}/api/tags`,

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -554,6 +554,17 @@ describe('PROVIDER_ENDPOINTS', () => {
     });
   });
 
+  it('tokenrouter uses the TokenRouter OpenAI-compatible inference endpoint', () => {
+    const ep = PROVIDER_ENDPOINTS['tokenrouter'];
+    expect(ep.baseUrl).toBe('https://api.tokenrouter.com');
+    expect(ep.format).toBe('openai');
+    expect(ep.buildPath('groq/llama-3.3-70b-versatile')).toBe('/v1/chat/completions');
+    expect(ep.buildHeaders('tr-token')).toEqual({
+      Authorization: 'Bearer tr-token',
+      'Content-Type': 'application/json',
+    });
+  });
+
   it('commandcode uses the Command Code Provider API chat endpoint', () => {
     const ep = PROVIDER_ENDPOINTS['commandcode'];
     expect(ep.baseUrl).toBe('https://api.commandcode.ai/provider');

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -112,6 +112,7 @@ const OPENCODE_ZEN_BASE = 'https://opencode.ai/zen';
 const KILO_GATEWAY_BASE = 'https://api.kilo.ai/api/gateway';
 const NVIDIA_NIM_BASE = 'https://integrate.api.nvidia.com';
 const FIREWORKS_INFERENCE_BASE = 'https://api.fireworks.ai/inference';
+const TOKENROUTER_BASE = 'https://api.tokenrouter.com';
 const chatgptSubscriptionHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   'Content-Type': 'application/json',
@@ -436,6 +437,17 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     }),
     buildPath: (model: string) => `/v1/models/${model}:generateContent`,
     format: 'google',
+  },
+  // TokenRouter — OpenAI-compatible aggregator in the same shape as
+  // OpenRouter. The model id is passed through to the gateway
+  // (e.g. `groq/llama-3.3-70b-versatile`) and TokenRouter routes it to
+  // the underlying provider.
+  tokenrouter: {
+    baseUrl: TOKENROUTER_BASE,
+    buildHeaders: openaiHeaders,
+    buildPath: openaiPath,
+    format: 'openai',
+    ...openaiStreamUsage,
   },
 };
 

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -16,6 +16,7 @@ export const ROUTING_PROVIDER_API_KEY_URLS: Record<string, string> = {
   'opencode-zen': 'https://opencode.ai/auth',
   openrouter: 'https://openrouter.ai/keys',
   qwen: 'https://www.alibabacloud.com/help/en/model-studio/developer-reference/get-api-key',
+  tokenrouter: 'https://www.tokenrouter.com/dashboard',
   xiaomi: 'https://platform.xiaomimimo.com/console',
   xai: 'https://docs.x.ai/docs/api-reference',
   zai: 'https://z.ai/manage-apikey/apikey-list',

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -337,6 +337,11 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
     subtitle: 'Auto-route to 300+ models',
     models: [],
   },
+  tokenrouter: {
+    initial: 'TR',
+    subtitle: 'Verified model aggregator with enterprise controls',
+    models: [],
+  },
   xai: {
     initial: 'X',
     subtitle: 'Grok 3, Grok 2',
@@ -405,6 +410,7 @@ const PROVIDER_ORDER = [
   'opencode-go',
   'opencode-zen',
   'openrouter',
+  'tokenrouter',
   'xai',
   'xiaomi',
   'zai',

--- a/packages/shared/__tests__/provider-inference.spec.ts
+++ b/packages/shared/__tests__/provider-inference.spec.ts
@@ -54,6 +54,8 @@ describe('inferProviderFromModel', () => {
     ['llamacpp/Qwen3.5-9B-Q4_K_M.gguf', 'llamacpp'],
     ['llamacpp/mistral-7b-instruct-v0.3.Q4_K_M.gguf', 'llamacpp'],
     ['openrouter/auto', 'openrouter'],
+    ['tokenrouter/groq/llama-3.3-70b-versatile', 'tokenrouter'],
+    ['tokenrouter/openai/gpt-4o', 'tokenrouter'],
     ['anthropic/claude-sonnet-4', 'openrouter'],
   ])('infers %s as %s', (model, expected) => {
     expect(inferProviderFromModel(model)).toBe(expected);
@@ -90,6 +92,7 @@ describe('underlyingGatewayModel', () => {
     expect(underlyingGatewayModel('opencode-go/deepseek-v4-pro')).toBe('deepseek-v4-pro');
     expect(underlyingGatewayModel('opencode-go/kimi-k2.6')).toBe('kimi-k2.6');
     expect(underlyingGatewayModel('opencode-zen/qwen3.6-plus')).toBe('qwen3.6-plus');
+    expect(underlyingGatewayModel('tokenrouter/groq/llama-3.3-70b-versatile')).toBe('groq/llama-3.3-70b-versatile');
   });
 
   it('returns null for non-gateway model ids', () => {
@@ -111,6 +114,17 @@ describe('resolveUnderlyingModelIdentity', () => {
     expect(resolveUnderlyingModelIdentity('opencode-zen', 'opencode-zen/qwen3.6-plus')).toEqual({
       provider: 'qwen',
       model: 'qwen3.6-plus',
+    });
+    // TokenRouter aggregates other providers under `vendor/model` ids.
+    // After stripping the `tokenrouter/` prefix, the underlying `vendor/...`
+    // id falls through to the catch-all OpenRouter inference path (since
+    // `groq/<id>` is not a first-class Manifest provider), matching how
+    // OpenRouter-hosted models are also attributed to OpenRouter today.
+    expect(
+      resolveUnderlyingModelIdentity('tokenrouter', 'tokenrouter/groq/llama-3.3-70b-versatile'),
+    ).toEqual({
+      provider: 'openrouter',
+      model: 'groq/llama-3.3-70b-versatile',
     });
   });
 

--- a/packages/shared/src/provider-inference.ts
+++ b/packages/shared/src/provider-inference.ts
@@ -21,6 +21,7 @@ const MODEL_PREFIX_MAP: [RegExp, string][] = [
   [/^opencode-zen\//, 'opencode-zen'],
   [/^kiro\//, 'kiro'],
   [/^llamacpp\//, 'llamacpp'],
+  [/^tokenrouter\//, 'tokenrouter'],
   [/^[a-z][\w-]*\//, 'openrouter'],
 ];
 
@@ -31,7 +32,7 @@ export { MODEL_PREFIX_MAP };
  * provider's API, so the id after the prefix is the underlying provider's
  * own model id (e.g. `opencode-go/deepseek-v4-pro` -> `deepseek-v4-pro`).
  */
-const GATEWAY_MODEL_PREFIXES = ['opencode-go/', 'opencode-zen/'] as const;
+const GATEWAY_MODEL_PREFIXES = ['opencode-go/', 'opencode-zen/', 'tokenrouter/'] as const;
 
 /**
  * If `model` is a gateway model id, return the underlying provider's model

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -257,6 +257,25 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     keyPlaceholder: '',
   },
   {
+    id: 'tokenrouter',
+    displayName: 'TokenRouter',
+    aliases: [],
+    // TokenRouter aggregates other providers behind a single OpenAI-
+    // compatible endpoint. Like OpenRouter, it returns model ids with a
+    // `vendor/model` prefix (e.g. `groq/llama-3.3-70b-versatile`), but
+    // the underlying providers are routed by TokenRouter's own vendor
+    // table, not by OpenRouter. Mapping OR's prefixes here would
+    // mis-attribute TokenRouter-hosted models to their upstream vendor
+    // the same way we deliberately skip the OpenRouter self-prefix.
+    openRouterPrefixes: [],
+    requiresApiKey: true,
+    localOnly: false,
+    color: '#6E56CF',
+    keyPrefix: '',
+    minKeyLength: 20,
+    keyPlaceholder: 'TokenRouter API key',
+  },
+  {
     id: 'lmstudio',
     displayName: 'LM Studio',
     aliases: ['lm-studio', 'lm studio'],


### PR DESCRIPTION
## What

Adds **TokenRouter** ([tokenrouter.com](https://www.tokenrouter.com)) as a new OpenAI-compatible API-key provider.

TokenRouter is a verified-model aggregator that converts leading LLMs into OpenAI-compatible endpoints with centralized management for individuals and enterprises. Users can generate an API key at the TokenRouter dashboard, point Manifest at it, and route requests through the gateway to upstream models (GPT-4o, Claude, Gemini, Llama, and more).

## Changes

### Core (packages/shared)
- **providers.ts**: Add `tokenrouter` entry with displayName `TokenRouter`, purple color `#6E56CF`, and no key prefix (TokenRouter keys use a custom format)
- **provider-inference.ts**: Map `tokenrouter/` prefix in `MODEL_PREFIX_MAP` so model IDs like `tokenrouter/groq/llama-3.3-70b-versatile` are correctly attributed. Add `tokenrouter/` to `GATEWAY_MODEL_PREFIXES` so the prefix is transparently stripped for upstream routing

### Backend routing (packages/backend)
- **provider-endpoints.ts**: Configure proxy endpoint at `https://api.tokenrouter.com` with standard OpenAI-compatible Bearer auth and `/v1/chat/completions` path
- **provider-model-fetcher.service.ts**: Wire model discovery via `/v1/models` using the existing OpenAI parser

### Frontend (packages/frontend)
- **providers.ts**: Add UI overlay (initial: `TR`, subtitle: `Verified model aggregator with enterprise controls`) and alphabetical `PROVIDER_ORDER` entry
- **provider-api-key-urls.ts**: Link to `https://www.tokenrouter.com/dashboard`

### Tests
- Provider inference: assert `tokenrouter/` prefix resolves to TokenRouter, gateway stripping returns vendor-prefixed underlying model
- Provider endpoints: verify base URL, format, path, and headers
- Model discovery: test vendor-prefixed catalog parsing and empty response handling
- Frontend: all 94 `providers.test.ts` tests pass (alphabetical sort invariant holds)

## Design notes

TokenRouter uses `vendor/model` IDs (like OpenRouter), so it's registered as a gateway provider. The `tokenrouter/` prefix is stripped and the underlying vendor-prefixed ID is forwarded to the gateway as-is. This mirrors the pattern established by OpenCode Go and OpenCode Zen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add TokenRouter as an OpenAI-compatible API-key provider and gateway. Users can add a TokenRouter key to route requests to vendor models (e.g., Groq, OpenAI) via `api.tokenrouter.com`.

- New Features
  - `packages/shared`: Register `tokenrouter` provider (name, color `#6E56CF`, key settings), map `tokenrouter/` model prefix, and treat as a gateway (prefix stripped for routing).
  - `packages/backend`: Add proxy endpoint `https://api.tokenrouter.com` with OpenAI format (`/v1/chat/completions`, Bearer auth) and model discovery via `/v1/models` using the OpenAI parser.
  - `packages/frontend`: Add provider UI (initial `TR`, subtitle), add dashboard link `https://www.tokenrouter.com/dashboard`, and insert into provider order.
  - Tests: Cover endpoint config, model discovery (including empty responses), and provider inference/gateway stripping.

<sup>Written for commit eb8a233e628177e82b3ca07a77278fc881bc5956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

