### PR TITLE
fix: make stream warmup timeout configurable

### DIFF
--- a/.changeset/configurable-stream-warmup.md
+++ b/.changeset/configurable-stream-warmup.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Allow self-hosted installs to tune streaming warmup timeout with STREAM_WARMUP_MS.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -34,6 +34,17 @@ BETTER_AUTH_SECRET=
 # DATABASE_URL=postgresql://manifest:change-me@postgres:5432/manifest
 
 
+# ─── LLM proxy ───────────────────────────────────────────────────────────────
+
+# Per-attempt timeout (ms) for upstream provider requests in the LLM proxy.
+# Set strictly below your client's timeout so the fallback chain has room to run.
+# PROVIDER_TIMEOUT_MS=180000
+
+# Timeout (ms) to wait for the first chunk from a streaming response before
+# considering it stalled and trying a fallback provider.
+# STREAM_WARMUP_MS=15000
+
+
 # ─── Email provider (optional) ─────────────────────────────────────────────
 #
 # Unified config — used for BOTH login emails (signup verification, password

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       # Defaults to the host-installed Ollama. Override in .env if your
       # Ollama runs elsewhere (e.g. on another host on your LAN).
       - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
+      - PROVIDER_TIMEOUT_MS=${PROVIDER_TIMEOUT_MS:-180000}
+      - STREAM_WARMUP_MS=${STREAM_WARMUP_MS:-15000}
       - SEED_DATA=false
       - NODE_ENV=production
       # Force self-hosted semantics regardless of the container runtime.

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -33,6 +33,9 @@ BETTER_AUTH_URL=http://localhost:3001
 # Per-attempt timeout (ms) for upstream provider requests in the LLM proxy.
 # Set strictly below your client's timeout so the fallback chain has room to run.
 # PROVIDER_TIMEOUT_MS=180000
+# Timeout (ms) to wait for the first chunk from a streaming response before
+# considering it stalled and trying a fallback provider.
+# STREAM_WARMUP_MS=15000
 
 # ── Email provider (optional, unified) ──────────────
 # Used for BOTH Better Auth transactional emails (login verification,

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -31,6 +31,7 @@ import type { ProviderParamSpecService } from '../../routing-core/provider-param
  */
 jest.mock('../stream-warmup', () => ({
   peekStream: jest.fn(),
+  STREAM_WARMUP_MS: 15_000,
 }));
 
 import { peekStream } from '../stream-warmup';
@@ -969,6 +970,7 @@ describe('ProxyService — orchestration', () => {
         ...baseOpts({ body: { messages: [{ role: 'user', content: 'hi' }], stream: true } }),
       });
       expect(result.forward.response.status).toBe(200);
+      expect(mockedPeek).toHaveBeenCalledWith(streamRes.body, 15_000);
       expect(momentum.recordTier).toHaveBeenCalled();
     });
 

--- a/packages/backend/src/routing/proxy/__tests__/stream-warmup.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-warmup.spec.ts
@@ -73,6 +73,13 @@ describe('peekStream', () => {
       expect(parseStreamWarmupMs('abc')).toBe(DEFAULT_STREAM_WARMUP_MS);
     });
 
+    it.each(['45000abc', '45000.5', '45_000', ' 45000'])(
+      'falls back to 15000 ms when env var is not digits-only: %s',
+      (rawValue) => {
+        expect(parseStreamWarmupMs(rawValue)).toBe(DEFAULT_STREAM_WARMUP_MS);
+      },
+    );
+
     it('falls back to 15000 ms when env var is negative', () => {
       expect(parseStreamWarmupMs('-1')).toBe(DEFAULT_STREAM_WARMUP_MS);
     });

--- a/packages/backend/src/routing/proxy/__tests__/stream-warmup.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-warmup.spec.ts
@@ -1,4 +1,4 @@
-import { peekStream, WarmupResult } from '../stream-warmup';
+import { DEFAULT_STREAM_WARMUP_MS, parseStreamWarmupMs, peekStream } from '../stream-warmup';
 
 function makeStream(chunks: Uint8Array[], delayMs = 0): ReadableStream<Uint8Array> {
   let i = 0;
@@ -60,6 +60,28 @@ async function collectStream(stream: ReadableStream<Uint8Array>): Promise<string
 }
 
 describe('peekStream', () => {
+  describe('timeout config', () => {
+    it('defaults to 15000 ms when env var is unset', () => {
+      expect(parseStreamWarmupMs(undefined)).toBe(DEFAULT_STREAM_WARMUP_MS);
+    });
+
+    it('uses the configured value when env var is a positive integer', () => {
+      expect(parseStreamWarmupMs('45000')).toBe(45_000);
+    });
+
+    it('falls back to 15000 ms when env var is non-numeric', () => {
+      expect(parseStreamWarmupMs('abc')).toBe(DEFAULT_STREAM_WARMUP_MS);
+    });
+
+    it('falls back to 15000 ms when env var is negative', () => {
+      expect(parseStreamWarmupMs('-1')).toBe(DEFAULT_STREAM_WARMUP_MS);
+    });
+
+    it('falls back to 15000 ms when env var is zero', () => {
+      expect(parseStreamWarmupMs('0')).toBe(DEFAULT_STREAM_WARMUP_MS);
+    });
+  });
+
   it('returns success and preserves data for a healthy stream', async () => {
     const data = new TextEncoder().encode('data: {"content":"hello"}\n\n');
     const stream = makeStream([data, new TextEncoder().encode('data: [DONE]\n\n')]);
@@ -127,6 +149,18 @@ describe('peekStream', () => {
     if (result.ok) {
       const text = await collectStream(result.stream);
       expect(text).toBe('only-chunk');
+    }
+  });
+
+  it('cancels the source reader when the returned stream is cancelled', async () => {
+    const data = new TextEncoder().encode('chunk');
+    const source = makeStream([data]);
+
+    const result = await peekStream(source, 5000);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      await expect(result.stream.cancel()).resolves.toBeUndefined();
     }
   });
 

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -50,12 +50,10 @@ import { AgentModelParamsService } from '../routing-core/agent-model-params.serv
 import { ProviderParamSpecService } from '../routing-core/provider-param-spec.service';
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
 import { formatManifestError } from '../../common/errors/error-codes';
-import { peekStream } from './stream-warmup';
+import { peekStream, STREAM_WARMUP_MS } from './stream-warmup';
 import { toChatCompletionsRequest } from './responses-adapter';
 import { messagesToChatCompletionsRequest } from './anthropic-messages-adapter';
 import { effectiveRoutesForResponseMode } from '../routing-core/response-mode-guard';
-
-const STREAM_WARMUP_MS = 15_000;
 
 type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>>;
 

--- a/packages/backend/src/routing/proxy/stream-warmup.ts
+++ b/packages/backend/src/routing/proxy/stream-warmup.ts
@@ -10,7 +10,12 @@
 export const DEFAULT_STREAM_WARMUP_MS = 15_000;
 
 export function parseStreamWarmupMs(rawValue = process.env.STREAM_WARMUP_MS): number {
-  const parsed = Number.parseInt(rawValue ?? '', 10);
+  const value = rawValue ?? '';
+  if (!/^\d+$/.test(value)) {
+    return DEFAULT_STREAM_WARMUP_MS;
+  }
+
+  const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STREAM_WARMUP_MS;
 }
 

--- a/packages/backend/src/routing/proxy/stream-warmup.ts
+++ b/packages/backend/src/routing/proxy/stream-warmup.ts
@@ -7,7 +7,14 @@
  * @see https://github.com/mnfst/manifest/issues/1656
  */
 
-const DEFAULT_WARMUP_MS = 15_000;
+export const DEFAULT_STREAM_WARMUP_MS = 15_000;
+
+export function parseStreamWarmupMs(rawValue = process.env.STREAM_WARMUP_MS): number {
+  const parsed = Number.parseInt(rawValue ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STREAM_WARMUP_MS;
+}
+
+export const STREAM_WARMUP_MS = parseStreamWarmupMs();
 
 export interface WarmupSuccess {
   ok: true;
@@ -31,7 +38,7 @@ export type WarmupResult = WarmupSuccess | WarmupFailure;
  */
 export async function peekStream(
   source: ReadableStream<Uint8Array>,
-  timeoutMs: number = DEFAULT_WARMUP_MS,
+  timeoutMs: number = STREAM_WARMUP_MS,
 ): Promise<WarmupResult> {
   const reader = source.getReader();
 


### PR DESCRIPTION
### ✨ What changed
- Read `STREAM_WARMUP_MS` from env with a 15000 ms fallback.
- Reuse the shared warmup timeout in proxy streaming checks.
- Pass and document the timeout for Docker/self-hosted installs.

### 💭 Why
Local inference can spend more than 15s in prefill before emitting the first streamed chunk. A hardcoded warmup threshold makes Manifest treat those healthy streams as stalled and fall back.

### 👤 For users
Self-hosted users can raise `STREAM_WARMUP_MS` when local models need longer first-token latency.

### 🔧 For operators
Set `STREAM_WARMUP_MS=<milliseconds>` in `.env` or container env. Invalid, zero, or negative values keep the 15000 ms default.

### 📝 Notes
Closes #2214
Refs #2094
Validation: focused backend tests, stream-warmup 100% line coverage, shared/backend builds, backend typecheck, targeted lint/format, changeset status, `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the streaming warmup timeout configurable and strictly validated to reduce false fallbacks when models take longer to emit the first chunk. The proxy now reads STREAM_WARMUP_MS (ms) with a 15,000 ms default and applies it to all stream warmup checks, including Docker/self-hosted setups.

- **Migration**
  - Optional: set STREAM_WARMUP_MS in your .env or container env.
  - Use a digits-only positive integer; anything else (non-numeric, zero, negative) falls back to 15000.
  - Docker and .env examples updated.

<sup>Written for commit 7e3cc3a389aeb41a8a6b747432dd2a2a0230f718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

