### PR TITLE
fix: allow clearing adaptive thinking mode

### DIFF
--- a/.changeset/clear-adaptive-thinking.md
+++ b/.changeset/clear-adaptive-thinking.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Allow adaptive-only Anthropic thinking mode parameters to be reset to unset from the model parameter dialog.

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -193,7 +193,7 @@ const ModelParamsDialog: Component<Props> = (props) => {
   };
 
   const selectOptions = (spec: ProviderParamSpec) => [
-    ...(canUnset(spec) ? [{ label: 'unset', value: UNSET_OPTION_VALUE }] : []),
+    ...(canUnset(spec) ? [{ label: 'None', value: UNSET_OPTION_VALUE }] : []),
     ...(spec.values ?? []).map((v) => ({ label: String(v), value: String(v) })),
   ];
 
@@ -426,7 +426,7 @@ const ModelParamsDialog: Component<Props> = (props) => {
   const ParamRow = (rowProps: { spec: ProviderParamSpec }) => {
     const spec = () => rowProps.spec;
     const description = () => trimTrailingPunct(spec().description) + '.';
-    const defaultLabel = () => (spec().default === undefined ? 'unset' : String(spec().default));
+    const defaultLabel = () => (spec().default === undefined ? 'none' : String(spec().default));
     return (
       <div
         class="model-params__row"

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -1,5 +1,6 @@
 import {
   compareProviderParamSpecs,
+  deleteProviderParamValue,
   getProviderParamValue,
   providerParamIsApplicable,
   setProviderParamValue,
@@ -26,6 +27,8 @@ interface Props {
 }
 
 type DraftState = Record<string, JsonValue>;
+
+const UNSET_OPTION_VALUE = '__manifest_param_unset__';
 
 const GROUP_LABELS: Record<ModelParamGroup, string> = {
   generation_length: 'Generation length',
@@ -116,6 +119,10 @@ const ModelParamsDialog: Component<Props> = (props) => {
     setDraft(setProviderParamValue(draft(), spec.path, value));
   };
 
+  const clearValue = (spec: ProviderParamSpec) => {
+    setDraft(deleteProviderParamValue(draft(), spec.path));
+  };
+
   const isApplicable = (spec: ProviderParamSpec): boolean =>
     providerParamIsApplicable(spec, draft());
   const isDisabled = (spec: ProviderParamSpec): boolean => saving() || !isApplicable(spec);
@@ -177,10 +184,18 @@ const ModelParamsDialog: Component<Props> = (props) => {
     return null;
   };
 
-  const stringValue = (spec: ProviderParamSpec): string => {
+  const canUnset = (spec: ProviderParamSpec): boolean => spec.default === undefined;
+
+  const selectValue = (spec: ProviderParamSpec): string => {
     const value = valueFor(spec);
+    if (value === undefined && canUnset(spec)) return UNSET_OPTION_VALUE;
     return typeof value === 'string' ? value : String(spec.default ?? '');
   };
+
+  const selectOptions = (spec: ProviderParamSpec) => [
+    ...(canUnset(spec) ? [{ label: 'unset', value: UNSET_OPTION_VALUE }] : []),
+    ...(spec.values ?? []).map((v) => ({ label: String(v), value: String(v) })),
+  ];
 
   const numericValue = (spec: ProviderParamSpec): number => {
     const value = valueFor(spec);
@@ -224,10 +239,16 @@ const ModelParamsDialog: Component<Props> = (props) => {
     <div class="model-params__field">
       <Select
         label={spec.label}
-        options={(spec.values ?? []).map((v) => ({ label: String(v), value: String(v) }))}
-        value={stringValue(spec)}
+        options={selectOptions(spec)}
+        value={selectValue(spec)}
         disabled={isDisabled(spec)}
-        onChange={(v) => setValue(spec, v)}
+        onChange={(v) => {
+          if (v === UNSET_OPTION_VALUE && canUnset(spec)) {
+            clearValue(spec);
+            return;
+          }
+          setValue(spec, v);
+        }}
       />
     </div>
   );

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -94,6 +94,34 @@ const anthropicSpecs: readonly ProviderParamSpec[] = [
   },
 ];
 
+const anthropicAdaptiveSpecs: readonly ProviderParamSpec[] = [
+  {
+    provider: 'anthropic',
+    authType: 'subscription',
+    model: 'claude-fable-5',
+    path: 'thinking.type',
+    type: 'enum',
+    label: 'Thinking mode',
+    description:
+      'Only adaptive thinking is supported; omit the parameter entirely to run without thinking.',
+    values: ['adaptive'],
+    group: 'reasoning',
+  },
+  {
+    provider: 'anthropic',
+    authType: 'subscription',
+    model: 'claude-fable-5',
+    path: 'thinking.display',
+    type: 'enum',
+    label: 'Thinking display',
+    description: 'Controls whether Anthropic returns summarized or omitted thinking content.',
+    default: 'omitted',
+    values: ['summarized', 'omitted'],
+    group: 'reasoning',
+    applicability: { only: { 'thinking.type': ['adaptive'] } },
+  },
+];
+
 const booleanSpecs: readonly ProviderParamSpec[] = [
   {
     provider: 'test',
@@ -182,7 +210,12 @@ describe('ModelParamsDialog', () => {
 
   it('shows fallback text when no specs and no requestParamsUrl', () => {
     render(() => (
-      <ModelParamsDialog {...baseProps} specs={[]} requestParamsUrl={undefined} slotLabel="gpt-4o" />
+      <ModelParamsDialog
+        {...baseProps}
+        specs={[]}
+        requestParamsUrl={undefined}
+        slotLabel="gpt-4o"
+      />
     ));
     expect(screen.getByText('This model has no configurable parameters.')).toBeTruthy();
     expect(screen.queryByRole('link')).toBeNull();
@@ -223,6 +256,50 @@ describe('ModelParamsDialog', () => {
     expect(screen.getByLabelText('Thinking mode')).toBeTruthy();
     expect(screen.getByRole('slider', { name: 'Temperature' })).toBeTruthy();
     expect(screen.getByLabelText('Max tokens')).toBeTruthy();
+  });
+
+  it('lets adaptive-only enum params return to unset', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => (
+      <ModelParamsDialog
+        {...baseProps}
+        specs={anthropicAdaptiveSpecs}
+        slotLabel="claude-fable-5"
+        current={{ thinking: { type: 'adaptive', display: 'summarized' } }}
+        onSave={onSave}
+      />
+    ));
+
+    fireEvent.click(screen.getByLabelText('Thinking mode'));
+    fireEvent.click(screen.getByRole('option', { name: 'unset' }));
+    expect((screen.getByLabelText('Thinking display') as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith(null));
+  });
+
+  it('saves adaptive-only enum params after selecting adaptive from unset', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => (
+      <ModelParamsDialog
+        {...baseProps}
+        specs={anthropicAdaptiveSpecs}
+        slotLabel="claude-fable-5"
+        onSave={onSave}
+      />
+    ));
+
+    fireEvent.click(screen.getByLabelText('Thinking mode'));
+    expect(screen.getByRole('option', { name: 'unset' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('option', { name: 'adaptive' }));
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        thinking: { type: 'adaptive', display: 'omitted' },
+      }),
+    );
   });
 
   it('updates slider controls from keyboard input', () => {

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -271,7 +271,7 @@ describe('ModelParamsDialog', () => {
     ));
 
     fireEvent.click(screen.getByLabelText('Thinking mode'));
-    fireEvent.click(screen.getByRole('option', { name: 'unset' }));
+    fireEvent.click(screen.getByRole('option', { name: 'None' }));
     expect((screen.getByLabelText('Thinking display') as HTMLButtonElement).disabled).toBe(true);
 
     fireEvent.click(screen.getByText('Save'));
@@ -291,7 +291,7 @@ describe('ModelParamsDialog', () => {
     ));
 
     fireEvent.click(screen.getByLabelText('Thinking mode'));
-    expect(screen.getByRole('option', { name: 'unset' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'None' })).toBeTruthy();
     fireEvent.click(screen.getByRole('option', { name: 'adaptive' }));
     fireEvent.click(screen.getByText('Save'));
 


### PR DESCRIPTION
### ✨ What changed
- Enum params without defaults now include a "None" option.
- Choosing "None" deletes the saved param leaf.
- Regression tests cover Anthropic adaptive thinking clear and reselect.

### 💭 Why
`claude-fable-5` only accepts `adaptive` for `thinking.type`. Disabling thinking means omitting the parameter, but the dialog only showed `adaptive`.

### 👤 For users
Anthropic adaptive thinking can be turned off again from Model parameters.

### 📝 Notes
Closes #2230
Validation: shared build, focused frontend test, frontend build, Prettier check, `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows clearing Anthropic adaptive thinking in the Model Parameters dialog by adding a “None” option for enum params without defaults. This lets users omit `thinking.type` to run Claude without thinking and reselect “adaptive” later.

- **Bug Fixes**
  - Enum params without defaults now show a “None” option in the select.
  - Selecting “None” removes the saved value and disables dependent fields.
  - Added tests covering clear and reselect flows for Anthropic thinking.

<sup>Written for commit 790a854da394dfe9a57a06c6d27c3df4c9fa0368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

