### PR TITLE
fix: enable prompt caching for Anthropic subscription auth

### DIFF
--- a/.changeset/anthropic-subscription-prompt-caching.md
+++ b/.changeset/anthropic-subscription-prompt-caching.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Inject cache_control prompt-caching breakpoints for Anthropic subscription OAuth requests. The skip dated from a misdiagnosed 400 that was actually caused by the missing Claude Code identity block, so subscription users were re-paying their full prompt prefix in quota on every request.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -545,48 +545,6 @@ describe('Anthropic Adapter', () => {
       expect(result.tools).toBeUndefined();
     });
 
-    it('omits cache_control from system blocks when injectCacheControl is false', () => {
-      const body = {
-        messages: [
-          { role: 'system', content: 'You are helpful.' },
-          { role: 'user', content: 'Hi' },
-        ],
-      };
-      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514', {
-        injectCacheControl: false,
-      });
-      const system = result.system as Array<{ cache_control?: unknown }>;
-      expect(system).toHaveLength(1);
-      expect(system[0].cache_control).toBeUndefined();
-    });
-
-    it('omits top-level cache_control when injectCacheControl is false', () => {
-      const body = {
-        messages: [{ role: 'user', content: 'Hi' }],
-      };
-      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514', {
-        injectCacheControl: false,
-      });
-      expect(result.cache_control).toBeUndefined();
-    });
-
-    it('omits cache_control from tools when injectCacheControl is false', () => {
-      const body = {
-        messages: [{ role: 'user', content: 'Hi' }],
-        tools: [
-          { type: 'function', function: { name: 'a', description: 'tool a' } },
-          { type: 'function', function: { name: 'b', description: 'tool b' } },
-        ],
-      };
-      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514', {
-        injectCacheControl: false,
-      });
-      const tools = result.tools as Array<{ cache_control?: unknown }>;
-      expect(tools).toHaveLength(2);
-      expect(tools[0].cache_control).toBeUndefined();
-      expect(tools[1].cache_control).toBeUndefined();
-    });
-
     it('prepends subscription identity block when injectSubscriptionIdentity is true', () => {
       const body = {
         messages: [
@@ -595,7 +553,6 @@ describe('Anthropic Adapter', () => {
         ],
       };
       const result = toAnthropicRequest(body, 'claude-sonnet-4-6', {
-        injectCacheControl: false,
         injectSubscriptionIdentity: true,
       });
       const system = result.system as Array<{
@@ -2102,15 +2059,12 @@ describe('Anthropic Adapter', () => {
       ]);
     });
 
-    it('leaves string system intact when no mutations are needed', () => {
-      const result = applyAnthropicMessagesMutations(
-        {
-          messages: [{ role: 'user', content: 'hi' }],
-          system: 'Be concise.',
-        },
-        { injectCacheControl: false },
-      );
-      expect(result.system).toBe('Be concise.');
+    it('leaves an empty string system intact', () => {
+      const result = applyAnthropicMessagesMutations({
+        messages: [{ role: 'user', content: 'hi' }],
+        system: '',
+      });
+      expect(result.system).toBe('');
     });
 
     it('prepends the subscription identity block ahead of an existing system', () => {
@@ -2119,18 +2073,19 @@ describe('Anthropic Adapter', () => {
           messages: [{ role: 'user', content: 'hi' }],
           system: 'You are Manifest.',
         },
-        { injectSubscriptionIdentity: true, injectCacheControl: false },
+        { injectSubscriptionIdentity: true },
       );
       const system = result.system as Array<Record<string, unknown>>;
       expect(system).toHaveLength(2);
       expect(system[0].text).toMatch(/Claude agent/);
       expect(system[1].text).toBe('You are Manifest.');
+      expect(system[1].cache_control).toEqual({ type: 'ephemeral' });
     });
 
     it('creates a system from scratch when subscription identity is requested and no system exists', () => {
       const result = applyAnthropicMessagesMutations(
         { messages: [{ role: 'user', content: 'hi' }] },
-        { injectSubscriptionIdentity: true, injectCacheControl: false },
+        { injectSubscriptionIdentity: true },
       );
       const system = result.system as Array<Record<string, unknown>>;
       expect(system).toHaveLength(1);
@@ -2155,19 +2110,16 @@ describe('Anthropic Adapter', () => {
       expect(result).not.toHaveProperty('system');
     });
 
-    it('omits cache_control when injectCacheControl is false', () => {
-      const result = applyAnthropicMessagesMutations(
-        {
-          messages: [{ role: 'user', content: 'hi' }],
-          system: [{ type: 'text', text: 'persona' }],
-          tools: [{ type: 'web_search_20250305', name: 'web_search' }],
-        },
-        { injectCacheControl: false },
-      );
+    it('injects cache_control on the last system block and last tool', () => {
+      const result = applyAnthropicMessagesMutations({
+        messages: [{ role: 'user', content: 'hi' }],
+        system: [{ type: 'text', text: 'persona' }],
+        tools: [{ type: 'web_search_20250305', name: 'web_search' }],
+      });
       const system = result.system as Array<Record<string, unknown>>;
-      expect(system[0].cache_control).toBeUndefined();
+      expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
       const tools = result.tools as Array<Record<string, unknown>>;
-      expect(tools[0].cache_control).toBeUndefined();
+      expect(tools[0].cache_control).toEqual({ type: 'ephemeral' });
     });
 
     it('defaults max_tokens to 4096 when not provided', () => {

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
@@ -30,9 +30,7 @@ describe('issue #1871: cache_control round-trip through /v1/messages', () => {
       };
 
       const chatBody = messagesToChatCompletionsRequest(inbound);
-      const wireBody = toAnthropicRequest(chatBody, 'claude-haiku-4-5', {
-        injectCacheControl: true,
-      });
+      const wireBody = toAnthropicRequest(chatBody, 'claude-haiku-4-5');
 
       const system = wireBody.system as Array<{ cache_control?: unknown }>;
       expect(system).toHaveLength(1);
@@ -56,9 +54,7 @@ describe('issue #1871: cache_control round-trip through /v1/messages', () => {
       };
 
       const chatBody = messagesToChatCompletionsRequest(inbound);
-      const wireBody = toAnthropicRequest(chatBody, 'claude-haiku-4-5', {
-        injectCacheControl: true,
-      });
+      const wireBody = toAnthropicRequest(chatBody, 'claude-haiku-4-5');
 
       const tools = wireBody.tools as Array<{ cache_control?: unknown }>;
       expect(tools[0].cache_control).toEqual({ type: 'ephemeral' });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -687,7 +687,7 @@ describe('ProviderClient', () => {
       expect(sentBody.stream).toBeUndefined();
     });
 
-    it('omits cache_control from request body for subscription auth', async () => {
+    it('injects cache_control breakpoints for subscription auth', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       const bodyWithSystem = {
@@ -713,10 +713,12 @@ describe('ProviderClient', () => {
       // First system block is the subscription identity prompt
       expect(system[0].text).toContain('Claude agent');
       expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
-      // User system block has no cache_control (subscription skips caching)
-      expect(system[1].cache_control).toBeUndefined();
+      // The OAuth API accepts cache_control (the #1193 400s were caused by the
+      // missing identity block, not caching), so subscription auth gets the
+      // same breakpoints as API-key auth.
+      expect(system[1].cache_control).toEqual({ type: 'ephemeral' });
       const tools = sentBody.tools as Array<{ cache_control?: unknown }>;
-      expect(tools[0].cache_control).toBeUndefined();
+      expect(tools[0].cache_control).toEqual({ type: 'ephemeral' });
     });
 
     it('includes block-level cache_control for regular Anthropic API key auth', async () => {

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -238,8 +238,6 @@ function convertTools(tools?: Array<Record<string, unknown>>): AnthropicTool[] |
 /* ── Request conversion ── */
 
 export interface AnthropicRequestOptions {
-  /** When false, cache_control fields are omitted from the request. Defaults to true. */
-  injectCacheControl?: boolean;
   /** When true, prepends the Claude Code agent system prompt required for subscription OAuth tokens. */
   injectSubscriptionIdentity?: boolean;
   /** Lookup for re-injecting cached extended-thinking blocks. */
@@ -251,10 +249,9 @@ export function toAnthropicRequest(
   _model: string,
   options?: AnthropicRequestOptions,
 ): Record<string, unknown> {
-  const shouldCache = options?.injectCacheControl !== false;
   const messages = (body.messages as OpenAIMessage[]) || [];
   const systemBlocks = extractSystemBlocks(messages);
-  if (systemBlocks.length > 0 && shouldCache) {
+  if (systemBlocks.length > 0) {
     systemBlocks[systemBlocks.length - 1].cache_control = CACHE;
   }
 
@@ -279,7 +276,7 @@ export function toAnthropicRequest(
   // assumption is safe.
   const tools = convertTools(body.tools as Array<Record<string, unknown>> | undefined);
   if (tools) {
-    if (shouldCache) tools[tools.length - 1].cache_control = CACHE;
+    tools[tools.length - 1].cache_control = CACHE;
     result.tools = tools;
   }
 
@@ -350,7 +347,6 @@ export function applyAnthropicMessagesMutations(
   body: Record<string, unknown>,
   options?: AnthropicRequestOptions,
 ): Record<string, unknown> {
-  const shouldCache = options?.injectCacheControl !== false;
   const result: Record<string, unknown> = { ...body };
 
   // Normalize `system` to a content-block array so cache_control + identity
@@ -359,7 +355,7 @@ export function applyAnthropicMessagesMutations(
   // mutation needs to happen, otherwise we leave a string system intact.
   const needsBlockSystem =
     options?.injectSubscriptionIdentity ||
-    (shouldCache && (typeof body.system === 'string' ? body.system : Array.isArray(body.system)));
+    (typeof body.system === 'string' ? body.system : Array.isArray(body.system));
   if (needsBlockSystem) {
     let systemBlocks: ContentBlock[] = [];
     if (typeof body.system === 'string') {
@@ -367,7 +363,7 @@ export function applyAnthropicMessagesMutations(
     } else if (Array.isArray(body.system)) {
       systemBlocks = (body.system as ContentBlock[]).map((b) => ({ ...b }));
     }
-    if (shouldCache && systemBlocks.length > 0) {
+    if (systemBlocks.length > 0) {
       systemBlocks[systemBlocks.length - 1].cache_control = CACHE;
     }
     if (options?.injectSubscriptionIdentity) {
@@ -385,7 +381,7 @@ export function applyAnthropicMessagesMutations(
   // custom tools' `input_schema` both survive unchanged.
   if (Array.isArray(body.tools)) {
     const tools = (body.tools as Array<Record<string, unknown>>).map((t) => ({ ...t }));
-    if (tools.length > 0 && shouldCache) {
+    if (tools.length > 0) {
       tools[tools.length - 1].cache_control = CACHE;
     }
     result.tools = tools;

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -366,8 +366,8 @@ export class ProviderClient {
     }
 
     if (endpoint.format === 'anthropic') {
-      const isSubscription = authType === 'subscription';
-      const injectSubscriptionIdentity = isSubscription && !endpoint.skipSubscriptionIdentity;
+      const injectSubscriptionIdentity =
+        authType === 'subscription' && !endpoint.skipSubscriptionIdentity;
       // When the inbound request is already Anthropic Messages
       // (`POST /v1/messages`) and the resolved upstream is also Anthropic,
       // skip the OpenAI translation round-trip and apply only the additive
@@ -380,12 +380,10 @@ export class ProviderClient {
       const requestBody =
         ctx.apiMode === 'messages'
           ? applyAnthropicMessagesMutations(body, {
-              injectCacheControl: !isSubscription,
               injectSubscriptionIdentity,
               thinkingLookup: ctx.thinkingLookup,
             })
           : toAnthropicRequest(requestSource, bareModel, {
-              injectCacheControl: !isSubscription,
               injectSubscriptionIdentity,
               thinkingLookup: ctx.thinkingLookup,
             });


### PR DESCRIPTION
### ✨ What changed
- Subscription OAuth requests now get `cache_control` breakpoints, same as api-key auth.
- Removed the `injectCacheControl` option entirely (it existed only for this gate). Net -51 lines.

### 💭 Why
The gate came from a misdiagnosis. #1193 saw 400s on sonnet/opus with `cache_control` (haiku fine) and blamed caching. #1448 later found the real cause: the missing Claude Code identity system block, same symptom signature. The gate was never re-tested after the identity fix, so subscription users re-pay their full prompt prefix in quota on every agentic-loop step.

Verified live against `api.anthropic.com` with an OAuth token + identity block + `cache_control`:
- sonnet: call 1 `cache_creation_input_tokens: 1858`, call 2 `cache_read_input_tokens: 1858`
- opus: `cache_creation_input_tokens: 2831`, no 400

The identity block itself already ships a `cache_control` field on every subscription request without errors, so the API accepting it was never in doubt.

### 👤 For users
Claude Pro/Max subscription routing now gets prompt-cache hits, cutting repeated-prefix latency and subscription usage in tool loops.

### 📝 Notes
- Same bug class as #2217 (Codex subscription cache misses).
- Full backend suite green (329 suites / 6149 tests). Changed-file coverage matches the main baseline line-for-line.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable prompt caching for Anthropic subscription OAuth requests by always injecting `cache_control` on the last system block and last tool, matching API-key behavior. Removed the `injectCacheControl` option; subscription users now get faster loops and reduced usage.

<sup>Written for commit abbf5741b087f864a100e81d11e63b891142d5b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

