### PR TITLE
fix: provider migration can now roll back without data loss

### DIFF
--- a/.changeset/provider-migration-rollback.md
+++ b/.changeset/provider-migration-rollback.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Provider migrations can now be rolled back without dropping connected providers.

--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
@@ -97,7 +97,7 @@ describe('LiftProvidersToUserLevel1791000000000', () => {
     expect(createIdx).toBeGreaterThan(relabelIdx);
   });
 
-  it('down restores agent_id strictness, the agent-scoped index, and drops access', async () => {
+  it('down reconstructs per-agent rows, recreates the agent-scoped index, and drops access', async () => {
     await migration.down(queryRunner);
     expect(
       queries.some(
@@ -110,18 +110,12 @@ describe('LiftProvidersToUserLevel1791000000000', () => {
     expect(queries.some((q) => q.includes('SET "agent_id" = first_grant."agent_id"'))).toBe(true);
     expect(
       queries.some(
-        (q) => q.includes('DELETE FROM "user_providers"') && q.includes('"agent_id" IS NULL'),
-      ),
-    ).toBe(true);
-    expect(
-      queries.some(
         (q) =>
           q.includes('CREATE UNIQUE INDEX IF NOT EXISTS') &&
           q.includes('"IDX_user_providers_agent_provider_auth_label"') &&
           q.includes('"agent_id"'),
       ),
     ).toBe(true);
-    expect(queries.some((q) => q.includes('ALTER COLUMN "agent_id" SET NOT NULL'))).toBe(true);
     expect(
       queries.some((q) =>
         q.includes('DROP CONSTRAINT IF EXISTS "FK_agent_provider_access_provider"'),
@@ -133,5 +127,28 @@ describe('LiftProvidersToUserLevel1791000000000', () => {
     expect(queries.some((q) => q.includes('DROP TABLE IF EXISTS "agent_provider_access"'))).toBe(
       true,
     );
+  });
+
+  it('down aliases agent_provider_access as "apa" in the first_grant CTE (regression: a missing alias made the whole revert throw at plan time)', async () => {
+    await migration.down(queryRunner);
+    const firstGrant = queries.find((q) => q.includes('SET "agent_id" = first_grant."agent_id"'));
+    expect(firstGrant).toBeDefined();
+    expect(firstGrant).toContain('FROM "agent_provider_access" apa');
+  });
+
+  it('down is lossless: no blanket delete, and NOT NULL is restored only when every row is mapped', async () => {
+    await migration.down(queryRunner);
+    // The old blanket `DELETE FROM "user_providers" WHERE "agent_id" IS NULL`
+    // dropped user-global providers (and their encrypted keys) on rollback — gone.
+    expect(queries.some((q) => /DELETE\s+FROM\s+"user_providers"/i.test(q))).toBe(false);
+    // NOT NULL is re-imposed only when no row is left unmapped, so an un-mappable
+    // connection keeps its row instead of blocking the revert.
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('IF NOT EXISTS (SELECT 1 FROM "user_providers" WHERE "agent_id" IS NULL)') &&
+          q.includes('ALTER COLUMN "agent_id" SET NOT NULL'),
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
@@ -269,7 +269,7 @@ export class LiftProvidersToUserLevel1791000000000 implements MigrationInterface
       SELECT DISTINCT ON (apa."user_provider_id")
         apa."user_provider_id",
         apa."agent_id"
-      FROM "agent_provider_access"
+      FROM "agent_provider_access" apa
       JOIN "user_providers" up ON up."id" = apa."user_provider_id"
       WHERE up."agent_id" IS NULL
       ORDER BY apa."user_provider_id", apa."agent_id"
@@ -281,13 +281,21 @@ export class LiftProvidersToUserLevel1791000000000 implements MigrationInterface
       AND up."agent_id" IS NULL
   `);
 
+    // Lossless rollback: do NOT delete user-global providers that can't be
+    // mapped back to a single agent (a connection owned by a user with no
+    // agents, or one that never received a grant). The two statements above
+    // already reconstructed per-agent rows for every granted provider; anything
+    // still unbound keeps agent_id = NULL so its encrypted key + config survive
+    // the revert. Re-impose NOT NULL only when every row could be mapped —
+    // otherwise leave the column nullable. This is a deliberate, lossless
+    // deviation from the exact pre-lift schema rather than dropping data.
     await queryRunner.query(`
-    DELETE FROM "user_providers"
-    WHERE "agent_id" IS NULL
-  `);
-
-    await queryRunner.query(`
-    ALTER TABLE "user_providers" ALTER COLUMN "agent_id" SET NOT NULL
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM "user_providers" WHERE "agent_id" IS NULL) THEN
+        ALTER TABLE "user_providers" ALTER COLUMN "agent_id" SET NOT NULL;
+      END IF;
+    END $$
   `);
     await queryRunner.query(`
     CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_providers_agent_provider_auth_label"

--- a/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.spec.ts
+++ b/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.spec.ts
@@ -84,4 +84,17 @@ describe('LiftCustomProvidersToUserLevel1791200000000', () => {
       ),
     ).toBe(true);
   });
+
+  it('down restores agent_id from the companion grant and never deletes a custom_providers row', async () => {
+    await migration.down(queryRunner);
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('UPDATE "custom_providers"') &&
+          q.includes("'custom:' || cp.") &&
+          q.includes('"agent_provider_access"'),
+      ),
+    ).toBe(true);
+    expect(queries.some((q) => /DELETE\s+FROM\s+"custom_providers"/i.test(q))).toBe(false);
+  });
 });

--- a/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.ts
+++ b/packages/backend/src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel.ts
@@ -124,11 +124,28 @@ export class LiftCustomProvidersToUserLevel1791200000000 implements MigrationInt
     await queryRunner.query(
       `ALTER TABLE "custom_providers" ADD COLUMN IF NOT EXISTS "agent_id" varchar`,
     );
+    // Best-effort restore of each custom provider's agent binding from its
+    // companion user_providers (custom:<id>) grant. agent_provider_access still
+    // exists here because LiftProviders.down() (1791000…) runs AFTER this
+    // migration's down() in revert order. Deterministic (earliest agent).
+    // custom_providers rows are never deleted on rollback, so this is lossless
+    // whether or not a binding is found; rows with no companion grant keep
+    // agent_id = NULL (the column stays nullable — the pre-lift NOT NULL can't be
+    // guaranteed for every row, and dropping data to satisfy it is not worth it).
+    await queryRunner.query(`
+      UPDATE "custom_providers" cp
+      SET "agent_id" = (
+        SELECT apa."agent_id"
+        FROM "user_providers" up
+        JOIN "agent_provider_access" apa ON apa."user_provider_id" = up."id"
+        WHERE up."provider" = 'custom:' || cp."id"
+        ORDER BY apa."agent_id"
+        LIMIT 1
+      )
+      WHERE cp."agent_id" IS NULL
+    `);
     // Restore the original agent FK (ON DELETE CASCADE) so the rolled-back schema
-    // re-enforces referential integrity. The original column was also NOT NULL,
-    // but that can't be restored on down() — the lift discarded each row's agent
-    // binding, so there are no values to backfill; leaving it nullable is the
-    // closest non-destructive equivalent.
+    // re-enforces referential integrity.
     await queryRunner.query(`
       ALTER TABLE "custom_providers"
         ADD CONSTRAINT "FK_custom_providers_agent"


### PR DESCRIPTION
### 💭 Why
The provider-lift migration's `down()` threw on revert (a missing SQL alias), and even past that it deleted user-global provider connections that couldn't be mapped back to an agent. Rolling these migrations back was impossible and lossy.

### ✨ What changed
- Alias `agent_provider_access` as `apa` in the rollback's `first_grant` query (was throwing `missing FROM-clause entry for table apa`).
- Drop the blanket delete of unmappable connections. Keep their rows and encrypted keys; restore `NOT NULL` only when every row maps.
- Custom-provider rollback restores `agent_id` from the companion `custom:<id>` grant instead of leaving it NULL.
- Specs cover the alias, the no-delete invariant, and the reconstruction.

### 🔧 For operators
Reverting these migrations now works and preserves every connected provider. The forward (`up`) migration is unchanged.

### 📝 Notes
Verified with an up→down→up round-trip on seeded Postgres: every encrypted key preserved, including a zero-grant orphan that the old delete removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the provider-lift migrations so they roll back cleanly and without data loss. The forward (`up`) path is unchanged.

- **Bug Fixes**
  - Added `apa` alias in the rollback CTE to stop the missing FROM-clause error.
  - Made rollback lossless: no blanket delete; keep user-global connections and keys; set `agent_id` NOT NULL only if every row maps.
  - Restored custom providers’ `agent_id` from the companion `user_providers` grant (`custom:<id>`); never delete rows during down.

<sup>Written for commit 3bb50ae79e6e1f5b686931ade48308cf5981eb95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

