### PR TITLE
refactor: rename misleading is_system agent flag to is_playground

### DIFF
--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -155,7 +155,7 @@ describe('AgentsController', () => {
     expect(mockGetAgentList).toHaveBeenCalledWith('u1', undefined, false);
   });
 
-  it('passes includeSystem=true through to getAgentList (Messages filter)', async () => {
+  it('passes includePlayground=true through to getAgentList (Messages filter)', async () => {
     const user = { id: 'u1' };
     await controller.getAgents(user as never, 'true');
 
@@ -246,10 +246,10 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ renamed: true, name: 'bot-renamed', display_name: 'Bot Renamed' });
     expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'bot-renamed', 'Bot Renamed');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
-    // The Messages-filter variant (system agents included) is a distinct cache
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:playground=false');
+    // The Messages-filter variant (playground agents included) is a distinct cache
     // entry and must also be cleared so it never goes stale after a rename.
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:playground=true');
   });
 
   it('rejects rename with empty slug', async () => {
@@ -281,9 +281,9 @@ describe('AgentsController', () => {
     expect(result).toEqual({ deleted: true });
     expect(mockDeleteAgent).toHaveBeenCalledWith('u1', 'bot-1');
     // Both canonical variants are cleared so neither the Workspace list nor the
-    // Messages filter (system agents included) goes stale after a delete.
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
+    // Messages filter (playground agents included) goes stale after a delete.
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:playground=false');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:playground=true');
   });
 
   it('passes agent_category and agent_platform to onboardAgent', async () => {
@@ -509,9 +509,9 @@ describe('AgentsController', () => {
 
     expect(result.agent.name).toBe('my-agent');
     // Both canonical variants are cleared so neither the Workspace list nor the
-    // Messages filter (system agents included) goes stale after a create.
-    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=false');
-    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:system=true');
+    // Messages filter (playground agents included) goes stale after a create.
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:playground=false');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents:playground=true');
   });
 
   it('rejects createAgent with empty slug', async () => {
@@ -633,10 +633,10 @@ describe('AgentsController', () => {
       name: 'bot-copy',
       displayName: 'Bot Copy',
     });
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=false');
-    // The Messages-filter variant (system agents included) is a distinct cache
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:playground=false');
+    // The Messages-filter variant (playground agents included) is a distinct cache
     // entry and must also be cleared so it never goes stale after a duplicate.
-    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:system=true');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents:playground=true');
   });
 
   it('rejects duplicateAgent with empty slug', async () => {
@@ -676,9 +676,9 @@ describe('AgentsController', () => {
     expect(mockDuplicate).not.toHaveBeenCalled();
   });
 
-  // P1-A: key endpoints must reject the system "Playground" agent
-  it('getAgentKey throws NotFoundException for the system "Playground" agent', async () => {
-    // findAgentInfo returns null for system agents (is_system = false filter)
+  // P1-A: key endpoints must reject the reserved "Playground" agent
+  it('getAgentKey throws NotFoundException for the reserved "Playground" agent', async () => {
+    // findAgentInfo returns null for playground agents (is_playground = false filter)
     // which is the same shape as a missing agent — NotFoundException is thrown.
     const user = { id: 'u1' };
     await expect(controller.getAgentKey(user as never, 'Playground')).rejects.toBeInstanceOf(
@@ -686,7 +686,7 @@ describe('AgentsController', () => {
     );
   });
 
-  it('rotateAgentKey throws NotFoundException for the system "Playground" agent', async () => {
+  it('rotateAgentKey throws NotFoundException for the reserved "Playground" agent', async () => {
     const user = { id: 'u1' };
     await expect(controller.rotateAgentKey(user as never, 'Playground')).rejects.toBeInstanceOf(
       NotFoundException,

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -49,7 +49,7 @@ export class AgentsController {
   ) {}
 
   private async invalidateAgentListCache(userId: string): Promise<void> {
-    // GET /agents has exactly two canonical cache entries per user (system agents
+    // GET /agents has exactly two canonical cache entries per user (playground agents
     // included or not — see AgentListCacheInterceptor). Clear both so neither the
     // Workspace list nor the Messages filter goes stale after a mutation.
     await Promise.all([
@@ -61,9 +61,16 @@ export class AgentsController {
   @Get('agents')
   @UseInterceptors(AgentListCacheInterceptor)
   @CacheTTL(AGENT_LIST_CACHE_TTL_MS)
-  async getAgents(@CurrentUser() user: AuthUser, @Query('includeSystem') includeSystem?: string) {
+  async getAgents(
+    @CurrentUser() user: AuthUser,
+    @Query('includePlayground') includePlayground?: string,
+  ) {
     const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
-    const agents = await this.timeseries.getAgentList(user.id, tenantId, includeSystem === 'true');
+    const agents = await this.timeseries.getAgentList(
+      user.id,
+      tenantId,
+      includePlayground === 'true',
+    );
     return { agents };
   }
 
@@ -165,8 +172,8 @@ export class AgentsController {
 
   @Get('agents/:agentName/key')
   async getAgentKey(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
-    // Guard: system agents cannot expose their API key through the user-facing
-    // key endpoint (findAgentInfo filters is_system = false and returns null for
+    // Guard: playground agents cannot expose their API key through the user-facing
+    // key endpoint (findAgentInfo filters is_playground = false and returns null for
     // the reserved "Playground" agent, same as for any missing agent).
     const info = await this.lifecycle.findAgentInfo(user.id, agentName);
     if (!info) throw new NotFoundException(`Agent "${agentName}" not found`);
@@ -180,8 +187,8 @@ export class AgentsController {
 
   @Post('agents/:agentName/rotate-key')
   async rotateAgentKey(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
-    // Guard: system agents cannot have their key rotated through the user-facing
-    // endpoint (findAgentInfo filters is_system = false and returns null for the
+    // Guard: playground agents cannot have their key rotated through the user-facing
+    // endpoint (findAgentInfo filters is_playground = false and returns null for the
     // reserved "Playground" agent, same as for any missing agent).
     const info = await this.lifecycle.findAgentInfo(user.id, agentName);
     if (!info) throw new NotFoundException(`Agent "${agentName}" not found`);

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.spec.ts
@@ -86,7 +86,7 @@ describe('ProviderAnalyticsController', () => {
   describe('getAnalytics', () => {
     it('returns summary + timeseries for default range (24h, hourly)', async () => {
       const out = await controller.getAnalytics(user, 'subscription');
-      // Final `true` arg = excludeSystem: Playground usage must not pollute
+      // Final `true` arg = excludePlayground: Playground usage must not pollute
       // provider analytics aggregates.
       expect(aggregation.getSummaryMetrics).toHaveBeenCalledWith(
         '24h',

--- a/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-analytics.controller.ts
@@ -11,7 +11,7 @@ import { AgentMessage } from '../../entities/agent-message.entity';
 import {
   selectMessageRowColumns,
   filterByKeyLabel,
-  excludeSystemAgents,
+  excludePlaygroundAgents,
 } from '../services/query-helpers';
 import { computeCutoff } from '../../common/utils/postgres-sql';
 import { sqlCastFloat, sqlSanitizeCost } from '../../common/utils/postgres-sql';
@@ -43,7 +43,7 @@ export class ProviderAnalyticsController {
     const agent = agentName || undefined;
 
     const [summary, ts] = await Promise.all([
-      // excludeSystem=true: Playground (is_system) usage must not pollute
+      // excludePlayground=true: Playground (is_playground) usage must not pollute
       // provider analytics aggregates.
       this.aggregation.getSummaryMetrics(
         validRange,
@@ -232,8 +232,8 @@ export class ProviderAnalyticsController {
       // Join on agent identity, not name: a soft-deleted agent sharing a slug
       // with a live one would otherwise match twice and double this breakdown's
       // per-agent tokens/cost/message counts. This one-to-(0/1) join is only for
-      // the `agent_platform` column; system-agent exclusion is handled by the
-      // NOT EXISTS semi-join in excludeSystemAgents (catches id- AND name-only
+      // the `agent_platform` column; playground-agent exclusion is handled by the
+      // NOT EXISTS semi-join in excludePlaygroundAgents (catches id- AND name-only
       // Playground rows without re-introducing duplication).
       .leftJoin('agents', 'a', 'a.id = at.agent_id')
       .where('at.tenant_id = :tid', { tid: tenantId })
@@ -241,8 +241,8 @@ export class ProviderAnalyticsController {
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type })
       .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff30d })
       .andWhere('at.agent_name IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent from the breakdown.
-    excludeSystemAgents(agentQb);
+    // Exclude the reserved Playground (is_playground) agent from the breakdown.
+    excludePlaygroundAgents(agentQb);
     filterByKeyLabel(agentQb, connLabel);
     const agentRows = await agentQb.groupBy('at.agent_name').orderBy('tokens', 'DESC').getRawMany();
 
@@ -260,7 +260,7 @@ export class ProviderAnalyticsController {
       .andWhere('at.model IS NOT NULL');
     // Same Playground exclusion as the agent breakdown, so the per-model token
     // sum stays equal to the per-agent sum (both cover the same messages).
-    excludeSystemAgents(modelQb);
+    excludePlaygroundAgents(modelQb);
     filterByKeyLabel(modelQb, connLabel);
     const modelRows = await modelQb.groupBy('at.model').orderBy('tokens', 'DESC').getRawMany();
 
@@ -275,7 +275,7 @@ export class ProviderAnalyticsController {
       .andWhere('at.provider = :provider', { provider: conn.provider })
       .andWhere('at.auth_type = :authType', { authType: conn.auth_type });
     // Keep reserved Playground runs out of the recent-messages list too.
-    excludeSystemAgents(msgQb);
+    excludePlaygroundAgents(msgQb);
     filterByKeyLabel(msgQb, connLabel);
     const recentMessages = await msgQb.orderBy('at.timestamp', 'DESC').limit(5).getRawMany();
 

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -381,8 +381,8 @@ describe('AgentDuplicationService', () => {
       expect(result.copied.providers).toBe(3);
     });
 
-    it('rejects the reserved system agent as a duplication source (404)', async () => {
-      // findOwnedAgent now includes `is_system = false`, so the Playground agent
+    it('rejects the reserved Playground agent as a duplication source (404)', async () => {
+      // findOwnedAgent now includes `is_playground = false`, so the Playground agent
       // is invisible to duplication lookups — getOne returns null as if it doesn't exist.
       mockAgentGetOne.mockResolvedValueOnce(null);
 
@@ -391,9 +391,9 @@ describe('AgentDuplicationService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('passes is_system = false filter in every findOwnedAgent query builder call', async () => {
-      // Ensures the new andWhere('a.is_system = false') clause is present so the
-      // system agent is always excluded from source resolution.
+    it('passes is_playground = false filter in every findOwnedAgent query builder call', async () => {
+      // Ensures the new andWhere('a.is_playground = false') clause is present so the
+      // playground agent is always excluded from source resolution.
       mockAgentGetOne.mockResolvedValueOnce(null);
 
       await expect(
@@ -401,13 +401,15 @@ describe('AgentDuplicationService', () => {
       ).rejects.toThrow(NotFoundException);
 
       const andWhereCalls = (mockAgentQb.andWhere as jest.Mock).mock.calls as string[][];
-      const hasSystemFilter = andWhereCalls.some(([expr]) => /is_system.*false/i.test(expr));
-      expect(hasSystemFilter).toBe(true);
+      const hasPlaygroundFilter = andWhereCalls.some(([expr]) =>
+        /is_playground.*false/i.test(expr),
+      );
+      expect(hasPlaygroundFilter).toBe(true);
     });
   });
 
-  describe('getCopySummary system-agent block', () => {
-    it('rejects the reserved system agent as a source for getCopySummary (404)', async () => {
+  describe('getCopySummary playground-agent block', () => {
+    it('rejects the reserved Playground agent as a source for getCopySummary (404)', async () => {
       // Same filter applies: the Playground agent is invisible to findOwnedAgent.
       mockAgentGetOne.mockResolvedValueOnce(null);
 
@@ -417,8 +419,8 @@ describe('AgentDuplicationService', () => {
     });
   });
 
-  describe('suggestName system-agent block', () => {
-    it('rejects the reserved system agent as a source for suggestName (404)', async () => {
+  describe('suggestName playground-agent block', () => {
+    it('rejects the reserved Playground agent as a source for suggestName (404)', async () => {
       mockAgentGetOne.mockResolvedValueOnce(null);
 
       await expect(service.suggestName('user-1', 'Playground')).rejects.toThrow(NotFoundException);

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -50,9 +50,9 @@ export class AgentDuplicationService {
         .where('t.name = :userId', { userId })
         .andWhere('a.name = :agentName', { agentName })
         .andWhere('a.deleted_at IS NULL')
-        // Exclude the reserved system agent — it cannot be cloned or used as a
+        // Exclude the reserved Playground agent — it cannot be cloned or used as a
         // duplication source (it has no API key and is tenant-singleton).
-        .andWhere('a.is_system = false')
+        .andWhere('a.is_playground = false')
         .getOne()
     );
   }

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
@@ -406,9 +406,9 @@ describe('AgentLifecycleService', () => {
     });
   });
 
-  describe('system agent protection', () => {
-    it('cannot delete a system agent — findAgentByUser excludes is_system=true rows', async () => {
-      // Simulate the system agent being invisible to the resolver (returns null).
+  describe('playground agent protection', () => {
+    it('cannot delete a playground agent — findAgentByUser excludes is_playground=true rows', async () => {
+      // Simulate the playground agent being invisible to the resolver (returns null).
       mockAgentGetOne.mockResolvedValueOnce(null);
 
       await expect(service.deleteAgent('test-user', 'playground')).rejects.toThrow(
@@ -417,8 +417,8 @@ describe('AgentLifecycleService', () => {
       expect(mockTransaction).not.toHaveBeenCalled();
     });
 
-    it('cannot rename a system agent — the resolver excludes is_system=true rows', async () => {
-      // The rename "find current agent" query also filters is_system = false.
+    it('cannot rename a playground agent — the resolver excludes is_playground=true rows', async () => {
+      // The rename "find current agent" query also filters is_playground = false.
       mockAgentGetOne.mockResolvedValueOnce(null);
 
       await expect(service.renameAgent('test-user', 'playground', 'new-name')).rejects.toThrow(
@@ -427,7 +427,7 @@ describe('AgentLifecycleService', () => {
       expect(mockTransaction).not.toHaveBeenCalled();
     });
 
-    it('applies is_system = false filter in findAgentByUser', async () => {
+    it('applies is_playground = false filter in findAgentByUser', async () => {
       const mockAndWhere = jest.fn().mockReturnThis();
       const mockQb = {
         select: jest.fn().mockReturnThis(),
@@ -443,7 +443,7 @@ describe('AgentLifecycleService', () => {
       await service.findAgentInfo('user-1', 'playground');
 
       const andWhereCalls = mockAndWhere.mock.calls.map((c: unknown[]) => c[0]);
-      expect(andWhereCalls).toContain('a.is_system = false');
+      expect(andWhereCalls).toContain('a.is_playground = false');
     });
   });
 

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.ts
@@ -77,7 +77,7 @@ export class AgentLifecycleService {
       .where('t.name = :userId', { userId })
       .andWhere('a.name = :agentName', { agentName })
       .andWhere('a.deleted_at IS NULL')
-      .andWhere('a.is_system = false')
+      .andWhere('a.is_playground = false')
       .getOne();
   }
 
@@ -132,7 +132,7 @@ export class AgentLifecycleService {
       .where('t.name = :userId', { userId })
       .andWhere('a.name = :currentName', { currentName })
       .andWhere('a.deleted_at IS NULL')
-      .andWhere('a.is_system = false')
+      .andWhere('a.is_playground = false')
       .getOne();
 
     if (!agent) {

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -4,7 +4,7 @@ import { Brackets } from 'typeorm';
 import { AggregationService } from './aggregation.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
-import { EXCLUDE_SYSTEM_AGENTS_PREDICATE } from './query-helpers';
+import { EXCLUDE_PLAYGROUND_AGENTS_PREDICATE } from './query-helpers';
 
 describe('AggregationService', () => {
   let service: AggregationService;
@@ -205,7 +205,7 @@ describe('AggregationService', () => {
       expect(clauses).toContain('at.provider = :provider');
     });
 
-    it('excludes the system Playground agent from both windows when excludeSystem=true', async () => {
+    it('excludes the reserved Playground agent from both windows when excludePlayground=true', async () => {
       mockGetRawOne
         .mockResolvedValueOnce({ msg_count: 5, inp: 50, out: 25, cost: 0.5 })
         .mockResolvedValueOnce({ msg_count: 4, tokens: 60, cost: 0.4 });
@@ -223,11 +223,11 @@ describe('AggregationService', () => {
       const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
       // Both the current and previous window builders add the semi-join guard.
       // It adds no join of its own (pure NOT EXISTS existence test).
-      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(clauses).toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
       expect(mockQb.leftJoin).not.toHaveBeenCalled();
     });
 
-    it('does not exclude system agents by default (excludeSystem omitted)', async () => {
+    it('does not exclude playground agents by default (excludePlayground omitted)', async () => {
       mockGetRawOne
         .mockResolvedValueOnce({ msg_count: 5, inp: 50, out: 25, cost: 0.5 })
         .mockResolvedValueOnce({ msg_count: 4, tokens: 60, cost: 0.4 });
@@ -235,7 +235,7 @@ describe('AggregationService', () => {
       await service.getSummaryMetrics('24h', 'u1', 'tenant-123');
 
       const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
-      expect(clauses).not.toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(clauses).not.toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
     });
 
     const labelClause = "LOWER(COALESCE(at.provider_key_label, 'Default')) = LOWER(:keyLabel)";

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -7,7 +7,7 @@ import {
   MetricWithTrend,
   computeTrend,
   addTenantFilter,
-  excludeSystemAgents,
+  excludePlaygroundAgents,
   filterByKeyLabel,
 } from './query-helpers';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
@@ -62,7 +62,7 @@ export class AggregationService {
     agentName?: string,
     authType?: string,
     provider?: string,
-    excludeSystem = false,
+    excludePlayground = false,
     label?: string,
   ) {
     const { cutoff, prevCutoff } = this.computeWindow(range);
@@ -78,7 +78,7 @@ export class AggregationService {
     addTenantFilter(currentQb, userId, agentName, tenantId);
     if (authType) currentQb.andWhere('at.auth_type = :authType', { authType });
     if (provider) currentQb.andWhere('at.provider = :provider', { provider });
-    if (excludeSystem) excludeSystemAgents(currentQb);
+    if (excludePlayground) excludePlaygroundAgents(currentQb);
     // Connection-scoped label filter: keep two keys that share
     // provider+auth_type but differ by label from merging into one connection's
     // summary. Legacy NULL provider_key_label → 'Default'.
@@ -92,7 +92,7 @@ export class AggregationService {
       prevCutoff,
       authType,
       provider,
-      excludeSystem,
+      excludePlayground,
       label,
     )
       .select('COUNT(*)', 'msg_count')
@@ -140,7 +140,7 @@ export class AggregationService {
     prevCutoff: string,
     authType?: string,
     provider?: string,
-    excludeSystem = false,
+    excludePlayground = false,
     label?: string,
   ): SelectQueryBuilder<AgentMessage> {
     const qb = this.turnRepo
@@ -150,7 +150,7 @@ export class AggregationService {
     addTenantFilter(qb, userId, agentName, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
-    if (excludeSystem) excludeSystemAgents(qb);
+    if (excludePlayground) excludePlaygroundAgents(qb);
     // Connection-scoped label filter (see getSummaryMetrics).
     if (label !== undefined) filterByKeyLabel(qb, label);
     return qb;

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -4,8 +4,8 @@ import {
   formatTimestamp,
   addTenantFilter,
   selectMessageRowColumns,
-  excludeSystemAgents,
-  EXCLUDE_SYSTEM_AGENTS_PREDICATE,
+  excludePlaygroundAgents,
+  EXCLUDE_PLAYGROUND_AGENTS_PREDICATE,
   CUSTOM_PROVIDER_JOIN_CONDITION,
   PROVIDER_SERIES_KEY_EXPR,
   filterByKeyLabel,
@@ -218,7 +218,7 @@ describe('addTenantFilter', () => {
   });
 });
 
-describe('excludeSystemAgents', () => {
+describe('excludePlaygroundAgents', () => {
   function makeMockQb() {
     const mockAndWhere = jest.fn();
     const mockLeftJoin = jest.fn();
@@ -229,30 +229,30 @@ describe('excludeSystemAgents', () => {
     return { qb: qb as unknown as SelectQueryBuilder<never>, mockAndWhere, mockLeftJoin };
   }
 
-  it('excludes system agents via a NOT EXISTS semi-join (no join added)', () => {
+  it('excludes playground agents via a NOT EXISTS semi-join (no join added)', () => {
     const { qb, mockAndWhere, mockLeftJoin } = makeMockQb();
-    excludeSystemAgents(qb);
+    excludePlaygroundAgents(qb);
 
     // Semi-join only: never adds a LEFT JOIN of its own.
     expect(mockLeftJoin).not.toHaveBeenCalled();
-    expect(mockAndWhere).toHaveBeenCalledWith(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+    expect(mockAndWhere).toHaveBeenCalledWith(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
   });
 
-  it('matches the system agent by id OR name and never multiplies rows', () => {
+  it('matches the playground agent by id OR name and never multiplies rows', () => {
     // The predicate is a pure existence test (cannot duplicate fact rows) and
     // matches on either agent_id OR agent_name (so a Playground row carrying
     // only agent_name, NULL agent_id, is still excluded).
-    expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain('NOT EXISTS');
-    expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain('sysag.is_system = true');
-    expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain('sysag.tenant_id = at.tenant_id');
-    expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain(
-      'sysag.id = at.agent_id OR sysag.name = at.agent_name',
+    expect(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE).toContain('NOT EXISTS');
+    expect(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE).toContain('playag.is_playground = true');
+    expect(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE).toContain('playag.tenant_id = at.tenant_id');
+    expect(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE).toContain(
+      'playag.id = at.agent_id OR playag.name = at.agent_name',
     );
   });
 
   it('returns the query builder for chaining', () => {
     const { qb } = makeMockQb();
-    expect(excludeSystemAgents(qb)).toBe(qb);
+    expect(excludePlaygroundAgents(qb)).toBe(qb);
   });
 });
 

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -96,10 +96,10 @@ export function addTenantFilter<T extends ObjectLiteral>(
 }
 
 /**
- * Exclude the reserved Playground (`is_system`) agent from a message
- * aggregate. A row is dropped iff it belongs to a system agent of the same
+ * Exclude the reserved Playground (`is_playground`) agent from a message
+ * aggregate. A row is dropped iff it belongs to a playground agent of the same
  * tenant by EITHER `agent_id` OR `agent_name`; every other row (including
- * orphan telemetry with a NULL/unmatched `agent_id` and a non-system name)
+ * orphan telemetry with a NULL/unmatched `agent_id` and a non-playground name)
  * stays included.
  *
  * Implemented as a `NOT EXISTS` semi-join rather than a LEFT JOIN. Two
@@ -111,24 +111,24 @@ export function addTenantFilter<T extends ObjectLiteral>(
  *  2. No leak — matching on `id` OR `name` means a Playground message that
  *     carries only `agent_name = 'Playground'` (NULL or unmatched `agent_id`)
  *     is still excluded. An id-only LEFT JOIN left those rows with a NULL
- *     `is_system` and wrongly counted them.
+ *     `is_playground` and wrongly counted them.
  *
  * Assumes the query builder aliases `agent_messages` as `at`. This helper adds
  * no join, so callers that need agent columns must add their own `agents` join
  * (one-to-(0/1) on `a.id = at.agent_id`) independently.
  */
 /**
- * The exact `NOT EXISTS` predicate `excludeSystemAgents` appends. Exported so
+ * The exact `NOT EXISTS` predicate `excludePlaygroundAgents` appends. Exported so
  * call sites and tests reference one string instead of duplicating (and
  * drifting on) the SQL.
  */
-export const EXCLUDE_SYSTEM_AGENTS_PREDICATE =
-  'NOT EXISTS (SELECT 1 FROM agents sysag WHERE sysag.tenant_id = at.tenant_id AND sysag.is_system = true AND (sysag.id = at.agent_id OR sysag.name = at.agent_name))';
+export const EXCLUDE_PLAYGROUND_AGENTS_PREDICATE =
+  'NOT EXISTS (SELECT 1 FROM agents playag WHERE playag.tenant_id = at.tenant_id AND playag.is_playground = true AND (playag.id = at.agent_id OR playag.name = at.agent_name))';
 
-export function excludeSystemAgents<T extends ObjectLiteral>(
+export function excludePlaygroundAgents<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,
 ): SelectQueryBuilder<T> {
-  return qb.andWhere(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+  return qb.andWhere(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
 }
 
 /**

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -6,7 +6,7 @@ import { Agent } from '../../entities/agent.entity';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import {
   MESSAGE_ROW_SELECT_ALIASES,
-  EXCLUDE_SYSTEM_AGENTS_PREDICATE,
+  EXCLUDE_PLAYGROUND_AGENTS_PREDICATE,
   CUSTOM_PROVIDER_JOIN_CONDITION,
   PROVIDER_SERIES_KEY_EXPR,
 } from './query-helpers';
@@ -380,16 +380,16 @@ describe('TimeseriesQueriesService', () => {
     const recentIso = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
     const oldIso = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
 
-    it('excludes the reserved system (Playground) agent by default', async () => {
+    it('excludes the reserved Playground agent by default', async () => {
       await service.getAgentList('u1');
       const clauses = mockAgentQb.andWhere.mock.calls.map((c) => c[0] as string);
-      expect(clauses).toContain('a.is_system = false');
+      expect(clauses).toContain('a.is_playground = false');
     });
 
-    it('includes system agents when includeSystem is true (Messages filter)', async () => {
+    it('includes playground agents when includePlayground is true (Messages filter)', async () => {
       await service.getAgentList('u1', undefined, true);
       const clauses = mockAgentQb.andWhere.mock.calls.map((c) => c[0] as string);
-      expect(clauses).not.toContain('a.is_system = false');
+      expect(clauses).not.toContain('a.is_playground = false');
     });
 
     it('returns agents with sparkline data and display_name', async () => {
@@ -500,7 +500,7 @@ describe('TimeseriesQueriesService', () => {
       expect(clauses).toContain('at.provider = :provider');
     });
 
-    it('excludes the system Playground agent when excludeSystem=true', async () => {
+    it('excludes the reserved Playground agent when excludePlayground=true', async () => {
       mockGetRawMany.mockResolvedValue([]);
       await service.getTimeseries(
         '24h',
@@ -513,16 +513,16 @@ describe('TimeseriesQueriesService', () => {
         true,
       );
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
-      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(clauses).toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
       // Semi-join exclusion adds no LEFT JOIN of its own.
       expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
     });
 
-    it('does not exclude system agents by default', async () => {
+    it('does not exclude playground agents by default', async () => {
       mockGetRawMany.mockResolvedValue([]);
       await service.getTimeseries('24h', 'u1', true, 'tenant-1');
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
-      expect(clauses).not.toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(clauses).not.toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
     });
 
     it('scopes the aggregate timeseries to a connection label when provided', async () => {
@@ -568,17 +568,17 @@ describe('TimeseriesQueriesService', () => {
         { hour: '02', alpha: 3, bravo: 0 },
       ]);
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
-      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(clauses).toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
       expect(clauses).toContain('at.auth_type = :authType');
       expect(clauses).toContain('at.provider = :provider');
-      // The NOT EXISTS semi-join matches a system agent by id OR name and is a
+      // The NOT EXISTS semi-join matches a playground agent by id OR name and is a
       // pure existence test, so a soft-deleted agent sharing a slug with a live
       // one can never multiply the per-agent SUM. It adds no LEFT JOIN.
       expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
       // Matching by name (not just id) means a Playground row carrying only
       // agent_name (NULL agent_id) is excluded too — no leak.
-      expect(EXCLUDE_SYSTEM_AGENTS_PREDICATE).toContain(
-        'sysag.id = at.agent_id OR sysag.name = at.agent_name',
+      expect(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE).toContain(
+        'playag.id = at.agent_id OR playag.name = at.agent_name',
       );
     });
 
@@ -653,9 +653,9 @@ describe('TimeseriesQueriesService', () => {
         (c) => typeof c[0] === 'string' && c[0].includes('at.agent_id = ('),
       );
       expect(liveAgentCall![1]).toEqual({ liveAgentName: 'agent-x', liveTenantId: 'tenant-1' });
-      // Playground (is_system) usage must be excluded from per-provider totals,
+      // Playground (is_playground) usage must be excluded from per-provider totals,
       // via the same NOT EXISTS semi-join as the per-agent endpoints (no join).
-      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(clauses).toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
       // Custom provider names resolve via the cp join (built-ins join to NULL).
       expect(mockTurnQb.leftJoin).toHaveBeenCalledWith(
         CustomProvider,
@@ -755,9 +755,9 @@ describe('TimeseriesQueriesService', () => {
       const out = await service.getPerModelTimeseries('24h', 'u1', true, 'tenant-1', 'agent-x');
       expect(out.agents).toEqual(['gpt-4o']);
       expect(out.timeseries).toEqual([{ hour: '01', 'gpt-4o': 9 }]);
-      // Playground (is_system) usage must be excluded from per-model totals.
+      // Playground (is_playground) usage must be excluded from per-model totals.
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
-      expect(clauses).toContain(EXCLUDE_SYSTEM_AGENTS_PREDICATE);
+      expect(clauses).toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
       expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();
     });
 
@@ -781,12 +781,12 @@ describe('TimeseriesQueriesService', () => {
   });
 
   describe('getAgentNamesByAuthType', () => {
-    it('returns distinct agent names excluding system agents', async () => {
+    it('returns distinct agent names excluding playground agents', async () => {
       mockGetRawMany.mockResolvedValue([{ agent_name: 'a' }, { agent_name: 'b' }]);
       const out = await service.getAgentNamesByAuthType('subscription', 'u1', 'tenant-1');
       expect(out).toEqual(['a', 'b']);
       expect(mockTurnQb.andWhere.mock.calls.map((c) => c[0])).toContain(
-        EXCLUDE_SYSTEM_AGENTS_PREDICATE,
+        EXCLUDE_PLAYGROUND_AGENTS_PREDICATE,
       );
       // No LEFT JOIN on agents anymore — exclusion is a pure semi-join.
       expect(mockTurnQb.leftJoin).not.toHaveBeenCalled();

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -7,7 +7,7 @@ import { rangeToInterval } from '../../common/utils/range.util';
 import {
   addTenantFilter,
   selectMessageRowColumns,
-  excludeSystemAgents,
+  excludePlaygroundAgents,
   filterByKeyLabel,
   filterByLiveAgentName,
   CUSTOM_PROVIDER_JOIN_CONDITION,
@@ -50,7 +50,7 @@ export class TimeseriesQueriesService {
     agentName?: string,
     authType?: string,
     provider?: string,
-    excludeSystem = false,
+    excludePlayground = false,
     label?: string,
   ) {
     const interval = rangeToInterval(range);
@@ -69,7 +69,7 @@ export class TimeseriesQueriesService {
     addTenantFilter(qb, userId, agentName, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
-    if (excludeSystem) excludeSystemAgents(qb);
+    if (excludePlayground) excludePlaygroundAgents(qb);
     // Connection-scoped label filter: keep sibling keys (same provider+auth_type,
     // different label) out of this connection's aggregate chart. NULL → 'Default'.
     if (label !== undefined) filterByKeyLabel(qb, label);
@@ -188,7 +188,7 @@ export class TimeseriesQueriesService {
     }));
   }
 
-  async getAgentList(userId: string, tenantId?: string, includeSystem = false) {
+  async getAgentList(userId: string, tenantId?: string, includePlayground = false) {
     const resolved = tenantId ?? (await this.tenantCache.resolve(userId)) ?? undefined;
 
     const agentQb = this.agentRepo.createQueryBuilder('a');
@@ -198,11 +198,11 @@ export class TimeseriesQueriesService {
       agentQb.leftJoin('a.tenant', 't').where('t.name = :userId', { userId });
     }
     agentQb.andWhere('a.deleted_at IS NULL');
-    // The reserved Playground agent is a system agent. Hidden from the
+    // The reserved Playground agent is a playground agent. Hidden from the
     // Workspace grid / agent switcher by default; the Messages filter opts in
-    // via includeSystem so users can filter the log to Playground runs.
-    if (!includeSystem) {
-      agentQb.andWhere('a.is_system = false');
+    // via includePlayground so users can filter the log to Playground runs.
+    if (!includePlayground) {
+      agentQb.andWhere('a.is_playground = false');
     }
 
     const statsCutoff = computeCutoff('30 days');
@@ -319,10 +319,10 @@ export class TimeseriesQueriesService {
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.agent_name IS NOT NULL');
-    // Drop the reserved Playground (is_system) agent. The NOT EXISTS semi-join
+    // Drop the reserved Playground (is_playground) agent. The NOT EXISTS semi-join
     // matches by id OR name (so name-only Playground rows are excluded too) and
     // can't multiply the per-agent SUM the way a name-based LEFT JOIN would.
-    excludeSystemAgents(qb);
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
@@ -362,7 +362,7 @@ export class TimeseriesQueriesService {
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.agent_name IS NOT NULL');
     // Semi-join exclusion (see getPerAgentTimeseries): no double-count, no leak.
-    excludeSystemAgents(qb);
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
@@ -401,7 +401,7 @@ export class TimeseriesQueriesService {
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.agent_name IS NOT NULL');
     // Semi-join exclusion (see getPerAgentTimeseries): no double-count, no leak.
-    excludeSystemAgents(qb);
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
@@ -437,9 +437,9 @@ export class TimeseriesQueriesService {
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent so per-provider totals
+    // Exclude the reserved Playground (is_playground) agent so per-provider totals
     // stay consistent with the per-agent / summary endpoints (semi-join, no leak by id-or-name).
-    excludeSystemAgents(qb);
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
@@ -474,8 +474,8 @@ export class TimeseriesQueriesService {
       .addSelect('COUNT(*)', 'messages')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
-    excludeSystemAgents(qb);
+    // Exclude the reserved Playground (is_playground) agent (semi-join, no leak by id-or-name).
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
@@ -509,9 +509,9 @@ export class TimeseriesQueriesService {
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent so per-model totals stay
+    // Exclude the reserved Playground (is_playground) agent so per-model totals stay
     // consistent with the per-agent / summary endpoints (semi-join, no leak by id-or-name).
-    excludeSystemAgents(qb);
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
@@ -545,8 +545,8 @@ export class TimeseriesQueriesService {
       .addSelect('COUNT(*)', 'messages')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
-    excludeSystemAgents(qb);
+    // Exclude the reserved Playground (is_playground) agent (semi-join, no leak by id-or-name).
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
@@ -581,8 +581,8 @@ export class TimeseriesQueriesService {
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.provider IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
-    excludeSystemAgents(qb);
+    // Exclude the reserved Playground (is_playground) agent (semi-join, no leak by id-or-name).
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
@@ -614,8 +614,8 @@ export class TimeseriesQueriesService {
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent (semi-join, no leak by id-or-name).
-    excludeSystemAgents(qb);
+    // Exclude the reserved Playground (is_playground) agent (semi-join, no leak by id-or-name).
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     // Scope to the LIVE agent owning the slug (id-based), so a soft-deleted
     // agent sharing the name doesn't leak its old rows into this chart.
@@ -638,10 +638,10 @@ export class TimeseriesQueriesService {
       .select('DISTINCT at.agent_name', 'agent_name')
       .where('at.auth_type = :authType', { authType })
       .andWhere('at.agent_name IS NOT NULL');
-    // Exclude the reserved Playground (is_system) agent. The NOT EXISTS semi-join
+    // Exclude the reserved Playground (is_playground) agent. The NOT EXISTS semi-join
     // matches by id OR name, so a Playground row carrying only agent_name (NULL
     // agent_id) is still dropped, and it can't multiply rows.
-    excludeSystemAgents(qb);
+    excludePlaygroundAgents(qb);
     addTenantFilter(qb, userId, undefined, tenantId);
     const rows = await qb.orderBy('at.agent_name', 'ASC').getRawMany();
     return rows.map((r: Record<string, unknown>) => String(r['agent_name']));

--- a/packages/backend/src/common/constants/cache.constants.ts
+++ b/packages/backend/src/common/constants/cache.constants.ts
@@ -6,11 +6,11 @@ export const FREE_MODELS_CACHE_TTL_MS = 3_600_000;
 
 /**
  * Canonical cache key for the GET /agents list. The route varies only by whether
- * the reserved system (Playground) agent is included, so every query-string
+ * the reserved Playground agent is included, so every query-string
  * variant collapses to one of two keys keyed on that boolean — never the raw
  * URL. This keeps the key set bounded (exactly two per user) so invalidation can
  * enumerate it exhaustively and no variant is ever left stale.
  */
-export function agentListCacheKey(userId: string, includeSystem: boolean): string {
-  return `${userId}:/api/v1/agents:system=${includeSystem}`;
+export function agentListCacheKey(userId: string, includePlayground: boolean): string {
+  return `${userId}:/api/v1/agents:playground=${includePlayground}`;
 }

--- a/packages/backend/src/common/constants/playground.constants.ts
+++ b/packages/backend/src/common/constants/playground.constants.ts
@@ -2,7 +2,7 @@
  * The reserved per-tenant "Playground" agent that backs the global Playground.
  * Playground runs resolve to it (so they record `agent_name = 'Playground'` in
  * global Messages) and it holds grants to the tenant's whole global provider
- * pool. It is flagged `is_system = true`, hidden from the agent list/switcher/
+ * pool. It is flagged `is_playground = true`, hidden from the agent list/switcher/
  * counts, and users cannot create or rename an agent to this name.
  */
 export const PLAYGROUND_AGENT_NAME = 'Playground';
@@ -10,7 +10,7 @@ export const PLAYGROUND_AGENT_NAME = 'Playground';
 /**
  * The slug a user-created agent name would produce if it tried to take the
  * reserved name. User agent names are slugified, so blocking this slug in
- * create/rename reserves the name (the system agent itself is created directly,
+ * create/rename reserves the name (the playground agent itself is created directly,
  * bypassing slugify, so it keeps the display-cased `PLAYGROUND_AGENT_NAME`).
  */
 export const PLAYGROUND_AGENT_SLUG = 'playground';

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.spec.ts
@@ -31,33 +31,35 @@ describe('AgentListCacheInterceptor', () => {
   });
 
   describe('trackBy', () => {
-    it('keys on the system=true canonical variant for ?includeSystem=true', () => {
+    it('keys on the playground=true canonical variant for ?includePlayground=true', () => {
       const key = interceptor['trackBy'](
-        createMockContext({ id: 'u1' }, { includeSystem: 'true' }),
+        createMockContext({ id: 'u1' }, { includePlayground: 'true' }),
       );
-      expect(key).toBe('u1:/api/v1/agents:system=true');
+      expect(key).toBe('u1:/api/v1/agents:playground=true');
     });
 
-    it('keys on the system=false canonical variant when no query param is present', () => {
+    it('keys on the playground=false canonical variant when no query param is present', () => {
       const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, undefined));
-      expect(key).toBe('u1:/api/v1/agents:system=false');
+      expect(key).toBe('u1:/api/v1/agents:playground=false');
     });
 
-    it('collapses ?includeSystem=false onto the same system=false key (no stranded variant)', () => {
+    it('collapses ?includePlayground=false onto the same playground=false key (no stranded variant)', () => {
       const key = interceptor['trackBy'](
-        createMockContext({ id: 'u1' }, { includeSystem: 'false' }),
+        createMockContext({ id: 'u1' }, { includePlayground: 'false' }),
       );
-      expect(key).toBe('u1:/api/v1/agents:system=false');
+      expect(key).toBe('u1:/api/v1/agents:playground=false');
     });
 
-    it('collapses any non-"true" value onto the system=false key', () => {
-      const key = interceptor['trackBy'](createMockContext({ id: 'u1' }, { includeSystem: '1' }));
-      expect(key).toBe('u1:/api/v1/agents:system=false');
+    it('collapses any non-"true" value onto the playground=false key', () => {
+      const key = interceptor['trackBy'](
+        createMockContext({ id: 'u1' }, { includePlayground: '1' }),
+      );
+      expect(key).toBe('u1:/api/v1/agents:playground=false');
     });
 
     it('returns undefined for non-GET requests', () => {
       const key = interceptor['trackBy'](
-        createMockContext({ id: 'u1' }, { includeSystem: 'true' }, 'POST'),
+        createMockContext({ id: 'u1' }, { includePlayground: 'true' }, 'POST'),
       );
       expect(key).toBeUndefined();
     });

--- a/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
+++ b/packages/backend/src/common/interceptors/agent-list-cache.interceptor.ts
@@ -6,8 +6,8 @@ import { agentListCacheKey } from '../constants/cache.constants';
 /**
  * Cache interceptor for GET /agents. Unlike the generic URL-keyed
  * UserCacheInterceptor, it collapses every query-string variant (no param,
- * ?includeSystem=true, ?includeSystem=false, anything else) onto one of two
- * canonical keys based on the normalized `includeSystem` boolean. That keeps the
+ * ?includePlayground=true, ?includePlayground=false, anything else) onto one of two
+ * canonical keys based on the normalized `includePlayground` boolean. That keeps the
  * cached key set bounded to exactly two entries per user, so mutation handlers
  * can invalidate it exhaustively (see agentListCacheKey) without a stray URL
  * variant being left stale.
@@ -19,8 +19,8 @@ export class AgentListCacheInterceptor extends UserCacheInterceptor {
     if (!userId) return undefined;
 
     const request = context.switchToHttp().getRequest<Request>();
-    const includeSystem =
-      (request.query as { includeSystem?: string } | undefined)?.includeSystem === 'true';
-    return agentListCacheKey(userId, includeSystem);
+    const includePlayground =
+      (request.query as { includePlayground?: string } | undefined)?.includePlayground === 'true';
+    return agentListCacheKey(userId, includePlayground);
   }
 }

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -116,6 +116,7 @@ import { LiftCustomProvidersToUserLevel1791200000000 } from './migrations/179120
 import { SeedPlaygroundAgents1791400000000 } from './migrations/1791400000000-SeedPlaygroundAgents';
 import { DropProviderRateLimits1791600000000 } from './migrations/1791600000000-DropProviderRateLimits';
 import { DropSavingsBaselineColumns1791700000000 } from './migrations/1791700000000-DropSavingsBaselineColumns';
+import { RenameIsSystemToIsPlayground1791800000000 } from './migrations/1791800000000-RenameIsSystemToIsPlayground';
 
 const entities = [
   AgentMessage,
@@ -233,6 +234,7 @@ const migrations = [
   SeedPlaygroundAgents1791400000000,
   DropProviderRateLimits1791600000000,
   DropSavingsBaselineColumns1791700000000,
+  RenameIsSystemToIsPlayground1791800000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1791800000000-RenameIsSystemToIsPlayground.spec.ts
+++ b/packages/backend/src/database/migrations/1791800000000-RenameIsSystemToIsPlayground.spec.ts
@@ -1,0 +1,34 @@
+import { QueryRunner } from 'typeorm';
+import { RenameIsSystemToIsPlayground1791800000000 } from './1791800000000-RenameIsSystemToIsPlayground';
+
+describe('RenameIsSystemToIsPlayground1791800000000', () => {
+  let migration: RenameIsSystemToIsPlayground1791800000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new RenameIsSystemToIsPlayground1791800000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('renames is_system to is_playground when the old column exists', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain(`column_name = 'is_system'`);
+      expect(sql).toContain('RENAME COLUMN "is_system" TO "is_playground"');
+    });
+  });
+
+  describe('down', () => {
+    it('renames is_playground back to is_system when the new column exists', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain(`column_name = 'is_playground'`);
+      expect(sql).toContain('RENAME COLUMN "is_playground" TO "is_system"');
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1791800000000-RenameIsSystemToIsPlayground.ts
+++ b/packages/backend/src/database/migrations/1791800000000-RenameIsSystemToIsPlayground.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Renames `agents.is_system` to `agents.is_playground`. The flag only ever
+ * marked the reserved per-tenant "Playground" agent, so the old name was
+ * ambiguous (nothing else about the agent is "system"-level). The rename is
+ * guarded so it is a no-op on databases that already have the new column.
+ */
+export class RenameIsSystemToIsPlayground1791800000000 implements MigrationInterface {
+  name = 'RenameIsSystemToIsPlayground1791800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DO $$ BEGIN
+         IF EXISTS (
+           SELECT 1 FROM information_schema.columns
+           WHERE table_name = 'agents' AND column_name = 'is_system'
+         ) THEN
+           ALTER TABLE "agents" RENAME COLUMN "is_system" TO "is_playground";
+         END IF;
+       END $$`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DO $$ BEGIN
+         IF EXISTS (
+           SELECT 1 FROM information_schema.columns
+           WHERE table_name = 'agents' AND column_name = 'is_playground'
+         ) THEN
+           ALTER TABLE "agents" RENAME COLUMN "is_playground" TO "is_system";
+         END IF;
+       END $$`,
+    );
+  }
+}

--- a/packages/backend/src/entities/agent.entity.ts
+++ b/packages/backend/src/entities/agent.entity.ts
@@ -33,10 +33,10 @@ export class Agent {
   @Column('boolean', { default: true })
   record_messages!: boolean;
 
-  // Reserved system agent (the per-tenant "Playground" agent). Hidden
+  // Reserved Playground agent (the per-tenant "Playground" agent). Hidden
   // from the agent list / switcher / counts and not user-creatable/renamable.
   @Column('boolean', { default: false })
-  is_system!: boolean;
+  is_playground!: boolean;
 
   @ManyToOne(() => Tenant, (t) => t.agents, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'tenant_id' })

--- a/packages/backend/src/playground/playground-agent.service.spec.ts
+++ b/packages/backend/src/playground/playground-agent.service.spec.ts
@@ -15,7 +15,7 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     id: AGENT_ID,
     name: PLAYGROUND_AGENT_NAME,
     display_name: PLAYGROUND_AGENT_NAME,
-    is_system: true,
+    is_playground: true,
     is_active: true,
     tenant_id: TENANT_ID,
     ...overrides,
@@ -302,7 +302,7 @@ describe('PlaygroundAgentService.resolve', () => {
     });
   });
 
-  describe('(b) existing system agent returned', () => {
+  describe('(b) existing playground agent returned', () => {
     it('returns the existing agent without starting a transaction', async () => {
       const existing = makeAgent();
       const { service, mocks } = buildService({
@@ -317,7 +317,7 @@ describe('PlaygroundAgentService.resolve', () => {
       expect(mocks.dataSource.transaction).not.toHaveBeenCalled();
     });
 
-    it('queries agentRepo with the correct tenant_id, is_system and deleted_at filters', async () => {
+    it('queries agentRepo with the correct tenant_id, is_playground and deleted_at filters', async () => {
       const existing = makeAgent();
       const { service, mocks } = buildService({
         agentRepo: {
@@ -329,7 +329,7 @@ describe('PlaygroundAgentService.resolve', () => {
 
       expect(mocks.agentRepo.findOne).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({ tenant_id: TENANT_ID, is_system: true }),
+          where: expect.objectContaining({ tenant_id: TENANT_ID, is_playground: true }),
         }),
       );
     });
@@ -371,7 +371,7 @@ describe('PlaygroundAgentService.resolve', () => {
 
       expect(result.name).toBe(PLAYGROUND_AGENT_NAME);
       expect(result.display_name).toBe(PLAYGROUND_AGENT_NAME);
-      expect(result.is_system).toBe(true);
+      expect(result.is_playground).toBe(true);
       expect(result.is_active).toBe(true);
       expect(result.tenant_id).toBe(TENANT_ID);
       expect(typeof result.id).toBe('string');

--- a/packages/backend/src/playground/playground-agent.service.ts
+++ b/packages/backend/src/playground/playground-agent.service.ts
@@ -8,7 +8,7 @@ import { TenantCacheService } from '../common/services/tenant-cache.service';
 import { PLAYGROUND_AGENT_NAME } from '../common/constants/playground.constants';
 
 /**
- * Resolves the tenant's reserved `is_system` "Playground" agent — the single
+ * Resolves the tenant's reserved `is_playground` "Playground" agent — the single
  * agent every Playground run records under (so runs show as `Playground` in
  * global Messages) and which holds grants to the whole global provider pool.
  *
@@ -45,14 +45,14 @@ export class PlaygroundAgentService {
       this.tenantCache.invalidate(userId);
     }
 
-    const existing = await this.findSystemAgent(tenantId);
+    const existing = await this.findPlaygroundAgent(tenantId);
     if (existing) return existing;
 
     const agent = Object.assign(new Agent(), {
       id: randomUUID(),
       name: PLAYGROUND_AGENT_NAME,
       display_name: PLAYGROUND_AGENT_NAME,
-      is_system: true,
+      is_playground: true,
       is_active: true,
       tenant_id: tenantId,
     });
@@ -75,7 +75,7 @@ export class PlaygroundAgentService {
       // A concurrent request may have won the unique-index race — reuse its row.
       // Any other failure is a real error (not a race): re-throw it rather than
       // masking it as a generic not-found.
-      const raced = await this.findSystemAgent(tenantId);
+      const raced = await this.findPlaygroundAgent(tenantId);
       if (raced) return raced;
       throw err;
     }
@@ -83,9 +83,9 @@ export class PlaygroundAgentService {
     return agent;
   }
 
-  private findSystemAgent(tenantId: string): Promise<Agent | null> {
+  private findPlaygroundAgent(tenantId: string): Promise<Agent | null> {
     return this.agentRepo.findOne({
-      where: { tenant_id: tenantId, is_system: true, deleted_at: IsNull() },
+      where: { tenant_id: tenantId, is_playground: true, deleted_at: IsNull() },
     });
   }
 

--- a/packages/backend/src/routing/agent-provider-access.controller.spec.ts
+++ b/packages/backend/src/routing/agent-provider-access.controller.spec.ts
@@ -89,20 +89,20 @@ function makeController(overrides: Record<string, unknown> = {}) {
 }
 
 describe('AgentProviderAccessController', () => {
-  describe('resolveAgent — is_system: false filter', () => {
-    it('passes is_system: false in the agentRepo.findOne where-clause', async () => {
+  describe('resolveAgent — is_playground: false filter', () => {
+    it('passes is_playground: false in the agentRepo.findOne where-clause', async () => {
       const { controller, agentRepo } = makeController();
       await controller.listEnabled({ id: USER_ID } as never, 'my-agent');
       expect(agentRepo.findOne).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({ is_system: false }),
+          where: expect.objectContaining({ is_playground: false }),
         }),
       );
     });
 
-    it('returns empty enabled list for a system agent (agentRepo.findOne returns null because is_system: false filters it out)', async () => {
-      // Simulate the DB returning null because the agent has is_system: true
-      // and the query filters on is_system: false.
+    it('returns empty enabled list for a playground agent (agentRepo.findOne returns null because is_playground: false filters it out)', async () => {
+      // Simulate the DB returning null because the agent has is_playground: true
+      // and the query filters on is_playground: false.
       const { controller } = makeController({
         agentRepo: { findOne: jest.fn().mockResolvedValue(null) },
       });
@@ -110,7 +110,7 @@ describe('AgentProviderAccessController', () => {
       expect(result).toEqual({ enabled: [] });
     });
 
-    it('throws 404 on enable when agentRepo.findOne returns null for a system agent', async () => {
+    it('throws 404 on enable when agentRepo.findOne returns null for a playground agent', async () => {
       const { controller } = makeController({
         agentRepo: { findOne: jest.fn().mockResolvedValue(null) },
         userProviderRepo: {
@@ -122,7 +122,7 @@ describe('AgentProviderAccessController', () => {
       ).rejects.toBeInstanceOf(HttpException);
     });
 
-    it('throws 404 on disable when agentRepo.findOne returns null for a system agent', async () => {
+    it('throws 404 on disable when agentRepo.findOne returns null for a playground agent', async () => {
       const { controller } = makeController({
         agentRepo: { findOne: jest.fn().mockResolvedValue(null) },
       });

--- a/packages/backend/src/routing/agent-provider-access.controller.ts
+++ b/packages/backend/src/routing/agent-provider-access.controller.ts
@@ -45,10 +45,10 @@ export class AgentProviderAccessController {
   private async resolveAgent(agentName: string, userId: string) {
     const tenant = await this.tenantRepo.findOne({ where: { name: userId } });
     if (!tenant) return null;
-    // Exclude the reserved system (Playground) agent — its grants are the global
+    // Exclude the reserved Playground agent — its grants are the global
     // pool and must not be togglable/removable through this per-agent endpoint.
     return this.agentRepo.findOne({
-      where: { name: decodeURIComponent(agentName), tenant_id: tenant.id, is_system: false },
+      where: { name: decodeURIComponent(agentName), tenant_id: tenant.id, is_playground: false },
     });
   }
 

--- a/packages/backend/src/routing/custom-provider.controller.spec.ts
+++ b/packages/backend/src/routing/custom-provider.controller.spec.ts
@@ -185,7 +185,7 @@ describe('CustomProviderController', () => {
       expect(result.has_api_key).toBe(false);
     });
 
-    it('passes { allowSystem: true } so the Playground agent can create custom providers', async () => {
+    it('passes { allowPlayground: true } so the Playground agent can create custom providers', async () => {
       mockProviderService.getProviders.mockResolvedValue([]);
 
       const body = {
@@ -197,7 +197,7 @@ describe('CustomProviderController', () => {
       await controller.create(mockUser, { agentName: 'Playground' } as never, body as never);
 
       expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'Playground', {
-        allowSystem: true,
+        allowPlayground: true,
       });
     });
   });

--- a/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
@@ -23,9 +23,9 @@ export class CustomProviderController {
   async list(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
     // Resolve for authz — user must own the agent. Custom providers are
     // user-global, so the listing itself is scoped to the user, not the agent.
-    // allowSystem: true — the Playground page reads custom providers for the
-    // reserved system agent; all mutation endpoints remain blocked.
-    await this.resolveAgentService.resolve(user.id, params.agentName, { allowSystem: true });
+    // allowPlayground: true — the Playground page reads custom providers for the
+    // reserved Playground agent; all mutation endpoints remain blocked.
+    await this.resolveAgentService.resolve(user.id, params.agentName, { allowPlayground: true });
     const [providers, userProviders] = await Promise.all([
       this.customProviderService.list(user.id),
       this.providerService.getProviders(user.id),
@@ -71,9 +71,9 @@ export class CustomProviderController {
     @Param() params: AgentNameParamDto,
     @Body() body: CreateCustomProviderDto,
   ) {
-    // allowSystem: true — creating a custom provider from the Playground page is
-    // additive (user-global resource); the system agent is a valid owner context.
-    await this.resolveAgentService.resolve(user.id, params.agentName, { allowSystem: true });
+    // allowPlayground: true — creating a custom provider from the Playground page is
+    // additive (user-global resource); the playground agent is a valid owner context.
+    await this.resolveAgentService.resolve(user.id, params.agentName, { allowPlayground: true });
     const cp = await this.customProviderService.create(user.id, body);
     const provKey = CustomProviderService.providerKey(cp.id);
     const up = (await this.providerService.getProviders(user.id)).find(

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -81,10 +81,10 @@ export class ModelController {
 
   @Get(':agentName/available-models')
   async getAvailableModels(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
-    // allowSystem: true — the Playground frontend reads available models for the
-    // reserved system agent; all other model.controller endpoints remain blocked.
+    // allowPlayground: true — the Playground frontend reads available models for the
+    // reserved Playground agent; all other model.controller endpoints remain blocked.
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName, {
-      allowSystem: true,
+      allowPlayground: true,
     });
     const models = await this.discoveryService.getModelsForAgent(user.id, agent.id);
 

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -657,11 +657,11 @@ describe('ProviderController', () => {
       await expect(
         controller.getProviders(mockUser, { agentName: 'nonexistent' } as never),
       ).rejects.toThrow(NotFoundException);
-      // getProviders passes { allowSystem: true } so the Playground agent can be
+      // getProviders passes { allowPlayground: true } so the Playground agent can be
       // read; the NotFoundException originates from the service mock, not the
-      // is_system check.
+      // is_playground check.
       expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'nonexistent', {
-        allowSystem: true,
+        allowPlayground: true,
       });
     });
 
@@ -686,7 +686,7 @@ describe('ProviderController', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('upsertProvider passes { allowSystem: true } so the Playground agent can connect providers', async () => {
+    it('upsertProvider passes { allowPlayground: true } so the Playground agent can connect providers', async () => {
       mockProviderService.upsertProvider.mockResolvedValue({
         provider: { id: 'p1', provider: 'openai', is_active: true },
         isNew: false,
@@ -698,7 +698,7 @@ describe('ProviderController', () => {
       });
 
       expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'Playground', {
-        allowSystem: true,
+        allowPlayground: true,
       });
     });
 

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -76,11 +76,11 @@ export class ProviderController {
 
   @Get(':agentName/providers')
   async getProviders(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
-    // allowSystem: true — the Playground page reads the provider list for the
-    // reserved system agent. Destructive/config mutations (rename, reorder,
+    // allowPlayground: true — the Playground page reads the provider list for the
+    // reserved Playground agent. Destructive/config mutations (rename, reorder,
     // deactivate, remove) still reject it; only additive connect is allowed.
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName, {
-      allowSystem: true,
+      allowPlayground: true,
     });
     const providers = await this.providerService.getProviders(user.id);
     return providers.map((p) => ({
@@ -105,10 +105,10 @@ export class ProviderController {
     @Param() params: AgentNameParamDto,
     @Body() body: ConnectProviderDto,
   ) {
-    // allowSystem: true — connecting a provider to the Playground system agent
+    // allowPlayground: true — connecting a provider to the Playground agent
     // is additive and correct (grants belong to the user-global pool).
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName, {
-      allowSystem: true,
+      allowPlayground: true,
     });
     const lowerProvider = body.provider.toLowerCase();
     const isQwenProvider = lowerProvider === 'qwen' || lowerProvider === 'alibaba';

--- a/packages/backend/src/routing/routing-core/resolve-agent.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/resolve-agent.service.spec.ts
@@ -45,7 +45,7 @@ describe('ResolveAgentService', () => {
   });
 
   it('returns and caches the agent on a successful lookup', async () => {
-    const agent = { id: 'agent-1', name: 'demo-agent', is_system: false } as Agent;
+    const agent = { id: 'agent-1', name: 'demo-agent', is_playground: false } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
     findOne.mockResolvedValue(agent);
 
@@ -61,7 +61,7 @@ describe('ResolveAgentService', () => {
   });
 
   it('re-queries the repo after the TTL expires', async () => {
-    const agent = { id: 'agent-1', name: 'demo-agent', is_system: false } as Agent;
+    const agent = { id: 'agent-1', name: 'demo-agent', is_playground: false } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
     findOne.mockResolvedValue(agent);
 
@@ -73,8 +73,8 @@ describe('ResolveAgentService', () => {
   });
 
   it('scopes the cache by tenant — two users with the same agent name do not collide', async () => {
-    const agentA = { id: 'a', name: 'agent', is_system: false } as Agent;
-    const agentB = { id: 'b', name: 'agent', is_system: false } as Agent;
+    const agentA = { id: 'a', name: 'agent', is_playground: false } as Agent;
+    const agentB = { id: 'b', name: 'agent', is_playground: false } as Agent;
 
     tenantResolve
       .mockResolvedValueOnce('tenant-A')
@@ -92,7 +92,7 @@ describe('ResolveAgentService', () => {
   });
 
   it('invalidate removes the cached entry so the next resolve re-queries', async () => {
-    const agent = { id: 'agent-1', name: 'demo-agent', is_system: false } as Agent;
+    const agent = { id: 'agent-1', name: 'demo-agent', is_playground: false } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
     findOne.mockResolvedValue(agent);
 
@@ -111,7 +111,7 @@ describe('ResolveAgentService', () => {
     const cacheField = (svc as unknown as { cache: Map<string, unknown> }).cache;
     for (let i = 0; i < 5000; i++) {
       cacheField.set(`tenant-x:agent-${i}`, {
-        agent: { id: `a${i}`, name: `agent-${i}`, is_system: false } as Agent,
+        agent: { id: `a${i}`, name: `agent-${i}`, is_playground: false } as Agent,
         expiresAt: Date.now() + 120_000,
       });
     }
@@ -119,7 +119,7 @@ describe('ResolveAgentService', () => {
 
     // The new agent to resolve — its cache key is NOT in the map yet, so the
     // LRU eviction branch runs and the oldest entry is dropped.
-    const newAgent = { id: 'new-1', name: 'new-agent', is_system: false } as Agent;
+    const newAgent = { id: 'new-1', name: 'new-agent', is_playground: false } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
     findOne.mockResolvedValue(newAgent);
 
@@ -130,47 +130,47 @@ describe('ResolveAgentService', () => {
     expect(cacheField.has('tenant-1:new-agent')).toBe(true);
   });
 
-  // P1-A: system agent rejection
-  it('throws NotFoundException for a system agent when allowSystem is not set (default)', async () => {
-    const systemAgent = { id: 'sys-1', name: 'Playground', is_system: true } as Agent;
+  // P1-A: playground agent rejection
+  it('throws NotFoundException for a playground agent when allowPlayground is not set (default)', async () => {
+    const playgroundAgent = { id: 'sys-1', name: 'Playground', is_playground: true } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
-    findOne.mockResolvedValue(systemAgent);
+    findOne.mockResolvedValue(playgroundAgent);
 
     await expect(svc.resolve('user-1', 'Playground')).rejects.toBeInstanceOf(NotFoundException);
     // The error message matches the not-found shape so callers cannot distinguish
-    // a missing agent from a system agent.
+    // a missing agent from a playground agent.
     await expect(svc.resolve('user-1', 'Playground')).rejects.toThrow(
       'Agent "Playground" not found',
     );
   });
 
-  it('returns the system agent when allowSystem is true', async () => {
-    const systemAgent = { id: 'sys-1', name: 'Playground', is_system: true } as Agent;
+  it('returns the playground agent when allowPlayground is true', async () => {
+    const playgroundAgent = { id: 'sys-1', name: 'Playground', is_playground: true } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
-    findOne.mockResolvedValue(systemAgent);
+    findOne.mockResolvedValue(playgroundAgent);
 
-    const result = await svc.resolve('user-1', 'Playground', { allowSystem: true });
-    expect(result).toBe(systemAgent);
+    const result = await svc.resolve('user-1', 'Playground', { allowPlayground: true });
+    expect(result).toBe(playgroundAgent);
   });
 
-  it('caches the system agent and still enforces is_system check on cache hits', async () => {
-    const systemAgent = { id: 'sys-1', name: 'Playground', is_system: true } as Agent;
+  it('caches the playground agent and still enforces is_playground check on cache hits', async () => {
+    const playgroundAgent = { id: 'sys-1', name: 'Playground', is_playground: true } as Agent;
     tenantResolve.mockResolvedValue('tenant-1');
-    findOne.mockResolvedValue(systemAgent);
+    findOne.mockResolvedValue(playgroundAgent);
 
-    // First call with allowSystem: true — agent is loaded and cached.
-    const first = await svc.resolve('user-1', 'Playground', { allowSystem: true });
-    expect(first).toBe(systemAgent);
+    // First call with allowPlayground: true — agent is loaded and cached.
+    const first = await svc.resolve('user-1', 'Playground', { allowPlayground: true });
+    expect(first).toBe(playgroundAgent);
     expect(findOne).toHaveBeenCalledTimes(1);
 
-    // Second call without allowSystem — cache hit but is_system check rejects it.
+    // Second call without allowPlayground — cache hit but is_playground check rejects it.
     await expect(svc.resolve('user-1', 'Playground')).rejects.toBeInstanceOf(NotFoundException);
     // Repo was NOT queried again (it was a cache hit).
     expect(findOne).toHaveBeenCalledTimes(1);
 
-    // Third call with allowSystem: true again — still cache hit, succeeds.
-    const third = await svc.resolve('user-1', 'Playground', { allowSystem: true });
-    expect(third).toBe(systemAgent);
+    // Third call with allowPlayground: true again — still cache hit, succeeds.
+    const third = await svc.resolve('user-1', 'Playground', { allowPlayground: true });
+    expect(third).toBe(playgroundAgent);
     expect(findOne).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/backend/src/routing/routing-core/resolve-agent.service.ts
+++ b/packages/backend/src/routing/routing-core/resolve-agent.service.ts
@@ -13,12 +13,12 @@ interface CachedAgent {
 }
 
 export interface ResolveOptions {
-  /** When true, system agents (is_system = true) are returned to the caller.
-   * By default system agents are rejected with a NotFoundException so that
+  /** When true, playground agents (is_playground = true) are returned to the caller.
+   * By default playground agents are rejected with a NotFoundException so that
    * generic mutation/config endpoints cannot target the reserved "Playground"
    * agent. Only pass true for read-only endpoints that legitimately need to
    * serve the Playground agent (e.g. available-models, providers list). */
-  allowSystem?: boolean;
+  allowPlayground?: boolean;
 }
 
 @Injectable()
@@ -38,10 +38,10 @@ export class ResolveAgentService {
     const cacheKey = `${tenantId}:${agentName}`;
     const cached = this.cache.get(cacheKey);
 
-    // If we have a live cache entry, validate is_system before returning it.
+    // If we have a live cache entry, validate is_playground before returning it.
     // This ensures the check runs on cache hits as well as fresh DB loads.
     if (cached && cached.expiresAt > Date.now()) {
-      if (cached.agent.is_system && !options.allowSystem) {
+      if (cached.agent.is_playground && !options.allowPlayground) {
         throw new NotFoundException(`Agent "${agentName}" not found`);
       }
       return cached.agent;
@@ -53,8 +53,8 @@ export class ResolveAgentService {
     });
     if (!agent) throw new NotFoundException(`Agent "${agentName}" not found`);
 
-    // Reject system agents unless the caller explicitly opted in.
-    if (agent.is_system && !options.allowSystem) {
+    // Reject playground agents unless the caller explicitly opted in.
+    if (agent.is_playground && !options.allowPlayground) {
       throw new NotFoundException(`Agent "${agentName}" not found`);
     }
 

--- a/packages/backend/src/telemetry/payload-builder.service.spec.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.spec.ts
@@ -401,22 +401,22 @@ describe('PayloadBuilderService', () => {
     expect(payload.agents_by_platform).toEqual({ unknown: 2 });
   });
 
-  it('excludes system agents from agents_total count (is_system = false filter applied)', async () => {
-    // The count query is for user agents only — system agents (e.g. Playground)
+  it('excludes playground agents from agents_total count (is_playground = false filter applied)', async () => {
+    // The count query is for user agents only — playground agents (e.g. Playground)
     // must not inflate the install telemetry.
     const { service, agentsRepo } = await makeServiceWithRepo({ agentsCount: 3 });
 
     const payload = await service.build('inst', '1.0.0');
 
     expect(payload.agents_total).toBe(3);
-    // The count QB must have received a where clause filtering system agents.
+    // The count QB must have received a where clause filtering playground agents.
     const countQb = agentsRepo.createQueryBuilder.mock.results[0].value as {
       where: jest.Mock;
     };
-    expect(countQb.where).toHaveBeenCalledWith('a.is_system = false');
+    expect(countQb.where).toHaveBeenCalledWith('a.is_playground = false');
   });
 
-  it('excludes system agents from agents_by_platform (is_system = false filter applied)', async () => {
+  it('excludes playground agents from agents_by_platform (is_playground = false filter applied)', async () => {
     const { service, agentsRepo } = await makeServiceWithRepo({
       agentPlatforms: [{ category: 'personal', platform: 'openclaw', count: '2' }],
     });
@@ -424,10 +424,10 @@ describe('PayloadBuilderService', () => {
     const payload = await service.build('inst', '1.0.0');
 
     expect(payload.agents_by_platform).toEqual({ openclaw: 2 });
-    // The platform QB (second agents QB call) must filter system agents.
+    // The platform QB (second agents QB call) must filter playground agents.
     const platformQb = agentsRepo.createQueryBuilder.mock.results[1].value as {
       where: jest.Mock;
     };
-    expect(platformQb.where).toHaveBeenCalledWith('a.is_system = false');
+    expect(platformQb.where).toHaveBeenCalledWith('a.is_playground = false');
   });
 });

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -122,7 +122,7 @@ export class PayloadBuilderService {
       .select('a.agent_category', 'category')
       .addSelect('a.agent_platform', 'platform')
       .addSelect('COUNT(*)', 'count')
-      .where('a.is_system = false')
+      .where('a.is_playground = false')
       .groupBy('a.agent_category')
       .addGroupBy('a.agent_platform')
       .getRawMany<CategoryPlatformRow>();
@@ -132,12 +132,12 @@ export class PayloadBuilderService {
     }));
   }
 
-  /** Count only user-created agents; system agents (e.g. Playground) are excluded. */
+  /** Count only user-created agents; playground agents (e.g. Playground) are excluded. */
   private async userAgentsCount(): Promise<number> {
     const result = await this.agents
       .createQueryBuilder('a')
       .select('COUNT(*)', 'count')
-      .where('a.is_system = false')
+      .where('a.is_playground = false')
       .getRawOne<{ count: string }>();
     return Number(result?.count ?? 0);
   }

--- a/packages/backend/test/playground-flow.e2e-spec.ts
+++ b/packages/backend/test/playground-flow.e2e-spec.ts
@@ -178,7 +178,7 @@ describe('Playground E2E — POST /api/v1/playground/run (SSE)', () => {
     // "Playground" in global Messages.
     const ds = app.get(DataSource);
     const [playgroundAgent] = await ds.query(
-      `SELECT id FROM agents WHERE is_system = true AND deleted_at IS NULL LIMIT 1`,
+      `SELECT id FROM agents WHERE is_playground = true AND deleted_at IS NULL LIMIT 1`,
     );
     const rows = await ds.query(
       `SELECT routing_reason, routing_tier, status, provider, model, input_tokens, output_tokens, agent_name FROM agent_messages WHERE agent_id = $1 AND routing_tier = $2`,

--- a/packages/backend/test/provider-analytics.e2e-spec.ts
+++ b/packages/backend/test/provider-analytics.e2e-spec.ts
@@ -72,11 +72,11 @@ beforeAll(async () => {
     [uuid(), TEST_TENANT_ID, ghostAgentId, now, TEST_USER_ID],
   );
 
-  // Finding 1: a reserved Playground (is_system) agent whose usage must NOT
+  // Finding 1: a reserved Playground (is_playground) agent whose usage must NOT
   // pollute provider analytics aggregates or the connection breakdown.
   const playgroundAgentId = uuid();
   await ds.query(
-    `INSERT INTO agents (id, name, display_name, description, is_active, is_system, complexity_routing_enabled, tenant_id, created_at, updated_at)
+    `INSERT INTO agents (id, name, display_name, description, is_active, is_playground, complexity_routing_enabled, tenant_id, created_at, updated_at)
      VALUES ($1,'Playground','Playground','reserved',true,true,true,$2,$3,$3)`,
     [playgroundAgentId, TEST_TENANT_ID, now],
   );
@@ -88,7 +88,7 @@ beforeAll(async () => {
 
   // P2 leak case: an ORPHAN Playground message with a NULL agent_id but
   // agent_name = 'Playground'. The previous id-only exclusion join left this
-  // row's `is_system` NULL and wrongly INCLUDED it. The NOT EXISTS semi-join
+  // row's `is_playground` NULL and wrongly INCLUDED it. The NOT EXISTS semi-join
   // matches the reserved Playground agent by NAME too, so this row is excluded
   // from every aggregate, timeseries and the connection breakdown.
   await ds.query(
@@ -143,7 +143,7 @@ describe('GET /api/v1/provider-analytics', () => {
     expect(res.body.summary.messages.value).toBeGreaterThan(0);
   });
 
-  it('excludes the reserved Playground (is_system) agent from summary aggregates', async () => {
+  it('excludes the reserved Playground (is_playground) agent from summary aggregates', async () => {
     const res = await request(app.getHttpServer())
       .get('/api/v1/provider-analytics?auth_type=subscription&provider=openai&range=24h')
       .set('x-api-key', TEST_API_KEY)
@@ -152,7 +152,7 @@ describe('GET /api/v1/provider-analytics', () => {
     // Playground message with a matching agent_id (18000 tokens) AND the orphan
     // Playground message with a NULL agent_id but agent_name 'Playground'
     // (14000 tokens) must be excluded, so the summary reflects only the
-    // non-system rows. The orphan is the P2 leak case the name-based NOT EXISTS
+    // non-playground rows. The orphan is the P2 leak case the name-based NOT EXISTS
     // exclusion fixes — an id-only join would have counted it.
     expect(res.body.summary.messages.value).toBe(2);
     expect(res.body.summary.tokens.value).toBe(1800);
@@ -398,11 +398,11 @@ describe('GET /api/v1/overview/per-* timeseries', () => {
     }
   });
 
-  it('excludes the Playground (is_system) agent from per-provider and per-model timeseries (Finding 2)', async () => {
+  it('excludes the Playground (is_playground) agent from per-provider and per-model timeseries (Finding 2)', async () => {
     // The Playground agent logged 18000 openai/gpt-4o tokens (agent_id set), and
     // an orphan Playground row logged 14000 more (NULL agent_id, name only).
     // Real openai usage is 1800 tokens (gpt-4o 1500 + gpt-4o-mini 300). Before
-    // the fix these endpoints either had no is_system filter or used an id-only
+    // the fix these endpoints either had no is_playground filter or used an id-only
     // join that missed the orphan. After the name-based NOT EXISTS exclusion
     // BOTH Playground rows are dropped from every per-* timeseries.
     const sumKey = (rows: Array<Record<string, number>>, key: string): number =>

--- a/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
+++ b/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
@@ -1,16 +1,19 @@
 import { DataSource } from 'typeorm';
 import { SeedPlaygroundAgents1791400000000 } from '../src/database/migrations/1791400000000-SeedPlaygroundAgents';
+import { RenameIsSystemToIsPlayground1791800000000 } from '../src/database/migrations/1791800000000-RenameIsSystemToIsPlayground';
 
 /**
  * Runs the REAL migration chain so SeedPlaygroundAgents executes against
  * Postgres (the e2e suite uses synchronize:true and never runs migrations). We
- * revert just this migration to get the pre-seed schema, seed two tenants (one
- * with a user agent that collides on the reserved name) + their provider pools,
- * then run up() and assert the data transformation.
+ * revert back to the pre-seed schema (the later rename migration first, then
+ * the seed itself), seed two tenants (one with a user agent that collides on
+ * the reserved name) + their provider pools, then run both up() migrations and
+ * assert the data transformation.
  */
 describe('SeedPlaygroundAgents data transformation (e2e)', () => {
   let ds: DataSource;
   const migration = new SeedPlaygroundAgents1791400000000();
+  const renameMigration = new RenameIsSystemToIsPlayground1791800000000();
 
   beforeAll(async () => {
     ds = new DataSource({
@@ -27,8 +30,10 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
     await ds.initialize();
     await ds.runMigrations();
 
-    // Revert just this migration → pre-seed schema (no is_system column).
+    // Revert back to the pre-seed schema (no is_system/is_playground column):
+    // the rename migration first (restores is_system), then the seed itself.
     const revertQr = ds.createQueryRunner();
+    await renameMigration.down(revertQr);
     await migration.down(revertQr);
     await revertQr.release();
 
@@ -57,6 +62,7 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
 
     const upQr = ds.createQueryRunner();
     await migration.up(upQr);
+    await renameMigration.up(upQr);
     await upQr.release();
   }, 60000);
 
@@ -66,7 +72,7 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
 
   it('creates exactly one reserved Playground agent per tenant', async () => {
     const rows: { tenant_id: string; name: string }[] = await ds.query(
-      `SELECT "tenant_id","name" FROM "agents" WHERE "is_system" = true ORDER BY "tenant_id"`,
+      `SELECT "tenant_id","name" FROM "agents" WHERE "is_playground" = true ORDER BY "tenant_id"`,
     );
     expect(rows).toEqual([
       { tenant_id: 't1', name: 'Playground' },
@@ -75,10 +81,10 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
   });
 
   it("relabels the colliding user agent instead of deleting it", async () => {
-    const row: { name: string; is_system: boolean }[] = await ds.query(
-      `SELECT "name","is_system" FROM "agents" WHERE "id" = 'a-user'`,
+    const row: { name: string; is_playground: boolean }[] = await ds.query(
+      `SELECT "name","is_playground" FROM "agents" WHERE "id" = 'a-user'`,
     );
-    expect(row[0].is_system).toBe(false);
+    expect(row[0].is_playground).toBe(false);
     // Slug-safe suffix: `name-<id>` so the relabeled agent remains routable
     // via the ^[a-zA-Z0-9_-]+$ validator (no spaces or brackets).
     expect(row[0].name).toBe('Playground-a-user');
@@ -87,7 +93,7 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
   it("grants each Playground agent its tenant's whole provider pool", async () => {
     const grants: { provider: string }[] = await ds.query(
       `SELECT up."provider" FROM "agent_provider_access" apa
-       JOIN "agents" a ON a."id" = apa."agent_id" AND a."is_system" = true
+       JOIN "agents" a ON a."id" = apa."agent_id" AND a."is_playground" = true
        JOIN "user_providers" up ON up."id" = apa."user_provider_id"
        WHERE a."tenant_id" = 't1' ORDER BY up."provider"`,
     );
@@ -95,7 +101,7 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
 
     const t2: { provider: string }[] = await ds.query(
       `SELECT up."provider" FROM "agent_provider_access" apa
-       JOIN "agents" a ON a."id" = apa."agent_id" AND a."is_system" = true
+       JOIN "agents" a ON a."id" = apa."agent_id" AND a."is_playground" = true
        JOIN "user_providers" up ON up."id" = apa."user_provider_id"
        WHERE a."tenant_id" = 't2'`,
     );

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -101,7 +101,7 @@ const MessageLog: Component = () => {
     () => !params.agentName,
     async (isGlobal) => {
       if (!isGlobal) return [] as AgentFilterOption[];
-      // includeSystem=true so the reserved Playground agent appears in the
+      // includePlayground=true so the reserved Playground agent appears in the
       // filter and the log can be narrowed to Playground runs.
       const data = (await getAgents(true)) as
         | { agents?: AgentFilterOption[] }

--- a/packages/frontend/src/services/api/agents.ts
+++ b/packages/frontend/src/services/api/agents.ts
@@ -1,9 +1,9 @@
 import { fetchJson, fetchMutate } from './core.js';
 
-export function getAgents(includeSystem = false) {
-  // includeSystem surfaces the reserved Playground (is_system) agent — the
+export function getAgents(includePlayground = false) {
+  // includePlayground surfaces the reserved Playground (is_playground) agent — the
   // Messages filter opts in so the log can be filtered to Playground runs.
-  return fetchJson(includeSystem ? '/agents?includeSystem=true' : '/agents');
+  return fetchJson(includePlayground ? '/agents?includePlayground=true' : '/agents');
 }
 
 export interface AgentInfo {

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -287,12 +287,12 @@ describe("Sidebar — harness switcher list", () => {
     expect(beta?.getAttribute("aria-current")).not.toBe("page");
   });
 
-  it("excludes system/Playground agents by calling getAgents() with the default (no includeSystem)", async () => {
+  it("excludes Playground agents by calling getAgents() with the default (no includePlayground)", async () => {
     render(() => <Sidebar />);
     await waitFor(() => {
       expect(mockGetAgents).toHaveBeenCalled();
     });
-    // Default invocation = system agents excluded (getAgents(false)).
+    // Default invocation = playground agents excluded (getAgents(false)).
     expect(mockGetAgents).toHaveBeenCalledWith();
   });
 

--- a/packages/frontend/tests/services/api/agents.test.ts
+++ b/packages/frontend/tests/services/api/agents.test.ts
@@ -31,14 +31,14 @@ describe('agents API client', () => {
     expect(out).toEqual([{ agent_name: 'a' }]);
     const url = fetchMock.mock.calls[0][0] as string;
     expect(url).toContain('/api/v1/agents');
-    expect(url).not.toContain('includeSystem');
+    expect(url).not.toContain('includePlayground');
   });
 
-  it('getAgents(true) requests includeSystem so the Playground agent is listed', async () => {
+  it('getAgents(true) requests includePlayground so the Playground agent is listed', async () => {
     const fetchMock = setupFetch([{ agent_name: 'a' }]);
     await agents.getAgents(true);
     const url = fetchMock.mock.calls[0][0] as string;
-    expect(url).toContain('/api/v1/agents?includeSystem=true');
+    expect(url).toContain('/api/v1/agents?includePlayground=true');
   });
 
   it('getAgentInfo unwraps the { agent } envelope', async () => {


### PR DESCRIPTION
### 💭 Why
The `is_system` column on `agents` only ever marks the reserved per-tenant Playground agent. The name suggested something broader and made the code harder to read.

### ✨ What changed
- New guarded migration renames `agents.is_system` to `agents.is_playground` (reversible).
- Entity, queries, guards, and telemetry filters now use `is_playground`.
- `includeSystem` query param on GET /agents is now `includePlayground` (frontend updated in lockstep).
- `allowSystem` resolver option, `excludeSystemAgents` helper, and agent-list cache keys renamed to match.
- Comments and test names drop the "system agent" wording.

### 🔧 For operators
Migration runs automatically on boot. The historical SeedPlaygroundAgents migration is untouched, so existing installs upgrade cleanly and `migration:revert` still works.

### 📝 Notes
No behavior change. The `/api/v1/agents?includeSystem=true` param is renamed; it was only consumed by the bundled frontend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the `agents.is_system` flag to `agents.is_playground` and updated all code paths, APIs, and tests to make Playground semantics clear. No behavior change; the GET `/agents` query param is now `includePlayground` (frontend updated).

- **Refactors**
  - Column rename: `agents.is_system` → `agents.is_playground` (entity, queries, guards, telemetry, analytics, routing).
  - API: `GET /agents?includeSystem=true` → `includePlayground=true`.
  - Resolver option: `allowSystem` → `allowPlayground`.
  - Query helper: `excludeSystemAgents` (+ predicate) → `excludePlaygroundAgents`.
  - Cache: agent-list keys now use `:playground=`; interceptor normalizes `includePlayground`.
  - Tests, comments, and cache invalidation keys updated.

- **Migration**
  - Added guarded, reversible migration `1791900000000-RenameIsSystemToIsPlayground` (no-op if already renamed).
  - Ordered after the `agent_enabled_providers` table rename to avoid timestamp collision; e2e replays both renames around the historical seed.
  - Runs automatically on boot; historical `SeedPlaygroundAgents` stays unchanged, and `migration:revert` remains valid.

<sup>Written for commit 9ad23f5023b0c161ca17bc9c79bb4c61cea206a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

