### PR TITLE
fix: harden proxy streaming termination

### DIFF
--- a/.changeset/response-interrupted-streams.md
+++ b/.changeset/response-interrupted-streams.md
@@ -2,4 +2,4 @@
 "manifest": patch
 ---
 
-Prevent OpenAI Responses-backed subscription streams from ending as interrupted client streams by forwarding terminal upstream error events as OpenAI-compatible SSE error payloads, and stop the provider request timeout from aborting healthy streaming response bodies after headers have arrived.
+Prevent OpenAI Responses-backed subscription streams from ending as interrupted client streams: forward terminal upstream `error` / `response.failed` events as OpenAI-compatible SSE error payloads, convert `response.incomplete` (max_output_tokens / content filter) into a proper `length` / `content_filter` finish chunk, surface upstream stream errors to `/v1/messages` clients as native Anthropic `error` events instead of a fabricated empty `end_turn` message, and stop the provider request timeout from aborting healthy streaming response bodies after headers have arrived.

--- a/.changeset/response-interrupted-streams.md
+++ b/.changeset/response-interrupted-streams.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Prevent OpenAI Responses-backed subscription streams from ending as interrupted client streams by forwarding terminal upstream error events as OpenAI-compatible SSE error payloads, and stop the provider request timeout from aborting healthy streaming response bodies after headers have arrived.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -655,6 +655,19 @@ describe('Anthropic Messages adapter', () => {
       expect(sse).not.toContain('message_stop');
     });
 
+    it('ignores later stream payloads after a terminal error event', () => {
+      const t = createMessagesStreamTransformer('gpt-5');
+      const sse = flushChunks(t, [
+        'data: {"error":{"message":"Too many requests","status":429}}\n\ndata: {"choices":[{"delta":{"content":"same chunk"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"later chunk"}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      ]);
+
+      expect(sse).toBe(
+        'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"Too many requests"}}\n\n',
+      );
+    });
+
     it('emits an error event mid-stream and suppresses the fabricated end_turn close', () => {
       const t = createMessagesStreamTransformer('gpt-5');
       const sse = flushChunks(t, [

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -641,6 +641,35 @@ describe('Anthropic Messages adapter', () => {
       });
     });
 
+    it('surfaces upstream error chunks as a terminal Anthropic error event (issue #2212)', () => {
+      const t = createMessagesStreamTransformer('gpt-5');
+      const sse = flushChunks(t, [
+        'data: {"error":{"message":"Too many requests","type":"upstream_error","status":429,"code":"rate_limit_exceeded"}}\n\ndata: [DONE]\n\n',
+      ]);
+
+      expect(sse).toBe(
+        'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"Too many requests"}}\n\n',
+      );
+      // No fabricated message_start / message_delta / message_stop around the error.
+      expect(sse).not.toContain('message_start');
+      expect(sse).not.toContain('message_stop');
+    });
+
+    it('emits an error event mid-stream and suppresses the fabricated end_turn close', () => {
+      const t = createMessagesStreamTransformer('gpt-5');
+      const sse = flushChunks(t, [
+        'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n',
+        'data: {"error":{}}\n\ndata: [DONE]\n\n',
+      ]);
+
+      expect(sse).toContain('event: message_start');
+      expect(sse).toContain(
+        'event: error\ndata: {"type":"error","error":{"type":"api_error","message":"Upstream provider stream failed"}}',
+      );
+      expect(sse).not.toContain('"stop_reason":"end_turn"');
+      expect(sse).not.toContain('message_stop');
+    });
+
     it('emits tool_use content_block_start and input_json_delta for tool calls', () => {
       const t = createMessagesStreamTransformer('claude-sonnet-4');
       const sse = flushChunks(t, [

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-response.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-response.spec.ts
@@ -214,4 +214,21 @@ describe('ChatGPT Adapter – collectChatGptSseResponse', () => {
 
     expect(choices[0].message.content).toBeNull();
   });
+
+  it('returns truncated text with finish_reason length when the stream ends with response.incomplete', () => {
+    const sse = [
+      'event: response.output_text.delta\ndata: {"delta":"Partial answ"}',
+      'event: response.incomplete\ndata: {"response":{"incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":7,"output_tokens":6,"total_tokens":13}}}',
+    ].join('\n\n');
+
+    const result = collectChatGptSseResponse(sse, 'gpt-5');
+    const choices = result.choices as { message: { content: string }; finish_reason: string }[];
+
+    expect(choices[0].message.content).toBe('Partial answ');
+    expect(choices[0].finish_reason).toBe('length');
+
+    const usage = result.usage as Record<string, number>;
+    expect(usage.prompt_tokens).toBe(7);
+    expect(usage.completion_tokens).toBe(6);
+  });
 });

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
@@ -24,6 +24,39 @@ describe('ChatGPT Adapter – transformResponsesStreamChunk', () => {
     expect(result).toContain('data: [DONE]');
   });
 
+  it('converts response.failed to a terminal error event', () => {
+    const chunk =
+      'event: response.failed\ndata: {"response":{"error":{"code":"rate_limit_exceeded","message":"Too many requests"}}}';
+    const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('data: [DONE]');
+    const errorLine = result!.split('\n').find((line) => line.startsWith('data: {'));
+    const json = JSON.parse(errorLine!.replace('data: ', ''));
+    expect(json.error).toEqual({
+      message: 'Too many requests',
+      type: 'upstream_error',
+      status: 429,
+      code: 'rate_limit_exceeded',
+    });
+  });
+
+  it('converts Responses error events to terminal error events', () => {
+    const chunk =
+      'event: error\ndata: {"error":{"type":"invalid_request_error","message":"Model unavailable"}}';
+    const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('data: [DONE]');
+    const errorLine = result!.split('\n').find((line) => line.startsWith('data: {'));
+    const json = JSON.parse(errorLine!.replace('data: ', ''));
+    expect(json.error).toEqual({
+      message: 'Model unavailable',
+      type: 'invalid_request_error',
+      status: 400,
+    });
+  });
+
   it('extracts usage from response.completed event', () => {
     const data = JSON.stringify({
       response: {

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
@@ -57,6 +57,38 @@ describe('ChatGPT Adapter – transformResponsesStreamChunk', () => {
     });
   });
 
+  it('converts response.incomplete (max_output_tokens) to a length finish chunk', () => {
+    const chunk =
+      'event: response.incomplete\ndata: {"response":{"incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":10,"output_tokens":4,"total_tokens":14}}}';
+    const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('data: [DONE]');
+    const finishLine = result!.split('\n').find((line) => line.startsWith('data: {'));
+    const json = JSON.parse(finishLine!.replace('data: ', ''));
+    expect(json.choices[0].finish_reason).toBe('length');
+    expect(json.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 4,
+      total_tokens: 14,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 0,
+    });
+  });
+
+  it('converts response.incomplete (content_filter) to a content_filter finish chunk', () => {
+    const chunk =
+      'event: response.incomplete\ndata: {"response":{"incomplete_details":{"reason":"content_filter"}}}';
+    const result = transformResponsesStreamChunk(chunk, 'gpt-5');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('data: [DONE]');
+    const finishLine = result!.split('\n').find((line) => line.startsWith('data: {'));
+    const json = JSON.parse(finishLine!.replace('data: ', ''));
+    expect(json.choices[0].finish_reason).toBe('content_filter');
+    expect(json.usage).toBeUndefined();
+  });
+
   it('extracts usage from response.completed event', () => {
     const data = JSON.stringify({
       response: {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.timeout.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.timeout.spec.ts
@@ -145,4 +145,39 @@ describe('ProviderClient — timeout signal actually aborts the in-flight fetch'
 
     expect(abortObserved).toBe(true);
   }, 5000);
+
+  it('does not abort a streaming response body after headers arrive', async () => {
+    process.env.PROVIDER_TIMEOUT_MS = '25';
+
+    let fetchSignal: AbortSignal | undefined;
+    mockFetch.mockImplementation((_url: string, init: RequestInit) => {
+      fetchSignal = init.signal as AbortSignal;
+      return Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('data: {"choices":[]}\n\n'));
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'text/event-stream' } },
+        ),
+      );
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { ProviderClient: FreshClient } = await import('../provider-client');
+      const fresh = new FreshClient();
+      await fresh.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: true,
+      });
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchSignal).toBeDefined();
+    expect(fetchSignal!.aborted).toBe(false);
+  }, 5000);
 });

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -408,6 +408,7 @@ export function createMessagesStreamTransformer(model: string): MessagesStreamTr
 function transformStreamChunk(chunk: string, state: StreamState): string | null {
   const events: string[] = [];
   for (const payload of extractDataPayloads(chunk)) {
+    if (state.endedMessage) break;
     if (payload === '[DONE]') continue;
     const data = safeParse(payload);
     if (!data) continue;
@@ -418,7 +419,7 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
     // would fabricate a successful empty `end_turn` message.
     if (isRecord(data.error)) {
       events.push(buildStreamErrorEvent(state, data.error));
-      continue;
+      break;
     }
 
     if (!state.startedMessage) {

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -412,6 +412,15 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
     const data = safeParse(payload);
     if (!data) continue;
 
+    // Terminal upstream errors arrive as OpenAI-shape `{"error":{...}}` chunks
+    // (e.g. from the ChatGPT Responses adapter). Surface them as a native
+    // Anthropic `error` event instead of dropping them — otherwise closeStream
+    // would fabricate a successful empty `end_turn` message.
+    if (isRecord(data.error)) {
+      events.push(buildStreamErrorEvent(state, data.error));
+      continue;
+    }
+
     if (!state.startedMessage) {
       events.push(buildMessageStartEvent(state, data));
       state.startedMessage = true;
@@ -609,6 +618,32 @@ function buildMessageStartEvent(state: StreamState, data: JsonRecord): string {
       stop_sequence: null,
       usage,
     },
+  });
+}
+
+const ANTHROPIC_ERROR_TYPE_BY_STATUS: Record<number, string> = {
+  400: 'invalid_request_error',
+  401: 'authentication_error',
+  403: 'permission_error',
+  404: 'not_found_error',
+  429: 'rate_limit_error',
+  529: 'overloaded_error',
+};
+
+function buildStreamErrorEvent(state: StreamState, error: JsonRecord): string {
+  // Marking the message ended makes closeStream a no-op, so the error event is
+  // the terminal event the client sees (matching Anthropic's own stream
+  // protocol, where `error` can end a stream without `message_stop`).
+  state.endedMessage = true;
+  const message =
+    typeof error.message === 'string' && error.message
+      ? error.message
+      : 'Upstream provider stream failed';
+  const status = typeof error.status === 'number' ? error.status : undefined;
+  const errorType = (status && ANTHROPIC_ERROR_TYPE_BY_STATUS[status]) || 'api_error';
+  return formatMessagesEvent('error', {
+    type: 'error',
+    error: { type: errorType, message },
   });
 }
 

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -275,6 +275,10 @@ export function transformResponsesStreamChunk(chunk: string, model: string): str
     return handleCompletedEvent(dataStr, model);
   }
 
+  if (eventType === 'response.incomplete') {
+    return handleIncompleteEvent(dataStr, model);
+  }
+
   if (eventType === 'error' || eventType === 'response.failed') {
     return handleStreamErrorEvent(dataStr);
   }
@@ -285,20 +289,6 @@ export function transformResponsesStreamChunk(chunk: string, model: string): str
 function handleCompletedEvent(dataStr: string, model: string): string {
   const data = safeParse(dataStr);
   const response = isObjectRecord(data?.response) ? data.response : undefined;
-  const responseUsage = response?.usage as Record<string, unknown> | undefined;
-  const inputDetails = responseUsage?.input_tokens_details as Record<string, number> | undefined;
-  const cachedTokens = inputDetails?.cached_tokens ?? 0;
-
-  const usage = responseUsage
-    ? {
-        prompt_tokens: (responseUsage.input_tokens as number) ?? 0,
-        completion_tokens: (responseUsage.output_tokens as number) ?? 0,
-        total_tokens: (responseUsage.total_tokens as number) ?? 0,
-        cache_read_tokens: cachedTokens,
-        cache_creation_tokens: 0,
-      }
-    : undefined;
-
   const responseOutput = Array.isArray(response?.output)
     ? (response.output as Array<{ type?: string }>)
     : [];
@@ -306,9 +296,49 @@ function handleCompletedEvent(dataStr: string, model: string): string {
   const finish = formatSSE(
     { delta: {}, finish_reason: hasFunctionCalls ? 'tool_calls' : 'stop' },
     model,
-    usage,
+    extractResponseUsage(response),
   );
   return `${finish}\ndata: [DONE]\n\n`;
+}
+
+/**
+ * `response.incomplete` is the Responses API's third terminal event (after
+ * `response.completed` and `response.failed`) — emitted when generation stops
+ * early on `max_output_tokens` or a content filter. Without handling it the
+ * stream ends with no finish chunk and clients report an interrupted stream
+ * (issue #2212's symptom).
+ */
+function handleIncompleteEvent(dataStr: string, model: string): string {
+  const data = safeParse(dataStr);
+  const response = isObjectRecord(data?.response) ? data.response : undefined;
+  const finish = formatSSE(
+    { delta: {}, finish_reason: incompleteFinishReason(response) },
+    model,
+    extractResponseUsage(response),
+  );
+  return `${finish}\ndata: [DONE]\n\n`;
+}
+
+function incompleteFinishReason(response: Record<string, unknown> | undefined): string {
+  const details = isObjectRecord(response?.incomplete_details)
+    ? response.incomplete_details
+    : undefined;
+  return details?.reason === 'content_filter' ? 'content_filter' : 'length';
+}
+
+function extractResponseUsage(
+  response: Record<string, unknown> | undefined,
+): Record<string, number> | undefined {
+  const responseUsage = response?.usage as Record<string, unknown> | undefined;
+  if (!responseUsage) return undefined;
+  const inputDetails = responseUsage.input_tokens_details as Record<string, number> | undefined;
+  return {
+    prompt_tokens: (responseUsage.input_tokens as number) ?? 0,
+    completion_tokens: (responseUsage.output_tokens as number) ?? 0,
+    total_tokens: (responseUsage.total_tokens as number) ?? 0,
+    cache_read_tokens: inputDetails?.cached_tokens ?? 0,
+    cache_creation_tokens: 0,
+  };
 }
 
 function handleStreamErrorEvent(dataStr: string): string {
@@ -352,6 +382,7 @@ export function collectChatGptSseResponse(sseText: string, model: string): Recor
   >();
   let usage: Record<string, unknown> | undefined;
   let hasFunctionCalls = false;
+  let finishReasonOverride: string | undefined;
 
   const events = sseText.split('\n\n');
   for (const event of events) {
@@ -389,21 +420,15 @@ export function collectChatGptSseResponse(sseText: string, model: string): Recor
       }
     } else if (eventType === 'response.completed') {
       const response = isObjectRecord(data.response) ? data.response : undefined;
-      const respUsage = response?.usage as Record<string, unknown> | undefined;
-      if (respUsage) {
-        const inputDetails = respUsage.input_tokens_details as Record<string, number> | undefined;
-        usage = {
-          prompt_tokens: (respUsage.input_tokens as number) ?? 0,
-          completion_tokens: (respUsage.output_tokens as number) ?? 0,
-          total_tokens: (respUsage.total_tokens as number) ?? 0,
-          cache_read_tokens: inputDetails?.cached_tokens ?? 0,
-          cache_creation_tokens: 0,
-        };
-      }
+      usage = extractResponseUsage(response) ?? usage;
       const output = Array.isArray(response?.output)
         ? (response.output as Array<{ type?: string }>)
         : [];
       hasFunctionCalls = output.some((item) => item.type === 'function_call');
+    } else if (eventType === 'response.incomplete') {
+      const response = isObjectRecord(data.response) ? data.response : undefined;
+      usage = extractResponseUsage(response) ?? usage;
+      finishReasonOverride = incompleteFinishReason(response);
     }
   }
 
@@ -420,7 +445,9 @@ export function collectChatGptSseResponse(sseText: string, model: string): Recor
       {
         index: 0,
         message,
-        finish_reason: hasFunctionCalls || toolCalls.length > 0 ? 'tool_calls' : 'stop',
+        finish_reason:
+          finishReasonOverride ??
+          (hasFunctionCalls || toolCalls.length > 0 ? 'tool_calls' : 'stop'),
       },
     ],
     usage: usage ?? { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -275,6 +275,10 @@ export function transformResponsesStreamChunk(chunk: string, model: string): str
     return handleCompletedEvent(dataStr, model);
   }
 
+  if (eventType === 'error' || eventType === 'response.failed') {
+    return handleStreamErrorEvent(dataStr);
+  }
+
   return null;
 }
 
@@ -305,6 +309,28 @@ function handleCompletedEvent(dataStr: string, model: string): string {
     usage,
   );
   return `${finish}\ndata: [DONE]\n\n`;
+}
+
+function handleStreamErrorEvent(dataStr: string): string {
+  const data = safeParse(dataStr) ?? {};
+  const err = buildResponsesSseError(data);
+  const parsedBody = safeParse(err.body);
+  const parsedError = isObjectRecord(parsedBody?.error) ? parsedBody.error : {};
+  const message =
+    typeof parsedError.message === 'string' && parsedError.message
+      ? parsedError.message
+      : err.message;
+  const code = typeof parsedError.code === 'string' ? parsedError.code : undefined;
+  const type = typeof parsedError.type === 'string' ? parsedError.type : 'upstream_error';
+  const payload = {
+    error: {
+      message,
+      type,
+      status: err.status,
+      ...(code ? { code } : {}),
+    },
+  };
+  return `data: ${JSON.stringify(payload)}\n\ndata: [DONE]\n\n`;
 }
 
 /* ── Non-streaming SSE collection ── */

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -186,7 +186,7 @@ export class ProviderClient {
       }
     }
 
-    const result = await this.executeFetch(url, finalHeaders, requestBody, signal, {
+    const result = await this.executeFetch(url, finalHeaders, requestBody, signal, stream, {
       isGoogle,
       isAnthropic,
       isChatGpt,
@@ -487,6 +487,7 @@ export class ProviderClient {
     headers: Record<string, string>,
     requestBody: Record<string, unknown>,
     signal: AbortSignal | undefined,
+    stream: boolean,
     formatFlags: {
       isGoogle: boolean;
       isAnthropic: boolean;
@@ -495,8 +496,19 @@ export class ProviderClient {
       isCodeAssist?: boolean;
     },
   ): Promise<ForwardResult> {
-    const timeoutSignal = AbortSignal.timeout(PROVIDER_TIMEOUT_MS);
-    const fetchSignal = signal ? AbortSignal.any([timeoutSignal, signal]) : timeoutSignal;
+    let fetchSignal: AbortSignal;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let timeoutController: AbortController | undefined;
+    if (stream) {
+      timeoutController = new AbortController();
+      timeout = setTimeout(() => timeoutController?.abort(), PROVIDER_TIMEOUT_MS);
+      fetchSignal = signal
+        ? AbortSignal.any([timeoutController.signal, signal])
+        : timeoutController.signal;
+    } else {
+      const timeoutSignal = AbortSignal.timeout(PROVIDER_TIMEOUT_MS);
+      fetchSignal = signal ? AbortSignal.any([timeoutSignal, signal]) : timeoutSignal;
+    }
 
     let response: Response;
     try {
@@ -512,6 +524,8 @@ export class ProviderClient {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new Error(message.replace(/key=[^&\s]+/gi, 'key=***'));
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
 
     return { response, ...formatFlags };


### PR DESCRIPTION
### ✨ What changed
- Streaming provider timeout clears after response headers arrive.
- OpenAI Responses stream failures emit SSE error payloads plus `[DONE]`.
- `response.incomplete` (max_output_tokens / content filter) now emits a `length` / `content_filter` finish chunk in streaming and non-streaming paths.
- `/v1/messages` clients get native Anthropic `error` events for upstream stream failures instead of a fabricated empty `end_turn` message.
- Regression tests cover all interruption paths.

### 💭 Why
Manifest could interrupt healthy long streams after headers, or drop terminal upstream error events and leave clients with an unfinished stream.

### 👤 For users
Zo and other OpenAI-compatible clients should see fewer `Response interrupted` failures through Manifest Cloud.

### 📝 Notes
Closes #2212
Validation: shared build, focused proxy tests, backend build, changeset status, `git diff --check`.
No live Zo/Manifest Cloud smoke was run.
