### PR TITLE
feat: sync manifest subscription model lists (2026-06-13)

### DIFF
--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -169,9 +169,13 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModels: Object.freeze([
       'glm-5.1',
       'glm-5-turbo',
+      'glm-5v-turbo',
       'glm-5',
       'glm-4.7',
+      'glm-4.7-flash',
+      'glm-4.6v',
       'glm-4.6',
+      'glm-4.5v',
       'glm-4.5',
       'glm-4.5-air',
     ]),


### PR DESCRIPTION
### ✨ What changed
- Syncs subscription `knownModels` in configs.ts against today's provider discovery.

### 💭 Why
Discovery found new subscription models missing from the curated list: xai/grok-4.20-0309-non-reasoning, xai/grok-4.20-0309-reasoning, xai/grok-4.3, xai/grok-build-0.1, zai/glm-5v-turbo, zai/glm-4.7-flash, zai/glm-4.6v, zai/glm-4.5v, zai/glm-4.5-air:free.

### 📝 Notes
- 134 new api_key models auto-discover at runtime, not listed here.
- Pricing (models.dev) and params (modelparams.dev) out of scope.
- Draft PR, auto-generated by the modelparams agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs subscription manifest `knownModels` with provider discovery by adding new Zhipu `zai` models: `glm-5v-turbo`, `glm-4.7-flash`, `glm-4.6v`, `glm-4.5v`. This keeps the curated subscription list up to date so these models appear in subscriptions.

<sup>Written for commit fae2a6ef4f39dc67efe890d6a21f01eeaf917145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

