### PR TITLE
fix: close cross-tenant log leak and harden the dashboard

### DIFF
--- a/.changeset/tenant-scope-dashboard-hardening.md
+++ b/.changeset/tenant-scope-dashboard-hardening.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Close a cross-tenant read path in message-detail logs (the llm_calls/agent_logs/tool_executions child queries are now tenant-scoped), and harden dashboard reliability: reject API keys past their own expiry from the auth cache, stop reporting routing-override saves that didn't persist, keep a demo-seed failure from aborting boot, and add a retryable error state to the connection page.

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -47,6 +47,10 @@ describe('AgentsController', () => {
     mockDeleteAgent = jest.fn().mockResolvedValue(undefined);
     mockRenameAgent = jest.fn().mockResolvedValue(undefined);
     mockTenantResolve = jest.fn().mockResolvedValue('tenant-123');
+    // Mirrors the real DuplicateAgentSummary shape (agent-duplication.service.ts):
+    // exactly { providers, tierAssignments, specificityAssignments, modelParams } —
+    // there is no `customProviders` field (custom providers are tenant-global and
+    // counted under `providers` via the enabled-provider junction).
     mockDuplicate = jest.fn().mockResolvedValue({
       agentId: 'new-id',
       agentName: 'bot-copy',
@@ -54,7 +58,6 @@ describe('AgentsController', () => {
       apiKey: 'mnfst_new',
       copied: {
         providers: 1,
-        customProviders: 0,
         tierAssignments: 2,
         specificityAssignments: 0,
         modelParams: 0,
@@ -62,7 +65,6 @@ describe('AgentsController', () => {
     });
     mockGetCopySummary = jest.fn().mockResolvedValue({
       providers: 1,
-      customProviders: 0,
       tierAssignments: 2,
       specificityAssignments: 0,
       modelParams: 0,
@@ -713,7 +715,6 @@ describe('AgentsController', () => {
     expect(result).toEqual({
       copied: {
         providers: 1,
-        customProviders: 0,
         tierAssignments: 2,
         specificityAssignments: 0,
         modelParams: 0,

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -150,6 +150,28 @@ describe('AgentDuplicationService', () => {
         NotFoundException,
       );
     });
+
+    it('summary exposes exactly the DuplicateAgentSummary key set (no customProviders drift)', async () => {
+      // Pins the public contract the AgentsController forwards verbatim to the
+      // dashboard. The Recent-Messages-style drift where a stray `customProviders`
+      // field crept into the controller mock is impossible to reintroduce while
+      // this exact-key assertion stands.
+      mockAgentGetOne.mockResolvedValueOnce({ id: 'src-1', tenant_id: 't1' });
+      repoCounts = {
+        AgentEnabledProvider: 1,
+        TierAssignment: 0,
+        SpecificityAssignment: 0,
+        AgentModelParams: 0,
+      };
+
+      const result = await service.getCopySummary('tenant-1', 'source-agent');
+      expect(Object.keys(result).sort()).toEqual([
+        'modelParams',
+        'providers',
+        'specificityAssignments',
+        'tierAssignments',
+      ]);
+    });
   });
 
   describe('suggestName', () => {

--- a/packages/backend/src/analytics/services/message-details.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-details.service.spec.ts
@@ -128,6 +128,25 @@ describe('MessageDetailsService', () => {
     expect(msgQb.andWhere).not.toHaveBeenCalled();
   });
 
+  it('tenant-scopes the llm_calls, agent_logs, and tool_executions child queries', async () => {
+    // An llm call is needed so the tool_executions query runs (llmCallIds.length > 0).
+    llmQb.getMany.mockResolvedValue([{ id: 'lc-1', call_index: 0 }]);
+
+    await service.getDetails('msg-1', 'tenant-xyz');
+
+    // trace_id child lookups must not rely on the parent gate alone: a forged/colliding
+    // trace_id off attacker-supplied telemetry could otherwise surface another tenant's rows.
+    expect(llmQb.andWhere).toHaveBeenCalledWith('lc.tenant_id = :tenantId', {
+      tenantId: 'tenant-xyz',
+    });
+    expect(logQb.andWhere).toHaveBeenCalledWith('al.tenant_id = :tenantId', {
+      tenantId: 'tenant-xyz',
+    });
+    expect(toolQb.andWhere).toHaveBeenCalledWith('te.tenant_id = :tenantId', {
+      tenantId: 'tenant-xyz',
+    });
+  });
+
   it('returns related llm calls', async () => {
     const llmCall = {
       id: 'lc-1',

--- a/packages/backend/src/analytics/services/message-details.service.ts
+++ b/packages/backend/src/analytics/services/message-details.service.ts
@@ -117,6 +117,7 @@ export class MessageDetailsService {
     const llmCallsQb = this.llmCallRepo
       .createQueryBuilder('lc')
       .where('lc.turn_id = :turnId', { turnId: messageId })
+      .andWhere('lc.tenant_id = :tenantId', { tenantId })
       .orderBy('lc.call_index', 'ASC')
       .addOrderBy('lc.timestamp', 'ASC');
 
@@ -124,6 +125,7 @@ export class MessageDetailsService {
       ? this.logRepo
           .createQueryBuilder('al')
           .where('al.trace_id = :traceId', { traceId: message.trace_id })
+          .andWhere('al.tenant_id = :tenantId', { tenantId })
           .orderBy('al.timestamp', 'ASC')
       : null;
 
@@ -143,6 +145,7 @@ export class MessageDetailsService {
         ? await this.toolRepo
             .createQueryBuilder('te')
             .where('te.llm_call_id IN (:...ids)', { ids: llmCallIds })
+            .andWhere('te.tenant_id = :tenantId', { tenantId })
             .orderBy('te.llm_call_id', 'ASC')
             .getMany()
         : [];

--- a/packages/backend/src/common/dto/duplicate-agent.dto.spec.ts
+++ b/packages/backend/src/common/dto/duplicate-agent.dto.spec.ts
@@ -1,0 +1,70 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { DuplicateAgentDto } from './duplicate-agent.dto';
+
+/**
+ * DuplicateAgentDto guards the POST body for the duplicate-agent endpoint.
+ * Validators (read off the source): @IsString, @IsNotEmpty, @MinLength(1),
+ * @MaxLength(100), @Matches(/^[a-zA-Z0-9 _-]+$/). The regex deliberately allows
+ * spaces — rejecting whitespace-only names is the controller's slug guard, NOT
+ * the DTO. The final test pins that two-layer contract so a future "tighten the
+ * regex to also forbid blank names" change can't silently move responsibility.
+ */
+describe('DuplicateAgentDto', () => {
+  const buildErrors = (name: unknown) => validate(plainToInstance(DuplicateAgentDto, { name }));
+
+  it('accepts valid agent names', async () => {
+    for (const name of ['my-agent', 'agent_1', 'TestBot', 'a', 'Bot Copy', 'a'.repeat(100)]) {
+      const errors = await buildErrors(name);
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it('rejects an empty string', async () => {
+    const errors = await buildErrors('');
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a missing name (required field)', async () => {
+    const errors = await validate(plainToInstance(DuplicateAgentDto, {}));
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects names longer than 100 characters', async () => {
+    const errors = await buildErrors('a'.repeat(101));
+    expect(errors.some((e) => e.constraints?.['maxLength'])).toBe(true);
+  });
+
+  it('rejects names containing a slash (regex-disallowed)', async () => {
+    const errors = await buildErrors('bot/copy');
+    expect(errors.some((e) => e.constraints?.['matches'])).toBe(true);
+  });
+
+  it('rejects names with other special characters', async () => {
+    for (const name of ['agent@home', 'bot!', 'a:b', 'name.with.dots']) {
+      const errors = await buildErrors(name);
+      expect(errors.some((e) => e.constraints?.['matches'])).toBe(true);
+    }
+  });
+
+  it('rejects non-ASCII letters (regex is ASCII-only)', async () => {
+    const errors = await buildErrors('café');
+    expect(errors.some((e) => e.constraints?.['matches'])).toBe(true);
+  });
+
+  it('rejects a non-string name', async () => {
+    const errors = await buildErrors(123);
+    expect(errors.some((e) => e.constraints?.['isString'])).toBe(true);
+  });
+
+  // Two-layer contract pin: the @Matches regex allows spaces, so a whitespace-
+  // only string is a VALID DTO. The controller's slug guard (slugify → empty →
+  // BadRequestException) is what rejects it, not the DTO. If someone tightens the
+  // regex to forbid blanks here, this assertion flips and forces a conscious
+  // decision about where the guard lives.
+  it('PASSES a whitespace-only name (rejection is the controller slug guard, not the DTO)', async () => {
+    const errors = await buildErrors('   ');
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -393,12 +393,31 @@ describe('DatabaseSeederService', () => {
       expect(auth.api.signUpEmail).toHaveBeenCalled();
     });
 
-    it('should propagate unhandled errors from seedAdminUser', async () => {
-      // checkBetterAuthUser returns false, signUpEmail throws
+    it('catches errors from the demo-data seed sequence so boot is not aborted', async () => {
+      // Demo-data seeding is best-effort dev-only convenience: a signup hiccup
+      // (or any other seed insert failure) must be logged and swallowed, NOT
+      // rejected up through onModuleInit where it would crash app bootstrap.
+      // checkBetterAuthUser returns false, signUpEmail throws.
       mockDataSource.query.mockResolvedValueOnce([]); // checkBetterAuthUser: no user
       auth.api.signUpEmail.mockRejectedValueOnce(new Error('signup failed'));
+      const errorSpy = jest
+        .spyOn((service as unknown as { logger: { error: jest.Mock } }).logger, 'error')
+        .mockImplementation(() => undefined);
 
-      await expect(service.onModuleInit()).rejects.toThrow('signup failed');
+      await expect(service.onModuleInit()).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('signup failed'));
+
+      errorSpy.mockRestore();
+    });
+
+    it('keeps the Better Auth migration fatal — its failure still aborts boot', async () => {
+      // The migration that creates Better Auth's own tables runs BEFORE the
+      // guarded demo-data block and must remain fatal: without those tables the
+      // app cannot authenticate at all, so a failure here should propagate.
+      const ctx = await auth.$context;
+      (ctx.runMigrations as jest.Mock).mockRejectedValueOnce(new Error('migration boom'));
+
+      await expect(service.onModuleInit()).rejects.toThrow('migration boom');
     });
 
     it('should skip api key insert when getAdminUserId returns null', async () => {

--- a/packages/backend/src/database/database-seeder.service.ts
+++ b/packages/backend/src/database/database-seeder.service.ts
@@ -49,18 +49,32 @@ export class DatabaseSeederService implements OnModuleInit {
     // Dev/test workflow: seed the well-known admin + demo data in one shot
     // so `/serve` and E2E tests get a non-empty dashboard without going
     // through the setup wizard on every run.
-    await this.seedAdminUser();
-    // Tenant first: the dashboard API key is tenant-scoped.
-    await this.seedTenantAndAgent();
-    await this.seedApiKey();
-    // Connections must exist before messages: each seeded message references a
-    // tenant_providers row via the FK on agent_messages.tenant_provider_id.
-    await this.seedTenantProviders();
-    await this.seedAgentMessages();
-    this.logger.log('Seeded demo data (SEED_DATA=true, dev/test only)');
-    this.logger.warn(
-      'SECURITY: Default seed credentials are active (admin@manifest.build). Do NOT use in production.',
-    );
+    //
+    // Seeding is best-effort dev-only convenience (gated on SEED_DATA): a
+    // partial DB, a flaky insert, or a Better Auth signup hiccup must not
+    // reject onModuleInit and abort app bootstrap. The Better Auth migration
+    // above stays fatal — without its tables the app can't authenticate at all
+    // — but everything below only populates demo rows, so we log and continue.
+    try {
+      await this.seedAdminUser();
+      // Tenant first: the dashboard API key is tenant-scoped.
+      await this.seedTenantAndAgent();
+      await this.seedApiKey();
+      // Connections must exist before messages: each seeded message references a
+      // tenant_providers row via the FK on agent_messages.tenant_provider_id.
+      await this.seedTenantProviders();
+      await this.seedAgentMessages();
+      this.logger.log('Seeded demo data (SEED_DATA=true, dev/test only)');
+      this.logger.warn(
+        'SECURITY: Default seed credentials are active (admin@manifest.build). Do NOT use in production.',
+      );
+    } catch (err) {
+      this.logger.error(
+        `Demo data seeding failed (SEED_DATA=true, dev/test only) — continuing boot without it: ${
+          err instanceof Error ? err.message : err
+        }`,
+      );
+    }
   }
 
   private async runBetterAuthMigrations() {

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -236,6 +236,83 @@ describe('AgentKeyAuthGuard', () => {
     expect(mockCreateQueryBuilder).not.toHaveBeenCalled();
   });
 
+  it('stops authenticating from cache once the key own expiry passes within the cache TTL', async () => {
+    // A key that expires (or is set to expire) while still cached must not keep
+    // authenticating until the 5-min cache TTL lapses. The fast path reads the
+    // key's own expires_at, not just the cache entry's TTL.
+    const token = 'mnfst_soon-expiring-key';
+    const keyHash = hashKey(token);
+    mockGetMany.mockResolvedValue([
+      {
+        id: 'key-exp',
+        tenant_id: 'tenant-1',
+        agent_id: 'agent-1',
+        key_hash: keyHash,
+        expires_at: null,
+        agent: { name: 'test-agent' },
+        tenant: { owner_user_id: 'user-1' },
+      },
+    ]);
+
+    // First call caches the key (DB lookup happens).
+    const { ctx: ctx1 } = makeContext({ authorization: `Bearer ${token}` });
+    expect(await guard.canActivate(ctx1)).toBe(true);
+    expect(mockGetMany).toHaveBeenCalledTimes(1);
+
+    // Simulate the key being set to expire in the past while still cached: its
+    // cache entry TTL is well in the future, but keyExpiresAt is now stale.
+    const internalCache = (guard as unknown as { cache: Map<string, { keyExpiresAt: number }> })
+      .cache;
+    const entry = internalCache.get(testCacheKey(token))!;
+    expect(entry).toBeDefined();
+    entry.keyExpiresAt = Date.now() - 1000;
+
+    // The DB now reports the key as expired — the fast path must drop the stale
+    // entry and fall through to the DB re-check, which rejects.
+    mockGetMany.mockResolvedValue([
+      {
+        id: 'key-exp',
+        tenant_id: 'tenant-1',
+        agent_id: 'agent-1',
+        key_hash: keyHash,
+        expires_at: new Date(Date.now() - 1000).toISOString(),
+        agent: { name: 'test-agent' },
+        tenant: { owner_user_id: 'user-1' },
+      },
+    ]);
+
+    const { ctx: ctx2 } = makeContext({ authorization: `Bearer ${token}` });
+    await expect(guard.canActivate(ctx2)).rejects.toThrow('API key expired');
+    // The cache entry was discarded rather than honored, so a DB re-check ran.
+    expect(internalCache.has(testCacheKey(token))).toBe(false);
+  });
+
+  it('stores the key own expires_at on the cached entry for non-expiring keys', async () => {
+    const token = 'mnfst_no-expiry-key';
+    mockGetMany.mockResolvedValue([
+      {
+        id: 'key-noexp',
+        tenant_id: 'tenant-1',
+        agent_id: 'agent-1',
+        key_hash: hashKey(token),
+        expires_at: null,
+        agent: { name: 'test-agent' },
+        tenant: { owner_user_id: 'user-1' },
+      },
+    ]);
+
+    const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+    await guard.canActivate(ctx);
+
+    const internalCache = (
+      guard as unknown as { cache: Map<string, { keyExpiresAt: number | null }> }
+    ).cache;
+    const entry = internalCache.get(testCacheKey(token));
+    expect(entry).toBeDefined();
+    // A null DB expiry stays null on the cache entry (key never expires).
+    expect(entry!.keyExpiresAt).toBeNull();
+  });
+
   it('requires auth for loopback IPs in non-development mode', async () => {
     const { ctx } = makeContext({}, '127.0.0.1');
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -28,7 +28,14 @@ interface CachedKey {
   agentId: string;
   agentName: string;
   userId: string | null;
+  // When this cache entry stops being trusted (the 5-min cache TTL).
   expiresAt: number;
+  // The API key's OWN expiry (epoch ms) copied off the DB row, or null when
+  // the key never expires. Distinct from `expiresAt`: a key can be set to
+  // expire while still inside the cache TTL window, so the fast path must
+  // honor this independently instead of trusting the cache entry until the
+  // TTL lapses.
+  keyExpiresAt: number | null;
 }
 
 @Injectable()
@@ -138,8 +145,15 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
 
   private async validateMnfstToken(request: Request, token: string): Promise<boolean> {
     const hashed = cacheKey(token);
+    const now = Date.now();
     const cached = this.cache.get(hashed);
-    if (cached && cached.expiresAt > Date.now()) {
+    // A key whose own expiry has passed must stop authenticating immediately,
+    // even if its cache entry is still inside the 5-min TTL. Drop the stale
+    // entry and fall through to the DB path (which re-checks expiry and rejects
+    // with "API key expired") rather than honoring it here.
+    if (cached && cached.keyExpiresAt !== null && cached.keyExpiresAt <= now) {
+      this.cache.delete(hashed);
+    } else if (cached && cached.expiresAt > now) {
       // LRU touch — re-insert to move to tail of insertion order
       this.cache.delete(hashed);
       this.cache.set(hashed, cached);
@@ -206,6 +220,7 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
       agentName: keyRecord.agent.name,
       userId: keyRecord.tenant.owner_user_id,
       expiresAt: Date.now() + this.CACHE_TTL_MS,
+      keyExpiresAt: keyRecord.expires_at ? new Date(keyRecord.expires_at).getTime() : null,
     });
 
     this.setContext(request, {

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -821,11 +821,21 @@ describe('CustomProviderService', () => {
   });
 
   describe('getById', () => {
-    it('returns the provider directly from the repository', async () => {
+    it('returns the provider scoped to the tenant', async () => {
       const cp = { id: 'cp1' } as CustomProvider;
       const { svc, findOne } = makeDeps({ findOneResults: [cp] });
-      await expect(svc.getById('cp1')).resolves.toBe(cp);
-      expect(findOne).toHaveBeenCalledWith({ where: { id: 'cp1' } });
+      await expect(svc.getById('cp1', 'tenant-1')).resolves.toBe(cp);
+      // Tenant-scoped lookup mirrors list/update/remove — the where-clause must
+      // include tenant_id so one tenant cannot read another's custom provider.
+      expect(findOne).toHaveBeenCalledWith({ where: { id: 'cp1', tenant_id: 'tenant-1' } });
+    });
+
+    it('returns null when the id belongs to a different tenant', async () => {
+      // findOneResults is empty → the mock resolves null, modelling a row that
+      // exists under another tenant_id and is therefore filtered out.
+      const { svc, findOne } = makeDeps({ findOneResults: [] });
+      await expect(svc.getById('cp1', 'tenant-other')).resolves.toBeNull();
+      expect(findOne).toHaveBeenCalledWith({ where: { id: 'cp1', tenant_id: 'tenant-other' } });
     });
   });
 

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -404,8 +404,11 @@ export class CustomProviderService {
     this.notifyChange(tenantId, actorUserId);
   }
 
-  async getById(id: string): Promise<CustomProvider | null> {
-    return this.repo.findOne({ where: { id } });
+  async getById(id: string, tenantId: string): Promise<CustomProvider | null> {
+    // Tenant-scoped to match list/update/remove — a bare `{ id }` lookup would
+    // let one tenant read another's custom provider row if a caller ever passed
+    // an attacker-controlled id. No in-repo callers today; scoped defensively.
+    return this.repo.findOne({ where: { id, tenant_id: tenantId } });
   }
 
   /**

--- a/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
@@ -126,12 +126,14 @@ describe('SpecificityService', () => {
       expect(result.is_active).toBe(true);
     });
 
-    it('returns the freshly built record when insert fails and no retry row exists', async () => {
+    it('rethrows when insert fails and no retry row exists (no phantom success)', async () => {
       repo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
-      repo.insert.mockRejectedValueOnce(new Error('unrelated'));
-      const result = await svc.toggleCategory('agent-1', 'coding', true);
-      expect(result.category).toBe('coding');
-      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+      const err = new Error('FK violation');
+      repo.insert.mockRejectedValueOnce(err);
+      // A non-conflict DB error with no conflicting row on re-read must
+      // propagate rather than returning a record that was never persisted.
+      await expect(svc.toggleCategory('agent-1', 'coding', true)).rejects.toThrow(err);
+      expect(routingCache.invalidateAgent).not.toHaveBeenCalled();
     });
   });
 
@@ -214,18 +216,16 @@ describe('SpecificityService', () => {
       expect(result.override_route).toEqual(route('openai', 'api_key', 'gpt-4o'));
     });
 
-    it('returns built record when insert fails without a retry row', async () => {
+    it('rethrows when insert fails without a retry row (no phantom success)', async () => {
       repo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
-      repo.insert.mockRejectedValueOnce(new Error('unrelated'));
-      const result = await svc.setOverride(
-        'agent-1',
-        'tenant-1',
-        'coding',
-        'gpt-4o',
-        'openai',
-        'api_key',
-      );
-      expect(result.override_route).toEqual(route('openai', 'api_key', 'gpt-4o'));
+      const err = new Error('FK violation');
+      repo.insert.mockRejectedValueOnce(err);
+      // A non-conflict DB error with no conflicting row on re-read must
+      // propagate rather than returning a record that was never persisted.
+      await expect(
+        svc.setOverride('agent-1', 'tenant-1', 'coding', 'gpt-4o', 'openai', 'api_key'),
+      ).rejects.toThrow(err);
+      expect(routingCache.invalidateAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
@@ -356,6 +356,8 @@ describe('TierService', () => {
       );
       expect(result.override_route).toEqual(route('openai', 'api_key', 'gpt-4o'));
       expect(tierRepo.save).toHaveBeenCalled();
+      // The existing-row branch invalidates the routing cache; assert that side effect.
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
     });
 
     it('rethrows when insert fails and no row exists on retry (no phantom success)', async () => {

--- a/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
@@ -325,7 +325,10 @@ describe('TierService', () => {
       expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
     });
 
-    it('retries when insert hits the unique index and another row exists', async () => {
+    it('retries on a unique-index conflict and returns the persisted row', async () => {
+      // Conflict path: the concurrent row already exists on re-read, so the
+      // service adopts it (recursing into the existing-row branch) and returns
+      // the persisted override rather than throwing.
       discoveryService.getModelsForAgent.mockResolvedValue([
         discovered('gpt-4o', 'openai', 'api_key'),
       ]);
@@ -352,25 +355,24 @@ describe('TierService', () => {
         'api_key',
       );
       expect(result.override_route).toEqual(route('openai', 'api_key', 'gpt-4o'));
+      expect(tierRepo.save).toHaveBeenCalled();
     });
 
-    it('returns the freshly built record when insert fails and no row exists on retry', async () => {
+    it('rethrows when insert fails and no row exists on retry (no phantom success)', async () => {
       discoveryService.getModelsForAgent.mockResolvedValue([
         discovered('gpt-4o', 'openai', 'api_key'),
       ]);
       tierRepo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
-      tierRepo.insert.mockRejectedValueOnce(new Error('unrelated'));
+      const err = new Error('FK violation');
+      tierRepo.insert.mockRejectedValueOnce(err);
 
-      // No throw — service returns the local record and invalidates cache.
-      const result = await svc.setOverride(
-        'agent-1',
-        'tenant-1',
-        'standard',
-        'gpt-4o',
-        'openai',
-        'api_key',
-      );
-      expect(result.override_route).toEqual(route('openai', 'api_key', 'gpt-4o'));
+      // A non-conflict DB error with no conflicting row on re-read must
+      // propagate — the row was never persisted, so reporting success would
+      // strand the caller with a phantom record and a stale cache.
+      await expect(
+        svc.setOverride('agent-1', 'tenant-1', 'standard', 'gpt-4o', 'openai', 'api_key'),
+      ).rejects.toThrow(err);
+      expect(routingCache.invalidateAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
@@ -1,5 +1,13 @@
 import { ProviderKeyService, SYNTHETIC_OLLAMA_PROVIDER_ID } from './provider-key.service';
 import type { CachedProviderKey } from './routing-cache.service';
+import type { Repository } from 'typeorm';
+import { encrypt } from '../../common/utils/crypto.util';
+import type { TenantProvider } from '../../entities/tenant-provider.entity';
+import type { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
+
+// getEncryptionSecret() falls back to BETTER_AUTH_SECRET; set it so the
+// per-agent filter tests can produce real ciphertext that decryptOne resolves.
+process.env['BETTER_AUTH_SECRET'] = 'a'.repeat(64);
 
 /**
  * Focused unit coverage for the key-selection projections. The proxy specs
@@ -103,5 +111,170 @@ describe('ProviderKeyService — selection projections', () => {
       jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([]);
       expect(await svc.getProviderRegion('u', 'openai', 'api_key')).toBeNull();
     });
+  });
+});
+
+/**
+ * Per-agent provider-visibility gate on the proxy hot path. The existing specs
+ * above construct ProviderKeyService WITHOUT an enabledProviderRepo, so every
+ * call hits the `enabledProviderRepo == null` short-circuit in
+ * filterProvidersForAgent and the real per-agent filter never runs. These tests
+ * build the service WITH a mocked enabledProviderRepo and drive the real filter
+ * through getProviderKeys → resolveProviderKeys → filterProvidersForAgent so a
+ * dropped `enabledIds.has(p.id)` check fails loudly.
+ */
+describe('ProviderKeyService — filterProvidersForAgent (per-agent visibility)', () => {
+  const SECRET = process.env['BETTER_AUTH_SECRET'] as string;
+
+  const tenantProvider = (over: Partial<TenantProvider>): TenantProvider =>
+    ({
+      id: 'tp-1',
+      tenant_id: 'tenant-1',
+      created_by_user_id: null,
+      agent_id: null,
+      provider: 'openai',
+      // Real ciphertext so the private decryptOne path resolves to a key without
+      // mocking crypto — exercises the full resolve→decrypt→filter chain.
+      api_key_encrypted: encrypt('sk-real', SECRET),
+      key_prefix: null,
+      auth_type: 'api_key',
+      label: 'Default',
+      priority: 0,
+      region: null,
+      is_active: true,
+      connected_at: '',
+      updated_at: '',
+      cached_models: null,
+      models_fetched_at: null,
+      ...over,
+    }) as TenantProvider;
+
+  const enabledRow = (tenantProviderId: string): AgentEnabledProvider =>
+    ({ agent_id: 'agent-1', tenant_provider_id: tenantProviderId }) as AgentEnabledProvider;
+
+  // providerRepo.find returns the tenant-global rows; routingCache always misses
+  // so resolveProviderKeys runs; enabledProviderRepo.find returns the agent's
+  // enabled junction rows.
+  const buildService = (opts: {
+    tenantProviders: TenantProvider[];
+    enabledRows: AgentEnabledProvider[];
+    enabledRepo?: Pick<Repository<AgentEnabledProvider>, 'find'> | null;
+  }): {
+    svc: ProviderKeyService;
+    enabledFind: jest.Mock;
+    setProviderKeys: jest.Mock;
+  } => {
+    const providerRepo = { find: jest.fn().mockResolvedValue(opts.tenantProviders) };
+    const setProviderKeys = jest.fn();
+    const routingCache = {
+      getProviderKeys: jest.fn().mockReturnValue(undefined),
+      setProviderKeys,
+    };
+    const enabledFind = jest.fn().mockResolvedValue(opts.enabledRows);
+    const enabledRepo = opts.enabledRepo === undefined ? { find: enabledFind } : opts.enabledRepo;
+
+    const svc = new ProviderKeyService(
+      providerRepo as never, // providerRepo
+      {} as never, // pricingCache
+      {} as never, // discoveryService
+      routingCache as never, // routingCache
+      {} as never, // providerService
+      enabledRepo as never, // enabledProviderRepo
+    );
+    return { svc, enabledFind, setProviderKeys };
+  };
+
+  it('returns [] when the agent has no enabled-provider rows (empty gate)', async () => {
+    const { svc, enabledFind } = buildService({
+      tenantProviders: [tenantProvider({ id: 'tp-openai', provider: 'openai' })],
+      enabledRows: [], // agent has enabled nothing → see nothing
+    });
+
+    const keys = await svc.getProviderKeys('tenant-1', 'openai', undefined, 'agent-1');
+
+    expect(keys).toEqual([]);
+    expect(enabledFind).toHaveBeenCalledWith({ where: { agent_id: 'agent-1' } });
+  });
+
+  it('returns only the provider the agent has enabled when 1 of 2 tenant providers is allowed', async () => {
+    // Two tenant-global openai keys; the agent's junction enables only tp-b.
+    const { svc } = buildService({
+      tenantProviders: [
+        tenantProvider({
+          id: 'tp-a',
+          label: 'Personal',
+          api_key_encrypted: encrypt('sk-a', SECRET),
+        }),
+        tenantProvider({ id: 'tp-b', label: 'Work', api_key_encrypted: encrypt('sk-b', SECRET) }),
+      ],
+      enabledRows: [enabledRow('tp-b')],
+    });
+
+    const keys = await svc.getProviderKeys('tenant-1', 'openai', undefined, 'agent-1');
+
+    expect(keys).toHaveLength(1);
+    expect(keys[0].id).toBe('tp-b');
+    expect(keys[0].label).toBe('Work');
+    expect(keys[0].apiKey).toBe('sk-b');
+  });
+
+  it('keeps multiple providers when several are enabled for the agent', async () => {
+    const { svc } = buildService({
+      tenantProviders: [
+        tenantProvider({
+          id: 'tp-a',
+          label: 'Personal',
+          api_key_encrypted: encrypt('sk-a', SECRET),
+        }),
+        tenantProvider({ id: 'tp-b', label: 'Work', api_key_encrypted: encrypt('sk-b', SECRET) }),
+      ],
+      enabledRows: [enabledRow('tp-a'), enabledRow('tp-b')],
+    });
+
+    const keys = await svc.getProviderKeys('tenant-1', 'openai', undefined, 'agent-1');
+
+    expect(keys.map((k) => k.id).sort()).toEqual(['tp-a', 'tp-b']);
+  });
+
+  it('falls back to all providers (no per-agent filter) when no agentId is passed', async () => {
+    // agentId undefined → filterProvidersForAgent short-circuits BEFORE touching
+    // the repo, so even with an enabledProviderRepo present every key is returned.
+    const { svc, enabledFind } = buildService({
+      tenantProviders: [
+        tenantProvider({
+          id: 'tp-a',
+          label: 'Personal',
+          api_key_encrypted: encrypt('sk-a', SECRET),
+        }),
+        tenantProvider({ id: 'tp-b', label: 'Work', api_key_encrypted: encrypt('sk-b', SECRET) }),
+      ],
+      enabledRows: [],
+    });
+
+    const keys = await svc.getProviderKeys('tenant-1', 'openai'); // no agentId
+
+    expect(keys.map((k) => k.id).sort()).toEqual(['tp-a', 'tp-b']);
+    expect(enabledFind).not.toHaveBeenCalled();
+  });
+
+  it('null-repo short-circuit still returns all tenant providers even with an agentId', async () => {
+    // The legacy/self-hosted path: enabledProviderRepo is null, so the agent
+    // scope is a no-op and every provider stays visible.
+    const { svc } = buildService({
+      tenantProviders: [
+        tenantProvider({
+          id: 'tp-a',
+          label: 'Personal',
+          api_key_encrypted: encrypt('sk-a', SECRET),
+        }),
+        tenantProvider({ id: 'tp-b', label: 'Work', api_key_encrypted: encrypt('sk-b', SECRET) }),
+      ],
+      enabledRows: [],
+      enabledRepo: null,
+    });
+
+    const keys = await svc.getProviderKeys('tenant-1', 'openai', undefined, 'agent-1');
+
+    expect(keys.map((k) => k.id).sort()).toEqual(['tp-a', 'tp-b']);
   });
 });

--- a/packages/backend/src/routing/routing-core/specificity.service.ts
+++ b/packages/backend/src/routing/routing-core/specificity.service.ts
@@ -62,9 +62,15 @@ export class SpecificityService {
 
     try {
       await this.repo.insert(record);
-    } catch {
+    } catch (err) {
+      // A concurrent request may have inserted the same (agent_id, category)
+      // first, hitting the unique index. Re-read and adopt its row if present;
+      // otherwise the failure is something else (FK violation, connection
+      // error, …) and we rethrow rather than reporting a phantom success for a
+      // row that was never persisted.
       const retry = await this.repo.findOne({ where: { agent_id: agentId, category } });
       if (retry) return this.toggleCategory(agentId, category, active);
+      throw err;
     }
     this.routingCache.invalidateAgent(agentId);
     return record;
@@ -124,9 +130,14 @@ export class SpecificityService {
 
     try {
       await this.repo.insert(record);
-    } catch {
+    } catch (err) {
+      // A concurrent request may have inserted the same (agent_id, category)
+      // first, hitting the unique index. Re-read and adopt its row if present;
+      // otherwise the failure is something else (FK violation, connection
+      // error, …) and we rethrow rather than reporting a phantom success for a
+      // row that was never persisted.
       const retry = await this.repo.findOne({ where: { agent_id: agentId, category } });
-      if (retry)
+      if (retry) {
         return this.setOverride(
           agentId,
           tenantId,
@@ -136,6 +147,8 @@ export class SpecificityService {
           authType,
           providerKeyLabel,
         );
+      }
+      throw err;
     }
     this.routingCache.invalidateAgent(agentId);
     return record;

--- a/packages/backend/src/routing/routing-core/tier.service.ts
+++ b/packages/backend/src/routing/routing-core/tier.service.ts
@@ -165,9 +165,14 @@ export class TierService {
 
     try {
       await this.tierRepo.insert(record);
-    } catch {
+    } catch (err) {
+      // A concurrent request may have inserted the same (agent_id, tier) first,
+      // hitting the unique index. Re-read and adopt its row if present;
+      // otherwise the failure is something else (FK violation, connection
+      // error, …) and we rethrow rather than reporting a phantom success for a
+      // row that was never persisted.
       const retry = await this.tierRepo.findOne({ where: { agent_id: agentId, tier } });
-      if (retry)
+      if (retry) {
         return this.setOverride(
           agentId,
           tenantId,
@@ -177,6 +182,8 @@ export class TierService {
           authType,
           providerKeyLabel,
         );
+      }
+      throw err;
     }
     this.routingCache.invalidateAgent(agentId);
     return record;

--- a/packages/frontend/src/components/AgentGuard.tsx
+++ b/packages/frontend/src/components/AgentGuard.tsx
@@ -1,5 +1,12 @@
 import { useParams } from '@solidjs/router';
-import { createResource, createMemo, Show, onCleanup, type ParentComponent } from 'solid-js';
+import {
+  createResource,
+  createMemo,
+  createEffect,
+  Show,
+  onCleanup,
+  type ParentComponent,
+} from 'solid-js';
 import ErrorState from './ErrorState.jsx';
 import NotFound from '../pages/NotFound.jsx';
 import { getAgents } from '../services/api.js';
@@ -33,11 +40,27 @@ const AgentGuard: ParentComponent = (props) => {
     () => getAgents() as Promise<AgentsData>,
   );
 
+  // Pure: only derives whether the viewed agent should be considered to exist.
+  // A memo must never write to external signals/stores — doing so triggers the
+  // SolidJS "computations created outside a `createRoot` will never be disposed"
+  // warning. The display-name / platform store writes live in the effect below.
   const agentExists = createMemo(() => {
     const decoded = decodeURIComponent(params.agentName);
     const recent = isRecentlyCreated(decoded);
     const list = data()?.agents;
     if (!list) return true; // still loading or no data yet — don't block
+    const agent = list.find((a) => a.agent_name === decoded);
+    return recent || !!agent;
+  });
+
+  // Side effects keyed on the resolved list + the viewed agent: sync the
+  // display-name / platform stores and clear the recent-agent flag once the
+  // agent is found. Mirrors the previous in-memo behavior exactly (same writes,
+  // same values) but in an effect so the memo stays pure.
+  createEffect(() => {
+    const decoded = decodeURIComponent(params.agentName);
+    const list = data()?.agents;
+    if (!list) return; // still loading or no data yet — leave stores untouched
     const agent = list.find((a) => a.agent_name === decoded);
     if (agent) {
       clearRecentAgent(agent.agent_name);
@@ -47,7 +70,6 @@ const AgentGuard: ParentComponent = (props) => {
       setAgentDisplayName(null);
       setAgentPlatform(null, null);
     }
-    return recent || !!agent;
   });
 
   onCleanup(() => {

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -807,7 +807,7 @@ const GlobalOverview: Component = () => {
                       const icon = platformIcon(agent.agent_platform, agent.agent_category);
                       return (
                         <A
-                          href={`/harnesses/${agent.agent_name}`}
+                          href={`/harnesses/${encodeURIComponent(agent.agent_name)}`}
                           style="display: flex; align-items: center; gap: 8px; text-decoration: none; font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));"
                         >
                           <Show when={icon}>
@@ -1179,7 +1179,9 @@ const GlobalOverview: Component = () => {
                     return (
                       <tr
                         style="cursor: pointer;"
-                        onClick={() => navigate(`/harnesses/${agent.agent_name}`)}
+                        onClick={() =>
+                          navigate(`/harnesses/${encodeURIComponent(agent.agent_name)}`)
+                        }
                       >
                         <td>
                           <div style="display: flex; align-items: center; gap: 8px;">

--- a/packages/frontend/src/pages/providers/ConnectionDetail.tsx
+++ b/packages/frontend/src/pages/providers/ConnectionDetail.tsx
@@ -112,7 +112,7 @@ const ConnectionDetail: Component = () => {
     (id) => getConnectionDetail(id) as Promise<DetailResponse>,
   );
 
-  const conn = () => detail()?.connection ?? null;
+  const conn = () => (detail.error ? null : (detail()?.connection ?? null));
   const provDef = () => PROVIDERS.find((p) => p.id === conn()?.provider);
   const isCustomProvider = () => conn()?.provider?.startsWith('custom:') ?? false;
 
@@ -449,10 +449,29 @@ const ConnectionDetail: Component = () => {
   // A resolved-but-null connection means the id is unknown / the connection
   // was deleted. Branch on the resource so this renders a not-found state
   // instead of the loading fallback spinning forever.
-  const notFound = () => !detail.loading && detail() !== undefined && conn() === null;
+  // A rejected fetch leaves the resource errored; surface a retryable error state
+  // instead of spinning the loading skeleton forever. Reading detail.error never
+  // throws, unlike calling detail(), so guard the other branches on it too.
+  const hasError = () => !detail.loading && !!detail.error;
+  const notFound = () =>
+    !hasError() && !detail.loading && detail() !== undefined && conn() === null;
 
   return (
     <div class="container--lg">
+      <Show when={hasError()}>
+        <Title>Couldn't load connection | Manifest</Title>
+        <div style="padding: 48px 0; text-align: center;">
+          <div style="font-size: var(--font-size-base); font-weight: 600; color: hsl(var(--foreground)); margin-bottom: 8px;">
+            Couldn't load this connection
+          </div>
+          <div style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); margin-bottom: 16px;">
+            Something went wrong loading this connection. Please try again.
+          </div>
+          <button type="button" class="btn btn--outline btn--sm" onClick={() => refetchDetail()}>
+            Retry
+          </button>
+        </div>
+      </Show>
       <Show when={notFound()}>
         <Title>Connection not found | Manifest</Title>
         <div style="padding: 48px 0; text-align: center;">
@@ -468,9 +487,9 @@ const ConnectionDetail: Component = () => {
         </div>
       </Show>
       <Show
-        when={!notFound() && detail() && conn()}
+        when={!notFound() && !hasError() && detail() && conn()}
         fallback={
-          <Show when={!notFound()}>
+          <Show when={!notFound() && !hasError()}>
             <div style="width: 100%; height: 300px; border-radius: var(--radius); background: hsl(var(--muted) / 0.45); animation: skeleton-pulse 1.2s ease-in-out infinite;" />
           </Show>
         }
@@ -794,7 +813,7 @@ const ConnectionDetail: Component = () => {
                             <tr>
                               <td>
                                 <A
-                                  href={`/harnesses/${agent.agent_name}`}
+                                  href={`/harnesses/${encodeURIComponent(agent.agent_name)}`}
                                   style="text-decoration: none; color: hsl(var(--foreground)); font-weight: 500; display: flex; align-items: center; gap: 8px;"
                                 >
                                   <Show when={platformIcon(agent.agent_platform, null)}>

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -1,6 +1,14 @@
 import { Title } from '@solidjs/meta';
 import { useNavigate, useSearchParams } from '@solidjs/router';
-import { createMemo, createResource, createSignal, For, Show, type Component } from 'solid-js';
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  Show,
+  type Component,
+} from 'solid-js';
 import {
   getAgents,
   getCustomProviders,
@@ -302,13 +310,6 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
     },
   );
 
-  if (searchParams.add === 'true') {
-    queueMicrotask(() => {
-      setSearchParams({ add: undefined });
-      openModal();
-    });
-  }
-
   const connectedSummaries = () =>
     (data()?.providers ?? []).filter((provider) => provider.auth_type === copy().authType);
 
@@ -382,6 +383,19 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
     void refetchModalProviders();
     setShowModal(true);
   };
+
+  // Deep-link support: visiting a provider page with ?add=true auto-opens the
+  // connect modal so onboarding surfaces can route a user straight into adding
+  // a provider. React on every navigation (not just initial mount) and clear the
+  // param (replace) so a refresh or back-nav doesn't re-trigger it. Runs in an
+  // effect — never the render body — so the param write/modal open stay reactive
+  // side effects rather than firing during render.
+  createEffect(() => {
+    if (searchParams.add === 'true') {
+      setSearchParams({ add: undefined }, { replace: true });
+      openModal();
+    }
+  });
 
   const openCustomProvider = () => {
     setDeepLink(null);

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -1001,6 +1001,23 @@ describe('ConnectionDetail (analytics)', () => {
     expect(screen.getByText('Back to overview')).toBeDefined();
   });
 
+  it('shows a retryable error state when the connection detail fetch fails', async () => {
+    // A rejected fetch must render a retryable error state, not spin the loading
+    // skeleton forever (calling detail() re-throws on error in Solid).
+    apiMocks.getConnectionDetail.mockRejectedValueOnce(new Error('network down'));
+
+    const { container } = render(() => <ConnectionDetail />);
+    await waitFor(() =>
+      expect(screen.getByText("Couldn't load this connection")).toBeDefined(),
+    );
+    expect(container.querySelector('[style*="skeleton-pulse"]')).toBeNull();
+
+    // Retry re-fetches; on success the connection renders.
+    apiMocks.getConnectionDetail.mockResolvedValueOnce(connectionDetail);
+    fireEvent.click(screen.getByText('Retry'));
+    await waitFor(() => expect(screen.getAllByText('Default').length).toBeGreaterThan(0));
+  });
+
   it('scopes every chart query to the connection label (P2)', async () => {
     // The detail page must pass the connection's label to all chart/summary
     // queries so two connections sharing provider+auth_type but differing by

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -239,9 +239,23 @@ describe('provider pages', () => {
     render(() => <LocalProviders />);
 
     await waitFor(() => {
-      expect(mockSetSearchParams).toHaveBeenCalledWith({ add: undefined });
+      // The deep-link handling lives in a createEffect (not the render body), and
+      // clears the param with replace so a refresh/back-nav can't re-trigger it.
+      expect(mockSetSearchParams).toHaveBeenCalledWith({ add: undefined }, { replace: true });
       expect(screen.getByRole('dialog', { name: 'provider modal' })).toBeDefined();
     });
+  });
+
+  it('does not auto-open the modal without the add=true deep-link', async () => {
+    mockSearchParams = {};
+    render(() => <Subscriptions />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Subscriptions')).toBeDefined();
+    });
+    // No deep-link → the effect must not clear the param or open the modal.
+    expect(mockSetSearchParams).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog', { name: 'provider modal' })).toBeNull();
   });
 
   it('disables Add buttons when no agent exists for the modal context', async () => {


### PR DESCRIPTION
### 💭 Why
A pre-merge audit of `next` found a cross-tenant read path in message-detail logs, plus a few reliability gaps: stale-key auth, silent save failures, and a connection page that spins forever on a fetch error.

### ✨ What changed
- Tenant-scope the message-detail child queries (llm_calls, agent_logs, tool_executions) so a forged/colliding trace_id can't surface another tenant's logs.
- Reject API keys past their own expiry from the auth cache, not just the 5-min cache TTL.
- Routing override saves that don't persist now throw instead of reporting success.
- A demo-seed failure is caught so it no longer aborts boot (Better Auth migrations stay fatal).
- Connection page gets a retryable error state; harness links are URL-encoded.
- Move AgentGuard and connections-page effects out of memos/render body (fixes leaked reactive computations seen as console warnings).
- Tenant-scope custom-provider getById like its siblings.
- Add unit tests: per-agent provider-visibility filter, DuplicateAgentDto, tenant-scoped child queries.

### 👤 For users
The connection page shows a retry instead of an endless loading skeleton when a request fails.

### 📝 Notes
Found auditing `next` ahead of the next->main merge. Deferred to follow-ups: split the provider/proxy services, finish the userProviderId->tenantProviderId rename, drop the dead tenant_providers.agent_id column. Operational reminder for next->main: run an orphan preflight (provider/api-key/config rows whose user has no tenant) before deploying, or the tenant migrations abort boot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cross-tenant log read in message details and hardens auth and dashboard behavior. Adds retryable errors and stricter save semantics to prevent endless spinners, stale cache, and phantom successes.

- **Bug Fixes**
  - Tenant-scope message-detail child queries (`llm_calls`, `agent_logs`, `tool_executions`) and `custom-provider` `getById` to prevent cross-tenant reads.
  - Reject cached API keys past their `expires_at` immediately (not just the 5‑min cache TTL).
  - Routing overrides (`setOverride`, `toggleCategory`) now rethrow when a save didn’t persist; on unique conflicts they adopt the persisted row and invalidate the routing cache.
  - Demo-data seed failures are logged and ignored so boot continues; Better Auth migrations remain fatal.
  - Connection detail page shows a retryable error instead of spinning; harness links are URL‑encoded; moved reactive effects into `createEffect` (AgentGuard and provider connections) to stop leaked computations.

<sup>Written for commit 0cb8ce38624bad310de8d0ef35f068c827f81326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

