### PR TITLE
fix: deleting a custom provider can't leave orphaned data

### DIFF
--- a/.changeset/custom-provider-referential-integrity.md
+++ b/.changeset/custom-provider-referential-integrity.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Deleting a custom provider can no longer leave orphaned key or routing data behind: the link between custom providers and their stored keys is now enforced by the database (with automatic cleanup of any pre-existing orphans), and creating or deleting a custom provider is atomic.

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -119,6 +119,7 @@ import { DropSavingsBaselineColumns1791700000000 } from './migrations/1791700000
 import { RenameProviderAccessToEnabledProviders1791800000000 } from './migrations/1791800000000-RenameProviderAccessToEnabledProviders';
 import { RenameIsSystemToIsPlayground1791900000000 } from './migrations/1791900000000-RenameIsSystemToIsPlayground';
 import { AddUserProviderIdToAgentMessages1792000000000 } from './migrations/1792000000000-AddUserProviderIdToAgentMessages';
+import { AddCustomProviderFkToUserProviders1792100000000 } from './migrations/1792100000000-AddCustomProviderFkToUserProviders';
 
 const entities = [
   AgentMessage,
@@ -239,6 +240,7 @@ const migrations = [
   RenameProviderAccessToEnabledProviders1791800000000,
   RenameIsSystemToIsPlayground1791900000000,
   AddUserProviderIdToAgentMessages1792000000000,
+  AddCustomProviderFkToUserProviders1792100000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1792100000000-AddCustomProviderFkToUserProviders.spec.ts
+++ b/packages/backend/src/database/migrations/1792100000000-AddCustomProviderFkToUserProviders.spec.ts
@@ -1,0 +1,71 @@
+import { QueryRunner } from 'typeorm';
+import { AddCustomProviderFkToUserProviders1792100000000 } from './1792100000000-AddCustomProviderFkToUserProviders';
+
+function makeQueryRunner() {
+  const calls: string[] = [];
+  const query = jest.fn(async (sql: string) => {
+    calls.push(sql.replace(/\s+/g, ' ').trim());
+    return undefined;
+  });
+  return { query, calls };
+}
+
+describe('AddCustomProviderFkToUserProviders1792100000000', () => {
+  let migration: AddCustomProviderFkToUserProviders1792100000000;
+
+  beforeEach(() => {
+    migration = new AddCustomProviderFkToUserProviders1792100000000();
+  });
+
+  describe('up', () => {
+    it('cleans orphans before adding the column, FK, and index — in that order', async () => {
+      const { query, calls } = makeQueryRunner();
+      await migration.up({ query } as unknown as QueryRunner);
+
+      expect(calls).toHaveLength(4);
+      expect(calls[0]).toMatch(/^DELETE FROM "user_providers"/);
+      expect(calls[1]).toMatch(/ADD COLUMN "custom_provider_id"/);
+      expect(calls[2]).toMatch(/ADD CONSTRAINT "FK_user_providers_custom_provider"/);
+      expect(calls[3]).toMatch(/CREATE INDEX "IDX_user_providers_custom_provider_id"/);
+    });
+
+    it('only deletes companion rows whose custom provider no longer exists', async () => {
+      const { query, calls } = makeQueryRunner();
+      await migration.up({ query } as unknown as QueryRunner);
+
+      // Scoped to custom:% rows AND guarded by a NOT EXISTS against
+      // custom_providers — plain provider rows (anthropic, openai, ...) and
+      // resolvable custom rows must never match.
+      expect(calls[0]).toContain(`"provider" LIKE 'custom:%'`);
+      expect(calls[0]).toContain('NOT EXISTS');
+      expect(calls[0]).toContain(`cp."id" = substring("user_providers"."provider" FROM 8)`);
+    });
+
+    it('derives the column with GENERATED ALWAYS ... STORED and cascades deletes', async () => {
+      const { query, calls } = makeQueryRunner();
+      await migration.up({ query } as unknown as QueryRunner);
+
+      expect(calls[1]).toContain('GENERATED ALWAYS AS');
+      expect(calls[1]).toContain(`CASE WHEN "provider" LIKE 'custom:%'`);
+      expect(calls[1]).toContain('STORED');
+      expect(calls[2]).toContain(`REFERENCES "custom_providers"("id")`);
+      expect(calls[2]).toContain('ON DELETE CASCADE');
+      // Partial index: only custom rows carry a non-NULL id, so don't index
+      // the (vastly more numerous) plain provider rows.
+      expect(calls[3]).toContain('WHERE "custom_provider_id" IS NOT NULL');
+    });
+  });
+
+  describe('down', () => {
+    it('drops index, FK, and column — and never re-inserts the deleted orphans', async () => {
+      const { query, calls } = makeQueryRunner();
+      await migration.down({ query } as unknown as QueryRunner);
+
+      expect(calls).toHaveLength(3);
+      expect(calls[0]).toContain('DROP INDEX IF EXISTS "IDX_user_providers_custom_provider_id"');
+      expect(calls[1]).toContain('DROP CONSTRAINT IF EXISTS "FK_user_providers_custom_provider"');
+      expect(calls[2]).toContain('DROP COLUMN IF EXISTS "custom_provider_id"');
+      expect(calls.some((sql) => /INSERT/i.test(sql))).toBe(false);
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1792100000000-AddCustomProviderFkToUserProviders.ts
+++ b/packages/backend/src/database/migrations/1792100000000-AddCustomProviderFkToUserProviders.ts
@@ -1,0 +1,83 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * A custom provider is two rows kept in sync by application code only: a
+ * `custom_providers` row (config) and a companion `user_providers` row whose
+ * `provider` column embeds the id as `'custom:<uuid>'`. That string is an
+ * application-enforced foreign key — deleting a custom provider could leave a
+ * ghost `user_providers` row (with an orphaned encrypted key) behind, and
+ * nothing at the DB level prevented inserting a companion row for a custom
+ * provider that doesn't exist (see #1603 for the orphan class this caused in
+ * routing config).
+ *
+ * This migration makes Postgres own that edge without changing the wire
+ * format: a STORED generated column extracts the embedded id from `provider`,
+ * and a real FK with ON DELETE CASCADE points it at `custom_providers(id)`.
+ * Application code keeps reading/writing the `provider` string exactly as
+ * before — the generated column is maintained by Postgres and never written
+ * by TypeORM (it is intentionally absent from the UserProvider entity).
+ *
+ * Orphan `user_providers` rows that already point at a deleted custom
+ * provider are removed first: they are unresolvable (provider resolution
+ * looks up the custom_providers row, which is gone), invisible in the UI,
+ * and would block the FK from validating. No reachable data is touched.
+ */
+export class AddCustomProviderFkToUserProviders1792100000000 implements MigrationInterface {
+  name = 'AddCustomProviderFkToUserProviders1792100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Drop unresolvable companion rows so the FK can validate. The cascade
+    //    on agent_enabled_providers.user_provider_id cleans their grants.
+    await queryRunner.query(`
+      DELETE FROM "user_providers"
+      WHERE "provider" LIKE 'custom:%'
+        AND NOT EXISTS (
+          SELECT 1 FROM "custom_providers" cp
+          WHERE cp."id" = substring("user_providers"."provider" FROM 8)
+        )
+    `);
+
+    // 2. Stored generated column mirroring the id embedded in `provider`.
+    //    NULL for every non-custom provider row.
+    await queryRunner.query(`
+      ALTER TABLE "user_providers"
+        ADD COLUMN "custom_provider_id" varchar
+        GENERATED ALWAYS AS (
+          CASE WHEN "provider" LIKE 'custom:%' THEN substring("provider" FROM 8) END
+        ) STORED
+    `);
+
+    // 3. The actual integrity edge. CASCADE matches application semantics:
+    //    CustomProviderService.remove() deletes both rows anyway — the FK is
+    //    the backstop that makes a ghost companion row impossible.
+    //    (ON UPDATE actions are not allowed on generated columns, but ids are
+    //    immutable so none is needed.)
+    await queryRunner.query(`
+      ALTER TABLE "user_providers"
+        ADD CONSTRAINT "FK_user_providers_custom_provider"
+        FOREIGN KEY ("custom_provider_id") REFERENCES "custom_providers"("id")
+        ON DELETE CASCADE
+    `);
+
+    // 4. Postgres doesn't index the referencing side of an FK — without this,
+    //    every custom_providers delete seq-scans user_providers.
+    await queryRunner.query(`
+      CREATE INDEX "IDX_user_providers_custom_provider_id"
+      ON "user_providers" ("custom_provider_id")
+      WHERE "custom_provider_id" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_user_providers_custom_provider_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "user_providers" DROP CONSTRAINT IF EXISTS "FK_user_providers_custom_provider"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_providers" DROP COLUMN IF EXISTS "custom_provider_id"`,
+    );
+    // The orphan rows deleted in up() are not restored: they pointed at
+    // custom providers that no longer exist and cannot be reconstructed
+    // (same stance as CleanupOrphanedCustomProviderRefs1776679833383).
+  }
+}

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.edge-cases.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.edge-cases.spec.ts
@@ -41,7 +41,18 @@ function makeDeps(overrides: {
   const results = overrides.findOneResults ?? [];
   findOne.mockImplementation(() => Promise.resolve(results.shift() ?? null));
 
-  const repo = { findOne, find, insert, save, remove } as unknown as Repository<CustomProvider>;
+  // create()/remove() wrap their writes in repo.manager.transaction; resolve
+  // getRepository() back to the same mock repo so assertions observe writes.
+  const txManager = { getRepository: jest.fn(() => repo) };
+  const transaction = jest.fn(async (cb: (manager: unknown) => Promise<unknown>) => cb(txManager));
+  const repo = {
+    findOne,
+    find,
+    insert,
+    save,
+    remove,
+    manager: { transaction },
+  } as unknown as Repository<CustomProvider>;
   const providerService = {
     upsertProvider: jest.fn().mockResolvedValue({ provider: {} }),
     removeProvider: jest.fn().mockResolvedValue(undefined),

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -35,7 +35,19 @@ function makeDeps(overrides: {
   const results = overrides.findOneResults ?? [];
   findOne.mockImplementation(() => Promise.resolve(results.shift() ?? null));
 
-  const repo = { findOne, find, insert, save, remove } as unknown as Repository<CustomProvider>;
+  // create()/remove() run their two-row dance inside repo.manager.transaction;
+  // the fake manager resolves getRepository() back to the same mock repo so
+  // existing insert/remove assertions keep observing the writes.
+  const txManager = { getRepository: jest.fn(() => repo) };
+  const transaction = jest.fn(async (cb: (manager: unknown) => Promise<unknown>) => cb(txManager));
+  const repo = {
+    findOne,
+    find,
+    insert,
+    save,
+    remove,
+    manager: { transaction },
+  } as unknown as Repository<CustomProvider>;
 
   const upsertProvider = jest.fn().mockResolvedValue({ provider: {} });
   const removeProvider = jest.fn().mockResolvedValue(undefined);
@@ -88,6 +100,8 @@ function makeDeps(overrides: {
     setCustomProviders,
     invalidateUser,
     reloadPricing,
+    txManager,
+    transaction,
   };
 }
 
@@ -320,14 +334,19 @@ describe('CustomProviderService', () => {
     });
 
     it('inserts the row, upserts a UserProvider, and defaults context_window to 128k', async () => {
-      const { svc, insert, upsertProvider, reloadPricing, emit } = makeDeps({
-        findOneResults: [null],
-      });
+      const { svc, insert, upsertProvider, reloadPricing, emit, txManager, transaction } = makeDeps(
+        {
+          findOneResults: [null],
+        },
+      );
       const cp = await svc.create('user-1', dto);
 
       // Custom providers are user-global: notify open clients to refresh.
       expect(emit).toHaveBeenCalledWith('user-1', 'routing');
 
+      // Both rows are written inside one transaction so a failed companion
+      // insert can't strand a custom_providers row.
+      expect(transaction).toHaveBeenCalledTimes(1);
       expect(insert).toHaveBeenCalledTimes(1);
       expect(cp.user_id).toBe('user-1');
       expect(cp.name).toBe('my-openai');
@@ -338,6 +357,9 @@ describe('CustomProviderService', () => {
         `custom:${cp.id}`,
         'sk-x',
         'api_key',
+        undefined,
+        undefined,
+        txManager,
       );
       expect(validatePublicUrl).toHaveBeenCalledWith(dto.base_url, { allowPrivate: false });
       // Price lookup cache must be refreshed so the proxy can compute cost
@@ -346,7 +368,7 @@ describe('CustomProviderService', () => {
     });
 
     it('tags the companion user_providers row as local when the name is LM Studio', async () => {
-      const { svc, upsertProvider } = makeDeps({ findOneResults: [null] });
+      const { svc, upsertProvider, txManager } = makeDeps({ findOneResults: [null] });
       await svc.create('user-1', { ...dto, name: 'LM Studio' });
       expect(upsertProvider).toHaveBeenCalledWith(
         null,
@@ -354,11 +376,14 @@ describe('CustomProviderService', () => {
         expect.stringMatching(/^custom:/),
         'sk-x',
         'local',
+        undefined,
+        undefined,
+        txManager,
       );
     });
 
     it('normalizes the name for detection (lm-studio / LMSTUDIO both resolve to local)', async () => {
-      const { svc, upsertProvider } = makeDeps({ findOneResults: [null] });
+      const { svc, upsertProvider, txManager } = makeDeps({ findOneResults: [null] });
       await svc.create('user-1', { ...dto, name: 'lm-studio' });
       expect(upsertProvider).toHaveBeenLastCalledWith(
         null,
@@ -366,11 +391,14 @@ describe('CustomProviderService', () => {
         expect.stringMatching(/^custom:/),
         'sk-x',
         'local',
+        undefined,
+        undefined,
+        txManager,
       );
     });
 
     it('keeps api_key tagging for freeform custom provider names', async () => {
-      const { svc, upsertProvider } = makeDeps({ findOneResults: [null] });
+      const { svc, upsertProvider, txManager } = makeDeps({ findOneResults: [null] });
       await svc.create('user-1', { ...dto, name: 'My Home Server' });
       expect(upsertProvider).toHaveBeenCalledWith(
         null,
@@ -378,6 +406,9 @@ describe('CustomProviderService', () => {
         expect.stringMatching(/^custom:/),
         'sk-x',
         'api_key',
+        undefined,
+        undefined,
+        txManager,
       );
     });
 
@@ -740,11 +771,21 @@ describe('CustomProviderService', () => {
 
     it('deletes the row and attempts provider removal', async () => {
       const cp = { id: 'cp1' } as CustomProvider;
-      const { svc, removeProvider, remove, reloadPricing, emit, invalidateUser } = makeDeps({
-        findOneResults: [cp],
-      });
+      const { svc, removeProvider, remove, reloadPricing, emit, invalidateUser, txManager } =
+        makeDeps({
+          findOneResults: [cp],
+        });
       await svc.remove('user-1', 'cp1');
-      expect(removeProvider).toHaveBeenCalledWith(null, 'user-1', 'custom:cp1');
+      // Both deletions run inside one transaction; the provider teardown
+      // receives the tx manager so its writes commit or roll back together.
+      expect(removeProvider).toHaveBeenCalledWith(
+        null,
+        'user-1',
+        'custom:cp1',
+        undefined,
+        undefined,
+        txManager,
+      );
       expect(remove).toHaveBeenCalledWith(cp);
       // The user-scoped custom-provider cache must be dropped so a later list()
       // doesn't serve the deleted provider from a warm cache.

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.transactions.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.transactions.spec.ts
@@ -1,0 +1,163 @@
+// Transactional coupling between the custom_providers row and its companion
+// user_providers row. create()/remove() must run both writes inside ONE
+// repo.manager.transaction so a failure on either side rolls back the other —
+// the DB-level FK (user_providers.custom_provider_id → custom_providers.id)
+// covers the reverse direction. The real rollback/cascade semantics are
+// asserted against Postgres in test/custom-provider-fk-migrations.e2e-spec.ts;
+// these tests pin the service-level contract.
+jest.mock('../../common/utils/url-validation', () => ({
+  validatePublicUrl: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../common/utils/detect-self-hosted', () => ({
+  isSelfHosted: jest.fn().mockReturnValue(false),
+}));
+
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { CustomProviderService } from './custom-provider.service';
+import { CustomProvider } from '../../entities/custom-provider.entity';
+import { ProviderService } from '../routing-core/provider.service';
+import { RoutingCacheService } from '../routing-core/routing-cache.service';
+import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
+import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
+import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
+
+function makeDeps(overrides: { findOneResult?: CustomProvider | null } = {}) {
+  const insert = jest.fn().mockResolvedValue(undefined);
+  const remove = jest.fn().mockResolvedValue(undefined);
+  const txManager = { getRepository: jest.fn(() => repo) };
+  const transaction = jest.fn(async (cb: (manager: unknown) => Promise<unknown>) => cb(txManager));
+  const repo = {
+    findOne: jest.fn().mockResolvedValue(overrides.findOneResult ?? null),
+    find: jest.fn().mockResolvedValue([]),
+    insert,
+    save: jest.fn().mockResolvedValue(undefined),
+    remove,
+    manager: { transaction },
+  } as unknown as Repository<CustomProvider>;
+
+  const upsertProvider = jest.fn().mockResolvedValue({ provider: {} });
+  const removeProvider = jest.fn().mockResolvedValue(undefined);
+  const reloadPricing = jest.fn().mockResolvedValue(undefined);
+  const emit = jest.fn();
+
+  const svc = new CustomProviderService(
+    repo,
+    { upsertProvider, removeProvider } as unknown as ProviderService,
+    {
+      getCustomProviders: jest.fn().mockReturnValue(null),
+      setCustomProviders: jest.fn(),
+      invalidateUser: jest.fn(),
+    } as unknown as RoutingCacheService,
+    { reload: reloadPricing } as unknown as ModelPricingCacheService,
+    { emit } as unknown as IngestEventBusService,
+    undefined as unknown as ModelsDevSyncService,
+  );
+
+  return {
+    svc,
+    insert,
+    remove,
+    upsertProvider,
+    removeProvider,
+    reloadPricing,
+    emit,
+    txManager,
+    transaction,
+  };
+}
+
+const dto = {
+  name: 'my-openai',
+  base_url: 'https://api.example.com/v1',
+  apiKey: 'sk-x',
+  models: [{ model_name: 'm1' }],
+};
+
+describe('CustomProviderService — transactional create/remove', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('create() inserts the custom_providers row before the companion upsert, inside the tx', async () => {
+    const { svc, insert, upsertProvider, txManager } = makeDeps();
+    await svc.create('user-1', dto);
+
+    expect(txManager.getRepository).toHaveBeenCalledWith(CustomProvider);
+    // FK ordering: the companion user_providers row references the
+    // custom_providers id, so the cp insert must land first.
+    expect(insert.mock.invocationCallOrder[0]).toBeLessThan(
+      upsertProvider.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('create() propagates a companion-upsert failure so the cp insert rolls back with it', async () => {
+    const { svc, insert, upsertProvider, reloadPricing, emit, transaction } = makeDeps();
+    upsertProvider.mockRejectedValue(new Error('encryption secret missing'));
+
+    await expect(svc.create('user-1', dto)).rejects.toThrow('encryption secret missing');
+
+    // The insert ran inside the failed transaction (Postgres discards it on
+    // rollback) and none of the post-commit side effects fired.
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(reloadPricing).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('remove() deletes the custom_providers row through the tx manager repository', async () => {
+    const cp = { id: 'cp1' } as CustomProvider;
+    const { svc, remove, removeProvider, txManager, transaction } = makeDeps({
+      findOneResult: cp,
+    });
+    await svc.remove('user-1', 'cp1');
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(txManager.getRepository).toHaveBeenCalledWith(CustomProvider);
+    expect(remove).toHaveBeenCalledWith(cp);
+    expect(removeProvider).toHaveBeenCalledWith(
+      null,
+      'user-1',
+      'custom:cp1',
+      undefined,
+      undefined,
+      txManager,
+    );
+  });
+
+  it('remove() propagates a cp-row delete failure so the companion teardown rolls back with it', async () => {
+    const cp = { id: 'cp1' } as CustomProvider;
+    const { svc, remove, reloadPricing, emit } = makeDeps({ findOneResult: cp });
+    remove.mockRejectedValue(new Error('db down'));
+
+    await expect(svc.remove('user-1', 'cp1')).rejects.toThrow('db down');
+    expect(reloadPricing).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('remove() swallows a NotFound companion teardown (partial-create) and still deletes the cp row', async () => {
+    // Creation may have stranded a custom_providers row with no companion.
+    // removeProvider throws NotFoundException; remove() must absorb it and
+    // continue to delete the cp row so the orphaned config is cleaned up.
+    const cp = { id: 'cp1' } as CustomProvider;
+    const { svc, remove, removeProvider, reloadPricing, emit } = makeDeps({ findOneResult: cp });
+    removeProvider.mockRejectedValue(new NotFoundException('Provider not found'));
+
+    await expect(svc.remove('user-1', 'cp1')).resolves.toBeUndefined();
+    expect(remove).toHaveBeenCalledWith(cp);
+    expect(reloadPricing).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('remove() aborts the whole tx when removeProvider fails for a non-NotFound reason — cp row is NOT deleted', async () => {
+    // "Provider is still routed" (a BadRequestException) must block deletion.
+    // The error escapes the transaction, so the cp remove never runs and no
+    // post-commit side effects fire.
+    const cp = { id: 'cp1' } as CustomProvider;
+    const { svc, remove, removeProvider, reloadPricing, emit } = makeDeps({ findOneResult: cp });
+    removeProvider.mockRejectedValue(new Error('provider is still routed'));
+
+    await expect(svc.remove('user-1', 'cp1')).rejects.toThrow('provider is still routed');
+    expect(remove).not.toHaveBeenCalled();
+    expect(reloadPricing).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -223,21 +223,33 @@ export class CustomProviderService {
       models: this.enrichCustomProviderModels(dto.name, dto.models),
       created_at: new Date().toISOString(),
     });
-    await this.repo.insert(cp);
 
-    // Create UserProvider + enable it for every owned agent (custom
-    // providers are user-global). When the display name resolves to Ollama /
-    // LM Studio we tag the row `'local'` so routed messages carry the
-    // grey-house badge and the row shows up under the Local tab. A null agentId
-    // tells the provider service the change is user-global rather than tied to
-    // one agent.
-    await this.providerService.upsertProvider(
-      null,
-      userId,
-      provKey,
-      dto.apiKey,
-      authTypeForCustomProvider(dto.name),
-    );
+    // A custom provider is two rows that must exist together: the
+    // custom_providers config row and its companion user_providers row
+    // (provider = 'custom:<id>', FK-backed via the generated
+    // custom_provider_id column). Insert both in ONE transaction so a failed
+    // companion insert can't strand a custom_providers row that squats the
+    // name while being invisible to routing.
+    //
+    // Inside the transaction: create UserProvider + enable it for every owned
+    // agent (custom providers are user-global). When the display name
+    // resolves to Ollama / LM Studio we tag the row `'local'` so routed
+    // messages carry the grey-house badge and the row shows up under the
+    // Local tab. A null agentId tells the provider service the change is
+    // user-global rather than tied to one agent.
+    await this.repo.manager.transaction(async (manager) => {
+      await manager.getRepository(CustomProvider).insert(cp);
+      await this.providerService.upsertProvider(
+        null,
+        userId,
+        provKey,
+        dto.apiKey,
+        authTypeForCustomProvider(dto.name),
+        undefined,
+        undefined,
+        manager,
+      );
+    });
 
     // Rebuild the shared pricing cache so the proxy can compute cost for
     // requests routed to this custom provider's models immediately (without
@@ -340,19 +352,33 @@ export class CustomProviderService {
 
     const provKey = CustomProviderService.providerKey(id);
 
-    // Remove the user-global UserProvider. ProviderService blocks removal while
-    // any explicit routes still point at this custom provider.
-    // A null agentId tells the provider service the removal is user-global.
-    try {
-      await this.providerService.removeProvider(null, userId, provKey);
-    } catch (err) {
-      // Provider may not exist if creation partially failed; every other
-      // failure (notably "provider is still routed") must block deletion.
-      if (!(err instanceof NotFoundException)) throw err;
-    }
+    // Tear down both rows in ONE transaction so a failure between them can't
+    // leave a custom provider listed without its companion user_providers row
+    // (or vice versa). The DB-level FK on user_providers.custom_provider_id
+    // additionally cascade-deletes any companion row the application pass
+    // missed once the custom_providers row goes.
+    await this.repo.manager.transaction(async (manager) => {
+      // Remove the user-global UserProvider. ProviderService blocks removal
+      // while any explicit routes still point at this custom provider.
+      // A null agentId tells the provider service the removal is user-global.
+      try {
+        await this.providerService.removeProvider(
+          null,
+          userId,
+          provKey,
+          undefined,
+          undefined,
+          manager,
+        );
+      } catch (err) {
+        // Provider may not exist if creation partially failed; every other
+        // failure (notably "provider is still routed") must block deletion.
+        if (!(err instanceof NotFoundException)) throw err;
+      }
 
-    // Delete CustomProvider row
-    await this.repo.remove(cp);
+      // Delete CustomProvider row
+      await manager.getRepository(CustomProvider).remove(cp);
+    });
 
     // Drop the now-deleted provider from the user-scoped custom-provider cache
     // so a subsequent list() doesn't serve it from a warm cache (mirrors update).

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.transactions.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.transactions.spec.ts
@@ -1,0 +1,282 @@
+// Transaction-manager threading for ProviderService.
+//
+// CustomProviderService wraps its two-row dance (custom_providers +
+// companion user_providers) in a single transaction and passes the
+// EntityManager down to upsertProvider / removeProvider. These tests pin
+// the contract that, when a manager is supplied, every UserProvider /
+// AgentEnabledProvider write goes through manager.getRepository(...) —
+// NOT the injected repositories — so the writes commit or roll back
+// together with the caller's transaction.
+import { ProviderService } from '../provider.service';
+import { UserProvider } from '../../../entities/user-provider.entity';
+import { TierAssignment } from '../../../entities/tier-assignment.entity';
+import { SpecificityAssignment } from '../../../entities/specificity-assignment.entity';
+import { Agent } from '../../../entities/agent.entity';
+import { HeaderTier } from '../../../entities/header-tier.entity';
+import { AgentEnabledProvider } from '../../../entities/agent-enabled-provider.entity';
+import type { EntityManager, Repository } from 'typeorm';
+import type { RoutingCacheService } from '../routing-cache.service';
+import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
+
+const makeQueryBuilder = (agentIds: string[]) => ({
+  leftJoin: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  getRawMany: jest.fn().mockResolvedValue(agentIds.map((id) => ({ id }))),
+});
+
+const makeRepo = (agentIds: string[] = ['agent-1']) => ({
+  find: jest.fn().mockResolvedValue([]),
+  findOne: jest.fn().mockResolvedValue(null),
+  insert: jest.fn().mockResolvedValue(undefined),
+  save: jest.fn().mockImplementation(async (rows) => rows),
+  delete: jest.fn().mockResolvedValue(undefined),
+  remove: jest.fn().mockResolvedValue(undefined),
+  createQueryBuilder: jest.fn().mockImplementation(() => ({
+    insert: jest.fn().mockReturnThis(),
+    into: jest.fn().mockReturnThis(),
+    values: jest.fn().mockReturnThis(),
+    orIgnore: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue(undefined),
+    ...makeQueryBuilder(agentIds),
+  })),
+});
+
+describe('ProviderService — transaction manager threading', () => {
+  let providerRepo: ReturnType<typeof makeRepo>;
+  let accessRepo: ReturnType<typeof makeRepo>;
+  let txUserRepo: ReturnType<typeof makeRepo>;
+  let txAccessRepo: ReturnType<typeof makeRepo>;
+  let manager: EntityManager;
+  let svc: ProviderService;
+  let originalSecret: string | undefined;
+
+  beforeEach(() => {
+    originalSecret = process.env.BETTER_AUTH_SECRET;
+    process.env.BETTER_AUTH_SECRET = 'a'.repeat(48);
+
+    providerRepo = makeRepo();
+    accessRepo = makeRepo();
+    txUserRepo = makeRepo();
+    txAccessRepo = makeRepo();
+    manager = {
+      getRepository: jest.fn((entity: unknown) =>
+        entity === UserProvider ? txUserRepo : txAccessRepo,
+      ),
+    } as unknown as EntityManager;
+
+    svc = new ProviderService(
+      providerRepo as unknown as Repository<UserProvider>,
+      makeRepo() as unknown as Repository<TierAssignment>,
+      makeRepo() as unknown as Repository<SpecificityAssignment>,
+      makeRepo() as unknown as Repository<Agent>,
+      makeRepo() as unknown as Repository<HeaderTier>,
+      { getByModel: jest.fn() } as unknown as ModelPricingCacheService,
+      {
+        getProviders: jest.fn().mockReturnValue(null),
+        setProviders: jest.fn(),
+        invalidateAgent: jest.fn(),
+        invalidateUser: jest.fn(),
+      } as unknown as RoutingCacheService,
+      accessRepo as unknown as Repository<AgentEnabledProvider>,
+    );
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.BETTER_AUTH_SECRET;
+    } else {
+      process.env.BETTER_AUTH_SECRET = originalSecret;
+    }
+  });
+
+  it('upsertProvider (new row) writes through the manager repositories only', async () => {
+    const { isNew } = await svc.upsertProvider(
+      null,
+      'user-1',
+      'custom:cp-1',
+      'sk-key',
+      'api_key',
+      undefined,
+      undefined,
+      manager,
+    );
+
+    expect(isNew).toBe(true);
+    expect(txUserRepo.insert).toHaveBeenCalledTimes(1);
+    expect(providerRepo.insert).not.toHaveBeenCalled();
+    // The all-agents grant must join the same transaction.
+    expect(txAccessRepo.createQueryBuilder).toHaveBeenCalled();
+    expect(accessRepo.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('upsertProvider (existing row) saves through the manager repository', async () => {
+    txUserRepo.findOne.mockResolvedValueOnce({
+      id: 'up-1',
+      user_id: 'user-1',
+      provider: 'custom:cp-1',
+      auth_type: 'api_key',
+      label: 'Default',
+      is_active: false,
+    } as unknown as UserProvider);
+
+    const { isNew } = await svc.upsertProvider(
+      null,
+      'user-1',
+      'custom:cp-1',
+      'sk-rotated',
+      'api_key',
+      undefined,
+      undefined,
+      manager,
+    );
+
+    expect(isNew).toBe(false);
+    expect(txUserRepo.save).toHaveBeenCalledTimes(1);
+    expect(providerRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('upsertProvider with a label updates an existing labeled row through the manager', async () => {
+    txUserRepo.find.mockResolvedValueOnce([
+      {
+        id: 'up-7',
+        user_id: 'user-1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'Work',
+        priority: 0,
+        is_active: false,
+      } as unknown as UserProvider,
+    ]);
+
+    const { isNew } = await svc.upsertProvider(
+      'agent-1',
+      'user-1',
+      'openai',
+      'sk-rotated',
+      'api_key',
+      undefined,
+      'Work',
+      manager,
+    );
+
+    expect(isNew).toBe(false);
+    expect(txUserRepo.save).toHaveBeenCalledTimes(1);
+    expect(providerRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('upsertProvider with a label routes the labeled path through the manager too', async () => {
+    await svc.upsertProvider(
+      'agent-1',
+      'user-1',
+      'openai',
+      'sk-labeled',
+      'api_key',
+      undefined,
+      'Work',
+      manager,
+    );
+
+    expect(txUserRepo.find).toHaveBeenCalled();
+    expect(txUserRepo.insert).toHaveBeenCalledTimes(1);
+    expect(providerRepo.find).not.toHaveBeenCalled();
+    expect(providerRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it('removeProvider deactivates rows and deletes grants through the manager', async () => {
+    txUserRepo.find.mockResolvedValueOnce([
+      {
+        id: 'up-1',
+        user_id: 'user-1',
+        provider: 'custom:cp-1',
+        auth_type: 'api_key',
+        label: 'Default',
+        priority: 0,
+        is_active: true,
+      } as unknown as UserProvider,
+    ]);
+
+    await svc.removeProvider(null, 'user-1', 'custom:cp-1', undefined, undefined, manager);
+
+    expect(txUserRepo.save).toHaveBeenCalledTimes(1);
+    expect(txAccessRepo.delete).toHaveBeenCalledTimes(1);
+    expect(providerRepo.save).not.toHaveBeenCalled();
+    expect(accessRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it('removeProvider with a label deletes the key and renumbers through the manager', async () => {
+    const target = {
+      id: 'up-2',
+      user_id: 'user-1',
+      provider: 'openai',
+      auth_type: 'api_key',
+      label: 'Work',
+      priority: 1,
+      is_active: true,
+    } as unknown as UserProvider;
+    const survivor = {
+      id: 'up-1',
+      user_id: 'user-1',
+      provider: 'openai',
+      auth_type: 'api_key',
+      label: 'Default',
+      priority: 0,
+      is_active: true,
+    } as unknown as UserProvider;
+    // First find: removeKeyByLabel lookup; second find: renumberPriorities.
+    txUserRepo.find.mockResolvedValueOnce([survivor, target]).mockResolvedValueOnce([survivor]);
+
+    await svc.removeProvider('agent-1', 'user-1', 'openai', 'api_key', 'Work', manager);
+
+    expect(txUserRepo.remove).toHaveBeenCalledWith(target);
+    expect(txAccessRepo.delete).toHaveBeenCalledTimes(1);
+    expect(providerRepo.remove).not.toHaveBeenCalled();
+    expect(accessRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it('removeProvider with a label delegates the LAST key to the no-label path, keeping the manager', async () => {
+    const onlyKey = {
+      id: 'up-only',
+      user_id: 'user-1',
+      provider: 'openai',
+      auth_type: 'api_key',
+      label: 'Work',
+      priority: 0,
+      is_active: true,
+    } as unknown as UserProvider;
+    // First find: removeKeyByLabel lookup; second find: the delegated
+    // no-label teardown listing active rows.
+    txUserRepo.find.mockResolvedValueOnce([onlyKey]).mockResolvedValueOnce([onlyKey]);
+
+    await svc.removeProvider('agent-1', 'user-1', 'openai', 'api_key', 'Work', manager);
+
+    // The delegated teardown deactivates through the manager repo.
+    expect(txUserRepo.save).toHaveBeenCalledTimes(1);
+    expect(txAccessRepo.delete).toHaveBeenCalledTimes(1);
+    expect(providerRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('enableProviderForAgent stays a no-op when no enabled-provider repository is injected, manager or not', async () => {
+    const svcWithoutAccess = new ProviderService(
+      providerRepo as unknown as Repository<UserProvider>,
+      makeRepo() as unknown as Repository<TierAssignment>,
+      makeRepo() as unknown as Repository<SpecificityAssignment>,
+      makeRepo() as unknown as Repository<Agent>,
+      makeRepo() as unknown as Repository<HeaderTier>,
+      { getByModel: jest.fn() } as unknown as ModelPricingCacheService,
+      {
+        getProviders: jest.fn().mockReturnValue(null),
+        setProviders: jest.fn(),
+        invalidateAgent: jest.fn(),
+        invalidateUser: jest.fn(),
+      } as unknown as RoutingCacheService,
+      null,
+    );
+
+    await expect(
+      svcWithoutAccess.enableProviderForAgent('agent-1', 'up-1', manager),
+    ).resolves.toBeUndefined();
+    expect(manager.getRepository).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -6,7 +6,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In, FindOptionsWhere } from 'typeorm';
+import { Repository, In, FindOptionsWhere, EntityManager } from 'typeorm';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
@@ -62,6 +62,25 @@ export class ProviderService {
   ) {}
 
   /**
+   * Resolve the UserProvider repository against an optional transaction
+   * manager. Callers that need the companion-row dance to be atomic (custom
+   * providers: custom_providers + user_providers must commit or roll back
+   * together) pass the manager of their enclosing transaction; everyone else
+   * gets the injected repository.
+   */
+  private userProviderRepo(manager?: EntityManager): Repository<UserProvider> {
+    return manager ? manager.getRepository(UserProvider) : this.providerRepo;
+  }
+
+  /** Transaction-aware counterpart of `enabledProviderRepo` (see userProviderRepo). */
+  private agentEnabledProviderRepo(
+    manager?: EntityManager,
+  ): Repository<AgentEnabledProvider> | null {
+    if (!this.enabledProviderRepo) return null;
+    return manager ? manager.getRepository(AgentEnabledProvider) : this.enabledProviderRepo;
+  }
+
+  /**
    * Back-compat entry point retained for callers that used to refresh automatic
    * routes after provider/model changes. Model routing is now user-controlled,
    * so this only invalidates caches.
@@ -94,9 +113,14 @@ export class ProviderService {
     return providers;
   }
 
-  async enableProviderForAgent(agentId: string, userProviderId: string): Promise<void> {
-    if (!this.enabledProviderRepo) return;
-    await this.enabledProviderRepo
+  async enableProviderForAgent(
+    agentId: string,
+    userProviderId: string,
+    manager?: EntityManager,
+  ): Promise<void> {
+    const enabledRepo = this.agentEnabledProviderRepo(manager);
+    if (!enabledRepo) return;
+    await enabledRepo
       .createQueryBuilder()
       .insert()
       .into(AgentEnabledProvider)
@@ -127,17 +151,25 @@ export class ProviderService {
    * user already owns must immediately gain access to it. Route assignment
    * remains user-controlled. No-op safe when the user owns 0 agents.
    */
-  async enableProviderForAllAgents(userId: string, userProviderId: string): Promise<void> {
+  async enableProviderForAllAgents(
+    userId: string,
+    userProviderId: string,
+    manager?: EntityManager,
+  ): Promise<void> {
     for (const agentId of await this.listOwnedAgentIds(userId)) {
-      await this.enableProviderForAgent(agentId, userProviderId);
+      await this.enableProviderForAgent(agentId, userProviderId, manager);
       this.routingCache.invalidateAgent(agentId);
     }
     this.routingCache.invalidateUser(userId);
   }
 
-  private async deleteProviderAccess(userProviderIds: string[]): Promise<void> {
-    if (!this.enabledProviderRepo || userProviderIds.length === 0) return;
-    await this.enabledProviderRepo.delete({ user_provider_id: In(userProviderIds) });
+  private async deleteProviderAccess(
+    userProviderIds: string[],
+    manager?: EntityManager,
+  ): Promise<void> {
+    const enabledRepo = this.agentEnabledProviderRepo(manager);
+    if (!enabledRepo || userProviderIds.length === 0) return;
+    await enabledRepo.delete({ user_provider_id: In(userProviderIds) });
   }
 
   /**
@@ -178,9 +210,11 @@ export class ProviderService {
     authType?: AuthType,
     region?: string,
     label?: string,
+    manager?: EntityManager,
   ): Promise<{ provider: UserProvider; isNew: boolean }> {
     const effectiveAuthType = authType ?? 'api_key';
     const trimmedLabel = this.normalizeLabel(label, effectiveAuthType);
+    const repo = this.userProviderRepo(manager);
 
     if (trimmedLabel) {
       return this.upsertProviderWithLabel(
@@ -191,6 +225,7 @@ export class ProviderService {
         effectiveAuthType,
         region,
         trimmedLabel,
+        manager,
       );
     }
 
@@ -200,7 +235,7 @@ export class ProviderService {
     // migration backfilled every pre-existing row with label='Default', so
     // this lookup is unambiguous (the unique index guarantees at most one
     // 'Default' row per tuple).
-    const existing = await this.providerRepo.findOne({
+    const existing = await repo.findOne({
       where: { user_id: userId, provider, auth_type: effectiveAuthType, label: DEFAULT_LABEL },
     });
     const resolvedRegion = await this.resolveProviderRegion(
@@ -221,8 +256,8 @@ export class ProviderService {
       existing.region = resolvedRegion;
       existing.is_active = true;
       existing.updated_at = new Date().toISOString();
-      await this.providerRepo.save(existing);
-      await this.afterProviderChange(agentId, userId, existing.id);
+      await repo.save(existing);
+      await this.afterProviderChange(agentId, userId, existing.id, manager);
       return { provider: existing, isNew: false };
     }
 
@@ -241,10 +276,10 @@ export class ProviderService {
       updated_at: new Date().toISOString(),
     });
 
-    await this.providerRepo.insert(record);
+    await repo.insert(record);
     // A brand-new provider is global + ON by default: enable it for every agent
     // the user owns, without changing model routes.
-    await this.enableProviderForAllAgents(userId, record.id);
+    await this.enableProviderForAllAgents(userId, record.id, manager);
     return { provider: record, isNew: true };
   }
 
@@ -256,8 +291,10 @@ export class ProviderService {
     authType: AuthType,
     region: string | undefined,
     label: string,
+    manager?: EntityManager,
   ): Promise<{ provider: UserProvider; isNew: boolean }> {
-    const existingRows = await this.providerRepo.find({
+    const repo = this.userProviderRepo(manager);
+    const existingRows = await repo.find({
       where: { user_id: userId, provider, auth_type: authType },
     });
     const existing =
@@ -280,8 +317,8 @@ export class ProviderService {
       existing.region = resolvedRegion;
       existing.is_active = true;
       existing.updated_at = new Date().toISOString();
-      await this.providerRepo.save(existing);
-      await this.afterProviderChange(agentId, userId, existing.id);
+      await repo.save(existing);
+      await this.afterProviderChange(agentId, userId, existing.id, manager);
       return { provider: existing, isNew: false };
     }
 
@@ -303,8 +340,8 @@ export class ProviderService {
         sameKey.region = resolvedRegion;
         sameKey.is_active = true;
         sameKey.updated_at = new Date().toISOString();
-        await this.providerRepo.save(sameKey);
-        await this.afterProviderChange(agentId, userId, sameKey.id);
+        await repo.save(sameKey);
+        await this.afterProviderChange(agentId, userId, sameKey.id, manager);
         return { provider: sameKey, isNew: false };
       }
     }
@@ -324,10 +361,10 @@ export class ProviderService {
       updated_at: new Date().toISOString(),
     });
 
-    await this.providerRepo.insert(record);
+    await repo.insert(record);
     // A brand-new provider is global + ON by default: enable it for every agent
     // the user owns, without changing model routes.
-    await this.enableProviderForAllAgents(userId, record.id);
+    await this.enableProviderForAllAgents(userId, record.id, manager);
     return { provider: record, isNew: true };
   }
 
@@ -537,11 +574,12 @@ export class ProviderService {
     agentId: string | null,
     userId: string,
     userProviderId?: string,
+    manager?: EntityManager,
   ): Promise<void> {
     if (agentId === null) {
       await this.recalculateTiersForUser(userId);
     } else {
-      if (userProviderId) await this.enableProviderForAgent(agentId, userProviderId);
+      if (userProviderId) await this.enableProviderForAgent(agentId, userProviderId, manager);
       this.routingCache.invalidateAgent(agentId);
     }
     this.routingCache.invalidateUser(userId);
@@ -598,26 +636,28 @@ export class ProviderService {
     provider: string,
     authType?: AuthType,
     label?: string,
+    manager?: EntityManager,
   ): Promise<{ notifications: string[] }> {
     if (label) {
       // Labeled key chains only exist for agent-scoped standard providers;
       // user-global custom providers never pass a label, so agentId is set.
-      return this.removeKeyByLabel(agentId as string, userId, provider, authType, label);
+      return this.removeKeyByLabel(agentId as string, userId, provider, authType, label, manager);
     }
 
     // Legacy disconnect: deactivate every active key for the (provider,
     // [auth_type]) tuple. Route rows are user-controlled, so disconnect is
     // blocked until all routes pointing at the target provider/key are removed
     // explicitly through the routing UI.
+    const repo = this.userProviderRepo(manager);
     const where: FindOptionsWhere<UserProvider> = { user_id: userId, provider, is_active: true };
     if (authType) where.auth_type = authType;
-    const activeRows = await this.providerRepo.find({ where });
+    const activeRows = await repo.find({ where });
     let affectedRows = activeRows;
 
     if (activeRows.length === 0) {
       const fallbackWhere: FindOptionsWhere<UserProvider> = { user_id: userId, provider };
       if (authType) fallbackWhere.auth_type = authType;
-      const any = await this.providerRepo.findOne({ where: fallbackWhere });
+      const any = await repo.findOne({ where: fallbackWhere });
       if (!any) throw new NotFoundException('Provider not found');
       affectedRows = [any];
     } else {
@@ -627,9 +667,12 @@ export class ProviderService {
         row.is_active = false;
         row.updated_at = now;
       }
-      await this.providerRepo.save(activeRows);
+      await repo.save(activeRows);
     }
-    await this.deleteProviderAccess(affectedRows.map((row) => row.id));
+    await this.deleteProviderAccess(
+      affectedRows.map((row) => row.id),
+      manager,
+    );
 
     const targetAgentIds = await this.listOwnedAgentIds(userId);
     for (const target of targetAgentIds) {
@@ -795,10 +838,12 @@ export class ProviderService {
     provider: string,
     authType: AuthType | undefined,
     label: string,
+    manager?: EntityManager,
   ): Promise<{ notifications: string[] }> {
+    const repo = this.userProviderRepo(manager);
     const where: FindOptionsWhere<UserProvider> = { user_id: userId, provider };
     if (authType) where.auth_type = authType;
-    const matching = await this.providerRepo.find({ where });
+    const matching = await repo.find({ where });
     if (matching.length === 0) throw new NotFoundException('Provider not found');
 
     const target = matching.find((r) => r.label.toLowerCase() === label.toLowerCase());
@@ -811,13 +856,13 @@ export class ProviderService {
     if (!stillHasOtherKeys) {
       // Last key — delegate to the no-label path. We pass authType through so
       // the lookup matches what we just deleted.
-      return this.removeProvider(agentId, userId, provider, target.auth_type);
+      return this.removeProvider(agentId, userId, provider, target.auth_type, undefined, manager);
     }
 
     await this.assertProviderRoutesNotUsed(userId, [target]);
-    await this.providerRepo.remove(target);
-    await this.deleteProviderAccess([target.id]);
-    await this.renumberPriorities(userId, provider, target.auth_type);
+    await repo.remove(target);
+    await this.deleteProviderAccess([target.id], manager);
+    await this.renumberPriorities(userId, provider, target.auth_type, manager);
     this.routingCache.invalidateAgent(agentId);
     this.routingCache.invalidateUser(userId);
     return { notifications: [] };
@@ -1004,8 +1049,10 @@ export class ProviderService {
     userId: string,
     provider: string,
     authType: AuthType,
+    manager?: EntityManager,
   ): Promise<void> {
-    const allRows = await this.providerRepo.find({
+    const repo = this.userProviderRepo(manager);
+    const allRows = await repo.find({
       where: { user_id: userId, provider, auth_type: authType },
       order: { priority: 'ASC' },
     });
@@ -1022,7 +1069,7 @@ export class ProviderService {
         changed = true;
       }
     }
-    if (changed) await this.providerRepo.save(rows);
+    if (changed) await repo.save(rows);
   }
 
   private normalizeLabel(label: string | undefined, authType: AuthType): string | undefined {

--- a/packages/backend/test/custom-provider-fk-data-loss.e2e-spec.ts
+++ b/packages/backend/test/custom-provider-fk-data-loss.e2e-spec.ts
@@ -1,0 +1,223 @@
+import { DataSource } from 'typeorm';
+import { AddCustomProviderFkToUserProviders1792100000000 } from '../src/database/migrations/1792100000000-AddCustomProviderFkToUserProviders';
+
+const DB_URL =
+  process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/manifest_duprepro';
+
+function makeDataSource(): DataSource {
+  return new DataSource({
+    type: 'postgres',
+    url: DB_URL,
+    entities: ['src/entities/!(*.spec).ts'],
+    migrations: ['src/database/migrations/!(*.spec).ts'],
+    synchronize: false,
+    dropSchema: true,
+    logging: false,
+  });
+}
+
+/**
+ * Deployment-shaped no-data-loss invariant. The migration ships to a live
+ * Postgres that already holds a realistic mix of provider rows. This spec
+ * snapshots the FULL contents of user_providers / custom_providers /
+ * agent_enabled_providers BEFORE up() and proves up() changes NOTHING except
+ * deleting the unresolvable orphans (and cascade-removing their grants).
+ *
+ * Edge cases seeded:
+ *  - 'custom:' (empty id) → orphan, deleted (must NOT crash the generated
+ *    column / FK; the cleanup DELETE removes it first — verified empirically).
+ *  - inactive-but-resolvable companion (is_active=false) → must survive.
+ *  - two companions for the same custom provider with different auth_type
+ *    ('local' vs 'api_key') → both survive, both get the same custom_provider_id.
+ *  - agent_enabled_providers grant on a survivor → survives.
+ *  - agent_enabled_providers grant on a deleted orphan → cascade-removed.
+ */
+describe('AddCustomProviderFkToUserProviders deployment data-loss invariant (e2e)', () => {
+  let ds: DataSource;
+  const migration = new AddCustomProviderFkToUserProviders1792100000000();
+
+  // The ids we expect to survive up() untouched.
+  const SURVIVOR_UP_IDS = [
+    'up-active', // resolvable, active, api_key
+    'up-inactive', // resolvable but is_active=false — must survive
+    'up-local', // same cp as up-active but auth_type='local'
+    'up-plain', // non-custom provider, out of scope
+  ];
+  // The ids we expect up() to delete.
+  const ORPHAN_UP_IDS = ['up-empty', 'up-gone'];
+
+  let beforeUserProviders: Record<string, unknown>[];
+  let beforeCustomProviders: Record<string, unknown>[];
+  let beforeAccessSurvivors: Record<string, unknown>[];
+
+  beforeAll(async () => {
+    ds = makeDataSource();
+    await ds.initialize();
+    await ds.runMigrations();
+
+    // Revert just this migration so we seed the realistic pre-FK schema.
+    const revertQr = ds.createQueryRunner();
+    await migration.down(revertQr);
+    await revertQr.release();
+
+    await ds.query(`DELETE FROM "agent_enabled_providers"`);
+    await ds.query(`DELETE FROM "user_providers"`);
+    await ds.query(`DELETE FROM "custom_providers"`);
+    await ds.query(`DELETE FROM "agents"`);
+    await ds.query(`DELETE FROM "tenants"`);
+
+    // Tenant + agent so agent_enabled_providers grants can be seeded.
+    await ds.query(`INSERT INTO "tenants" ("id","name","is_active") VALUES ('t1','u-1',true)`);
+    await ds.query(`INSERT INTO "agents" ("id","name","tenant_id") VALUES ('ag-1','ag-1','t1')`);
+
+    // One resolvable custom provider, shared by two companion rows.
+    await ds.query(
+      `INSERT INTO "custom_providers" ("id","user_id","name","base_url","api_kind","models","created_at")
+       VALUES ('cp-live','u-1','My LLM Server','https://llm.example.com/v1','openai','[]', now())`,
+    );
+
+    // Resolvable + active companion (api_key).
+    await ds.query(
+      `INSERT INTO "user_providers"
+         ("id","user_id","provider","api_key_encrypted","key_prefix","auth_type","label","priority","is_active","connected_at","updated_at")
+       VALUES ('up-active','u-1','custom:cp-live','enc-active','sk-act','api_key','Default',0,true, now(), now())`,
+    );
+    // Resolvable but INACTIVE companion — disabled by the user, still valid.
+    await ds.query(
+      `INSERT INTO "user_providers"
+         ("id","user_id","provider","api_key_encrypted","auth_type","label","priority","is_active","connected_at","updated_at")
+       VALUES ('up-inactive','u-1','custom:cp-live','enc-inactive','api_key','Backup',1,false, now(), now())`,
+    );
+    // Same custom provider, different auth_type ('local') — Ollama/LM Studio shape.
+    await ds.query(
+      `INSERT INTO "user_providers"
+         ("id","user_id","provider","api_key_encrypted","auth_type","label","priority","is_active","connected_at","updated_at")
+       VALUES ('up-local','u-1','custom:cp-live',NULL,'local','Local',2,true, now(), now())`,
+    );
+    // Plain non-custom provider — completely out of scope.
+    await ds.query(
+      `INSERT INTO "user_providers"
+         ("id","user_id","provider","api_key_encrypted","auth_type","label","priority","is_active","connected_at","updated_at")
+       VALUES ('up-plain','u-1','anthropic','enc-plain','api_key','Default',0,true, now(), now())`,
+    );
+    // Orphan: empty embedded id. Must be deleted, not crash the FK.
+    await ds.query(
+      `INSERT INTO "user_providers"
+         ("id","user_id","provider","api_key_encrypted","auth_type","label","priority","is_active","connected_at","updated_at")
+       VALUES ('up-empty','u-1','custom:','enc-empty','api_key','Default',0,true, now(), now())`,
+    );
+    // Orphan: points at a custom provider that no longer exists.
+    await ds.query(
+      `INSERT INTO "user_providers"
+         ("id","user_id","provider","api_key_encrypted","auth_type","label","priority","is_active","connected_at","updated_at")
+       VALUES ('up-gone','u-1','custom:vanished','enc-gone','api_key','Default',0,true, now(), now())`,
+    );
+
+    // Grants: one on a survivor (must persist), one on an orphan (must cascade).
+    await ds.query(
+      `INSERT INTO "agent_enabled_providers" ("agent_id","user_provider_id") VALUES ('ag-1','up-active')`,
+    );
+    await ds.query(
+      `INSERT INTO "agent_enabled_providers" ("agent_id","user_provider_id") VALUES ('ag-1','up-gone')`,
+    );
+
+    // Snapshot the full pre-migration contents of every governed table.
+    beforeUserProviders = await ds.query(
+      `SELECT "id","user_id","provider","api_key_encrypted","key_prefix","auth_type","label",
+              "priority","region","is_active"
+         FROM "user_providers" WHERE "id" = ANY($1) ORDER BY "id"`,
+      [SURVIVOR_UP_IDS],
+    );
+    beforeCustomProviders = await ds.query(
+      `SELECT "id","user_id","name","base_url","api_kind","models" FROM "custom_providers" ORDER BY "id"`,
+    );
+    beforeAccessSurvivors = await ds.query(
+      `SELECT "agent_id","user_provider_id" FROM "agent_enabled_providers"
+         WHERE "user_provider_id" = ANY($1) ORDER BY "agent_id","user_provider_id"`,
+      [SURVIVOR_UP_IDS],
+    );
+
+    const upQr = ds.createQueryRunner();
+    await migration.up(upQr);
+    await upQr.release();
+  }, 60000);
+
+  afterAll(async () => {
+    await ds?.destroy();
+  });
+
+  it('deletes exactly the two unresolvable orphans (including the empty-id row) and nothing else', async () => {
+    const all: { id: string }[] = await ds.query(`SELECT "id" FROM "user_providers" ORDER BY "id"`);
+    expect(all.map((r) => r.id)).toEqual(SURVIVOR_UP_IDS);
+    for (const orphan of ORPHAN_UP_IDS) {
+      const gone: { id: string }[] = await ds.query(
+        `SELECT "id" FROM "user_providers" WHERE "id" = $1`,
+        [orphan],
+      );
+      expect(gone).toHaveLength(0);
+    }
+  });
+
+  it('leaves every surviving user_providers row byte-for-byte identical to its pre-migration snapshot', async () => {
+    const afterUserProviders: Record<string, unknown>[] = await ds.query(
+      `SELECT "id","user_id","provider","api_key_encrypted","key_prefix","auth_type","label",
+              "priority","region","is_active"
+         FROM "user_providers" WHERE "id" = ANY($1) ORDER BY "id"`,
+      [SURVIVOR_UP_IDS],
+    );
+    // Whole-table content snapshot: the migration must mutate no existing column.
+    expect(afterUserProviders).toEqual(beforeUserProviders);
+  });
+
+  it('leaves the custom_providers table entirely untouched', async () => {
+    const afterCustomProviders: Record<string, unknown>[] = await ds.query(
+      `SELECT "id","user_id","name","base_url","api_kind","models" FROM "custom_providers" ORDER BY "id"`,
+    );
+    expect(afterCustomProviders).toEqual(beforeCustomProviders);
+  });
+
+  it('computes the same custom_provider_id for every resolvable companion regardless of auth_type / is_active', async () => {
+    const rows: { id: string; custom_provider_id: string | null }[] = await ds.query(
+      `SELECT "id","custom_provider_id" FROM "user_providers"
+         WHERE "id" IN ('up-active','up-inactive','up-local','up-plain') ORDER BY "id"`,
+    );
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r.custom_provider_id]));
+    // All three companions of cp-live resolve to the same id — active, inactive,
+    // and local alike — proving the generated column ignores row state.
+    expect(byId['up-active']).toBe('cp-live');
+    expect(byId['up-inactive']).toBe('cp-live');
+    expect(byId['up-local']).toBe('cp-live');
+    // The plain provider carries a NULL generated id.
+    expect(byId['up-plain']).toBeNull();
+  });
+
+  it('preserves the grant attached to a surviving companion row', async () => {
+    const afterAccessSurvivors: Record<string, unknown>[] = await ds.query(
+      `SELECT "agent_id","user_provider_id" FROM "agent_enabled_providers"
+         WHERE "user_provider_id" = ANY($1) ORDER BY "agent_id","user_provider_id"`,
+      [SURVIVOR_UP_IDS],
+    );
+    expect(afterAccessSurvivors).toEqual(beforeAccessSurvivors);
+    expect(afterAccessSurvivors).toEqual([{ agent_id: 'ag-1', user_provider_id: 'up-active' }]);
+  });
+
+  it('cascade-removes the grant that pointed at a deleted orphan companion', async () => {
+    const orphanGrants: { user_provider_id: string }[] = await ds.query(
+      `SELECT "user_provider_id" FROM "agent_enabled_providers" WHERE "user_provider_id" = 'up-gone'`,
+    );
+    expect(orphanGrants).toHaveLength(0);
+    // The only grant left is the survivor's — no dangling references remain.
+    const allGrants: { user_provider_id: string }[] = await ds.query(
+      `SELECT "user_provider_id" FROM "agent_enabled_providers" ORDER BY "user_provider_id"`,
+    );
+    expect(allGrants.map((g) => g.user_provider_id)).toEqual(['up-active']);
+  });
+
+  it('deleting the shared custom provider cascade-removes all of its companions at once', async () => {
+    await ds.query(`DELETE FROM "custom_providers" WHERE "id" = 'cp-live'`);
+    const all: { id: string }[] = await ds.query(`SELECT "id" FROM "user_providers" ORDER BY "id"`);
+    // up-active / up-inactive / up-local all reference cp-live → all cascade.
+    // Only the plain provider remains.
+    expect(all.map((r) => r.id)).toEqual(['up-plain']);
+  });
+});

--- a/packages/backend/test/custom-provider-fk-migrations.e2e-spec.ts
+++ b/packages/backend/test/custom-provider-fk-migrations.e2e-spec.ts
@@ -1,0 +1,213 @@
+import { DataSource } from 'typeorm';
+import { AddCustomProviderFkToUserProviders1792100000000 } from '../src/database/migrations/1792100000000-AddCustomProviderFkToUserProviders';
+
+const DB_URL =
+  process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/manifest_duprepro';
+
+function makeDataSource(): DataSource {
+  return new DataSource({
+    type: 'postgres',
+    url: DB_URL,
+    entities: ['src/entities/!(*.spec).ts'],
+    migrations: ['src/database/migrations/!(*.spec).ts'],
+    synchronize: false,
+    dropSchema: true,
+    logging: false,
+  });
+}
+
+/**
+ * Runs the REAL migration chain (synchronize:false) so
+ * AddCustomProviderFkToUserProviders actually executes against Postgres —
+ * the e2e suite uses synchronize:true, which never runs migrations, so a
+ * broken generated column or an FK that doesn't enforce would otherwise go
+ * unnoticed until production.
+ */
+describe('AddCustomProviderFkToUserProviders schema (e2e)', () => {
+  let ds: DataSource;
+
+  beforeAll(async () => {
+    ds = makeDataSource();
+    await ds.initialize();
+    await ds.runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await ds?.destroy();
+  });
+
+  it('adds custom_provider_id as a STORED generated column', async () => {
+    const cols: { column_name: string; is_generated: string }[] = await ds.query(
+      `SELECT column_name, is_generated FROM information_schema.columns
+        WHERE table_name = 'user_providers' AND column_name = 'custom_provider_id'`,
+    );
+    expect(cols).toHaveLength(1);
+    expect(cols[0].is_generated).toBe('ALWAYS');
+  });
+
+  it('wires the FK to custom_providers with ON DELETE CASCADE', async () => {
+    const fks: { confdeltype: string }[] = await ds.query(
+      `SELECT confdeltype FROM pg_constraint
+        WHERE conname = 'FK_user_providers_custom_provider'
+          AND conrelid = '"user_providers"'::regclass
+          AND confrelid = '"custom_providers"'::regclass`,
+    );
+    expect(fks).toHaveLength(1);
+    expect(fks[0].confdeltype).toBe('c'); // c = CASCADE
+  });
+
+  it('creates the partial index on the referencing column', async () => {
+    const idx: { indexname: string }[] = await ds.query(
+      `SELECT indexname FROM pg_indexes
+        WHERE tablename = 'user_providers'
+          AND indexname = 'IDX_user_providers_custom_provider_id'`,
+    );
+    expect(idx).toHaveLength(1);
+  });
+});
+
+/**
+ * Real-data test: seeds a pre-migration dataset (valid companion rows, an
+ * orphan, plain providers), runs up(), and proves that every reachable row
+ * survives byte-for-byte while only the unresolvable orphan is removed.
+ * Then exercises the live FK: orphan inserts rejected, cascade on delete.
+ */
+describe('AddCustomProviderFkToUserProviders data preservation (e2e)', () => {
+  let ds: DataSource;
+  const migration = new AddCustomProviderFkToUserProviders1792100000000();
+
+  beforeAll(async () => {
+    ds = makeDataSource();
+    await ds.initialize();
+    await ds.runMigrations();
+
+    // Revert just this migration to get the pre-FK schema, then seed the
+    // exact half-states the FK is meant to govern.
+    const revertQr = ds.createQueryRunner();
+    await migration.down(revertQr);
+    await revertQr.release();
+
+    await ds.query(`DELETE FROM "agent_enabled_providers"`);
+    await ds.query(`DELETE FROM "user_providers"`);
+    await ds.query(`DELETE FROM "custom_providers"`);
+
+    await ds.query(
+      `INSERT INTO "custom_providers" ("id","user_id","name","base_url","api_kind","models","created_at")
+       VALUES ('cp-alive','u-1','My Server','https://llm.example.com/v1','openai','[]', now())`,
+    );
+    // Valid companion row — must survive the migration untouched.
+    await ds.query(
+      `INSERT INTO "user_providers"
+         ("id","user_id","provider","api_key_encrypted","key_prefix","auth_type","label","priority","is_active","connected_at","updated_at")
+       VALUES ('up-alive','u-1','custom:cp-alive','enc-blob-1','sk-alive','api_key','Default',0,true, now(), now())`,
+    );
+    // Orphan companion — its custom provider was deleted long ago. The
+    // migration must remove it (it is unresolvable and blocks the FK).
+    await ds.query(
+      `INSERT INTO "user_providers"
+         ("id","user_id","provider","api_key_encrypted","auth_type","label","priority","is_active","connected_at","updated_at")
+       VALUES ('up-orphan','u-1','custom:gone-forever','enc-blob-2','api_key','Default',0,false, now(), now())`,
+    );
+    // Plain providers — completely out of scope, must survive untouched.
+    await ds.query(
+      `INSERT INTO "user_providers"
+         ("id","user_id","provider","api_key_encrypted","auth_type","label","priority","is_active","connected_at","updated_at")
+       VALUES ('up-plain','u-1','anthropic','enc-blob-3','api_key','Default',0,true, now(), now()),
+              ('up-plain-2','u-2','openai','enc-blob-4','subscription','Work',1,false, now(), now())`,
+    );
+
+    const upQr = ds.createQueryRunner();
+    await migration.up(upQr);
+    await upQr.release();
+  }, 60000);
+
+  afterAll(async () => {
+    await ds?.destroy();
+  });
+
+  it('preserves the valid companion row byte-for-byte and computes its custom_provider_id', async () => {
+    const rows: Record<string, unknown>[] = await ds.query(
+      `SELECT "id","user_id","provider","api_key_encrypted","key_prefix","auth_type","label","priority","is_active","custom_provider_id"
+         FROM "user_providers" WHERE "id" = 'up-alive'`,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      user_id: 'u-1',
+      provider: 'custom:cp-alive',
+      api_key_encrypted: 'enc-blob-1',
+      key_prefix: 'sk-alive',
+      auth_type: 'api_key',
+      label: 'Default',
+      priority: 0,
+      is_active: true,
+      custom_provider_id: 'cp-alive',
+    });
+  });
+
+  it('preserves plain provider rows untouched, with a NULL custom_provider_id', async () => {
+    const rows: Record<string, unknown>[] = await ds.query(
+      `SELECT "id","provider","api_key_encrypted","auth_type","label","custom_provider_id"
+         FROM "user_providers" WHERE "id" IN ('up-plain','up-plain-2') ORDER BY "id"`,
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      provider: 'anthropic',
+      api_key_encrypted: 'enc-blob-3',
+      custom_provider_id: null,
+    });
+    expect(rows[1]).toMatchObject({
+      provider: 'openai',
+      auth_type: 'subscription',
+      label: 'Work',
+      custom_provider_id: null,
+    });
+  });
+
+  it('removes only the unresolvable orphan companion row', async () => {
+    const orphans: { id: string }[] = await ds.query(
+      `SELECT "id" FROM "user_providers" WHERE "id" = 'up-orphan'`,
+    );
+    expect(orphans).toHaveLength(0);
+    // Total sanity check: exactly the three reachable rows remain.
+    const all: { id: string }[] = await ds.query(
+      `SELECT "id" FROM "user_providers" ORDER BY "id"`,
+    );
+    expect(all.map((r) => r.id)).toEqual(['up-alive', 'up-plain', 'up-plain-2']);
+  });
+
+  it('rejects inserting a companion row for a custom provider that does not exist', async () => {
+    await expect(
+      ds.query(
+        `INSERT INTO "user_providers"
+           ("id","user_id","provider","auth_type","label","priority","is_active","connected_at","updated_at")
+         VALUES ('up-bad','u-1','custom:never-existed','api_key','Default',0,true, now(), now())`,
+      ),
+    ).rejects.toThrow(/violates foreign key constraint/);
+  });
+
+  it('cascade-deletes the companion row when the custom provider is deleted — plain rows untouched', async () => {
+    await ds.query(`DELETE FROM "custom_providers" WHERE "id" = 'cp-alive'`);
+    const all: { id: string }[] = await ds.query(
+      `SELECT "id" FROM "user_providers" ORDER BY "id"`,
+    );
+    expect(all.map((r) => r.id)).toEqual(['up-plain', 'up-plain-2']);
+  });
+
+  it('down() drops the generated column without touching the remaining rows', async () => {
+    const downQr = ds.createQueryRunner();
+    await migration.down(downQr);
+    await downQr.release();
+
+    const cols: { column_name: string }[] = await ds.query(
+      `SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'user_providers' AND column_name = 'custom_provider_id'`,
+    );
+    expect(cols).toHaveLength(0);
+
+    const all: { id: string; api_key_encrypted: string }[] = await ds.query(
+      `SELECT "id","api_key_encrypted" FROM "user_providers" ORDER BY "id"`,
+    );
+    expect(all.map((r) => r.id)).toEqual(['up-plain', 'up-plain-2']);
+    expect(all[0].api_key_encrypted).toBe('enc-blob-3');
+  });
+});


### PR DESCRIPTION
### 💭 Why
A custom provider is two rows (config + stored key) linked only by an application-managed string. Deleting one side could orphan the other, and a failure mid-create could strand a half-created provider. This already bit us once: #1603 needed a cleanup migration after deleted custom providers kept receiving routed requests.

### ✨ What changed
- New migration adds a real FK between the two tables via a stored generated column, with cascade delete.
- The migration removes pre-existing orphan key rows (unresolvable, invisible in the UI); reachable rows are untouched.
- Creating and deleting a custom provider now run both rows in one transaction.
- Two new e2e suites run the real migration chain against Postgres: whole-table snapshots prove nothing changes except orphan removal, plus FK rejection, cascade, and rollback checks.

### 🔧 For operators
Migration runs automatically on boot. No env vars or deploy-order constraints. Rollback (`migration:revert`) drops the FK and column; deleted orphans are not restored (they were unreachable).

### 📝 Notes
Edge cases pinned by tests: empty-id keys (`custom:`), inactive keys, multiple keys per provider with different auth types, agent grants on surviving vs orphaned keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deleting a custom provider can no longer leave orphaned keys or routing/grant data. We enforce a real DB link and make create/delete atomic to protect data integrity.

- **Bug Fixes**
  - Added a stored generated column and real FK from `user_providers` to `custom_providers` with ON DELETE CASCADE, plus a partial index.
  - One-time cleanup removes pre-existing orphan companion rows (including empty-id `custom:`); reachable rows are untouched.
  - `CustomProviderService.create/remove` run both rows in one transaction; `ProviderService` now threads an optional `EntityManager` so all `user_providers` and `agent_enabled_providers` writes (including labeled-key paths) join the same tx.
  - New tests: migration unit, ProviderService tx-manager threading, and Postgres e2e suites proving no data loss, FK enforcement, cascade, and rollback.

- **Migration**
  - Runs automatically on boot; no config changes required.
  - Revert drops the FK and helper column; deleted orphans are not restored.

<sup>Written for commit 30539c2312ba3a81a704310912eb70671413b448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

