### PR TITLE
refactor: use one name for per-agent provider toggles

### DIFF
--- a/.changeset/rename-enabled-providers.md
+++ b/.changeset/rename-enabled-providers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Rename the agent_provider_access table to agent_enabled_providers so the database, API routes, and dashboard all use the same "enabled providers" naming. The migration is a pure rename — no data is modified — and rolls back cleanly.

--- a/packages/backend/src/analytics/analytics.module.ts
+++ b/packages/backend/src/analytics/analytics.module.ts
@@ -8,7 +8,7 @@ import { ToolExecution } from '../entities/tool-execution.entity';
 import { AgentLog } from '../entities/agent-log.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { UserProvider } from '../entities/user-provider.entity';
-import { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { TierAssignment } from '../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../entities/specificity-assignment.entity';
 import { HeaderTier } from '../entities/header-tier.entity';
@@ -47,7 +47,7 @@ import { ProxyModule } from '../routing/proxy/proxy.module';
       AgentLog,
       CustomProvider,
       UserProvider,
-      AgentProviderAccess,
+      AgentEnabledProvider,
       TierAssignment,
       SpecificityAssignment,
       HeaderTier,

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -7,7 +7,7 @@ import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { ProviderService } from '../../routing/routing-core/provider.service';
 import { ResolveAgentService } from '../../routing/routing-core/resolve-agent.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { AgentProviderAccess } from '../../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
 
 function mockAggregation(): Record<string, jest.Mock> {
   return {
@@ -72,7 +72,7 @@ describe('OverviewController', () => {
         { provide: TenantCacheService, useValue: { resolve: mockTenantResolve } },
         { provide: ProviderService, useValue: { getProviders: mockGetProviders } },
         { provide: ResolveAgentService, useValue: { resolve: mockResolveAgent } },
-        { provide: getRepositoryToken(AgentProviderAccess), useValue: { find: mockAccessFind } },
+        { provide: getRepositoryToken(AgentEnabledProvider), useValue: { find: mockAccessFind } },
       ],
     }).compile();
 
@@ -171,7 +171,7 @@ describe('OverviewController', () => {
     expect(mockAccessFind).toHaveBeenCalledWith({ where: { agent_id: 'agent-uuid-1' } });
   });
 
-  it('returns has_providers false when active providers are not granted to the agent', async () => {
+  it('returns has_providers false when active providers are not enabled for the agent', async () => {
     mockGetProviders.mockResolvedValueOnce([{ id: 'provider-1', is_active: true }]);
     mockAccessFind.mockResolvedValueOnce([
       { agent_id: 'agent-uuid-1', user_provider_id: 'provider-2' },

--- a/packages/backend/src/analytics/controllers/overview.controller.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.ts
@@ -13,7 +13,7 @@ import { ProviderService } from '../../routing/routing-core/provider.service';
 import { ResolveAgentService } from '../../routing/routing-core/resolve-agent.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { AgentProviderAccess } from '../../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
 
 @Controller('api/v1')
 @UseInterceptors(UserCacheInterceptor)
@@ -25,8 +25,8 @@ export class OverviewController {
     private readonly tenantCache: TenantCacheService,
     private readonly providerService: ProviderService,
     private readonly resolveAgent: ResolveAgentService,
-    @InjectRepository(AgentProviderAccess)
-    private readonly accessRepo: Repository<AgentProviderAccess>,
+    @InjectRepository(AgentEnabledProvider)
+    private readonly enabledProviderRepo: Repository<AgentEnabledProvider>,
   ) {}
 
   @Get('overview')
@@ -166,8 +166,8 @@ export class OverviewController {
       const providers = await this.providerService.getProviders(userId);
       const activeProviderIds = new Set(providers.filter((p) => p.is_active).map((p) => p.id));
       if (activeProviderIds.size === 0) return false;
-      const grants = await this.accessRepo.find({ where: { agent_id: agent.id } });
-      return grants.some((grant) => activeProviderIds.has(grant.user_provider_id));
+      const enabledRows = await this.enabledProviderRepo.find({ where: { agent_id: agent.id } });
+      return enabledRows.some((row) => activeProviderIds.has(row.user_provider_id));
     } catch {
       return false;
     }

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -55,7 +55,7 @@ describe('AgentDuplicationService', () => {
       const tierRepo = makeRepoMock('TierAssignment');
       const specRepo = makeRepoMock('SpecificityAssignment');
       const modelParamsRepo = makeRepoMock('AgentModelParams');
-      const agentProviderAccessRepo = makeRepoMock('AgentProviderAccess');
+      const agentProviderAccessRepo = makeRepoMock('AgentEnabledProvider');
       const manager = {
         getRepository: (entity: { name: string }) => {
           switch (entity.name) {
@@ -69,7 +69,7 @@ describe('AgentDuplicationService', () => {
               return specRepo;
             case 'AgentModelParams':
               return modelParamsRepo;
-            case 'AgentProviderAccess':
+            case 'AgentEnabledProvider':
               return agentProviderAccessRepo;
             default:
               throw new Error(`Unexpected entity ${entity.name}`);
@@ -125,10 +125,10 @@ describe('AgentDuplicationService', () => {
   });
 
   describe('getCopySummary', () => {
-    it('returns grant count for providers and counts of other copyable rows for the source agent', async () => {
+    it('returns enabled-provider count and counts of other copyable rows for the source agent', async () => {
       mockAgentGetOne.mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1' });
       repoCounts = {
-        AgentProviderAccess: 3,
+        AgentEnabledProvider: 3,
         TierAssignment: 4,
         SpecificityAssignment: 2,
         AgentModelParams: 5,
@@ -202,9 +202,9 @@ describe('AgentDuplicationService', () => {
       ).rejects.toThrow(ConflictException);
     });
 
-    it('copies provider access grants verbatim (no new credential rows) for both global and custom providers', async () => {
-      // The main correctness test: both a global provider (anthropic) grant and a
-      // custom provider grant must be copied pointing at the SAME user_providers rows.
+    it('copies enabled-provider rows verbatim (no new credential rows) for both global and custom providers', async () => {
+      // The main correctness test: both a global provider (anthropic) row and a
+      // custom provider row must be copied pointing at the SAME user_providers rows.
       // No new UserProvider rows, no new CustomProvider rows.
       mockAgentGetOne
         .mockResolvedValueOnce({
@@ -219,7 +219,7 @@ describe('AgentDuplicationService', () => {
         .mockResolvedValueOnce(null);
 
       repoRows = {
-        AgentProviderAccess: [
+        AgentEnabledProvider: [
           { agent_id: 'src-1', user_provider_id: 'up-global' },
           { agent_id: 'src-1', user_provider_id: 'up-custom' },
         ],
@@ -279,7 +279,7 @@ describe('AgentDuplicationService', () => {
       expect(mockTransaction).toHaveBeenCalledTimes(1);
       expect(result.agentName).toBe('source-copy');
       expect(result.apiKey).toMatch(/^mnfst_/);
-      // 2 grants copied: one for the global provider, one for the custom provider
+      // 2 enabled-provider rows copied: one for the global provider, one for the custom provider
       expect(result.copied).toEqual({
         providers: 2,
         tierAssignments: 1,
@@ -299,15 +299,15 @@ describe('AgentDuplicationService', () => {
       expect(apiKeyRow['agent_id']).toBe(agentRow['id']);
       expect(apiKeyRow['label']).toContain('source-copy');
 
-      // Two grants inserted verbatim — pointing at the original user_provider_id values
-      const grants = insertedRows['AgentProviderAccess'] as Array<Record<string, unknown>>;
-      expect(grants).toHaveLength(2);
-      const globalGrant = grants.find((g) => g['user_provider_id'] === 'up-global');
-      expect(globalGrant).toBeDefined();
-      expect(globalGrant!['agent_id']).toBe(agentRow['id']);
-      const customGrant = grants.find((g) => g['user_provider_id'] === 'up-custom');
-      expect(customGrant).toBeDefined();
-      expect(customGrant!['agent_id']).toBe(agentRow['id']);
+      // Two enabled-provider rows inserted verbatim — pointing at the original user_provider_id values
+      const enabledRows = insertedRows['AgentEnabledProvider'] as Array<Record<string, unknown>>;
+      expect(enabledRows).toHaveLength(2);
+      const globalRow = enabledRows.find((g) => g['user_provider_id'] === 'up-global');
+      expect(globalRow).toBeDefined();
+      expect(globalRow!['agent_id']).toBe(agentRow['id']);
+      const customRow = enabledRows.find((g) => g['user_provider_id'] === 'up-custom');
+      expect(customRow).toBeDefined();
+      expect(customRow!['agent_id']).toBe(agentRow['id']);
 
       // Per-route model params: both rows copied verbatim (custom:cp1 NOT remapped)
       const mpRows = insertedRows['AgentModelParams'] as Array<Record<string, unknown>>;
@@ -323,8 +323,8 @@ describe('AgentDuplicationService', () => {
       expect(mockInvalidateAgent).toHaveBeenCalledWith(agentRow['id']);
     });
 
-    it('skips insert batches when source has no grants or rows', async () => {
-      // Covers the `sourceGrants.length === 0` branch and empty-row branches.
+    it('skips insert batches when source has no enabled providers or rows', async () => {
+      // Covers the `sourceEnabledRows.length === 0` branch and empty-row branches.
       mockAgentGetOne
         .mockResolvedValueOnce({
           id: 'src-1',
@@ -351,17 +351,17 @@ describe('AgentDuplicationService', () => {
       expect(insertedRows['TierAssignment']).toBeUndefined();
       expect(insertedRows['SpecificityAssignment']).toBeUndefined();
       expect(insertedRows['AgentModelParams']).toBeUndefined();
-      expect(insertedRows['AgentProviderAccess']).toBeUndefined();
+      expect(insertedRows['AgentEnabledProvider']).toBeUndefined();
     });
 
-    it('copies multiple grants pointing at their original user_provider_id values', async () => {
-      // Covers copying 3 grants (two custom, one global) all verbatim.
+    it('copies multiple enabled-provider rows pointing at their original user_provider_id values', async () => {
+      // Covers copying 3 enabled-provider rows (two custom, one global) all verbatim.
       mockAgentGetOne
         .mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1', name: 'source' })
         .mockResolvedValueOnce(null);
 
       repoRows = {
-        AgentProviderAccess: [
+        AgentEnabledProvider: [
           { agent_id: 'src-1', user_provider_id: 'up1' },
           { agent_id: 'src-1', user_provider_id: 'up2' },
           { agent_id: 'src-1', user_provider_id: 'up3' },
@@ -373,9 +373,9 @@ describe('AgentDuplicationService', () => {
         displayName: 'copy',
       });
 
-      const grants = insertedRows['AgentProviderAccess'] as Array<Record<string, unknown>>;
-      expect(grants).toHaveLength(3);
-      expect(grants.map((g) => g['user_provider_id'])).toEqual(
+      const enabledRows = insertedRows['AgentEnabledProvider'] as Array<Record<string, unknown>>;
+      expect(enabledRows).toHaveLength(3);
+      expect(enabledRows.map((g) => g['user_provider_id'])).toEqual(
         expect.arrayContaining(['up1', 'up2', 'up3']),
       );
       expect(result.copied.providers).toBe(3);

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -5,7 +5,7 @@ import { randomBytes } from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import { Agent } from '../../entities/agent.entity';
 import { AgentApiKey } from '../../entities/agent-api-key.entity';
-import { AgentProviderAccess } from '../../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 import { AgentModelParams } from '../../entities/agent-model-params.entity';
@@ -63,9 +63,9 @@ export class AgentDuplicationService {
 
     const [providers, tierAssignments, specificityAssignments, modelParams] = await Promise.all([
       // Providers (including custom providers) are user-global; access is the
-      // agent_provider_access grant, so the copyable unit is the grant count,
+      // agent_enabled_providers row, so the copyable unit is the enabled-provider count,
       // not the credential rows.
-      this.dataSource.getRepository(AgentProviderAccess).count({ where: { agent_id: source.id } }),
+      this.dataSource.getRepository(AgentEnabledProvider).count({ where: { agent_id: source.id } }),
       this.dataSource.getRepository(TierAssignment).count({ where: { agent_id: source.id } }),
       this.dataSource
         .getRepository(SpecificityAssignment)
@@ -139,23 +139,23 @@ export class AgentDuplicationService {
       });
 
       // Providers — regular AND custom — are user-global, shared across agents
-      // via the agent_provider_access junction. Cloning the credential rows
+      // via the agent_enabled_providers junction. Cloning the credential rows
       // under the new agent_id would duplicate a (user_id, provider, auth_type,
       // label) tuple and violate the user-scoped unique index. Instead, copy the
-      // source agent's GRANTS verbatim; every `custom:<id>` reference stays valid
+      // source agent's ENABLED-PROVIDER rows verbatim; every `custom:<id>` reference stays valid
       // because the underlying custom provider is shared, not re-created.
-      const sourceGrants = await manager
-        .getRepository(AgentProviderAccess)
+      const sourceEnabledRows = await manager
+        .getRepository(AgentEnabledProvider)
         .find({ where: { agent_id: source.id } });
-      if (sourceGrants.length > 0) {
-        await manager.getRepository(AgentProviderAccess).insert(
-          sourceGrants.map((g) => ({
+      if (sourceEnabledRows.length > 0) {
+        await manager.getRepository(AgentEnabledProvider).insert(
+          sourceEnabledRows.map((g) => ({
             agent_id: newAgentId,
             user_provider_id: g.user_provider_id,
           })),
         );
       }
-      const providerGrants = sourceGrants.length;
+      const providersEnabled = sourceEnabledRows.length;
 
       const tiers = await manager
         .getRepository(TierAssignment)
@@ -234,7 +234,7 @@ export class AgentDuplicationService {
       }
 
       return {
-        providers: providerGrants,
+        providers: providersEnabled,
         tierAssignments: tiers.length,
         specificityAssignments: specificity.length,
         modelParams: modelParams.length,

--- a/packages/backend/src/common/constants/playground.constants.ts
+++ b/packages/backend/src/common/constants/playground.constants.ts
@@ -1,8 +1,8 @@
 /**
  * The reserved per-tenant "Playground" agent that backs the global Playground.
  * Playground runs resolve to it (so they record `agent_name = 'Playground'` in
- * global Messages) and it holds grants to the tenant's whole global provider
- * pool. It is flagged `is_system = true`, hidden from the agent list/switcher/
+ * global Messages) and it has the tenant's whole global provider
+ * pool enabled. It is flagged `is_system = true`, hidden from the agent list/switcher/
  * counts, and users cannot create or rename an agent to this name.
  */
 export const PLAYGROUND_AGENT_NAME = 'Playground';

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -24,7 +24,7 @@ import { AgentModelParams } from '../entities/agent-model-params.entity';
 import { PlaygroundRun } from '../entities/playground-run.entity';
 import { PlaygroundColumn } from '../entities/playground-column.entity';
 import { ReasoningContentCacheEntry } from '../entities/reasoning-content-cache-entry.entity';
-import { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { DatabaseSeederService } from './database-seeder.service';
 import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
@@ -116,6 +116,7 @@ import { LiftCustomProvidersToUserLevel1791200000000 } from './migrations/179120
 import { SeedPlaygroundAgents1791400000000 } from './migrations/1791400000000-SeedPlaygroundAgents';
 import { DropProviderRateLimits1791600000000 } from './migrations/1791600000000-DropProviderRateLimits';
 import { DropSavingsBaselineColumns1791700000000 } from './migrations/1791700000000-DropSavingsBaselineColumns';
+import { RenameProviderAccessToEnabledProviders1791800000000 } from './migrations/1791800000000-RenameProviderAccessToEnabledProviders';
 
 const entities = [
   AgentMessage,
@@ -140,7 +141,7 @@ const entities = [
   PlaygroundRun,
   PlaygroundColumn,
   ReasoningContentCacheEntry,
-  AgentProviderAccess,
+  AgentEnabledProvider,
 ];
 
 const migrations = [
@@ -233,6 +234,7 @@ const migrations = [
   SeedPlaygroundAgents1791400000000,
   DropProviderRateLimits1791600000000,
   DropSavingsBaselineColumns1791700000000,
+  RenameProviderAccessToEnabledProviders1791800000000,
 ];
 
 @Module({
@@ -284,7 +286,7 @@ const migrations = [
       MessageRecording,
       AgentModelParams,
       ReasoningContentCacheEntry,
-      AgentProviderAccess,
+      AgentEnabledProvider,
     ]),
     ModelPricesModule,
   ],

--- a/packages/backend/src/database/migrations/1791800000000-RenameProviderAccessToEnabledProviders.spec.ts
+++ b/packages/backend/src/database/migrations/1791800000000-RenameProviderAccessToEnabledProviders.spec.ts
@@ -1,0 +1,86 @@
+import { QueryRunner } from 'typeorm';
+import { RenameProviderAccessToEnabledProviders1791800000000 } from './1791800000000-RenameProviderAccessToEnabledProviders';
+
+describe('RenameProviderAccessToEnabledProviders1791800000000', () => {
+  let migration: RenameProviderAccessToEnabledProviders1791800000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new RenameProviderAccessToEnabledProviders1791800000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('renames the table and its constraints/index to the enabled-providers names', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(5);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        `ALTER TABLE "agent_provider_access" RENAME TO "agent_enabled_providers"`,
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "PK_agent_provider_access" TO "PK_agent_enabled_providers"',
+        ),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "FK_agent_provider_access_agent" TO "FK_agent_enabled_providers_agent"',
+        ),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "FK_agent_provider_access_provider" TO "FK_agent_enabled_providers_provider"',
+        ),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        `ALTER INDEX "IDX_agent_provider_access_provider" RENAME TO "IDX_agent_enabled_providers_provider"`,
+      );
+    });
+
+    it('never issues DROP/DELETE/TRUNCATE — the rename must be data-preserving', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      for (const [sql] of queryRunner.query.mock.calls) {
+        expect(sql).not.toMatch(/DROP|DELETE|TRUNCATE/i);
+      }
+    });
+  });
+
+  describe('down', () => {
+    it('restores the original table, constraint, and index names', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(5);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        `ALTER TABLE "agent_enabled_providers" RENAME TO "agent_provider_access"`,
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "PK_agent_enabled_providers" TO "PK_agent_provider_access"',
+        ),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "FK_agent_enabled_providers_agent" TO "FK_agent_provider_access_agent"',
+        ),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "FK_agent_enabled_providers_provider" TO "FK_agent_provider_access_provider"',
+        ),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        `ALTER INDEX "IDX_agent_enabled_providers_provider" RENAME TO "IDX_agent_provider_access_provider"`,
+      );
+    });
+
+    it('never issues DROP/DELETE/TRUNCATE — the revert must be data-preserving', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      for (const [sql] of queryRunner.query.mock.calls) {
+        expect(sql).not.toMatch(/DROP|DELETE|TRUNCATE/i);
+      }
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1791800000000-RenameProviderAccessToEnabledProviders.ts
+++ b/packages/backend/src/database/migrations/1791800000000-RenameProviderAccessToEnabledProviders.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Renames agent_provider_access → agent_enabled_providers, aligning the table
+ * with the "enabled providers" vocabulary used everywhere else (UI toggles,
+ * `{ enabled: [...] }` API responses, enable/disable endpoints). A pure rename:
+ * RENAME TO keeps all rows, constraints, and indexes attached, so the
+ * follow-up statements only rename the constraint/index identifiers for
+ * consistency. No data is touched.
+ */
+export class RenameProviderAccessToEnabledProviders1791800000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agent_provider_access" RENAME TO "agent_enabled_providers"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_enabled_providers" RENAME CONSTRAINT "PK_agent_provider_access" TO "PK_agent_enabled_providers"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_enabled_providers" RENAME CONSTRAINT "FK_agent_provider_access_agent" TO "FK_agent_enabled_providers_agent"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_enabled_providers" RENAME CONSTRAINT "FK_agent_provider_access_provider" TO "FK_agent_enabled_providers_provider"`,
+    );
+    await queryRunner.query(
+      `ALTER INDEX "IDX_agent_provider_access_provider" RENAME TO "IDX_agent_enabled_providers_provider"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER INDEX "IDX_agent_enabled_providers_provider" RENAME TO "IDX_agent_provider_access_provider"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_enabled_providers" RENAME CONSTRAINT "FK_agent_enabled_providers_provider" TO "FK_agent_provider_access_provider"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_enabled_providers" RENAME CONSTRAINT "FK_agent_enabled_providers_agent" TO "FK_agent_provider_access_agent"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_enabled_providers" RENAME CONSTRAINT "PK_agent_enabled_providers" TO "PK_agent_provider_access"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_enabled_providers" RENAME TO "agent_provider_access"`,
+    );
+  }
+}

--- a/packages/backend/src/entities/agent-enabled-provider.entity.spec.ts
+++ b/packages/backend/src/entities/agent-enabled-provider.entity.spec.ts
@@ -1,11 +1,11 @@
 import { getMetadataArgsStorage } from 'typeorm';
-import { AgentProviderAccess } from './agent-provider-access.entity';
+import { AgentEnabledProvider } from './agent-enabled-provider.entity';
 import { Agent } from './agent.entity';
 import { UserProvider } from './user-provider.entity';
 
-describe('AgentProviderAccess entity', () => {
+describe('AgentEnabledProvider entity', () => {
   it('creates an instance with both key columns', () => {
-    const access = new AgentProviderAccess();
+    const access = new AgentEnabledProvider();
     access.agent_id = 'agent-1';
     access.user_provider_id = 'provider-1';
 
@@ -15,7 +15,7 @@ describe('AgentProviderAccess entity', () => {
 
   it('declares cascade relations to agents and user providers', () => {
     const relations = getMetadataArgsStorage().relations.filter(
-      (r) => r.target === AgentProviderAccess,
+      (r) => r.target === AgentEnabledProvider,
     );
 
     const agentRelation = relations.find((r) => r.propertyName === 'agent');

--- a/packages/backend/src/entities/agent-enabled-provider.entity.ts
+++ b/packages/backend/src/entities/agent-enabled-provider.entity.ts
@@ -2,8 +2,8 @@ import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Agent } from './agent.entity';
 import { UserProvider } from './user-provider.entity';
 
-@Entity('agent_provider_access')
-export class AgentProviderAccess {
+@Entity('agent_enabled_providers')
+export class AgentEnabledProvider {
   @PrimaryColumn('varchar')
   agent_id!: string;
 

--- a/packages/backend/src/model-discovery/model-discovery.module.ts
+++ b/packages/backend/src/model-discovery/model-discovery.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserProvider } from '../entities/user-provider.entity';
-import { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { ProviderModelFetcherService } from './provider-model-fetcher.service';
@@ -11,7 +11,7 @@ import { CopilotTokenService } from '../routing/proxy/copilot-token.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([UserProvider, AgentProviderAccess, CustomProvider]),
+    TypeOrmModule.forFeature([UserProvider, AgentEnabledProvider, CustomProvider]),
     ModelPricesModule,
   ],
   providers: [

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { AuthType } from 'manifest-shared';
 import { UserProvider } from '../entities/user-provider.entity';
-import { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { ProviderModelFetcherService, filterNonChatModels } from './provider-model-fetcher.service';
 import { ProviderModelRegistryService } from './provider-model-registry.service';
@@ -82,8 +82,8 @@ export class ModelDiscoveryService {
     @Inject(CopilotTokenService)
     private readonly copilotTokenService: CopilotTokenService | null,
     @Optional()
-    @InjectRepository(AgentProviderAccess)
-    private readonly accessRepo: Repository<AgentProviderAccess> | null = null,
+    @InjectRepository(AgentEnabledProvider)
+    private readonly enabledProviderRepo: Repository<AgentEnabledProvider> | null = null,
   ) {}
 
   async discoverModels(provider: UserProvider): Promise<DiscoveredModel[]> {
@@ -374,9 +374,9 @@ export class ModelDiscoveryService {
 
   private async invalidateProviderAccess(provider: UserProvider): Promise<void> {
     if (provider.agent_id) this.invalidate(provider.agent_id);
-    if (!this.accessRepo) return;
+    if (!this.enabledProviderRepo) return;
 
-    const rows = await this.accessRepo.find({ where: { user_provider_id: provider.id } });
+    const rows = await this.enabledProviderRepo.find({ where: { user_provider_id: provider.id } });
     for (const row of rows) {
       this.invalidate(row.agent_id);
     }
@@ -467,8 +467,8 @@ export class ModelDiscoveryService {
     providers: UserProvider[],
     agentId?: string,
   ): Promise<UserProvider[]> {
-    if (!agentId || !this.accessRepo) return providers;
-    const rows = await this.accessRepo.find({ where: { agent_id: agentId } });
+    if (!agentId || !this.enabledProviderRepo) return providers;
+    const rows = await this.enabledProviderRepo.find({ where: { agent_id: agentId } });
     if (rows.length === 0) return [];
     const enabledIds = new Set(rows.map((r) => r.user_provider_id));
     return providers.filter((p) => enabledIds.has(p.id));

--- a/packages/backend/src/playground/playground-agent.service.spec.ts
+++ b/packages/backend/src/playground/playground-agent.service.spec.ts
@@ -336,7 +336,7 @@ describe('PlaygroundAgentService.resolve', () => {
   });
 
   describe('(c) lazy-create path', () => {
-    it('runs a transaction that inserts the agent and calls the grant query', async () => {
+    it('runs a transaction that inserts the agent and calls the provider-pool enable query', async () => {
       const insertFn = jest.fn().mockResolvedValue(undefined);
       const queryFn = jest.fn().mockResolvedValue(undefined);
       const manager = makeManager(insertFn, queryFn);
@@ -357,7 +357,7 @@ describe('PlaygroundAgentService.resolve', () => {
       expect(mocks.dataSource.transaction).toHaveBeenCalledTimes(1);
       expect(insertFn).toHaveBeenCalledTimes(1);
 
-      // The grant query must receive [agentId, userId].
+      // The enable query must receive [agentId, userId].
       expect(queryFn).toHaveBeenCalledTimes(1);
       const [_sql, params] = queryFn.mock.calls[0] as [string, [string, string]];
       expect(params[0]).toBe(result.id);

--- a/packages/backend/src/playground/playground-agent.service.ts
+++ b/packages/backend/src/playground/playground-agent.service.ts
@@ -10,14 +10,14 @@ import { PLAYGROUND_AGENT_NAME } from '../common/constants/playground.constants'
 /**
  * Resolves the tenant's reserved `is_system` "Playground" agent — the single
  * agent every Playground run records under (so runs show as `Playground` in
- * global Messages) and which holds grants to the whole global provider pool.
+ * global Messages) and which has the whole global provider pool enabled.
  *
  * The migration seeds it for existing tenants and onboarding creates it for new
  * ones; this lazily creates it on first use as a safety net so the Playground
  * always has an agent to run under.
  *
- * The agent insert and provider-pool grant are executed inside a single DB
- * transaction so a committed reserved agent is always fully granted.  If a
+ * The agent insert and provider-pool enablement are executed inside a single DB
+ * transaction so a committed reserved agent always has the full pool enabled.  If a
  * concurrent request wins the unique-index race the transaction throws and we
  * simply return the winner's row.
  */
@@ -62,11 +62,11 @@ export class PlaygroundAgentService {
         // Insert the reserved agent row.
         await manager.getRepository(Agent).insert(agent);
 
-        // Grant the new agent the tenant's whole provider pool atomically — the
+        // Enable the tenant's whole provider pool for the new agent atomically — the
         // same shape the seed migration uses.  No tier recalculation needed here;
         // symmetric auto-connect handles providers added later.
         await manager.query(
-          `INSERT INTO "agent_provider_access" ("agent_id","user_provider_id") ` +
+          `INSERT INTO "agent_enabled_providers" ("agent_id","user_provider_id") ` +
             `SELECT $1, "id" FROM "user_providers" WHERE "user_id" = $2 ON CONFLICT DO NOTHING`,
           [agent.id, userId],
         );

--- a/packages/backend/src/routing/agent-enabled-providers.controller.spec.ts
+++ b/packages/backend/src/routing/agent-enabled-providers.controller.spec.ts
@@ -1,6 +1,6 @@
 import { HttpException } from '@nestjs/common';
-import { AgentProviderAccessController } from './agent-provider-access.controller';
-import type { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import { AgentEnabledProvidersController } from './agent-enabled-providers.controller';
+import type { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import type { UserProvider } from '../entities/user-provider.entity';
 import type { TierAssignment } from '../entities/tier-assignment.entity';
 import type { SpecificityAssignment } from '../entities/specificity-assignment.entity';
@@ -15,7 +15,7 @@ function makeController(overrides: Record<string, unknown> = {}) {
   const tenant = { id: TENANT_ID };
   const agent = { id: AGENT_ID, name: 'my-agent', tenant_id: TENANT_ID };
 
-  const accessRepo = {
+  const enabledProviderRepo = {
     find: jest.fn().mockResolvedValue([]),
     delete: jest.fn().mockResolvedValue(undefined),
     createQueryBuilder: jest.fn().mockReturnValue({
@@ -25,7 +25,7 @@ function makeController(overrides: Record<string, unknown> = {}) {
       orIgnore: jest.fn().mockReturnThis(),
       execute: jest.fn().mockResolvedValue(undefined),
     }),
-    ...((overrides.accessRepo as object) ?? {}),
+    ...((overrides.enabledProviderRepo as object) ?? {}),
   };
 
   const agentRepo = {
@@ -65,8 +65,8 @@ function makeController(overrides: Record<string, unknown> = {}) {
   };
 
   return {
-    controller: new AgentProviderAccessController(
-      accessRepo as never,
+    controller: new AgentEnabledProvidersController(
+      enabledProviderRepo as never,
       agentRepo as never,
       tenantRepo as never,
       userProviderRepo as never,
@@ -75,7 +75,7 @@ function makeController(overrides: Record<string, unknown> = {}) {
       headerTierRepo as never,
       providerService as never,
     ),
-    accessRepo,
+    enabledProviderRepo,
     agentRepo,
     tenantRepo,
     userProviderRepo,
@@ -88,7 +88,7 @@ function makeController(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe('AgentProviderAccessController', () => {
+describe('AgentEnabledProvidersController', () => {
   describe('resolveAgent — is_system: false filter', () => {
     it('passes is_system: false in the agentRepo.findOne where-clause', async () => {
       const { controller, agentRepo } = makeController();
@@ -142,12 +142,12 @@ describe('AgentProviderAccessController', () => {
     });
 
     it('returns enabled user_provider_ids for agent', async () => {
-      const rows: Partial<AgentProviderAccess>[] = [
+      const rows: Partial<AgentEnabledProvider>[] = [
         { agent_id: AGENT_ID, user_provider_id: 'prov-1' },
         { agent_id: AGENT_ID, user_provider_id: 'prov-2' },
       ];
       const { controller } = makeController({
-        accessRepo: { find: jest.fn().mockResolvedValue(rows) },
+        enabledProviderRepo: { find: jest.fn().mockResolvedValue(rows) },
       });
       const result = await controller.listEnabled({ id: USER_ID } as never, 'my-agent');
       expect(result).toEqual({ enabled: ['prov-1', 'prov-2'] });
@@ -419,7 +419,7 @@ describe('AgentProviderAccessController', () => {
       ).rejects.toBeInstanceOf(HttpException);
     });
 
-    it('inserts grant and invalidates routing cache on success', async () => {
+    it('inserts enabled-provider row and invalidates routing cache on success', async () => {
       const qb = {
         insert: jest.fn().mockReturnThis(),
         into: jest.fn().mockReturnThis(),
@@ -427,14 +427,14 @@ describe('AgentProviderAccessController', () => {
         orIgnore: jest.fn().mockReturnThis(),
         execute: jest.fn().mockResolvedValue(undefined),
       };
-      const { controller, accessRepo, providerService } = makeController({
+      const { controller, enabledProviderRepo, providerService } = makeController({
         userProviderRepo: {
           findOne: jest.fn().mockResolvedValue({
             id: PROVIDER_ID,
             user_id: USER_ID,
           } as Partial<UserProvider>),
         },
-        accessRepo: {
+        enabledProviderRepo: {
           createQueryBuilder: jest.fn().mockReturnValue(qb),
         },
       });
@@ -442,7 +442,7 @@ describe('AgentProviderAccessController', () => {
       const result = await controller.enable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
 
       expect(result).toEqual({ ok: true });
-      expect(accessRepo.createQueryBuilder).toHaveBeenCalled();
+      expect(enabledProviderRepo.createQueryBuilder).toHaveBeenCalled();
       expect(qb.orIgnore).toHaveBeenCalled();
       expect(qb.execute).toHaveBeenCalled();
       expect(providerService.recalculateTiers).toHaveBeenCalledWith(AGENT_ID, USER_ID);
@@ -460,12 +460,12 @@ describe('AgentProviderAccessController', () => {
     });
 
     it('deletes access row and invalidates routing cache when provider not found', async () => {
-      const { controller, accessRepo, providerService } = makeController();
+      const { controller, enabledProviderRepo, providerService } = makeController();
 
       const result = await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
 
       expect(result).toEqual({ ok: true });
-      expect(accessRepo.delete).toHaveBeenCalledWith({
+      expect(enabledProviderRepo.delete).toHaveBeenCalledWith({
         agent_id: AGENT_ID,
         user_provider_id: PROVIDER_ID,
       });
@@ -479,7 +479,7 @@ describe('AgentProviderAccessController', () => {
         auto_assigned_route: null,
         fallback_routes: null,
       };
-      const { controller, accessRepo, providerService } = makeController({
+      const { controller, enabledProviderRepo, providerService } = makeController({
         userProviderRepo: {
           findOne: jest.fn().mockResolvedValue({
             id: PROVIDER_ID,
@@ -499,7 +499,7 @@ describe('AgentProviderAccessController', () => {
         controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID),
       ).rejects.toThrow(/assigned to this harness/);
 
-      expect(accessRepo.delete).not.toHaveBeenCalled();
+      expect(enabledProviderRepo.delete).not.toHaveBeenCalled();
       expect(providerService.recalculateTiers).not.toHaveBeenCalled();
       expect(tier.override_route).not.toBeNull();
     });
@@ -511,7 +511,7 @@ describe('AgentProviderAccessController', () => {
         auto_assigned_route: null,
         fallback_routes: null,
       };
-      const { controller, accessRepo, providerService } = makeController({
+      const { controller, enabledProviderRepo, providerService } = makeController({
         userProviderRepo: {
           findOne: jest.fn().mockResolvedValue({
             id: PROVIDER_ID,
@@ -530,7 +530,7 @@ describe('AgentProviderAccessController', () => {
       const result = await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
 
       expect(result).toEqual({ ok: true });
-      expect(accessRepo.delete).toHaveBeenCalledWith({
+      expect(enabledProviderRepo.delete).toHaveBeenCalledWith({
         agent_id: AGENT_ID,
         user_provider_id: PROVIDER_ID,
       });
@@ -545,7 +545,7 @@ describe('AgentProviderAccessController', () => {
         auto_assigned_route: null,
         fallback_routes: null,
       };
-      const { controller, accessRepo } = makeController({
+      const { controller, enabledProviderRepo } = makeController({
         userProviderRepo: {
           findOne: jest.fn().mockResolvedValue({
             id: PROVIDER_ID,
@@ -565,7 +565,7 @@ describe('AgentProviderAccessController', () => {
         controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID),
       ).rejects.toThrow(/assigned to this harness/);
 
-      expect(accessRepo.delete).not.toHaveBeenCalled();
+      expect(enabledProviderRepo.delete).not.toHaveBeenCalled();
       expect(tier.override_route).not.toBeNull();
     });
 
@@ -576,7 +576,7 @@ describe('AgentProviderAccessController', () => {
         auto_assigned_route: null,
         fallback_routes: null,
       };
-      const { controller, accessRepo } = makeController({
+      const { controller, enabledProviderRepo } = makeController({
         userProviderRepo: {
           findOne: jest.fn().mockResolvedValue({
             id: PROVIDER_ID,
@@ -594,7 +594,7 @@ describe('AgentProviderAccessController', () => {
 
       await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
 
-      expect(accessRepo.delete).toHaveBeenCalled();
+      expect(enabledProviderRepo.delete).toHaveBeenCalled();
       expect(tier.override_route).not.toBeNull();
     });
 
@@ -605,7 +605,7 @@ describe('AgentProviderAccessController', () => {
         auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
         fallback_routes: null,
       };
-      const { controller, accessRepo } = makeController({
+      const { controller, enabledProviderRepo } = makeController({
         userProviderRepo: {
           findOne: jest.fn().mockResolvedValue({
             id: PROVIDER_ID,
@@ -623,7 +623,7 @@ describe('AgentProviderAccessController', () => {
 
       await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
 
-      expect(accessRepo.delete).toHaveBeenCalled();
+      expect(enabledProviderRepo.delete).toHaveBeenCalled();
       expect(tier.auto_assigned_route).not.toBeNull();
     });
 
@@ -634,7 +634,7 @@ describe('AgentProviderAccessController', () => {
         auto_assigned_route: null,
         fallback_routes: [{ provider: 'openai', authType: 'api_key', model: 'gpt-4o' }],
       };
-      const { controller, accessRepo } = makeController({
+      const { controller, enabledProviderRepo } = makeController({
         userProviderRepo: {
           findOne: jest.fn().mockResolvedValue({
             id: PROVIDER_ID,
@@ -654,7 +654,7 @@ describe('AgentProviderAccessController', () => {
         controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID),
       ).rejects.toThrow(/assigned to this harness/);
 
-      expect(accessRepo.delete).not.toHaveBeenCalled();
+      expect(enabledProviderRepo.delete).not.toHaveBeenCalled();
       expect(tier.fallback_routes).toHaveLength(1);
     });
 
@@ -670,7 +670,7 @@ describe('AgentProviderAccessController', () => {
         auto_assigned_route: null,
         fallback_routes: null,
       };
-      const { controller, accessRepo } = makeController({
+      const { controller, enabledProviderRepo } = makeController({
         userProviderRepo: {
           findOne: jest.fn().mockResolvedValue({
             id: PROVIDER_ID,
@@ -688,7 +688,7 @@ describe('AgentProviderAccessController', () => {
 
       await controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID);
 
-      expect(accessRepo.delete).toHaveBeenCalled();
+      expect(enabledProviderRepo.delete).toHaveBeenCalled();
       expect(tier.override_route).not.toBeNull();
     });
 
@@ -702,7 +702,7 @@ describe('AgentProviderAccessController', () => {
           { provider: 'anthropic', authType: 'api_key', model: 'claude-3-5-sonnet' },
         ],
       };
-      const { controller, accessRepo } = makeController({
+      const { controller, enabledProviderRepo } = makeController({
         userProviderRepo: {
           findOne: jest.fn().mockResolvedValue({
             id: PROVIDER_ID,
@@ -722,7 +722,7 @@ describe('AgentProviderAccessController', () => {
         controller.disable({ id: USER_ID } as never, 'my-agent', PROVIDER_ID),
       ).rejects.toThrow(/assigned to this harness/);
 
-      expect(accessRepo.delete).not.toHaveBeenCalled();
+      expect(enabledProviderRepo.delete).not.toHaveBeenCalled();
       expect(tier.fallback_routes).toHaveLength(2);
     });
   });

--- a/packages/backend/src/routing/agent-enabled-providers.controller.ts
+++ b/packages/backend/src/routing/agent-enabled-providers.controller.ts
@@ -12,7 +12,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthUser } from '../auth/auth.instance';
-import { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { Agent } from '../entities/agent.entity';
 import { Tenant } from '../entities/tenant.entity';
 import { UserProvider } from '../entities/user-provider.entity';
@@ -22,11 +22,11 @@ import { HeaderTier } from '../entities/header-tier.entity';
 import { ProviderService } from './routing-core/provider.service';
 import type { ModelRoute } from 'manifest-shared';
 
-@Controller('api/v1/agents/:agentName/provider-access')
-export class AgentProviderAccessController {
+@Controller('api/v1/agents/:agentName/enabled-providers')
+export class AgentEnabledProvidersController {
   constructor(
-    @InjectRepository(AgentProviderAccess)
-    private readonly accessRepo: Repository<AgentProviderAccess>,
+    @InjectRepository(AgentEnabledProvider)
+    private readonly enabledProviderRepo: Repository<AgentEnabledProvider>,
     @InjectRepository(Agent)
     private readonly agentRepo: Repository<Agent>,
     @InjectRepository(Tenant)
@@ -45,7 +45,7 @@ export class AgentProviderAccessController {
   private async resolveAgent(agentName: string, userId: string) {
     const tenant = await this.tenantRepo.findOne({ where: { name: userId } });
     if (!tenant) return null;
-    // Exclude the reserved system (Playground) agent — its grants are the global
+    // Exclude the reserved system (Playground) agent — its enabled providers are the global
     // pool and must not be togglable/removable through this per-agent endpoint.
     return this.agentRepo.findOne({
       where: { name: decodeURIComponent(agentName), tenant_id: tenant.id, is_system: false },
@@ -57,7 +57,7 @@ export class AgentProviderAccessController {
     const agent = await this.resolveAgent(agentName, user.id);
     if (!agent) return { enabled: [] };
 
-    const rows = await this.accessRepo.find({ where: { agent_id: agent.id } });
+    const rows = await this.enabledProviderRepo.find({ where: { agent_id: agent.id } });
     return { enabled: rows.map((r) => r.user_provider_id) };
   }
 
@@ -164,10 +164,10 @@ export class AgentProviderAccessController {
     });
     if (!provider) throw new HttpException('Provider not found', HttpStatus.NOT_FOUND);
 
-    await this.accessRepo
+    await this.enabledProviderRepo
       .createQueryBuilder()
       .insert()
-      .into(AgentProviderAccess)
+      .into(AgentEnabledProvider)
       .values({ agent_id: agent.id, user_provider_id: userProviderId })
       .orIgnore()
       .execute();
@@ -197,7 +197,7 @@ export class AgentProviderAccessController {
       }
     }
 
-    await this.accessRepo.delete({ agent_id: agent.id, user_provider_id: userProviderId });
+    await this.enabledProviderRepo.delete({ agent_id: agent.id, user_provider_id: userProviderId });
     await this.providerService.recalculateTiers(agent.id, user.id);
     return { ok: true };
   }

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -225,7 +225,7 @@ export class CustomProviderService {
     });
     await this.repo.insert(cp);
 
-    // Create UserProvider + grant access across every owned agent (custom
+    // Create UserProvider + enable it for every owned agent (custom
     // providers are user-global). When the display name resolves to Ollama /
     // LM Studio we tag the row `'local'` so routed messages carry the
     // grey-house badge and the row shows up under the Local tab. A null agentId

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -15,7 +15,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../auth/auth.instance';
-import { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { ProviderService } from './routing-core/provider.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
 import { TierService } from './routing-core/tier.service';
@@ -44,8 +44,8 @@ export class ProviderController {
     private readonly tierService: TierService,
     private readonly pricingSync: PricingSyncService,
     @Optional()
-    @InjectRepository(AgentProviderAccess)
-    private readonly accessRepo: Repository<AgentProviderAccess> | null = null,
+    @InjectRepository(AgentEnabledProvider)
+    private readonly enabledProviderRepo: Repository<AgentEnabledProvider> | null = null,
   ) {}
 
   @Get(':agentName/status')
@@ -106,7 +106,7 @@ export class ProviderController {
     @Body() body: ConnectProviderDto,
   ) {
     // allowSystem: true — connecting a provider to the Playground system agent
-    // is additive and correct (grants belong to the user-global pool).
+    // is additive and correct (enabled providers belong to the user-global pool).
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName, {
       allowSystem: true,
     });
@@ -147,13 +147,13 @@ export class ProviderController {
       body.region,
       body.label,
     );
-    // Insert a sparse access grant for this agent so per-agent filtering works.
+    // Insert a sparse enabled-provider row for this agent so per-agent filtering works.
     // .orIgnore() is intentional — reconnect/update flows must not throw on duplicate.
-    if (this.accessRepo) {
-      await this.accessRepo
+    if (this.enabledProviderRepo) {
+      await this.enabledProviderRepo
         .createQueryBuilder()
         .insert()
-        .into(AgentProviderAccess)
+        .into(AgentEnabledProvider)
         .values({ agent_id: agent.id, user_provider_id: result.id })
         .orIgnore()
         .execute();

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -5,7 +5,7 @@ import { TierAssignment } from '../../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../../entities/specificity-assignment.entity';
 import { Agent } from '../../../entities/agent.entity';
 import { HeaderTier } from '../../../entities/header-tier.entity';
-import { AgentProviderAccess } from '../../../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../../../entities/agent-enabled-provider.entity';
 import type { Repository } from 'typeorm';
 import type { RoutingCacheService } from '../routing-cache.service';
 import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
@@ -1014,15 +1014,15 @@ describe('ProviderService — route-only cleanup paths', () => {
 describe('ProviderService — symmetric provider↔agent auto-connect', () => {
   const PREV_SECRET = process.env.BETTER_AUTH_SECRET;
 
-  // A query-builder mock whose insert chain records the granted (agent, provider)
-  // pairs so the symmetric-grant tests can assert exactly which grants were made.
-  const makeAccessRepo = (granted: Array<{ agent: string; provider: string }>) => {
+  // A query-builder mock whose insert chain records the enabled (agent, provider)
+  // pairs so the symmetric auto-enable tests can assert exactly which pairs were enabled.
+  const makeEnabledProviderRepo = (enabled: Array<{ agent: string; provider: string }>) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const insertChain: any = {
       insert: jest.fn().mockReturnThis(),
       into: jest.fn().mockReturnThis(),
       values: jest.fn((v: { agent_id: string; user_provider_id: string }) => {
-        granted.push({ agent: v.agent_id, provider: v.user_provider_id });
+        enabled.push({ agent: v.agent_id, provider: v.user_provider_id });
         return insertChain;
       }),
       orIgnore: jest.fn().mockReturnThis(),
@@ -1034,7 +1034,7 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
     };
   };
 
-  const build = (agentIds: string[], granted: Array<{ agent: string; provider: string }>) => {
+  const build = (agentIds: string[], enabled: Array<{ agent: string; provider: string }>) => {
     const providerRepo = makeRepo();
     const agentRepo = makeRepo(agentIds);
     const routingCache = {
@@ -1043,7 +1043,7 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
       invalidateAgent: jest.fn(),
       invalidateUser: jest.fn(),
     };
-    const accessRepo = makeAccessRepo(granted);
+    const enabledProviderRepo = makeEnabledProviderRepo(enabled);
     const svc = new ProviderService(
       providerRepo as unknown as Repository<UserProvider>,
       makeRepo() as unknown as Repository<TierAssignment>,
@@ -1052,7 +1052,7 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
       makeRepo() as unknown as Repository<HeaderTier>,
       { getByModel: jest.fn() } as unknown as ModelPricingCacheService,
       routingCache as unknown as RoutingCacheService,
-      accessRepo as unknown as Repository<AgentProviderAccess>,
+      enabledProviderRepo as unknown as Repository<AgentEnabledProvider>,
     );
     return { svc, providerRepo, routingCache };
   };
@@ -1066,9 +1066,9 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
   });
 
   describe('enableAllProvidersForAgent', () => {
-    it('grants every usable provider to the agent and invalidates that agent', async () => {
-      const granted: Array<{ agent: string; provider: string }> = [];
-      const { svc, providerRepo, routingCache } = build(['agent-x'], granted);
+    it('enables every usable provider for the agent and invalidates that agent', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, providerRepo, routingCache } = build(['agent-x'], enabled);
       providerRepo.find.mockResolvedValue([
         { id: 'p1', provider: 'openai', auth_type: 'api_key', is_active: true } as UserProvider,
         { id: 'p2', provider: 'anthropic', auth_type: 'api_key', is_active: true } as UserProvider,
@@ -1076,7 +1076,7 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
 
       await svc.enableAllProvidersForAgent('new-agent', 'user-1');
 
-      expect(granted).toEqual([
+      expect(enabled).toEqual([
         { agent: 'new-agent', provider: 'p1' },
         { agent: 'new-agent', provider: 'p2' },
       ]);
@@ -1084,26 +1084,26 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
       expect(routingCache.invalidateUser).toHaveBeenCalledWith('user-1');
     });
 
-    it('is a no-op grant when the user has no usable providers', async () => {
-      const granted: Array<{ agent: string; provider: string }> = [];
-      const { svc, providerRepo, routingCache } = build(['agent-x'], granted);
+    it('is a no-op when the user has no usable providers', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, providerRepo, routingCache } = build(['agent-x'], enabled);
       providerRepo.find.mockResolvedValue([]);
 
       await expect(svc.enableAllProvidersForAgent('new-agent', 'user-1')).resolves.toBeUndefined();
-      expect(granted).toEqual([]);
+      expect(enabled).toEqual([]);
       expect(routingCache.invalidateAgent).toHaveBeenCalledWith('new-agent');
       expect(routingCache.invalidateUser).toHaveBeenCalledWith('user-1');
     });
   });
 
-  describe('grantNewProviderToAllAgents', () => {
-    it('grants the new provider to every owned agent and invalidates their caches', async () => {
-      const granted: Array<{ agent: string; provider: string }> = [];
-      const { svc, routingCache } = build(['agent-1', 'agent-2'], granted);
+  describe('enableProviderForAllAgents', () => {
+    it('enables the new provider for every owned agent and invalidates their caches', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, routingCache } = build(['agent-1', 'agent-2'], enabled);
 
-      await svc.grantNewProviderToAllAgents('user-1', 'new-provider');
+      await svc.enableProviderForAllAgents('user-1', 'new-provider');
 
-      expect(granted).toEqual([
+      expect(enabled).toEqual([
         { agent: 'agent-1', provider: 'new-provider' },
         { agent: 'agent-2', provider: 'new-provider' },
       ]);
@@ -1112,23 +1112,23 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
       expect(routingCache.invalidateUser).toHaveBeenCalledWith('user-1');
     });
 
-    it('is a no-op grant when the user owns no agents', async () => {
-      const granted: Array<{ agent: string; provider: string }> = [];
-      const { svc, routingCache } = build([], granted);
+    it('is a no-op when the user owns no agents', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, routingCache } = build([], enabled);
 
       await expect(
-        svc.grantNewProviderToAllAgents('user-1', 'new-provider'),
+        svc.enableProviderForAllAgents('user-1', 'new-provider'),
       ).resolves.toBeUndefined();
-      expect(granted).toEqual([]);
+      expect(enabled).toEqual([]);
       expect(routingCache.invalidateAgent).not.toHaveBeenCalled();
       expect(routingCache.invalidateUser).toHaveBeenCalledWith('user-1');
     });
   });
 
   describe('upsertProvider — new provider connect fans out to all agents', () => {
-    it('grants a brand-new api_key provider to every owned agent (Default label path)', async () => {
-      const granted: Array<{ agent: string; provider: string }> = [];
-      const { svc, providerRepo } = build(['agent-1', 'agent-2'], granted);
+    it('enables a brand-new api_key provider for every owned agent (Default label path)', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, providerRepo } = build(['agent-1', 'agent-2'], enabled);
       // No existing row → new-row branch.
       providerRepo.findOne.mockResolvedValue(null);
 
@@ -1141,16 +1141,16 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
       );
 
       expect(isNew).toBe(true);
-      // Every owned agent (not just the connecting one) gets the grant.
-      expect(granted).toEqual([
+      // Every owned agent (not just the connecting one) gets the provider enabled.
+      expect(enabled).toEqual([
         { agent: 'agent-1', provider: provider.id },
         { agent: 'agent-2', provider: provider.id },
       ]);
     });
 
-    it('grants a brand-new labeled provider to every owned agent', async () => {
-      const granted: Array<{ agent: string; provider: string }> = [];
-      const { svc, providerRepo } = build(['agent-1', 'agent-2'], granted);
+    it('enables a brand-new labeled provider for every owned agent', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, providerRepo } = build(['agent-1', 'agent-2'], enabled);
       // upsertProviderWithLabel: no existing rows → new-row branch.
       providerRepo.find.mockResolvedValue([]);
 
@@ -1165,30 +1165,30 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
       );
 
       expect(isNew).toBe(true);
-      expect(granted).toEqual([
+      expect(enabled).toEqual([
         { agent: 'agent-1', provider: provider.id },
         { agent: 'agent-2', provider: provider.id },
       ]);
     });
 
-    it('grants a brand-new tokenless subscription provider to every owned agent', async () => {
-      const granted: Array<{ agent: string; provider: string }> = [];
-      const { svc, providerRepo } = build(['agent-1', 'agent-2'], granted);
+    it('enables a brand-new tokenless subscription provider for every owned agent', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, providerRepo } = build(['agent-1', 'agent-2'], enabled);
       // registerSubscriptionProvider new-row branch: no existing sub/api_key row.
       providerRepo.findOne.mockResolvedValue(null);
 
       const { isNew } = await svc.registerSubscriptionProvider('agent-1', 'user-1', 'anthropic');
 
       expect(isNew).toBe(true);
-      expect(granted.map((g) => g.agent)).toEqual(['agent-1', 'agent-2']);
+      expect(enabled.map((g) => g.agent)).toEqual(['agent-1', 'agent-2']);
     });
   });
 
-  describe('reconnect of an EXISTING provider does NOT re-grant (per-agent disables preserved)', () => {
-    it('does not grant other agents when an existing Default-label row is updated', async () => {
-      const granted: Array<{ agent: string; provider: string }> = [];
-      const { svc, providerRepo } = build(['agent-1', 'agent-2'], granted);
-      const grantSpy = jest.spyOn(svc, 'grantNewProviderToAllAgents');
+  describe('reconnect of an EXISTING provider does NOT re-enable (per-agent disables preserved)', () => {
+    it('does not enable other agents when an existing Default-label row is updated', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, providerRepo } = build(['agent-1', 'agent-2'], enabled);
+      const enableSpy = jest.spyOn(svc, 'enableProviderForAllAgents');
       // Existing row → update-in-place branch (afterProviderChange path).
       providerRepo.findOne.mockResolvedValue({
         id: 'p-existing',
@@ -1202,17 +1202,17 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
 
       expect(isNew).toBe(false);
       // The fan-out-to-all-agents path is NOT taken on reconnect.
-      expect(grantSpy).not.toHaveBeenCalled();
-      // Only the connecting agent is (re)granted via afterProviderChange —
+      expect(enableSpy).not.toHaveBeenCalled();
+      // Only the connecting agent is (re)enabled via afterProviderChange —
       // sibling agent-2 keeps whatever per-agent disable state it had.
-      expect(granted).toEqual([{ agent: 'agent-1', provider: 'p-existing' }]);
-      expect(granted.some((g) => g.agent === 'agent-2')).toBe(false);
+      expect(enabled).toEqual([{ agent: 'agent-1', provider: 'p-existing' }]);
+      expect(enabled.some((g) => g.agent === 'agent-2')).toBe(false);
     });
 
-    it('does not re-grant when reconnecting the same key under a new label (sameKey path)', async () => {
-      const granted: Array<{ agent: string; provider: string }> = [];
-      const { svc, providerRepo } = build(['agent-1', 'agent-2'], granted);
-      const grantSpy = jest.spyOn(svc, 'grantNewProviderToAllAgents');
+    it('does not re-enable when reconnecting the same key under a new label (sameKey path)', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, providerRepo } = build(['agent-1', 'agent-2'], enabled);
+      const enableSpy = jest.spyOn(svc, 'enableProviderForAllAgents');
       const sameKeyEncrypted = encrypt('sk-same-key', getEncryptionSecret());
       // upsertProviderWithLabel: a row with the SAME decrypted key already
       // exists under a different label → sameKey reactivation branch.
@@ -1240,11 +1240,11 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
 
       expect(isNew).toBe(false);
       // The fan-out-to-all-agents path is NOT taken on a same-key reconnect.
-      expect(grantSpy).not.toHaveBeenCalled();
-      // Only the connecting agent is (re)granted via afterProviderChange —
+      expect(enableSpy).not.toHaveBeenCalled();
+      // Only the connecting agent is (re)enabled via afterProviderChange —
       // sibling agent-2 keeps whatever per-agent disable state it had.
-      expect(granted).toEqual([{ agent: 'agent-1', provider: 'p-same' }]);
-      expect(granted.some((g) => g.agent === 'agent-2')).toBe(false);
+      expect(enabled).toEqual([{ agent: 'agent-1', provider: 'p-same' }]);
+      expect(enabled.some((g) => g.agent === 'agent-2')).toBe(false);
     });
   });
 });

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { AuthType } from 'manifest-shared';
 import { UserProvider } from '../../entities/user-provider.entity';
-import { AgentProviderAccess } from '../../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
@@ -28,8 +28,8 @@ export class ProviderKeyService {
     private readonly routingCache: RoutingCacheService,
     private readonly providerService: ProviderService,
     @Optional()
-    @InjectRepository(AgentProviderAccess)
-    private readonly accessRepo: Repository<AgentProviderAccess> | null = null,
+    @InjectRepository(AgentEnabledProvider)
+    private readonly enabledProviderRepo: Repository<AgentEnabledProvider> | null = null,
   ) {}
 
   /**
@@ -306,15 +306,15 @@ export class ProviderKeyService {
 
   /**
    * Filters a list of global user providers down to only those the given
-   * agent has been granted access to. If no agentId is provided, or if the
-   * access repo is not available, returns the full list unchanged.
+   * agent has enabled. If no agentId is provided, or if the
+   * enabled-provider repo is not available, returns the full list unchanged.
    */
   private async filterProvidersForAgent(
     providers: UserProvider[],
     agentId?: string,
   ): Promise<UserProvider[]> {
-    if (!agentId || !this.accessRepo) return providers;
-    const rows = await this.accessRepo.find({ where: { agent_id: agentId } });
+    if (!agentId || !this.enabledProviderRepo) return providers;
+    const rows = await this.enabledProviderRepo.find({ where: { agent_id: agentId } });
     if (rows.length === 0) return [];
     const enabledIds = new Set(rows.map((r) => r.user_provider_id));
     return providers.filter((p) => enabledIds.has(p.id));

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -8,7 +8,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In, FindOptionsWhere } from 'typeorm';
 import { UserProvider } from '../../entities/user-provider.entity';
-import { AgentProviderAccess } from '../../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 import { Agent } from '../../entities/agent.entity';
@@ -57,8 +57,8 @@ export class ProviderService {
     private readonly headerTierRepo: Repository<HeaderTier>,
     private readonly pricingCache: ModelPricingCacheService,
     private readonly routingCache: RoutingCacheService,
-    @InjectRepository(AgentProviderAccess)
-    private readonly accessRepo: Repository<AgentProviderAccess> | null = null,
+    @InjectRepository(AgentEnabledProvider)
+    private readonly enabledProviderRepo: Repository<AgentEnabledProvider> | null = null,
   ) {}
 
   /**
@@ -94,12 +94,12 @@ export class ProviderService {
     return providers;
   }
 
-  async grantProviderAccess(agentId: string, userProviderId: string): Promise<void> {
-    if (!this.accessRepo) return;
-    await this.accessRepo
+  async enableProviderForAgent(agentId: string, userProviderId: string): Promise<void> {
+    if (!this.enabledProviderRepo) return;
+    await this.enabledProviderRepo
       .createQueryBuilder()
       .insert()
-      .into(AgentProviderAccess)
+      .into(AgentEnabledProvider)
       .values({ agent_id: agentId, user_provider_id: userProviderId })
       .orIgnore()
       .execute();
@@ -114,7 +114,7 @@ export class ProviderService {
    */
   async enableAllProvidersForAgent(agentId: string, userId: string): Promise<void> {
     for (const provider of await this.getProviders(userId)) {
-      await this.grantProviderAccess(agentId, provider.id);
+      await this.enableProviderForAgent(agentId, provider.id);
     }
     this.routingCache.invalidateAgent(agentId);
     this.routingCache.invalidateUser(userId);
@@ -127,17 +127,17 @@ export class ProviderService {
    * user already owns must immediately gain access to it. Route assignment
    * remains user-controlled. No-op safe when the user owns 0 agents.
    */
-  async grantNewProviderToAllAgents(userId: string, userProviderId: string): Promise<void> {
+  async enableProviderForAllAgents(userId: string, userProviderId: string): Promise<void> {
     for (const agentId of await this.listOwnedAgentIds(userId)) {
-      await this.grantProviderAccess(agentId, userProviderId);
+      await this.enableProviderForAgent(agentId, userProviderId);
       this.routingCache.invalidateAgent(agentId);
     }
     this.routingCache.invalidateUser(userId);
   }
 
   private async deleteProviderAccess(userProviderIds: string[]): Promise<void> {
-    if (!this.accessRepo || userProviderIds.length === 0) return;
-    await this.accessRepo.delete({ user_provider_id: In(userProviderIds) });
+    if (!this.enabledProviderRepo || userProviderIds.length === 0) return;
+    await this.enabledProviderRepo.delete({ user_provider_id: In(userProviderIds) });
   }
 
   /**
@@ -242,9 +242,9 @@ export class ProviderService {
     });
 
     await this.providerRepo.insert(record);
-    // A brand-new provider is global + ON by default: grant it to every agent
+    // A brand-new provider is global + ON by default: enable it for every agent
     // the user owns, without changing model routes.
-    await this.grantNewProviderToAllAgents(userId, record.id);
+    await this.enableProviderForAllAgents(userId, record.id);
     return { provider: record, isNew: true };
   }
 
@@ -325,9 +325,9 @@ export class ProviderService {
     });
 
     await this.providerRepo.insert(record);
-    // A brand-new provider is global + ON by default: grant it to every agent
+    // A brand-new provider is global + ON by default: enable it for every agent
     // the user owns, without changing model routes.
-    await this.grantNewProviderToAllAgents(userId, record.id);
+    await this.enableProviderForAllAgents(userId, record.id);
     return { provider: record, isNew: true };
   }
 
@@ -527,9 +527,9 @@ export class ProviderService {
     });
 
     await this.providerRepo.insert(record);
-    // A brand-new subscription provider is global + ON by default: grant it to
+    // A brand-new subscription provider is global + ON by default: enable it for
     // every agent the user owns, without changing model routes.
-    await this.grantNewProviderToAllAgents(userId, record.id);
+    await this.enableProviderForAllAgents(userId, record.id);
     return { isNew: true };
   }
 
@@ -541,7 +541,7 @@ export class ProviderService {
     if (agentId === null) {
       await this.recalculateTiersForUser(userId);
     } else {
-      if (userProviderId) await this.grantProviderAccess(agentId, userProviderId);
+      if (userProviderId) await this.enableProviderForAgent(agentId, userProviderId);
       this.routingCache.invalidateAgent(agentId);
     }
     this.routingCache.invalidateUser(userId);

--- a/packages/backend/src/routing/routing-core/routing-core.module.ts
+++ b/packages/backend/src/routing/routing-core/routing-core.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserProvider } from '../../entities/user-provider.entity';
-import { AgentProviderAccess } from '../../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 import { AgentModelParams } from '../../entities/agent-model-params.entity';
@@ -26,7 +26,7 @@ import { ProviderParamSpecService } from './provider-param-spec.service';
   imports: [
     TypeOrmModule.forFeature([
       UserProvider,
-      AgentProviderAccess,
+      AgentEnabledProvider,
       TierAssignment,
       SpecificityAssignment,
       AgentModelParams,

--- a/packages/backend/src/routing/routing.module.ts
+++ b/packages/backend/src/routing/routing.module.ts
@@ -16,11 +16,11 @@ import { CopilotController } from './copilot.controller';
 import { SpecificityController } from './specificity.controller';
 import { ModelParamsController } from './model-params.controller';
 import { UserProvidersController } from './user-providers.controller';
-import { AgentProviderAccessController } from './agent-provider-access.controller';
+import { AgentEnabledProvidersController } from './agent-enabled-providers.controller';
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { UserProvider } from '../entities/user-provider.entity';
-import { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { Agent } from '../entities/agent.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { Tenant } from '../entities/tenant.entity';
@@ -32,7 +32,7 @@ import { HeaderTier } from '../entities/header-tier.entity';
   imports: [
     TypeOrmModule.forFeature([
       UserProvider,
-      AgentProviderAccess,
+      AgentEnabledProvider,
       Agent,
       AgentMessage,
       Tenant,
@@ -59,7 +59,7 @@ import { HeaderTier } from '../entities/header-tier.entity';
     SpecificityController,
     ModelParamsController,
     UserProvidersController,
-    AgentProviderAccessController,
+    AgentEnabledProvidersController,
   ],
   providers: [OllamaSyncService],
   exports: [RoutingCoreModule, CustomProviderModule, OAuthModule],

--- a/packages/backend/test/agent-duplication-migrations.e2e-spec.ts
+++ b/packages/backend/test/agent-duplication-migrations.e2e-spec.ts
@@ -4,7 +4,7 @@ import { DataSource } from 'typeorm';
 import { Tenant } from '../src/entities/tenant.entity';
 import { Agent } from '../src/entities/agent.entity';
 import { UserProvider } from '../src/entities/user-provider.entity';
-import { AgentProviderAccess } from '../src/entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../src/entities/agent-enabled-provider.entity';
 import { AgentDuplicationService } from '../src/analytics/services/agent-duplication.service';
 
 /**
@@ -50,7 +50,7 @@ describe('Agent duplication under migration-built schema (e2e)', () => {
 
   beforeEach(async () => {
     // Clean slate per test (FK-safe order).
-    await ds.query('DELETE FROM "agent_provider_access"');
+    await ds.query('DELETE FROM "agent_enabled_providers"');
     await ds.query('DELETE FROM "user_providers"');
     await ds.query('DELETE FROM "agents"');
     await ds.query('DELETE FROM "tenants"');
@@ -82,7 +82,7 @@ describe('Agent duplication under migration-built schema (e2e)', () => {
       models_fetched_at: null,
     });
     await ds
-      .getRepository(AgentProviderAccess)
+      .getRepository(AgentEnabledProvider)
       .insert({ agent_id: 'dup-src', user_provider_id: 'dup-up1' });
   });
 
@@ -92,7 +92,7 @@ describe('Agent duplication under migration-built schema (e2e)', () => {
     ).resolves.toMatchObject({ agentName: 'src-agent-copy' });
   });
 
-  it('shares the global provider via a copied grant instead of cloning the row', async () => {
+  it('shares the global provider via a copied enabled-provider row instead of cloning it', async () => {
     const result = await svc.duplicate(USER, 'src-agent', {
       name: 'src-agent-copy',
       displayName: 'Copy',
@@ -102,10 +102,10 @@ describe('Agent duplication under migration-built schema (e2e)', () => {
     const ups = await ds.getRepository(UserProvider).find({ where: { user_id: USER } });
     expect(ups).toHaveLength(1);
 
-    // The new agent gets its own grant pointing at the SAME global provider.
-    const grants = await ds
-      .getRepository(AgentProviderAccess)
+    // The new agent gets its own enabled-provider row pointing at the SAME global provider.
+    const enabledRows = await ds
+      .getRepository(AgentEnabledProvider)
       .find({ where: { agent_id: result.agentId } });
-    expect(grants).toEqual([{ agent_id: result.agentId, user_provider_id: 'dup-up1' }]);
+    expect(enabledRows).toEqual([{ agent_id: result.agentId, user_provider_id: 'dup-up1' }]);
   });
 });

--- a/packages/backend/test/agent-duplication.e2e-spec.ts
+++ b/packages/backend/test/agent-duplication.e2e-spec.ts
@@ -8,7 +8,7 @@ import { TierAssignment } from '../src/entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../src/entities/specificity-assignment.entity';
 import { Agent } from '../src/entities/agent.entity';
 import { AgentApiKey } from '../src/entities/agent-api-key.entity';
-import { AgentProviderAccess } from '../src/entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../src/entities/agent-enabled-provider.entity';
 
 describe('Agent Duplication (e2e)', () => {
   let app: INestApplication;
@@ -41,8 +41,8 @@ describe('Agent Duplication (e2e)', () => {
       models_fetched_at: null,
     });
 
-    // Grant the source agent access to the global provider via agent_provider_access.
-    await ds.getRepository(AgentProviderAccess).insert({
+    // Enable the global provider for the source agent via agent_enabled_providers.
+    await ds.getRepository(AgentEnabledProvider).insert({
       agent_id: TEST_AGENT_ID,
       user_provider_id: 'up-e2e-1',
     });
@@ -98,7 +98,7 @@ describe('Agent Duplication (e2e)', () => {
       .set(headers)
       .expect(200);
 
-    // providers = count of agent_provider_access grants for the source agent (1 grant for up-e2e-1)
+    // providers = count of agent_enabled_providers rows for the source agent (1 row for up-e2e-1)
     expect(res.body.copied).toEqual({
       providers: 1,
       tierAssignments: 1,
@@ -115,7 +115,7 @@ describe('Agent Duplication (e2e)', () => {
       .expect(404);
   });
 
-  it('POST /agents/:name/duplicate copies grants to a new agent (providers are user-global, not cloned)', async () => {
+  it('POST /agents/:name/duplicate copies enabled-provider rows to a new agent (providers are user-global, not cloned)', async () => {
     const res = await request(app.getHttpServer())
       .post(`/api/v1/agents/${sourceAgent}/duplicate`)
       .set(headers)
@@ -124,7 +124,7 @@ describe('Agent Duplication (e2e)', () => {
 
     expect(res.body.agent.name).toBe('test-agent-copy');
     expect(res.body.apiKey).toMatch(/^mnfst_/);
-    // providers = 1 grant copied (the global anthropic row gets a new grant, not a clone)
+    // providers = 1 row copied (the global anthropic row gets a new enabled-provider row, not a clone)
     expect(res.body.copied).toEqual({
       providers: 1,
       tierAssignments: 1,
@@ -153,9 +153,9 @@ describe('Agent Duplication (e2e)', () => {
     expect(allAnthropicProviders).toHaveLength(1);
     expect(allAnthropicProviders[0].id).toBe('up-e2e-1');
 
-    // The new agent gets an agent_provider_access grant pointing at the original row.
+    // The new agent gets an agent_enabled_providers row pointing at the original row.
     const newGrants = await ds
-      .getRepository(AgentProviderAccess)
+      .getRepository(AgentEnabledProvider)
       .find({ where: { agent_id: res.body.agent.id } });
     expect(newGrants).toHaveLength(1);
     expect(newGrants[0].user_provider_id).toBe('up-e2e-1');
@@ -182,8 +182,8 @@ describe('Agent Duplication (e2e)', () => {
     expect(newSpec[0].category).toBe('coding');
   });
 
-  it('POST /agents/:name/duplicate copies a custom provider grant verbatim (shared row, not re-credentialed)', async () => {
-    // Custom providers are user-global. Their agent_provider_access grant is copied
+  it('POST /agents/:name/duplicate copies a custom provider enablement verbatim (shared row, not re-credentialed)', async () => {
+    // Custom providers are user-global. Their agent_enabled_providers row is copied
     // verbatim pointing at the SAME user_providers row — no new CustomProvider row,
     // no new UserProvider row.
     const now = new Date().toISOString();
@@ -234,7 +234,7 @@ describe('Agent Duplication (e2e)', () => {
       models_fetched_at: null,
     });
 
-    // A regular global provider grant alongside the custom one.
+    // A regular global provider enabled alongside the custom one.
     await ds.getRepository(UserProvider).insert({
       id: 'up-ollama-e2e',
       user_id: 'test-user-001',
@@ -251,8 +251,8 @@ describe('Agent Duplication (e2e)', () => {
       models_fetched_at: null,
     });
 
-    // Grant the source agent access to both providers.
-    await ds.getRepository(AgentProviderAccess).insert([
+    // Enable both providers for the source agent.
+    await ds.getRepository(AgentEnabledProvider).insert([
       { agent_id: srcAgentId, user_provider_id: 'up-lmstudio-e2e' },
       { agent_id: srcAgentId, user_provider_id: 'up-ollama-e2e' },
     ]);
@@ -265,9 +265,9 @@ describe('Agent Duplication (e2e)', () => {
 
     const newAgentId = res.body.agent.id;
 
-    // 2 grants copied verbatim — same user_provider_id values as the source.
+    // 2 enabled-provider rows copied verbatim — same user_provider_id values as the source.
     const newGrants = await ds
-      .getRepository(AgentProviderAccess)
+      .getRepository(AgentEnabledProvider)
       .find({ where: { agent_id: newAgentId } });
     expect(newGrants).toHaveLength(2);
 
@@ -291,7 +291,7 @@ describe('Agent Duplication (e2e)', () => {
       .find({ where: { agent_id: newAgentId } });
     expect(newUserProviders).toHaveLength(0);
 
-    // Summary reflects 2 grants copied.
+    // Summary reflects 2 enabled-provider rows copied.
     expect(res.body.copied.providers).toBe(2);
   });
 

--- a/packages/backend/test/agent-enabled-providers.e2e-spec.ts
+++ b/packages/backend/test/agent-enabled-providers.e2e-spec.ts
@@ -5,11 +5,11 @@
  * them per-agent. This spec proves both directions of the symmetric model and
  * that manual disable/enable stays isolated per agent:
  *
- *   Direction 2 (new provider): connecting a provider auto-grants EVERY agent
+ *   Direction 2 (new provider): connecting a provider auto-enables it for EVERY agent
  *     the user already owns + auto-assigns routes.
- *   Direction 1 (new agent): creating an agent auto-grants EVERY usable
+ *   Direction 1 (new agent): creating an agent auto-enables EVERY usable
  *     provider the user already connected + auto-assigns routes.
- *   Disable isolation: DELETE a grant for agent A leaves agent B untouched;
+ *   Disable isolation: disabling a provider for agent A leaves agent B untouched;
  *     re-enable restores it. Reconnecting the SAME key does NOT resurrect a
  *     per-agent disable.
  */
@@ -17,7 +17,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
 import { createTestApp, TEST_API_KEY, TEST_USER_ID } from './helpers';
-import { AgentProviderAccess } from '../src/entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../src/entities/agent-enabled-provider.entity';
 import { UserProvider } from '../src/entities/user-provider.entity';
 
 let app: INestApplication;
@@ -28,7 +28,7 @@ const auth = (r: request.Test) => r.set('x-api-key', TEST_API_KEY);
 
 // Agent A = the shared `test-agent` seeded by createTestApp. Agent B is created
 // via the public API before any provider is connected, so it must be auto-
-// granted when a provider connects (Direction 2).
+// enabled when a provider connects (Direction 2).
 const AGENT_A_NAME = 'test-agent';
 const AGENT_B_NAME = 'isolation-agent-b';
 // Agent C is created AFTER a provider exists, so it must inherit it (Direction 1).
@@ -50,8 +50,8 @@ afterAll(async () => {
   await app?.close();
 });
 
-describe('Direction 2 – connecting a NEW provider auto-grants every existing agent', () => {
-  it('creates one global user_providers row and grants BOTH agent A and agent B', async () => {
+describe('Direction 2 – connecting a NEW provider auto-enables it for every existing agent', () => {
+  it('creates one global user_providers row and enables it for BOTH agent A and agent B', async () => {
     const res = await auth(api().post(`/api/v1/routing/${AGENT_A_NAME}/providers`))
       .send({ provider: 'openai', apiKey: 'sk-test-openai-key' })
       .expect(201);
@@ -65,30 +65,30 @@ describe('Direction 2 – connecting a NEW provider auto-grants every existing a
     expect(rows).toHaveLength(1);
     expect(rows[0].agent_id).toBeNull();
 
-    // Symmetric auto-connect: the new provider is granted to EVERY owned agent,
-    // not just the connecting one. Both A and B now have a grant.
-    const grants = await ds.getRepository(AgentProviderAccess).find({
+    // Symmetric auto-connect: the new provider is enabled for EVERY owned agent,
+    // not just the connecting one. Both A and B now have it enabled.
+    const enabledRows = await ds.getRepository(AgentEnabledProvider).find({
       where: { user_provider_id: providerId },
     });
-    const grantedAgentIds = grants.map((g) => g.agent_id);
-    expect(grantedAgentIds).toContain(agentBId);
-    expect(grantedAgentIds).toHaveLength(2); // agent A + agent B
+    const enabledAgentIds = enabledRows.map((g) => g.agent_id);
+    expect(enabledAgentIds).toContain(agentBId);
+    expect(enabledAgentIds).toHaveLength(2); // agent A + agent B
   });
 
   it('agent B (created before connect) now lists the provider as enabled', async () => {
-    const res = await auth(api().get(`/api/v1/agents/${AGENT_B_NAME}/provider-access`)).expect(200);
+    const res = await auth(api().get(`/api/v1/agents/${AGENT_B_NAME}/enabled-providers`)).expect(200);
     const enabled: string[] = res.body.enabled ?? [];
     expect(enabled).toContain(providerId);
   });
 
   it('agent A (the connecting agent) lists the provider as enabled', async () => {
-    const res = await auth(api().get(`/api/v1/agents/${AGENT_A_NAME}/provider-access`)).expect(200);
+    const res = await auth(api().get(`/api/v1/agents/${AGENT_A_NAME}/enabled-providers`)).expect(200);
     const enabled: string[] = res.body.enabled ?? [];
     expect(enabled).toContain(providerId);
   });
 
   it('sibling agent B has a tier route computed AGAINST the post-discovery model set', async () => {
-    // The bug: grantNewProviderToAllAgents recalcs every agent INSIDE
+    // The bug: enableProviderForAllAgents recalcs every agent INSIDE
     // upsertProvider, but that runs BEFORE discoverModels populates the new
     // provider's cached_models — so siblings would be left with auto-assigned
     // routes derived from a model set that excluded the new provider. The fix
@@ -114,7 +114,7 @@ describe('Direction 2 – connecting a NEW provider auto-grants every existing a
 });
 
 describe('Direction 1 – creating a NEW agent inherits every existing provider', () => {
-  it('creating agent C auto-grants the already-connected provider + assigns routes', async () => {
+  it('creating agent C auto-enables the already-connected provider + assigns routes', async () => {
     // Seed discovered models so the auto-assigned route is observable.
     await ds.query(
       `UPDATE user_providers SET cached_models = $1 WHERE id = $2`,
@@ -140,13 +140,13 @@ describe('Direction 1 – creating a NEW agent inherits every existing provider'
     agentCId = res.body.agent.id as string;
 
     // The brand-new agent inherited the existing provider.
-    const grants = await ds.getRepository(AgentProviderAccess).find({
+    const enabledRows = await ds.getRepository(AgentEnabledProvider).find({
       where: { agent_id: agentCId, user_provider_id: providerId },
     });
-    expect(grants).toHaveLength(1);
+    expect(enabledRows).toHaveLength(1);
 
     const enabledRes = await auth(
-      api().get(`/api/v1/agents/${AGENT_C_NAME}/provider-access`),
+      api().get(`/api/v1/agents/${AGENT_C_NAME}/enabled-providers`),
     ).expect(200);
     expect((enabledRes.body.enabled ?? []) as string[]).toContain(providerId);
 
@@ -167,14 +167,14 @@ describe('Direction 1 – creating a NEW agent inherits every existing provider'
     // Snapshot then physically remove the provider so getProviders() returns an
     // empty set (it filters by isManifestUsableProvider, which ignores
     // is_active), proving the 0-provider create path is a safe no-op. Restore
-    // the row + its A/B/C grants afterwards so later isolation tests still run.
+    // the row + its A/B/C enabled rows afterwards so later isolation tests still run.
     const snapshot = await ds.getRepository(UserProvider).findOneOrFail({
       where: { id: providerId },
     });
-    const grantsSnapshot = await ds.getRepository(AgentProviderAccess).find({
+    const enabledSnapshot = await ds.getRepository(AgentEnabledProvider).find({
       where: { user_provider_id: providerId },
     });
-    await ds.getRepository(AgentProviderAccess).delete({ user_provider_id: providerId });
+    await ds.getRepository(AgentEnabledProvider).delete({ user_provider_id: providerId });
     await ds.getRepository(UserProvider).delete({ id: providerId });
 
     const res = await auth(api().post('/api/v1/agents'))
@@ -182,46 +182,46 @@ describe('Direction 1 – creating a NEW agent inherits every existing provider'
       .expect(201);
     const emptyAgentId = res.body.agent.id as string;
 
-    const grants = await ds.getRepository(AgentProviderAccess).find({
+    const enabledRows = await ds.getRepository(AgentEnabledProvider).find({
       where: { agent_id: emptyAgentId },
     });
-    expect(grants).toHaveLength(0);
+    expect(enabledRows).toHaveLength(0);
 
     const enabledRes = await auth(
-      api().get('/api/v1/agents/isolation-agent-empty/provider-access'),
+      api().get('/api/v1/agents/isolation-agent-empty/enabled-providers'),
     ).expect(200);
     expect(enabledRes.body.enabled ?? []).toEqual([]);
 
-    // Restore the provider row + its prior grants for the remaining tests.
+    // Restore the provider row + its prior enabled rows for the remaining tests.
     await ds.getRepository(UserProvider).save(snapshot);
-    if (grantsSnapshot.length > 0) {
-      await ds.getRepository(AgentProviderAccess).save(grantsSnapshot);
+    if (enabledSnapshot.length > 0) {
+      await ds.getRepository(AgentEnabledProvider).save(enabledSnapshot);
     }
   });
 });
 
-describe('Disable isolation – DELETE a grant affects only the targeted agent', () => {
-  it('DELETE provider-access for agent A removes only A\'s grant', async () => {
+describe('Disable isolation – disabling affects only the targeted agent', () => {
+  it('DELETE enabled-providers for agent A removes only A\'s row', async () => {
     await auth(
-      api().delete(`/api/v1/agents/${AGENT_A_NAME}/provider-access/${providerId}`),
+      api().delete(`/api/v1/agents/${AGENT_A_NAME}/enabled-providers/${providerId}`),
     ).expect(200);
 
     const aRes = await auth(
-      api().get(`/api/v1/agents/${AGENT_A_NAME}/provider-access`),
+      api().get(`/api/v1/agents/${AGENT_A_NAME}/enabled-providers`),
     ).expect(200);
     expect((aRes.body.enabled ?? []) as string[]).not.toContain(providerId);
   });
 
   it('agent B is unaffected by A\'s disable', async () => {
     const bRes = await auth(
-      api().get(`/api/v1/agents/${AGENT_B_NAME}/provider-access`),
+      api().get(`/api/v1/agents/${AGENT_B_NAME}/enabled-providers`),
     ).expect(200);
     expect((bRes.body.enabled ?? []) as string[]).toContain(providerId);
   });
 
   it('reconnecting the SAME provider key does NOT resurrect agent A\'s disable', async () => {
     // Reconnect openai for agent A with the same key. This hits the
-    // update-in-place reconnect branch, which re-grants ONLY the connecting
+    // update-in-place reconnect branch, which re-enables ONLY the connecting
     // agent (A) and must NOT fan out to re-enable everywhere — but it also must
     // not leave A disabled, since the user explicitly reconnected on A.
     await auth(api().post(`/api/v1/routing/${AGENT_A_NAME}/providers`))
@@ -235,21 +235,21 @@ describe('Disable isolation – DELETE a grant affects only the targeted agent',
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toBe(providerId);
 
-    // A is re-granted (it was the reconnect target); B keeps its grant.
-    const grants = await ds.getRepository(AgentProviderAccess).find({
+    // A is re-enabled (it was the reconnect target); B keeps its row.
+    const enabledRows = await ds.getRepository(AgentEnabledProvider).find({
       where: { user_provider_id: providerId },
     });
-    const grantedAgentIds = grants.map((g) => g.agent_id);
-    expect(grantedAgentIds).toContain(agentBId);
-    expect(grantedAgentIds).toContain(agentCId);
+    const enabledAgentIds = enabledRows.map((g) => g.agent_id);
+    expect(enabledAgentIds).toContain(agentBId);
+    expect(enabledAgentIds).toContain(agentCId);
   });
 
-  it('re-enabling agent A via PUT restores its grant without touching B', async () => {
+  it('re-enabling agent A via PUT restores its row without touching B', async () => {
     await auth(
-      api().put(`/api/v1/agents/${AGENT_B_NAME}/provider-access/${providerId}`),
+      api().put(`/api/v1/agents/${AGENT_B_NAME}/enabled-providers/${providerId}`),
     ).expect(200);
 
-    const bGrants = await ds.getRepository(AgentProviderAccess).find({
+    const bGrants = await ds.getRepository(AgentEnabledProvider).find({
       where: { agent_id: agentBId, user_provider_id: providerId },
     });
     expect(bGrants).toHaveLength(1);
@@ -271,7 +271,7 @@ describe('Disable impact preview – mirrors what the disable handler will strip
     );
 
     const res = await auth(
-      api().get(`/api/v1/agents/${AGENT_B_NAME}/provider-access/${providerId}/impact`),
+      api().get(`/api/v1/agents/${AGENT_B_NAME}/enabled-providers/${providerId}/impact`),
     ).expect(200);
 
     const affected: Array<{ tier: string; model: string; position: string }> =
@@ -289,8 +289,8 @@ describe('Disable impact preview – mirrors what the disable handler will strip
   });
 });
 
-describe('Structural invariant – the global key row survives grant churn', () => {
-  it('global user_providers row is not deleted by any access-grant change', async () => {
+describe('Structural invariant – the global key row survives enable/disable churn', () => {
+  it('global user_providers row is not deleted by any enable/disable change', async () => {
     const row = await ds.getRepository(UserProvider).findOne({ where: { id: providerId } });
     expect(row).not.toBeNull();
     expect(row!.is_active).toBe(true);

--- a/packages/backend/test/custom-providers-lift-migrations.e2e-spec.ts
+++ b/packages/backend/test/custom-providers-lift-migrations.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { DataSource } from 'typeorm';
 import { LiftCustomProvidersToUserLevel1791200000000 } from '../src/database/migrations/1791200000000-LiftCustomProvidersToUserLevel';
+import { RenameProviderAccessToEnabledProviders1791800000000 } from '../src/database/migrations/1791800000000-RenameProviderAccessToEnabledProviders';
 
 /**
  * Runs the REAL migration chain (synchronize:false) so LiftCustomProvidersToUserLevel
@@ -87,6 +88,12 @@ describe('LiftCustomProvidersToUserLevel data transformation (e2e)', () => {
     });
     await ds.initialize();
     await ds.runMigrations();
+
+    // Revert the later table rename first so this historical migration can be
+    // replayed against the schema naming it expects (agent_provider_access).
+    const renameQr = ds.createQueryRunner();
+    await new RenameProviderAccessToEnabledProviders1791800000000().down(renameQr);
+    await renameQr.release();
 
     // Revert just this migration to get the pre-lift schema (agent_id back).
     const revertQr = ds.createQueryRunner();

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -38,7 +38,7 @@ import { AgentModelParams } from '../src/entities/agent-model-params.entity';
 import { PlaygroundRun } from '../src/entities/playground-run.entity';
 import { PlaygroundColumn } from '../src/entities/playground-column.entity';
 import { ReasoningContentCacheEntry } from '../src/entities/reasoning-content-cache-entry.entity';
-import { AgentProviderAccess } from '../src/entities/agent-provider-access.entity';
+import { AgentEnabledProvider } from '../src/entities/agent-enabled-provider.entity';
 import { HealthModule } from '../src/health/health.module';
 import { AnalyticsModule } from '../src/analytics/analytics.module';
 import { OtlpModule } from '../src/otlp/otlp.module';
@@ -80,7 +80,7 @@ const entities = [
   PlaygroundRun,
   PlaygroundColumn,
   ReasoningContentCacheEntry,
-  AgentProviderAccess,
+  AgentEnabledProvider,
 ];
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 const OPENROUTER_MODELS_FIXTURE = {

--- a/packages/backend/test/messages-cache-tokens.e2e-spec.ts
+++ b/packages/backend/test/messages-cache-tokens.e2e-spec.ts
@@ -80,10 +80,10 @@ beforeAll(async () => {
     ],
   );
 
-  // Grant the test agent access to the user-level provider (PR3 requires
-  // explicit grants in agent_provider_access for per-agent filtering).
+  // Enable the user-level provider for the test agent (PR3 requires
+  // explicit rows in agent_enabled_providers for per-agent filtering).
   await ds.query(
-    `INSERT INTO agent_provider_access (agent_id, user_provider_id) VALUES ($1,$2)`,
+    `INSERT INTO agent_enabled_providers (agent_id, user_provider_id) VALUES ($1,$2)`,
     [TEST_AGENT_ID, 'up-anthropic-1871'],
   );
 

--- a/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
+++ b/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
@@ -99,10 +99,10 @@ beforeAll(async () => {
     ],
   );
 
-  // Grant the test agent access to both user-level providers (PR3 requires
-  // explicit grants in agent_provider_access for per-agent filtering).
+  // Enable both user-level providers for the test agent (PR3 requires
+  // explicit rows in agent_enabled_providers for per-agent filtering).
   await ds.query(
-    `INSERT INTO agent_provider_access (agent_id, user_provider_id) VALUES ($1,$2),($1,$3)`,
+    `INSERT INTO agent_enabled_providers (agent_id, user_provider_id) VALUES ($1,$2),($1,$3)`,
     [TEST_AGENT_ID, 'up-anthropic', 'up-openai-sub'],
   );
 

--- a/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
+++ b/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { DataSource } from 'typeorm';
 import { SeedPlaygroundAgents1791400000000 } from '../src/database/migrations/1791400000000-SeedPlaygroundAgents';
+import { RenameProviderAccessToEnabledProviders1791800000000 } from '../src/database/migrations/1791800000000-RenameProviderAccessToEnabledProviders';
 
 /**
  * Runs the REAL migration chain so SeedPlaygroundAgents executes against
@@ -26,6 +27,12 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
     });
     await ds.initialize();
     await ds.runMigrations();
+
+    // Revert the later table rename first so this historical migration can be
+    // replayed against the schema naming it expects (agent_provider_access).
+    const renameQr = ds.createQueryRunner();
+    await new RenameProviderAccessToEnabledProviders1791800000000().down(renameQr);
+    await renameQr.release();
 
     // Revert just this migration → pre-seed schema (no is_system column).
     const revertQr = ds.createQueryRunner();

--- a/packages/frontend/src/pages/AgentProviders.tsx
+++ b/packages/frontend/src/pages/AgentProviders.tsx
@@ -1,9 +1,9 @@
 import { useParams } from '@solidjs/router';
 import { createResource, createSignal, For, Show, type Component } from 'solid-js';
 import {
-  disableAgentProviderAccess,
-  enableAgentProviderAccess,
-  getAgentProviderAccess,
+  disableProviderForAgent,
+  enableProviderForAgent,
+  getEnabledProviders,
   getAgentProviderDisableImpact,
   getCustomProviders,
 } from '../services/api.js';
@@ -45,7 +45,7 @@ const AgentProviders: Component = () => {
     () => agentName(),
     async (name) => {
       try {
-        return new Set((await getAgentProviderAccess(name)).enabled);
+        return new Set((await getEnabledProviders(name)).enabled);
       } catch {
         return new Set<string>();
       }
@@ -92,7 +92,7 @@ const AgentProviders: Component = () => {
   const enableConnection = async (userProviderId: string) => {
     setBusy(userProviderId);
     try {
-      await enableAgentProviderAccess(agentName(), userProviderId);
+      await enableProviderForAgent(agentName(), userProviderId);
       await refetchAccess();
     } catch {
       // fetchMutate already surfaces the toast.
@@ -132,7 +132,7 @@ const AgentProviders: Component = () => {
     }
 
     try {
-      await disableAgentProviderAccess(agentName(), connection.userProviderId);
+      await disableProviderForAgent(agentName(), connection.userProviderId);
       await refetchAccess();
     } catch {
       // fetchMutate already surfaces the toast.

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -29,7 +29,7 @@ import {
   getAvailableModels,
   getProviders,
   getCustomProviders,
-  getAgentProviderAccess,
+  getEnabledProviders,
   getSpecificityAssignments,
   setSpecificityResponseMode,
   overrideSpecificity,
@@ -91,9 +91,9 @@ const Routing: Component = () => {
     () => agentName(),
     getCustomProviders,
   );
-  const [agentProviderAccess, { refetch: refetchAgentProviderAccess }] = createResource(
+  const [enabledProviders, { refetch: refetchEnabledProviders }] = createResource(
     () => agentName(),
-    async (name) => getAgentProviderAccess(name).catch(() => ({ enabled: [] })),
+    async (name) => getEnabledProviders(name).catch(() => ({ enabled: [] })),
   );
   const [specificityAssignments, { refetch: refetchSpecificity, mutate: mutateSpecificity }] =
     createResource(() => agentName(), getSpecificityAssignments);
@@ -308,7 +308,7 @@ const Routing: Component = () => {
       refetchModels(),
       refetchSpecificity(),
       refetchHeaderTiers(),
-      refetchAgentProviderAccess(),
+      refetchEnabledProviders(),
     ]);
   };
 
@@ -365,11 +365,11 @@ const Routing: Component = () => {
     return actions.handleAddFallback(tierId, modelName, providerId, authType, providerKeyLabel);
   };
 
-  const grantedProviderIds = () => new Set(agentProviderAccess()?.enabled ?? []);
-  const grantedConnectedProviders = () =>
-    (connectedProviders() ?? []).filter((provider) => grantedProviderIds().has(provider.id));
-  const isEnabled = () => grantedConnectedProviders().some((p) => p.is_active);
-  const activeProviders = () => grantedConnectedProviders().filter((p) => p.is_active);
+  const enabledProviderIds = () => new Set(enabledProviders()?.enabled ?? []);
+  const enabledConnectedProviders = () =>
+    (connectedProviders() ?? []).filter((provider) => enabledProviderIds().has(provider.id));
+  const isEnabled = () => enabledConnectedProviders().some((p) => p.is_active);
+  const activeProviders = () => enabledConnectedProviders().filter((p) => p.is_active);
   const hasProviders = () => activeProviders().length > 0;
   const hasOverrides = () => tiers()?.some((t) => t.override_route !== null) ?? false;
 
@@ -464,7 +464,7 @@ const Routing: Component = () => {
       />
 
       <Show
-        when={!connectedProviders.loading && !agentProviderAccess.loading}
+        when={!connectedProviders.loading && !enabledProviders.loading}
         fallback={<RoutingLoadingSkeleton />}
       >
         <Show when={hasProviders()} fallback={<NoConnectionsPrompt />}>
@@ -539,7 +539,7 @@ const Routing: Component = () => {
                   models={() => models() ?? []}
                   customProviders={() => customProviders() ?? []}
                   activeProviders={activeProviders}
-                  connectedProviders={grantedConnectedProviders}
+                  connectedProviders={enabledConnectedProviders}
                   tiersLoading={tiers.loading}
                   changingTier={actions.changingTier}
                   resettingTier={actions.resettingTier}
@@ -571,7 +571,7 @@ const Routing: Component = () => {
                   models={() => models() ?? []}
                   customProviders={() => customProviders() ?? []}
                   activeProviders={activeProviders}
-                  connectedProviders={grantedConnectedProviders}
+                  connectedProviders={enabledConnectedProviders}
                   changingTier={changingSpecificity}
                   resettingTier={resettingSpecificity}
                   resettingAll={() => false}
@@ -618,7 +618,7 @@ const Routing: Component = () => {
                   agentName={agentName}
                   models={() => models() ?? []}
                   customProviders={() => customProviders() ?? []}
-                  connectedProviders={grantedConnectedProviders}
+                  connectedProviders={enabledConnectedProviders}
                   externalTiers={() => headerTiers()}
                   externalRefetch={() => void refetchHeaderTiers()}
                   externalMutate={mutateHeaderTiers}
@@ -724,7 +724,7 @@ const Routing: Component = () => {
         tiers={() => tiers() ?? []}
         specificityAssignments={() => specificityAssignments() ?? []}
         customProviders={() => customProviders() ?? []}
-        connectedProviders={grantedConnectedProviders}
+        connectedProviders={enabledConnectedProviders}
         getTier={(tierId) => {
           const generalist = actions.getTier(tierId);
           if (generalist) return generalist;

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -328,9 +328,9 @@ export function refreshProviderModels(agentName: string, provider: string, authT
   return fetchMutate<ProviderRefreshResult>(path, { method: 'POST' });
 }
 
-/* -- Agent Provider Access -- */
+/* -- Agent Enabled Providers -- */
 
-export interface AgentProviderAccess {
+export interface EnabledProviders {
   enabled: string[];
 }
 
@@ -338,33 +338,33 @@ export interface AgentProviderDisableImpact {
   affected_tiers: Array<{ tier: string; model: string; position: string }>;
 }
 
-function agentProviderAccessPath(agentName: string, suffix = ''): string {
+function enabledProvidersPath(agentName: string, suffix = ''): string {
   const encodedAgent = encodeURIComponent(agentName);
   return suffix
-    ? `/agents/${encodedAgent}/provider-access${suffix.startsWith('/') ? suffix : `/${suffix}`}`
-    : `/agents/${encodedAgent}/provider-access`;
+    ? `/agents/${encodedAgent}/enabled-providers${suffix.startsWith('/') ? suffix : `/${suffix}`}`
+    : `/agents/${encodedAgent}/enabled-providers`;
 }
 
-export function getAgentProviderAccess(agentName: string) {
-  return fetchJson<AgentProviderAccess>(agentProviderAccessPath(agentName));
+export function getEnabledProviders(agentName: string) {
+  return fetchJson<EnabledProviders>(enabledProvidersPath(agentName));
 }
 
 export function getAgentProviderDisableImpact(agentName: string, userProviderId: string) {
   return fetchJson<AgentProviderDisableImpact>(
-    agentProviderAccessPath(agentName, `${encodeURIComponent(userProviderId)}/impact`),
+    enabledProvidersPath(agentName, `${encodeURIComponent(userProviderId)}/impact`),
   );
 }
 
-export function enableAgentProviderAccess(agentName: string, userProviderId: string) {
+export function enableProviderForAgent(agentName: string, userProviderId: string) {
   return fetchMutate<{ ok: boolean }>(
-    agentProviderAccessPath(agentName, encodeURIComponent(userProviderId)),
+    enabledProvidersPath(agentName, encodeURIComponent(userProviderId)),
     { method: 'PUT' },
   );
 }
 
-export function disableAgentProviderAccess(agentName: string, userProviderId: string) {
+export function disableProviderForAgent(agentName: string, userProviderId: string) {
   return fetchMutate<{ ok: boolean }>(
-    agentProviderAccessPath(agentName, encodeURIComponent(userProviderId)),
+    enabledProvidersPath(agentName, encodeURIComponent(userProviderId)),
     { method: 'DELETE' },
   );
 }

--- a/packages/frontend/tests/pages/AgentProviders.test.tsx
+++ b/packages/frontend/tests/pages/AgentProviders.test.tsx
@@ -2,10 +2,10 @@ import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetGlobalProviders = vi.fn();
-const mockGetAgentProviderAccess = vi.fn();
+const mockGetEnabledProviders = vi.fn();
 const mockGetAgentProviderDisableImpact = vi.fn();
-const mockEnableAgentProviderAccess = vi.fn();
-const mockDisableAgentProviderAccess = vi.fn();
+const mockEnableEnabledProviders = vi.fn();
+const mockDisableEnabledProviders = vi.fn();
 const mockGetCustomProviders = vi.fn();
 
 vi.mock('@solidjs/router', () => ({
@@ -17,11 +17,11 @@ vi.mock('../../src/services/api/providers.js', () => ({
 }));
 
 vi.mock('../../src/services/api.js', () => ({
-  getAgentProviderAccess: (...args: unknown[]) => mockGetAgentProviderAccess(...args),
+  getEnabledProviders: (...args: unknown[]) => mockGetEnabledProviders(...args),
   getAgentProviderDisableImpact: (...args: unknown[]) =>
     mockGetAgentProviderDisableImpact(...args),
-  enableAgentProviderAccess: (...args: unknown[]) => mockEnableAgentProviderAccess(...args),
-  disableAgentProviderAccess: (...args: unknown[]) => mockDisableAgentProviderAccess(...args),
+  enableProviderForAgent: (...args: unknown[]) => mockEnableEnabledProviders(...args),
+  disableProviderForAgent: (...args: unknown[]) => mockDisableEnabledProviders(...args),
   getCustomProviders: (...args: unknown[]) => mockGetCustomProviders(...args),
 }));
 
@@ -131,12 +131,12 @@ describe('AgentProviders', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetGlobalProviders.mockResolvedValue(providersResponse);
-    mockGetAgentProviderAccess.mockResolvedValue({ enabled: ['up-openai'] });
+    mockGetEnabledProviders.mockResolvedValue({ enabled: ['up-openai'] });
     mockGetAgentProviderDisableImpact.mockResolvedValue({
       affected_tiers: [{ tier: 'default', model: 'gpt-4o', position: 'primary' }],
     });
-    mockEnableAgentProviderAccess.mockResolvedValue({ ok: true });
-    mockDisableAgentProviderAccess.mockResolvedValue({ ok: true });
+    mockEnableEnabledProviders.mockResolvedValue({ ok: true });
+    mockDisableEnabledProviders.mockResolvedValue({ ok: true });
     mockGetCustomProviders.mockResolvedValue([
       {
         id: 'cp-1',
@@ -150,7 +150,7 @@ describe('AgentProviders', () => {
     ]);
   });
 
-  it('renders connected global providers with grant toggles', async () => {
+  it('renders connected global providers with enable toggles', async () => {
     render(() => <AgentProviders />);
 
     await waitFor(() => {
@@ -165,7 +165,7 @@ describe('AgentProviders', () => {
     expect(screen.getByLabelText('Enable Anthropic Max')).toBeDefined();
   });
 
-  it('enables a provider grant with PUT', async () => {
+  it('enables a provider with PUT', async () => {
     render(() => <AgentProviders />);
 
     await waitFor(() => {
@@ -174,7 +174,7 @@ describe('AgentProviders', () => {
     fireEvent.click(screen.getByLabelText('Enable Anthropic Max'));
 
     await waitFor(() => {
-      expect(mockEnableAgentProviderAccess).toHaveBeenCalledWith('demo-agent', 'up-anthropic');
+      expect(mockEnableEnabledProviders).toHaveBeenCalledWith('demo-agent', 'up-anthropic');
     });
   });
 
@@ -190,7 +190,7 @@ describe('AgentProviders', () => {
       expect(mockGetAgentProviderDisableImpact).toHaveBeenCalledWith('demo-agent', 'up-openai');
       expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining("Can't disable OpenAI"));
     });
-    expect(mockDisableAgentProviderAccess).not.toHaveBeenCalled();
+    expect(mockDisableEnabledProviders).not.toHaveBeenCalled();
   });
 
   it('disables directly with DELETE when no models are routed', async () => {
@@ -203,7 +203,7 @@ describe('AgentProviders', () => {
     fireEvent.click(screen.getByLabelText('Disable OpenAI Work'));
 
     await waitFor(() => {
-      expect(mockDisableAgentProviderAccess).toHaveBeenCalledWith('demo-agent', 'up-openai');
+      expect(mockDisableEnabledProviders).toHaveBeenCalledWith('demo-agent', 'up-openai');
     });
     expect(mockToastError).not.toHaveBeenCalled();
   });
@@ -219,7 +219,7 @@ describe('AgentProviders', () => {
 
   it('falls back to an empty state when initial API calls fail', async () => {
     mockGetGlobalProviders.mockRejectedValue(new Error('providers failed'));
-    mockGetAgentProviderAccess.mockRejectedValue(new Error('access failed'));
+    mockGetEnabledProviders.mockRejectedValue(new Error('access failed'));
     mockGetCustomProviders.mockRejectedValue(new Error('custom failed'));
 
     render(() => <AgentProviders />);
@@ -241,13 +241,13 @@ describe('AgentProviders', () => {
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining("Couldn't check"));
     });
-    expect(mockDisableAgentProviderAccess).not.toHaveBeenCalled();
+    expect(mockDisableEnabledProviders).not.toHaveBeenCalled();
   });
 
   it('clears busy state when enable or disable calls fail', async () => {
-    mockEnableAgentProviderAccess.mockRejectedValueOnce(new Error('enable failed'));
+    mockEnableEnabledProviders.mockRejectedValueOnce(new Error('enable failed'));
     mockGetAgentProviderDisableImpact.mockResolvedValue({ affected_tiers: [] });
-    mockDisableAgentProviderAccess.mockRejectedValueOnce(new Error('disable failed'));
+    mockDisableEnabledProviders.mockRejectedValueOnce(new Error('disable failed'));
     render(() => <AgentProviders />);
 
     await waitFor(() => {
@@ -262,7 +262,7 @@ describe('AgentProviders', () => {
 
     fireEvent.click(screen.getByLabelText('Disable OpenAI Work'));
     await waitFor(() => {
-      expect(mockDisableAgentProviderAccess).toHaveBeenCalledWith('demo-agent', 'up-openai');
+      expect(mockDisableEnabledProviders).toHaveBeenCalledWith('demo-agent', 'up-openai');
     });
     await waitFor(() => {
       expect((screen.getByLabelText('Disable OpenAI Work') as HTMLButtonElement).disabled).toBe(

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -6,7 +6,7 @@ const mockGetTierAssignments = vi.fn();
 const mockGetAvailableModels = vi.fn();
 const mockGetProviders = vi.fn();
 const mockGetCustomProviders = vi.fn();
-const mockGetAgentProviderAccess = vi.fn();
+const mockGetEnabledProviders = vi.fn();
 const mockGetSpecificityAssignments = vi.fn();
 const mockOverrideSpecificity = vi.fn();
 const mockResetSpecificity = vi.fn();
@@ -27,7 +27,7 @@ vi.mock('../../src/services/api.js', () => ({
   getAvailableModels: (...args: unknown[]) => mockGetAvailableModels(...args),
   getProviders: (...args: unknown[]) => mockGetProviders(...args),
   getCustomProviders: (...args: unknown[]) => mockGetCustomProviders(...args),
-  getAgentProviderAccess: (...args: unknown[]) => mockGetAgentProviderAccess(...args),
+  getEnabledProviders: (...args: unknown[]) => mockGetEnabledProviders(...args),
   getSpecificityAssignments: (...args: unknown[]) => mockGetSpecificityAssignments(...args),
   overrideSpecificity: (...args: unknown[]) => mockOverrideSpecificity(...args),
   resetSpecificity: (...args: unknown[]) => mockResetSpecificity(...args),
@@ -650,7 +650,7 @@ beforeEach(() => {
   mockGetAvailableModels.mockResolvedValue([]);
   mockGetProviders.mockResolvedValue([baseProvider]);
   mockGetCustomProviders.mockResolvedValue([]);
-  mockGetAgentProviderAccess.mockResolvedValue({ enabled: ['p1'] });
+  mockGetEnabledProviders.mockResolvedValue({ enabled: ['p1'] });
   mockGetSpecificityAssignments.mockResolvedValue([]);
   mockListHeaderTiers.mockResolvedValue([]);
   mockGetComplexityStatus.mockResolvedValue({ enabled: true });
@@ -693,7 +693,7 @@ describe('Routing page', () => {
     });
   });
 
-  it('passes only granted providers into the model picker path', async () => {
+  it('passes only enabled providers into the model picker path', async () => {
     mockGetProviders.mockResolvedValue([
       baseProvider,
       {
@@ -705,7 +705,7 @@ describe('Routing page', () => {
         connected_at: '2025-01-01',
       },
     ]);
-    mockGetAgentProviderAccess.mockResolvedValue({ enabled: ['p1'] });
+    mockGetEnabledProviders.mockResolvedValue({ enabled: ['p1'] });
     render(() => <Routing />);
 
     await waitFor(() => {

--- a/packages/frontend/tests/services/api/routing-extra.test.ts
+++ b/packages/frontend/tests/services/api/routing-extra.test.ts
@@ -208,34 +208,34 @@ describe('routing API client (additional coverage)', () => {
     expect(url).toContain('/api/v1/routing/demo/providers/openai/refresh-models?authType=api_key');
   });
 
-  it('getAgentProviderAccess GETs enabled user provider ids', async () => {
+  it('getEnabledProviders GETs enabled user provider ids', async () => {
     const fetchMock = setupFetch({ enabled: ['up-1'] });
-    const out = await routing.getAgentProviderAccess('demo agent');
+    const out = await routing.getEnabledProviders('demo agent');
     expect(out).toEqual({ enabled: ['up-1'] });
     const url = fetchMock.mock.calls[0][0] as string;
-    expect(url).toContain('/api/v1/agents/demo%20agent/provider-access');
+    expect(url).toContain('/api/v1/agents/demo%20agent/enabled-providers');
   });
 
   it('getAgentProviderDisableImpact GETs the disable impact endpoint', async () => {
     const fetchMock = setupFetch({ affected_tiers: [] });
     await routing.getAgentProviderDisableImpact('demo', 'up/1');
     const url = fetchMock.mock.calls[0][0] as string;
-    expect(url).toContain('/api/v1/agents/demo/provider-access/up%2F1/impact');
+    expect(url).toContain('/api/v1/agents/demo/enabled-providers/up%2F1/impact');
   });
 
-  it('enableAgentProviderAccess PUTs to the grant endpoint', async () => {
+  it('enableProviderForAgent PUTs to the enabled-providers endpoint', async () => {
     const fetchMock = setupFetch({ ok: true });
-    await routing.enableAgentProviderAccess('demo', 'up-1');
+    await routing.enableProviderForAgent('demo', 'up-1');
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toContain('/api/v1/agents/demo/provider-access/up-1');
+    expect(url).toContain('/api/v1/agents/demo/enabled-providers/up-1');
     expect((init as RequestInit).method).toBe('PUT');
   });
 
-  it('disableAgentProviderAccess DELETEs the grant endpoint', async () => {
+  it('disableProviderForAgent DELETEs the enabled-providers endpoint', async () => {
     const fetchMock = setupFetch({ ok: true });
-    await routing.disableAgentProviderAccess('demo', 'up-1');
+    await routing.disableProviderForAgent('demo', 'up-1');
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toContain('/api/v1/agents/demo/provider-access/up-1');
+    expect(url).toContain('/api/v1/agents/demo/enabled-providers/up-1');
     expect((init as RequestInit).method).toBe('DELETE');
   });
 


### PR DESCRIPTION
### 💭 Why
The per-agent provider toggle had three names depending on where you looked: `agent_provider_access` (table), "grants" (comments, tests), and "enabled" (UI, API responses). One concept, one name.

### ✨ What changed
- Table renamed `agent_provider_access` → `agent_enabled_providers` (migration is a pure rename, rolls back cleanly).
- Entity, controller, route (`/provider-access` → `/enabled-providers`), repo vars, and frontend API functions renamed to match.
- "grant" wording in comments and test names replaced with enable/disable vocabulary.
- Historical migrations untouched; their replay e2e specs revert the rename first.

### 🔧 For operators
The migration runs automatically on boot. Anyone querying `agent_provider_access` directly should switch to `agent_enabled_providers`.

### 📝 Notes
Verified on a real Postgres DB with synthetic data: up, down, and re-up all preserve every row, FK cascade and PK uniqueness keep working under the new names.
Frontend/backend CI failures on `next` (189 frontend test failures, router mock issue) pre-date this branch; the failing set is byte-identical with and without this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized per-agent provider toggles to “enabled providers” across the database, API, and UI. This is a pure rename with a safe migration and updated routes, entities, services, and frontend calls.

- **Refactors**
  - Renamed table `agent_provider_access` to `agent_enabled_providers` and entity to `AgentEnabledProvider` (constraints/index names updated).
  - Replaced route `GET/POST/DELETE /api/v1/agents/:agentName/provider-access` with `/api/v1/agents/:agentName/enabled-providers`.
  - Updated backend repos/services/controllers and tests; wording switched from “grant” to “enable/disable”.
  - Frontend API functions renamed: `getEnabledProviders`, `enableProviderForAgent`, `disableProviderForAgent`; pages and tests updated.

- **Migration**
  - Runs automatically; pure rename, no data changes; rollbacks clean.
  - If you query `agent_provider_access`, switch to `agent_enabled_providers`.
  - Historical migrations remain unchanged; e2e tests temporarily revert the rename to replay them.

<sup>Written for commit 97b401a824d0fe882d3d9b6ad14a83e2b58a5238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

