### PR TITLE
fix: clearer names for migrated provider connections

### DIFF
--- a/.changeset/migrated-connection-naming.md
+++ b/.changeset/migrated-connection-naming.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Provider connections lifted from per-agent keys now get clearer names (e.g. "from Agent A") instead of the bare agent name.

--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
@@ -29,8 +29,8 @@ describe('LiftProvidersToUserLevel1791000000000', () => {
     expect(relabel).toContain('LEFT JOIN "agents" a ON a."id" = up."agent_id"');
     expect(relabel).toContain('NULLIF(TRIM(a."display_name"), \'\')');
     expect(relabel).toContain('NULLIF(TRIM(a."name"), \'\')');
-    expect(relabel).toContain('WHEN LOWER("label") = \'default\' THEN "agent_label"');
-    expect(relabel).toContain('ELSE "label" || \' - \' || "agent_label"');
+    expect(relabel).toContain('WHEN LOWER("label") = \'default\' THEN \'from \' || "agent_label"');
+    expect(relabel).toContain('ELSE "label" || \' (from \' || "agent_label" || \')\'');
     expect(relabel).toContain('generate_series(0, 1000)');
     expect(relabel).toContain('candidate_reserved_labels AS');
     expect(relabel).toContain('ranked."proposed_label" || \' [\' || ranked."id" || \']\'');

--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
@@ -54,11 +54,12 @@ export class LiftProvidersToUserLevel1791000000000 implements MigrationInterface
     //    (user_id, provider, auth_type, LOWER(label)) by RELABELING, never
     //    deleting. Keys are AES-256-GCM with a random IV so SQL can't prove two
     //    rows hold the same plaintext key; deleting "duplicates" would silently
-    //    drop a distinct key. For old agent-scoped "Default" connections, use
-    //    the agent display name so the global connection keeps its source
-    //    context. Custom labels keep the user's label and append the source
-    //    agent name. If the generated label is still not unique, choose the
-    //    first row-id suffix that does not collide with pre-existing labels.
+    //    drop a distinct key. Name the carried-over connection after its source
+    //    agent so it reads as a key that came from that agent rather than being
+    //    mistaken for the agent itself: an old "Default" connection becomes
+    //    "from <agent>", a custom label becomes "<label> (from <agent>)". If the
+    //    generated label is still not unique, choose the first row-id suffix that
+    //    does not collide with pre-existing labels.
     await queryRunner.query(`
     WITH colliding_labels AS (
       SELECT "user_id", "provider", "auth_type", LOWER("label") AS "label_key"
@@ -99,8 +100,8 @@ export class LiftProvidersToUserLevel1791000000000 implements MigrationInterface
         "priority",
         "connected_at",
         CASE
-          WHEN LOWER("label") = 'default' THEN "agent_label"
-          ELSE "label" || ' - ' || "agent_label"
+          WHEN LOWER("label") = 'default' THEN 'from ' || "agent_label"
+          ELSE "label" || ' (from ' || "agent_label" || ')'
         END AS "proposed_label"
       FROM agent_labels
     ),


### PR DESCRIPTION
### 💭 Why
The provider-key upgrade lifts per-agent keys to the account. When two agents connected the same provider, the resulting account connections were labeled with the bare agent name (`Agent A`), which reads like the connection is the agent.

### ✨ What changed
- Relabel collisions attributively: `Default` → `from <agent>` (was `<agent>`), custom labels → `<label> (from <agent>)` (was `<label> - <agent>`).
- Only the relabel naming changed. Dedup, grants, and rollback are untouched.

### 👤 For users
After the upgrade, carried-over connections read clearly, e.g. `from Agent A` and `work (from Agent A)`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies names for migrated provider connections so they read as “from <agent>” instead of looking like the agent itself. This applies when lifting provider keys to the account level and resolving label collisions.

- **Bug Fixes**
  - “Default” → “from <agent>”
  - Custom labels → “<label> (from <agent>)”
  - No changes to dedup, grants, or rollback.

<sup>Written for commit 28dbedbe205a84437578479f8587bad805d5e467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

