### PR TITLE
chore: ignore superpowers-generated markdown docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ coverage/
 .gstack/
 scripts/.env.verify
 scripts/verify-free-model-ids.sh
+# Superpowers-generated markdown (plans, brainstorms, specs)
+docs/superpowers/
+docs/plans/


### PR DESCRIPTION
Adds `docs/superpowers/` and `docs/plans/` to `.gitignore` so locally generated planning/spec markdown (plans, brainstorms, specs from agent tooling) never gets committed.

These directories are scratch output from local AI-assisted planning workflows and aren't part of the project documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignores locally generated planning/spec markdown by adding `docs/superpowers/` and `docs/plans/` to `.gitignore`. This prevents committing scratch docs.

<sup>Written for commit 3961aea1710f8b74bfe1092ee428253d8d750ed4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

