### PR TITLE
feat: add MiniMax Coding Plan subscription config (minimax)

### DIFF
--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -2353,6 +2353,7 @@ describe('ModelDiscoveryService', () => {
       const result = buildSubscriptionFallbackModels(null as never, 'minimax');
 
       expect(result.map((m) => m.id)).toEqual([
+        'MiniMax-M3',
         'MiniMax-M2.7',
         'MiniMax-M2.7-highspeed',
         'MiniMax-M2.5',

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -76,7 +76,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       'MiniMax-M2',
     ]),
     subscriptionCapabilities: Object.freeze({
-      maxContextWindow: 1000000,
+      maxContextWindow: 200000,
       supportsPromptCaching: false,
       supportsBatching: false,
     }),

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -76,7 +76,6 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       'MiniMax-M2.1-highspeed',
       'MiniMax-M2',
     ]),
-    knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 1000000,
       supportsPromptCaching: false,

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -76,7 +76,9 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       'MiniMax-M2',
     ]),
     subscriptionCapabilities: Object.freeze({
-      maxContextWindow: 200000,
+      // MiniMax-M3's 1M window (MSA); M2.x models keep their own lower
+      // per-model contexts from the pricing cache — this is only the cap.
+      maxContextWindow: 1000000,
       supportsPromptCaching: false,
       supportsBatching: false,
     }),

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -67,7 +67,6 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionAuthMode: 'device_code' as const,
     knownModels: Object.freeze([
       'MiniMax-M3',
-      'MiniMax-M3-highspeed',
       'MiniMax-M2.7',
       'MiniMax-M2.7-highspeed',
       'MiniMax-M2.5',

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -66,6 +66,8 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionLabel: 'MiniMax Coding Plan',
     subscriptionAuthMode: 'device_code' as const,
     knownModels: Object.freeze([
+      'MiniMax-M3',
+      'MiniMax-M3-highspeed',
       'MiniMax-M2.7',
       'MiniMax-M2.7-highspeed',
       'MiniMax-M2.5',
@@ -74,8 +76,9 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       'MiniMax-M2.1-highspeed',
       'MiniMax-M2',
     ]),
+    knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
-      maxContextWindow: 200000,
+      maxContextWindow: 1000000,
       supportsPromptCaching: false,
       supportsBatching: false,
     }),


### PR DESCRIPTION
### ✨ What changed
- Adds `MiniMax-M3` to the MiniMax Coding Plan `knownModels`.
- Raises the plan context cap from 200000 to 1000000 (M3's window).
- Updates the backend fallback spec expectation to match.

### 💭 Why
MiniMax shipped M3 on the Coding Plan around Jun 1. API discovery can't see subscription launches, so the curated list needs a manual entry.

### 📝 Notes
- Smoke ✅: `MiniMax-M3` answered on the plan endpoint (api.minimax.io/anthropic), served as itself. A 220K-input-token probe returned 200, confirming the plan accepts more than the old 200K cap.
- `MiniMax-M3-highspeed` left out, not confirmed on the pricing page yet.
- M2.x models keep their own per-model contexts from the pricing cache (the cap only clamps).
- https://www.minimax.io/models/text/m3
- Draft PR, auto-generated by manifest-model-watch.