### PR TITLE
feat: sync manifest subscription model lists (2026-06-14)

### DIFF
--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -169,10 +169,14 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModels: Object.freeze([
       'glm-5.1',
       'glm-5-turbo',
+      'glm-5v-turbo',
       'glm-5',
       'glm-4.7',
+      'glm-4.7-flash',
       'glm-4.6',
+      'glm-4.6v',
       'glm-4.5',
+      'glm-4.5v',
       'glm-4.5-air',
     ]),
     subscriptionCapabilities: Object.freeze({


### PR DESCRIPTION
### ✨ What changed
- Adds `glm-5v-turbo`, `glm-4.7-flash`, `glm-4.6v`, `glm-4.5v` to the zai subscription `knownModels` in configs.ts.

### 💭 Why
Discovery found these GLM subscription models served by z.ai but missing from the curated `knownModels` list.

### 📝 Notes
- Smoke (refreshed z.ai key): `glm-4.6v` ✅ and `glm-4.5v` ✅ answered live on the plan endpoint (HTTP 200). `glm-5v-turbo` is a valid id but not in the current plan tier (HTTP 429, `subscription plan does not yet include access`). `glm-4.7-flash` was rate-limited (HTTP 429), id recognized. No id was rejected as nonexistent.
- The xai grok models from discovery were not added: xai fetches its subscription model list dynamically (no `knownModels` to curate). `glm-4.5-air:free` was skipped as a routing artifact.
- Pricing (models.dev) and params (modelparams.dev) out of scope.
- Draft PR, auto-generated by the modelparams agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs subscription `knownModels` with the latest provider discovery so new GLM variants are available under subscription. Adds `glm-5v-turbo`, `glm-4.7-flash`, `glm-4.6v`, and `glm-4.5v`.

<sup>Written for commit 2472723e3801b0906f31c4a5a92719c751e6062d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

