### PR TITLE
test: report e2e coverage to Codecov and close coverage gaps

### DIFF
--- a/packages/backend/src/common/constants/subscription-clients.spec.ts
+++ b/packages/backend/src/common/constants/subscription-clients.spec.ts
@@ -1,0 +1,37 @@
+import {
+  buildClaudeCodeSubscriptionHeaders,
+  claudeCodeStainlessArch,
+  claudeCodeStainlessOs,
+} from './subscription-clients';
+
+describe('claudeCodeStainlessArch', () => {
+  it.each([
+    ['arm64', 'arm64'],
+    ['x64', 'x64'],
+    ['mips', 'Other:mips'],
+  ])('maps %s to %s', (arch, expected) => {
+    expect(claudeCodeStainlessArch(arch as NodeJS.Architecture)).toBe(expected);
+  });
+});
+
+describe('claudeCodeStainlessOs', () => {
+  it.each([
+    ['darwin', 'MacOS'],
+    ['linux', 'Linux'],
+    ['win32', 'Windows'],
+    ['freebsd', 'FreeBSD'],
+    ['sunos', 'Other:sunos'],
+  ])('maps %s to %s', (platform, expected) => {
+    expect(claudeCodeStainlessOs(platform as NodeJS.Platform)).toBe(expected);
+  });
+});
+
+describe('buildClaudeCodeSubscriptionHeaders', () => {
+  it('sets the bearer token and stainless metadata headers', () => {
+    const headers = buildClaudeCodeSubscriptionHeaders('key-123');
+    expect(headers.Authorization).toBe('Bearer key-123');
+    expect(headers['x-app']).toBe('cli');
+    expect(headers['x-stainless-arch']).toBeDefined();
+    expect(headers['x-stainless-os']).toBeDefined();
+  });
+});

--- a/packages/backend/src/common/constants/subscription-clients.ts
+++ b/packages/backend/src/common/constants/subscription-clients.ts
@@ -22,7 +22,7 @@ export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.80.0';
 export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v24.14.0';
 export const CLAUDE_CODE_BETA_FLAGS = ['claude-code-20250219', 'oauth-2025-04-20'].join(',');
 
-function claudeCodeStainlessArch(arch = process.arch): string {
+export function claudeCodeStainlessArch(arch = process.arch): string {
   switch (arch) {
     case 'arm64':
       return 'arm64';
@@ -33,7 +33,7 @@ function claudeCodeStainlessArch(arch = process.arch): string {
   }
 }
 
-function claudeCodeStainlessOs(platform = process.platform): string {
+export function claudeCodeStainlessOs(platform = process.platform): string {
   switch (platform) {
     case 'darwin':
       return 'MacOS';

--- a/packages/backend/src/common/utils/crypto.util.cache.spec.ts
+++ b/packages/backend/src/common/utils/crypto.util.cache.spec.ts
@@ -1,0 +1,26 @@
+// Force the derivation KDF down to scrypt N=2 so we can exercise the key-cache
+// eviction path (1024+ distinct salts) without paying full-cost scrypt per call.
+jest.mock('crypto', () => {
+  const actual = jest.requireActual('crypto');
+  return {
+    ...actual,
+    scryptSync: (secret: string, salt: Buffer | string, keylen: number) =>
+      actual.scryptSync(secret, salt, keylen, { N: 2, r: 1, p: 1 }),
+  };
+});
+
+import { encrypt, decrypt } from './crypto.util';
+
+describe('crypto.util key cache eviction', () => {
+  const SECRET = 'secret-key-at-least-32-characters-long!!';
+
+  it('evicts the oldest entry once the cache exceeds its bound', () => {
+    // Each encrypt uses a fresh random salt → a distinct cache key → the cache
+    // grows past KEY_CACHE_MAX (1024) and the LRU eviction branch runs.
+    let last = '';
+    for (let i = 0; i < 1100; i++) {
+      last = encrypt(`message-${i}`, SECRET);
+    }
+    expect(decrypt(last, SECRET)).toBe('message-1099');
+  });
+});

--- a/packages/backend/src/common/utils/crypto.util.spec.ts
+++ b/packages/backend/src/common/utils/crypto.util.spec.ts
@@ -19,6 +19,23 @@ describe('getEncryptionSecret', () => {
     expect(getEncryptionSecret()).toBe(key);
   });
 
+  it('warns once when falling back to BETTER_AUTH_SECRET in production', () => {
+    jest.resetModules();
+    process.env['NODE_ENV'] = 'production';
+    process.env['BETTER_AUTH_SECRET'] = 'b'.repeat(48);
+    delete process.env['MANIFEST_ENCRYPTION_KEY'];
+    let warnSpy: jest.SpyInstance | undefined;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Logger } = require('@nestjs/common');
+      warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require('./crypto.util') as typeof import('./crypto.util');
+      expect(mod.getEncryptionSecret()).toBe('b'.repeat(48));
+    });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
   it('returns BETTER_AUTH_SECRET when MANIFEST_ENCRYPTION_KEY is not set and secret is >= 32 chars', () => {
     const secret = 'b'.repeat(64);
     process.env['BETTER_AUTH_SECRET'] = secret;

--- a/packages/backend/src/free-models/free-models-sync.service.spec.ts
+++ b/packages/backend/src/free-models/free-models-sync.service.spec.ts
@@ -164,6 +164,19 @@ describe('FreeModelsSyncService', () => {
       expect(service.getAll()[0].name).toBe('Google Gemini');
     });
 
+    it('drops entries whose url string cannot be parsed as a URL', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          lastUpdated: '2026-04-17',
+          providers: [{ ...sampleData.providers[0], url: ':::not a url' }, sampleData.providers[1]],
+        }),
+      } as never);
+      const count = await service.refreshCache();
+      expect(count).toBe(1);
+      expect(service.getAll()[0].name).toBe('Google Gemini');
+    });
+
     it('drops entries whose baseUrl is not https or null', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,

--- a/packages/backend/src/model-discovery/model-capabilities.spec.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.spec.ts
@@ -1,0 +1,19 @@
+import { inputModalitiesFromCapabilities } from './model-capabilities';
+
+describe('inputModalitiesFromCapabilities', () => {
+  it('keeps text first and appends each novel capability once', () => {
+    const out = inputModalitiesFromCapabilities([
+      'text',
+      'stream',
+      'tools',
+      'image',
+      'image',
+      'audio',
+    ] as never);
+    expect(out).toEqual(['text', 'image', 'audio']);
+  });
+
+  it('defaults to text-only for nullish capabilities', () => {
+    expect(inputModalitiesFromCapabilities(null)).toEqual(['text']);
+  });
+});

--- a/packages/backend/src/model-prices/model-name-normalizer.spec.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.spec.ts
@@ -7,6 +7,13 @@ import {
   stripGoogleVariant,
 } from './model-name-normalizer';
 
+describe('resolveModelName — dot-normalized, date-stripped fallback', () => {
+  it('resolves a dotted, dated name via its dot-normalized no-date alias', () => {
+    const aliasMap = new Map([['foo-bar', 'CANONICAL']]);
+    expect(resolveModelName('foo.bar-2024-01-01', aliasMap)).toBe('CANONICAL');
+  });
+});
+
 describe('model-name-normalizer', () => {
   describe('stripProviderPrefix', () => {
     it('strips anthropic/ prefix', () => {

--- a/packages/backend/src/notifications/dto/set-email-provider.dto.spec.ts
+++ b/packages/backend/src/notifications/dto/set-email-provider.dto.spec.ts
@@ -1,7 +1,11 @@
 import 'reflect-metadata';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { SetEmailProviderDto, TestEmailProviderDto } from './set-email-provider.dto';
+import {
+  SetEmailProviderDto,
+  TestEmailProviderDto,
+  TestSavedEmailProviderDto,
+} from './set-email-provider.dto';
 
 describe('SetEmailProviderDto', () => {
   function create(data: Record<string, unknown>): SetEmailProviderDto {
@@ -417,5 +421,12 @@ describe('TestEmailProviderDto', () => {
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
+  });
+});
+
+describe('TestSavedEmailProviderDto', () => {
+  it('trims and lowercases the recipient address', () => {
+    const dto = plainToInstance(TestSavedEmailProviderDto, { to: '  Recipient@Example.COM  ' });
+    expect(dto.to).toBe('recipient@example.com');
   });
 });

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -95,6 +95,41 @@ describe('AgentKeyAuthGuard', () => {
     guard.onModuleDestroy();
   });
 
+  describe('onModuleInit legacy-hash audit', () => {
+    const makeAuditRepo = (getCount: jest.Mock) =>
+      ({
+        createQueryBuilder: jest.fn(() => ({
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          getCount,
+        })),
+      }) as never;
+
+    it('warns when legacy static-salt keys are still active', async () => {
+      const g = new AgentKeyAuthGuard(
+        makeAuditRepo(jest.fn().mockResolvedValue(3)),
+        createMockConfig(),
+      );
+      const logger = (g as unknown as { logger: { warn: jest.Mock } }).logger;
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      await g.onModuleInit();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('legacy static-salt'));
+      g.onModuleDestroy();
+    });
+
+    it('swallows audit query failures with a debug log', async () => {
+      const g = new AgentKeyAuthGuard(
+        makeAuditRepo(jest.fn().mockRejectedValue(new Error('no table'))),
+        createMockConfig(),
+      );
+      const logger = (g as unknown as { logger: { debug: jest.Mock } }).logger;
+      const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => undefined);
+      await g.onModuleInit();
+      expect(debugSpy).toHaveBeenCalled();
+      g.onModuleDestroy();
+    });
+  });
+
   it('throws UnauthorizedException when Authorization header is missing', async () => {
     const { ctx } = makeContext({});
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);

--- a/packages/backend/src/routing/agent-enabled-providers.controller.spec.ts
+++ b/packages/backend/src/routing/agent-enabled-providers.controller.spec.ts
@@ -363,6 +363,78 @@ describe('AgentEnabledProvidersController', () => {
         position: 'fallback 1',
       });
     });
+
+    it('reports affected specificity and header-tier routes (primary and fallback)', async () => {
+      const match = { provider: 'openai', authType: 'api_key', model: 'gpt-4o' };
+      const { controller } = makeController({
+        tenantProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({
+            id: PROVIDER_ID,
+            tenant_id: TENANT_ID,
+            provider: 'openai',
+            auth_type: 'api_key',
+            label: 'Default',
+            priority: 0,
+            cached_models: [{ id: 'gpt-4o' }],
+          } as Partial<TenantProvider>),
+        },
+        specificityRepo: {
+          find: jest.fn().mockResolvedValue([
+            {
+              category: 'coding',
+              override_route: match,
+              auto_assigned_route: null,
+              fallback_routes: [match],
+            } as Partial<SpecificityAssignment>,
+          ]),
+        },
+        headerTierRepo: {
+          find: jest.fn().mockResolvedValue([
+            {
+              name: 'h1',
+              override_route: match,
+              auto_assigned_route: null,
+              fallback_routes: [match],
+            } as Partial<HeaderTier>,
+          ]),
+        },
+      });
+      const result = await controller.getDisableImpact(ctx, 'my-agent', PROVIDER_ID);
+      expect(result.affected_tiers).toEqual([
+        { tier: 'coding', model: 'gpt-4o', position: 'primary' },
+        { tier: 'coding', model: 'gpt-4o', position: 'fallback 1' },
+        { tier: 'h1', model: 'gpt-4o', position: 'primary' },
+        { tier: 'h1', model: 'gpt-4o', position: 'fallback 1' },
+      ]);
+    });
+
+    it('excludes a no-keyLabel route when the provider is a non-default secondary key', async () => {
+      const { controller } = makeController({
+        tenantProviderRepo: {
+          findOne: jest.fn().mockResolvedValue({
+            id: PROVIDER_ID,
+            tenant_id: TENANT_ID,
+            provider: 'openai',
+            auth_type: 'api_key',
+            label: 'Work',
+            priority: 1,
+            cached_models: [],
+          } as Partial<TenantProvider>),
+        },
+        tierRepo: {
+          find: jest.fn().mockResolvedValue([
+            {
+              tier: 'standard',
+              override_route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+              auto_assigned_route: null,
+              fallback_routes: null,
+            } as Partial<TierAssignment>,
+          ]),
+        },
+      });
+      const result = await controller.getDisableImpact(ctx, 'my-agent', PROVIDER_ID);
+      expect(result.affected_tiers).toEqual([]);
+    });
   });
 
   describe('enable (PUT)', () => {

--- a/packages/backend/src/routing/dto/routing.dto.spec.ts
+++ b/packages/backend/src/routing/dto/routing.dto.spec.ts
@@ -264,6 +264,6 @@ describe('routing.dto decorator transforms', () => {
       routes: [{ provider: 'openai', authType: 'api_key', model: 'gpt-4o' }],
     });
     expect(dto.routes).toHaveLength(1);
-    expect(Array.isArray(await validate(dto))).toBe(true);
+    expect(await validate(dto)).toHaveLength(0);
   });
 });

--- a/packages/backend/src/routing/dto/routing.dto.spec.ts
+++ b/packages/backend/src/routing/dto/routing.dto.spec.ts
@@ -5,6 +5,8 @@ import {
   AgentNameParamDto,
   ConnectProviderDto,
   CopilotPollDto,
+  ModelRouteDto,
+  SetOverrideDto,
   SetResponseModeDto,
   SetFallbacksDto,
   responseModeFromDto,
@@ -232,5 +234,36 @@ describe('SetResponseModeDto', () => {
     const dto = toResponseModeDto({ response_mode: 'instant' });
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('routing.dto decorator transforms', () => {
+  it('ModelRouteDto trims keyLabel', () => {
+    const dto = plainToInstance(ModelRouteDto, {
+      provider: 'openai',
+      authType: 'api_key',
+      model: 'gpt-4o',
+      keyLabel: '  Work  ',
+    });
+    expect(dto.keyLabel).toBe('Work');
+  });
+
+  it('SetOverrideDto trims providerKeyLabel and parses the nested route', () => {
+    const dto = plainToInstance(SetOverrideDto, {
+      model: 'gpt-4o',
+      providerKeyLabel: '  Work  ',
+      route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+    });
+    expect(dto.providerKeyLabel).toBe('Work');
+    expect(dto.route?.model).toBe('gpt-4o');
+  });
+
+  it('SetFallbacksDto parses nested routes', async () => {
+    const dto = plainToInstance(SetFallbacksDto, {
+      models: ['gpt-4o'],
+      routes: [{ provider: 'openai', authType: 'api_key', model: 'gpt-4o' }],
+    });
+    expect(dto.routes).toHaveLength(1);
+    expect(Array.isArray(await validate(dto))).toBe(true);
   });
 });

--- a/packages/backend/src/routing/dto/specificity.dto.spec.ts
+++ b/packages/backend/src/routing/dto/specificity.dto.spec.ts
@@ -1,0 +1,17 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { SetSpecificityOverrideDto } from './specificity.dto';
+
+describe('SetSpecificityOverrideDto', () => {
+  it('trims the provider key label and parses the nested route', async () => {
+    const dto = plainToInstance(SetSpecificityOverrideDto, {
+      model: 'gpt-4o',
+      providerKeyLabel: '  Work  ',
+      route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+    });
+    expect(dto.providerKeyLabel).toBe('Work');
+    expect(dto.route?.model).toBe('gpt-4o');
+    expect(Array.isArray(await validate(dto))).toBe(true);
+  });
+});

--- a/packages/backend/src/routing/dto/specificity.dto.spec.ts
+++ b/packages/backend/src/routing/dto/specificity.dto.spec.ts
@@ -12,6 +12,6 @@ describe('SetSpecificityOverrideDto', () => {
     });
     expect(dto.providerKeyLabel).toBe('Work');
     expect(dto.route?.model).toBe('gpt-4o');
-    expect(Array.isArray(await validate(dto))).toBe(true);
+    expect(await validate(dto)).toHaveLength(0);
   });
 });

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
@@ -65,7 +65,7 @@ describe('HeaderTierController', () => {
     });
     expect(dto.providerKeyLabel).toBe('Work');
     expect(dto.route?.model).toBe('gpt-4o');
-    expect(Array.isArray(await validate(dto))).toBe(true);
+    expect(await validate(dto)).toHaveLength(0);
   });
 
   it('FallbacksBody parses nested route objects', async () => {
@@ -74,7 +74,7 @@ describe('HeaderTierController', () => {
       routes: [{ provider: 'openai', authType: 'api_key', model: 'gpt-4o' }],
     });
     expect(dto.routes).toHaveLength(1);
-    expect(Array.isArray(await validate(dto))).toBe(true);
+    expect(await validate(dto)).toHaveLength(0);
   });
 
   it('create forwards the resolved tenant_id and body', async () => {

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
@@ -1,4 +1,6 @@
-import { HeaderTierController } from './header-tier.controller';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { HeaderTierController, OverrideBody, FallbacksBody } from './header-tier.controller';
 import type { HeaderTierService } from './header-tier.service';
 import type { ResolveAgentService } from '../routing-core/resolve-agent.service';
 import type { TenantContext } from '../../common/decorators/tenant-context.decorator';
@@ -34,6 +36,45 @@ describe('HeaderTierController', () => {
     expect(resolveAgentService.resolve).toHaveBeenCalledWith('tenant-1', 'my-agent');
     expect(service.list).toHaveBeenCalledWith('agent-1');
     expect(out).toEqual(['tiers']);
+  });
+
+  it('setResponseMode resolves the agent then delegates to the service', async () => {
+    const { controller, service, resolveAgentService } = makeController();
+    const setResponseMode = jest.fn().mockResolvedValue({ id: 'ht-1', response_mode: 'buffered' });
+    (service as unknown as { setResponseMode: jest.Mock }).setResponseMode = setResponseMode;
+    const out = await controller.setResponseMode(ctx, 'my-agent', 'ht-1', {
+      response_mode: 'buffered',
+    });
+    expect(resolveAgentService.resolve).toHaveBeenCalledWith('tenant-1', 'my-agent');
+    expect(setResponseMode).toHaveBeenCalledWith('agent-1', 'ht-1', 'buffered');
+    expect(out).toEqual({ id: 'ht-1', response_mode: 'buffered' });
+  });
+
+  it('setResponseMode rejects a missing response_mode', async () => {
+    const { controller } = makeController();
+    await expect(controller.setResponseMode(ctx, 'my-agent', 'ht-1', {})).rejects.toThrow(
+      'response_mode is required',
+    );
+  });
+
+  it('OverrideBody trims the key label and parses the nested route', async () => {
+    const dto = plainToInstance(OverrideBody, {
+      model: 'gpt-4o',
+      providerKeyLabel: '  Work  ',
+      route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+    });
+    expect(dto.providerKeyLabel).toBe('Work');
+    expect(dto.route?.model).toBe('gpt-4o');
+    expect(Array.isArray(await validate(dto))).toBe(true);
+  });
+
+  it('FallbacksBody parses nested route objects', async () => {
+    const dto = plainToInstance(FallbacksBody, {
+      models: ['gpt-4o'],
+      routes: [{ provider: 'openai', authType: 'api_key', model: 'gpt-4o' }],
+    });
+    expect(dto.routes).toHaveLength(1);
+    expect(Array.isArray(await validate(dto))).toBe(true);
   });
 
   it('create forwards the resolved tenant_id and body', async () => {

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.ts
@@ -49,7 +49,7 @@ interface ReorderBody {
   ids: string[];
 }
 
-class OverrideBody {
+export class OverrideBody {
   @IsString()
   @IsNotEmpty()
   model!: string;
@@ -78,7 +78,7 @@ class OverrideBody {
   route?: ModelRouteDto;
 }
 
-class FallbacksBody {
+export class FallbacksBody {
   @IsArray()
   @IsString({ each: true })
   models!: string[];

--- a/packages/backend/src/routing/oauth/codeassist-client.service.spec.ts
+++ b/packages/backend/src/routing/oauth/codeassist-client.service.spec.ts
@@ -232,5 +232,50 @@ describe('CodeAssistClientService', () => {
         expect(metadata.pluginVersion).toBe('0.1.0');
       }
     });
+
+    it('throws when the onboard operation has no name to poll', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockOkResponse({ allowedTiers: [{ id: 'free-tier', isDefault: true }] }),
+        )
+        .mockResolvedValueOnce(mockOkResponse({ done: false }));
+
+      await expect(svc.onboard('access-token')).rejects.toThrow(
+        'CodeAssist onboardUser operation returned no operation name.',
+      );
+    });
+
+    it('throws when the operation never completes within the poll budget', async () => {
+      jest.useFakeTimers();
+      fetchMock
+        .mockResolvedValueOnce(
+          mockOkResponse({ allowedTiers: [{ id: 'free-tier', isDefault: true }] }),
+        )
+        .mockResolvedValue(mockOkResponse({ name: 'operations/op-1' }));
+
+      const resultPromise = svc.onboard('access-token');
+      const assertion = expect(resultPromise).rejects.toThrow(
+        'CodeAssist onboardUser operation did not complete.',
+      );
+      await jest.advanceTimersByTimeAsync(5_000 * 13);
+      await assertion;
+    });
+
+    it('throws when polling an operation returns non-OK', async () => {
+      jest.useFakeTimers();
+      fetchMock
+        .mockResolvedValueOnce(
+          mockOkResponse({ allowedTiers: [{ id: 'free-tier', isDefault: true }] }),
+        )
+        .mockResolvedValueOnce(mockOkResponse({ name: 'operations/op-err' }))
+        .mockResolvedValueOnce(mockErrorResponse(403, 'Forbidden'));
+
+      const resultPromise = svc.onboard('access-token');
+      const assertion = expect(resultPromise).rejects.toThrow(
+        'CodeAssist operation operations/op-err failed (403)',
+      );
+      await jest.advanceTimersByTimeAsync(5_000);
+      await assertion;
+    });
   });
 });

--- a/packages/backend/src/routing/oauth/kiro-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.controller.spec.ts
@@ -1,0 +1,19 @@
+import { HttpException, NotFoundException } from '@nestjs/common';
+import { KiroOauthController } from './kiro-oauth.controller';
+import type { TenantContext } from '../../common/decorators/tenant-context.decorator';
+
+describe('KiroOauthController', () => {
+  const controller = new KiroOauthController({} as never, {} as never, {} as never);
+
+  it('poll rejects with BadRequest when flowId is missing', async () => {
+    await expect(
+      controller.poll('', { tenantId: 't1', userId: 'u1' } as TenantContext),
+    ).rejects.toBeInstanceOf(HttpException);
+  });
+
+  it('poll rejects with NotFound when the tenant context is missing', async () => {
+    await expect(
+      controller.poll('flow-1', { tenantId: '', userId: 'u1' } as TenantContext),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/packages/backend/src/routing/oauth/minimax-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.controller.spec.ts
@@ -1,0 +1,19 @@
+import { HttpException, NotFoundException } from '@nestjs/common';
+import { MinimaxOauthController } from './minimax-oauth.controller';
+import type { TenantContext } from '../../common/decorators/tenant-context.decorator';
+
+describe('MinimaxOauthController', () => {
+  const controller = new MinimaxOauthController({} as never, {} as never, {} as never);
+
+  it('poll rejects with BadRequest when flowId is missing', async () => {
+    await expect(
+      controller.poll('', { tenantId: 't1', userId: 'u1' } as TenantContext),
+    ).rejects.toBeInstanceOf(HttpException);
+  });
+
+  it('poll rejects with NotFound when the tenant context is missing', async () => {
+    await expect(
+      controller.poll('flow-1', { tenantId: '', userId: 'u1' } as TenantContext),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
@@ -191,6 +191,21 @@ describe('MinimaxOauthService', () => {
       expect(svc.getPendingCount()).toBe(0);
     });
 
+    it('purges and reports error when the flow expires between cleanup and the expiry check', async () => {
+      const start = await startFlow();
+      // cleanupExpired() and the explicit expiry check share Date.now(); only a
+      // clock that advances between the two reads reaches the expiry branch.
+      const nowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(start.expiresAt - 1)
+        .mockReturnValueOnce(start.expiresAt + 1);
+      const out = await svc.pollAuthorization(start.flowId, 'user-1');
+      nowSpy.mockRestore();
+      expect(out.status).toBe('error');
+      expect(out.message).toContain('expired');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
     it('returns "pending" when the token endpoint reports a pending approval', async () => {
       const start = await startFlow();
       fetchMock.mockResolvedValueOnce(mockResponse(200, { status: 'pending' }));

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
@@ -1,7 +1,39 @@
 import { ConfigService } from '@nestjs/config';
+import type { ServerResponse } from 'http';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { ProviderService } from '../../routing-core/provider.service';
 import { XaiOauthService } from './xai-oauth.service';
+
+const mockHttpControl: {
+  reqHandler?: (req: unknown, res: unknown) => void;
+  errorHandler?: (err: NodeJS.ErrnoException) => void;
+  listenCb?: () => void;
+  server?: { on: jest.Mock; listen: jest.Mock; close: jest.Mock; unref: jest.Mock };
+} = {};
+
+jest.mock('http', () => {
+  const actual = jest.requireActual('http');
+  return {
+    ...actual,
+    createServer: jest.fn((reqHandler: (req: unknown, res: unknown) => void) => {
+      mockHttpControl.reqHandler = reqHandler;
+      const server: { on: jest.Mock; listen: jest.Mock; close: jest.Mock; unref: jest.Mock } = {
+        on: jest.fn((event: string, cb: (err: NodeJS.ErrnoException) => void) => {
+          if (event === 'error') mockHttpControl.errorHandler = cb;
+          return server;
+        }),
+        listen: jest.fn((_port: number, _host: string, cb: () => void) => {
+          mockHttpControl.listenCb = cb;
+          return server;
+        }),
+        close: jest.fn(),
+        unref: jest.fn(),
+      };
+      mockHttpControl.server = server;
+      return server;
+    }),
+  };
+});
 
 const originalFetch = global.fetch;
 
@@ -229,5 +261,163 @@ describe('XaiOauthService', () => {
     expect(revokeUrl).toBe('https://auth.x.ai/oauth2/revoke');
     const body = new URLSearchParams(init.body.toString());
     expect(body.get('token')).toBe('tok');
+  });
+
+  it('swallows model-discovery failures after a successful exchange', async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 3600 }),
+    );
+    discovery.discoverModels.mockRejectedValueOnce(new Error('discovery boom'));
+    const url = await svc.generateAuthorizationUrl('agent-1', 'tenant-1');
+    const state = new URL(url).searchParams.get('state')!;
+
+    await expect(svc.exchangeCode(state, 'code')).resolves.toBeUndefined();
+    expect(providerService.upsertProvider).toHaveBeenCalled();
+    expect(svc.getPendingCount()).toBe(0);
+  });
+
+  it('throws when the refresh endpoint returns an error', async () => {
+    fetchMock.mockResolvedValue(mockResponse(400, {}, 'bad_refresh'));
+    await expect(svc.refreshAccessToken('refresh-x')).rejects.toThrow('Token refresh failed');
+  });
+
+  it('keeps the existing refresh token when the response omits a new one', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, { access_token: 'na', expires_in: 3600 }));
+    const blob = await svc.refreshAccessToken('keep-me');
+    expect(blob.t).toBe('na');
+    expect(blob.r).toBe('keep-me');
+  });
+
+  it('returns null and logs when a refresh during unwrap fails', async () => {
+    const blob = { t: 'old', r: 'refresh-old', e: Date.now() + 30_000 };
+    fetchMock.mockRejectedValue(new Error('network down'));
+    const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'tenant-1', 'Work');
+    expect(token).toBeNull();
+  });
+
+  it('logs a warning when revocation returns an error status', async () => {
+    fetchMock.mockResolvedValue(mockResponse(400, {}, 'revoke_failed'));
+    await expect(svc.revokeToken('tok')).resolves.toBeUndefined();
+  });
+
+  it('swallows revocation network errors', async () => {
+    fetchMock.mockRejectedValue(new Error('revoke network'));
+    await expect(svc.revokeToken('tok')).resolves.toBeUndefined();
+  });
+
+  it('ignores a malformed backend redirect URL', async () => {
+    const url = await svc.generateAuthorizationUrl('a', 't', 'not a url');
+    expect(new URL(url).searchParams.get('state')).toBeTruthy();
+  });
+
+  it('ignores a non-loopback backend redirect URL', async () => {
+    const url = await svc.generateAuthorizationUrl('a', 't', 'http://evil.example.com');
+    expect(new URL(url).searchParams.get('state')).toBeTruthy();
+  });
+
+  describe('dev-mode callback server', () => {
+    let devSvc: XaiOauthService;
+    const flush = () => new Promise((r) => setImmediate(r));
+    const mockRes = () => ({ writeHead: jest.fn(), end: jest.fn() }) as unknown as ServerResponse;
+
+    beforeEach(() => {
+      jest.useRealTimers();
+      mockHttpControl.reqHandler = undefined;
+      mockHttpControl.errorHandler = undefined;
+      mockHttpControl.listenCb = undefined;
+      (jest.requireMock('http').createServer as jest.Mock).mockClear();
+      devSvc = new XaiOauthService(providerService.svc, createConfig('development'), discovery.svc);
+    });
+
+    it('starts the callback server and resolves once it is listening', async () => {
+      const p = devSvc.generateAuthorizationUrl('agent-1', 'tenant-1', 'http://localhost:3001');
+      expect(mockHttpControl.listenCb).toBeDefined();
+      mockHttpControl.listenCb!();
+      const url = await p;
+      expect(new URL(url).searchParams.get('state')).toBeTruthy();
+      expect(mockHttpControl.server!.unref).toHaveBeenCalled();
+    });
+
+    it('reuses an in-flight server-ready promise across concurrent flows', async () => {
+      const p1 = devSvc.generateAuthorizationUrl('a', 't');
+      const p2 = devSvc.generateAuthorizationUrl('b', 't');
+      mockHttpControl.listenCb!();
+      await Promise.all([p1, p2]);
+      expect(jest.requireMock('http').createServer).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses the running callback server on later flows', async () => {
+      const p1 = devSvc.generateAuthorizationUrl('a', 't');
+      mockHttpControl.listenCb!();
+      await p1;
+      await devSvc.generateAuthorizationUrl('b', 't');
+      expect(jest.requireMock('http').createServer).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects when the callback port is already in use', async () => {
+      const p = devSvc.generateAuthorizationUrl('a', 't');
+      mockHttpControl.errorHandler!({ code: 'EADDRINUSE' } as NodeJS.ErrnoException);
+      await expect(p).rejects.toThrow(/already in use/);
+    });
+
+    it('rejects on a generic callback server error', async () => {
+      const p = devSvc.generateAuthorizationUrl('a', 't');
+      mockHttpControl.errorHandler!({ message: 'boom' } as NodeJS.ErrnoException);
+      await expect(p).rejects.toThrow('Callback server failed: boom');
+    });
+
+    it('returns 404 for non-callback request paths', async () => {
+      const p = devSvc.generateAuthorizationUrl('a', 't');
+      mockHttpControl.listenCb!();
+      await p;
+      const res = mockRes();
+      mockHttpControl.reqHandler!({ url: '/nope' }, res);
+      expect(res.writeHead).toHaveBeenCalledWith(404);
+      expect(res.end).toHaveBeenCalledWith('Not found');
+    });
+
+    it('redirects to the app with ok=0 when the provider returns an error', async () => {
+      const p = devSvc.generateAuthorizationUrl('a', 't', 'http://localhost:3001');
+      mockHttpControl.listenCb!();
+      const url = await p;
+      const state = new URL(url).searchParams.get('state')!;
+      const res = mockRes();
+      mockHttpControl.reqHandler!(
+        { url: `/callback?error=access_denied&error_description=nope&state=${state}` },
+        res,
+      );
+      expect(res.writeHead).toHaveBeenCalledWith(
+        302,
+        expect.objectContaining({ Location: expect.stringContaining('done?ok=0') }),
+      );
+    });
+
+    it('exchanges the code and serves the done HTML on a valid callback', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 3600 }),
+      );
+      const p = devSvc.generateAuthorizationUrl('agent-1', 'tenant-1');
+      mockHttpControl.listenCb!();
+      const url = await p;
+      const state = new URL(url).searchParams.get('state')!;
+      const res = mockRes();
+      mockHttpControl.reqHandler!({ url: `/callback?code=auth&state=${state}` }, res);
+      await flush();
+      expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+      expect(res.end).toHaveBeenCalled();
+      expect(mockHttpControl.server!.close).toHaveBeenCalled();
+    });
+
+    it('serves a failure response when the callback exchange rejects', async () => {
+      fetchMock.mockResolvedValue(mockResponse(400, {}, 'bad'));
+      const p = devSvc.generateAuthorizationUrl('agent-1', 'tenant-1');
+      mockHttpControl.listenCb!();
+      const url = await p;
+      const state = new URL(url).searchParams.get('state')!;
+      const res = mockRes();
+      mockHttpControl.reqHandler!({ url: `/callback?code=bad&state=${state}` }, res);
+      await flush();
+      expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+    });
   });
 });

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ProviderController } from './provider.controller';
 import { ProviderService } from './routing-core/provider.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
@@ -62,6 +62,18 @@ describe('ProviderController', () => {
       mockTierService as unknown as TierService,
       mockPricingSync as unknown as PricingSyncService,
     );
+  });
+
+  describe('upsertProvider region validation', () => {
+    it('rejects an invalid Qwen region on connect', async () => {
+      await expect(
+        controller.upsertProvider(mockCtx, mockAgentName, {
+          provider: 'qwen',
+          authType: 'api_key',
+          region: 'mars',
+        } as never),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
   });
 
   /* ── getStatus ── */

--- a/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
@@ -534,4 +534,48 @@ describe('ProviderKeyService', () => {
       expect(await svc.isModelAvailable('agent-1', 'gpt-4o')).toBe(true);
     });
   });
+
+  describe('resolveProviderKeys ordering and local keys', () => {
+    it('orders same-auth-type matches by priority when no auth type is preferred', async () => {
+      providerRepo.find.mockResolvedValue([
+        {
+          id: 'b',
+          provider: 'openai',
+          auth_type: 'api_key',
+          api_key_encrypted: 'encB',
+          is_active: true,
+          label: 'B',
+          priority: 1,
+        },
+        {
+          id: 'a',
+          provider: 'openai',
+          auth_type: 'api_key',
+          api_key_encrypted: 'encA',
+          is_active: true,
+          label: 'A',
+          priority: 0,
+        },
+      ]);
+      mockedDecrypt.mockImplementation((v) => (v === 'encA' ? 'key-a' : 'key-b'));
+      const keys = await svc.getProviderKeys('tenant-1', 'openai');
+      expect(keys.map((k) => k.apiKey)).toEqual(['key-a', 'key-b']);
+    });
+
+    it('returns an empty-string key for local providers with no stored credential', async () => {
+      providerRepo.find.mockResolvedValue([
+        {
+          id: 'l',
+          provider: 'lmstudio',
+          auth_type: 'local',
+          api_key_encrypted: null,
+          is_active: true,
+          label: 'Default',
+          priority: 0,
+        },
+      ]);
+      const keys = await svc.getProviderKeys('tenant-1', 'lmstudio');
+      expect(keys[0].apiKey).toBe('');
+    });
+  });
 });

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -305,6 +305,12 @@ describe('ProviderParamSpecService', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
+  it('treats a providerless fetch network error as no specs', async () => {
+    fetchSpy.mockRejectedValue(new Error('network down'));
+    const service = new ProviderParamSpecService();
+    await expect(service.getSpecs('openai', 'api_key', 'gpt-throw')).resolves.toEqual([]);
+  });
+
   it('bounds providerless cache entries', async () => {
     fetchSpy.mockImplementation(async (url: string | URL) => {
       const slug = String(url).match(/\/params\/(.+)\.json$/)?.[1] ?? 'unknown';

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.coverage.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.coverage.spec.ts
@@ -1,0 +1,239 @@
+import type { ModelRoute } from 'manifest-shared';
+import { ProviderService } from '../provider.service';
+import { TenantProvider } from '../../../entities/tenant-provider.entity';
+import { TierAssignment } from '../../../entities/tier-assignment.entity';
+import { SpecificityAssignment } from '../../../entities/specificity-assignment.entity';
+import { Agent } from '../../../entities/agent.entity';
+import { HeaderTier } from '../../../entities/header-tier.entity';
+import type { Repository } from 'typeorm';
+import type { RoutingCacheService } from '../routing-cache.service';
+import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
+
+const route = (provider: string, model: string): ModelRoute =>
+  ({ provider, authType: 'api_key', model }) as ModelRoute;
+
+const makeQueryBuilder = () => ({
+  leftJoin: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  getRawMany: jest.fn().mockResolvedValue([{ id: 'agent-1' }]),
+});
+const makeRepo = () => ({
+  find: jest.fn().mockResolvedValue([]),
+  findOne: jest.fn().mockResolvedValue(null),
+  insert: jest.fn().mockResolvedValue(undefined),
+  save: jest.fn().mockImplementation(async (rows) => rows),
+  delete: jest.fn().mockResolvedValue(undefined),
+  remove: jest.fn().mockResolvedValue(undefined),
+  update: jest.fn().mockResolvedValue(undefined),
+  manager: { transaction: jest.fn() },
+  createQueryBuilder: jest.fn().mockReturnValue(makeQueryBuilder()),
+});
+
+const provRow = (over: Partial<TenantProvider>): TenantProvider =>
+  ({
+    id: 'p',
+    agent_id: 'agent-1',
+    tenant_id: 'tenant-1',
+    provider: 'openai',
+    auth_type: 'api_key',
+    label: 'Default',
+    priority: 0,
+    is_active: true,
+    ...over,
+  }) as unknown as TenantProvider;
+
+describe('ProviderService — coverage completion', () => {
+  let providerRepo: ReturnType<typeof makeRepo>;
+  let tierRepo: ReturnType<typeof makeRepo>;
+  let specRepo: ReturnType<typeof makeRepo>;
+  let headerTierRepo: ReturnType<typeof makeRepo>;
+  let routingCache: {
+    invalidateAgent: jest.Mock;
+    invalidateTenant: jest.Mock;
+    getProviders: jest.Mock;
+    setProviders: jest.Mock;
+  };
+  let svc: ProviderService;
+  const priv = () => svc as unknown as Record<string, (...args: unknown[]) => unknown>;
+
+  beforeEach(() => {
+    providerRepo = makeRepo();
+    tierRepo = makeRepo();
+    specRepo = makeRepo();
+    headerTierRepo = makeRepo();
+    routingCache = {
+      invalidateAgent: jest.fn(),
+      invalidateTenant: jest.fn(),
+      getProviders: jest.fn().mockReturnValue(null),
+      setProviders: jest.fn(),
+    };
+    svc = new ProviderService(
+      providerRepo as unknown as Repository<TenantProvider>,
+      tierRepo as unknown as Repository<TierAssignment>,
+      specRepo as unknown as Repository<SpecificityAssignment>,
+      makeRepo() as unknown as Repository<Agent>,
+      headerTierRepo as unknown as Repository<HeaderTier>,
+      { getByModel: jest.fn().mockReturnValue(undefined) } as unknown as ModelPricingCacheService,
+      routingCache as unknown as RoutingCacheService,
+    );
+  });
+
+  describe('reorderKeys', () => {
+    it('throws when no active rows exist', async () => {
+      providerRepo.find.mockResolvedValueOnce([provRow({ is_active: false })]);
+      await expect(svc.reorderKeys('a', 't', 'openai', 'api_key', [])).rejects.toThrow(
+        'Provider not found',
+      );
+    });
+    it('throws when the label count does not match', async () => {
+      providerRepo.find.mockResolvedValueOnce([provRow({ label: 'A' }), provRow({ label: 'B' })]);
+      await expect(svc.reorderKeys('a', 't', 'openai', 'api_key', ['A'])).rejects.toThrow(
+        'exactly 2 labels',
+      );
+    });
+    it('throws on a duplicate label', async () => {
+      providerRepo.find.mockResolvedValueOnce([provRow({ label: 'A' }), provRow({ label: 'B' })]);
+      await expect(svc.reorderKeys('a', 't', 'openai', 'api_key', ['A', 'A'])).rejects.toThrow(
+        'Duplicate label "A"',
+      );
+    });
+    it('throws on an unknown label', async () => {
+      providerRepo.find.mockResolvedValueOnce([provRow({ label: 'A' }), provRow({ label: 'B' })]);
+      await expect(svc.reorderKeys('a', 't', 'openai', 'api_key', ['A', 'C'])).rejects.toThrow(
+        'Unknown label "C"',
+      );
+    });
+    it('reorders rows and assigns priorities by position', async () => {
+      providerRepo.find.mockResolvedValueOnce([
+        provRow({ label: 'A', priority: 0 }),
+        provRow({ label: 'B', priority: 1 }),
+      ]);
+      const out = await svc.reorderKeys('agent-1', 'tenant-1', 'openai', 'api_key', ['B', 'A']);
+      expect(out.map((r) => [r.label, r.priority])).toEqual([
+        ['B', 0],
+        ['A', 1],
+      ]);
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+    });
+  });
+
+  describe('renameKey', () => {
+    it('rejects a name that collides with another key', async () => {
+      providerRepo.find.mockResolvedValueOnce([
+        provRow({ id: 't', label: 'Old' }),
+        provRow({ id: 'o', label: 'Taken' }),
+      ]);
+      await expect(
+        svc.renameKey('a', 'tenant-1', 'openai', 'api_key', 'Old', 'Taken'),
+      ).rejects.toThrow('already exists');
+    });
+    it('rewrites pinned fallback routes on specificity and header tiers', async () => {
+      providerRepo.find.mockResolvedValueOnce([provRow({ id: 't', label: 'Old' })]);
+      const match = { ...route('openai', 'gpt-4o'), keyLabel: 'Old' };
+      specRepo.find.mockResolvedValueOnce([
+        { agent_id: 'agent-1', override_route: null, fallback_routes: [match] },
+      ]);
+      headerTierRepo.find.mockResolvedValueOnce([
+        { agent_id: 'agent-1', override_route: null, fallback_routes: [match] },
+      ]);
+      await svc.renameKey('agent-1', 'tenant-1', 'openai', 'api_key', 'Old', 'New');
+      expect(specRepo.save).toHaveBeenCalled();
+      expect(headerTierRepo.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('retagAuthType', () => {
+    it('removes a colliding row, flips auth_type, and invalidates caches', async () => {
+      const txRepo = makeRepo();
+      txRepo.find.mockResolvedValueOnce([
+        provRow({ id: 'src', auth_type: 'local', label: 'Default' }),
+        provRow({ id: 'dst', auth_type: 'api_key', label: 'Default' }),
+      ]);
+      providerRepo.manager.transaction.mockImplementation(
+        async (cb: (m: { getRepository: () => unknown }) => unknown) =>
+          cb({ getRepository: () => txRepo }),
+      );
+      await svc.retagAuthType('agent-1', 'tenant-1', 'lmstudio', 'api_key');
+      expect(txRepo.remove).toHaveBeenCalled();
+      expect(txRepo.save).toHaveBeenCalled();
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+    });
+    it('is a no-op when there is no row to retag', async () => {
+      const txRepo = makeRepo();
+      txRepo.find.mockResolvedValueOnce([provRow({ auth_type: 'api_key' })]);
+      providerRepo.manager.transaction.mockImplementation(
+        async (cb: (m: { getRepository: () => unknown }) => unknown) =>
+          cb({ getRepository: () => txRepo }),
+      );
+      await svc.retagAuthType(null, 'tenant-1', 'lmstudio', 'api_key');
+      expect(txRepo.save).not.toHaveBeenCalled();
+      expect(routingCache.invalidateTenant).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeProvider route guards', () => {
+    it('blocks disconnect when a tier fallback route pins the provider', async () => {
+      providerRepo.find.mockResolvedValueOnce([provRow({})]);
+      tierRepo.find.mockResolvedValueOnce([
+        { tier: 'standard', override_route: null, fallback_routes: [route('OpenAI', 'gpt-4o')] },
+      ]);
+      await expect(svc.removeProvider('agent-1', 'tenant-1', 'openai')).rejects.toThrow(
+        /Cannot disconnect provider/,
+      );
+    });
+    it('blocks disconnect when a specificity override route pins the provider', async () => {
+      providerRepo.find.mockResolvedValueOnce([provRow({})]);
+      specRepo.find.mockResolvedValueOnce([
+        { category: 'coding', override_route: route('OpenAI', 'gpt-4o'), fallback_routes: null },
+      ]);
+      await expect(svc.removeProvider('agent-1', 'tenant-1', 'openai')).rejects.toThrow(
+        /Cannot disconnect provider/,
+      );
+    });
+  });
+
+  it('routeBelongsToProviderRows matches a route against a row by cached model id', () => {
+    const row = provRow({
+      provider: 'openrouter',
+      cached_models: [{ id: 'Foo-Model' }] as unknown as TenantProvider['cached_models'],
+      priority: 1,
+    });
+    expect(
+      priv().routeBelongsToProviderRows({ authType: 'api_key', model: 'foo-model' }, [row]),
+    ).toBe(true);
+  });
+
+  it('normalizeLabel rejects empty and local custom labels', () => {
+    expect(() => priv().normalizeLabel('   ', 'api_key')).toThrow('must not be empty');
+    expect(() => priv().normalizeLabel('Custom', 'local')).toThrow('not supported for local');
+  });
+
+  it('assertLabelLooksValid rejects empty and overly long labels', () => {
+    expect(() => priv().assertLabelLooksValid('')).toThrow('must not be empty');
+    expect(() => priv().assertLabelLooksValid('x'.repeat(300))).toThrow('at most');
+  });
+
+  it('decryptOrNull returns null for ciphertext that cannot be decrypted', () => {
+    expect(priv().decryptOrNull('not-real-ciphertext')).toBeNull();
+  });
+
+  it('nextOAuthLabel falls back to Key N+1 when the candidate range is exhausted', async () => {
+    const rows = Array.from({ length: 99 }, (_, i) =>
+      provRow({ id: `k${i}`, label: `Key ${i + 1}` }),
+    );
+    providerRepo.find.mockResolvedValueOnce(rows);
+    expect(await svc.nextOAuthLabel('tenant-1', 'anthropic')).toBe('Key 100');
+  });
+
+  it('cleanupUnsupportedSubscriptionProviders deactivates unusable subscription rows', async () => {
+    providerRepo.find.mockResolvedValueOnce([
+      provRow({ id: 'sub', provider: 'somecustomsub', auth_type: 'subscription' }),
+      provRow({ id: 'key', provider: 'openai', auth_type: 'api_key' }),
+    ]);
+    await priv().cleanupUnsupportedSubscriptionProviders('tenant-1');
+    expect(providerRepo.save).toHaveBeenCalled();
+    expect(routingCache.invalidateTenant).toHaveBeenCalledWith('tenant-1');
+  });
+});

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.region.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.region.spec.ts
@@ -1,0 +1,114 @@
+import { ProviderService } from '../provider.service';
+import { TenantProvider } from '../../../entities/tenant-provider.entity';
+import { TierAssignment } from '../../../entities/tier-assignment.entity';
+import { SpecificityAssignment } from '../../../entities/specificity-assignment.entity';
+import { Agent } from '../../../entities/agent.entity';
+import { HeaderTier } from '../../../entities/header-tier.entity';
+import type { Repository } from 'typeorm';
+import type { RoutingCacheService } from '../routing-cache.service';
+import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
+import { encrypt, getEncryptionSecret } from '../../../common/utils/crypto.util';
+
+jest.mock('../../qwen-region', () => {
+  const actual = jest.requireActual('../../qwen-region');
+  return { ...actual, detectQwenRegion: jest.fn() };
+});
+
+const { detectQwenRegion } = jest.requireMock('../../qwen-region') as {
+  detectQwenRegion: jest.Mock;
+};
+
+const makeRepo = () => ({
+  find: jest.fn().mockResolvedValue([]),
+  findOne: jest.fn().mockResolvedValue(null),
+  save: jest.fn().mockImplementation(async (rows) => rows),
+  remove: jest.fn().mockResolvedValue(undefined),
+  manager: { transaction: jest.fn() },
+  createQueryBuilder: jest.fn().mockReturnValue({
+    leftJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue([{ id: 'agent-1' }]),
+  }),
+});
+
+describe('ProviderService — Qwen region resolution', () => {
+  let svc: ProviderService;
+  let originalSecret: string | undefined;
+
+  beforeEach(() => {
+    originalSecret = process.env.BETTER_AUTH_SECRET;
+    process.env.BETTER_AUTH_SECRET = 'a'.repeat(48);
+    detectQwenRegion.mockReset();
+    svc = new ProviderService(
+      makeRepo() as unknown as Repository<TenantProvider>,
+      makeRepo() as unknown as Repository<TierAssignment>,
+      makeRepo() as unknown as Repository<SpecificityAssignment>,
+      makeRepo() as unknown as Repository<Agent>,
+      makeRepo() as unknown as Repository<HeaderTier>,
+      { getByModel: jest.fn() } as unknown as ModelPricingCacheService,
+      {
+        invalidateAgent: jest.fn(),
+        invalidateTenant: jest.fn(),
+      } as unknown as RoutingCacheService,
+    );
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+    else process.env.BETTER_AUTH_SECRET = originalSecret;
+  });
+
+  const resolve = (
+    region: string | undefined,
+    apiKey: string | undefined,
+    existing: Partial<TenantProvider> | null = null,
+  ): Promise<string | null> =>
+    (
+      svc as unknown as {
+        resolveProviderRegion: (
+          p: string,
+          a: string,
+          r: string | undefined,
+          k: string | undefined,
+          e: TenantProvider | null,
+        ) => Promise<string | null>;
+      }
+    ).resolveProviderRegion('qwen', 'api_key', region, apiKey, existing as TenantProvider | null);
+
+  it('detects the region from a supplied api key when no region is requested', async () => {
+    detectQwenRegion.mockResolvedValue('singapore');
+    expect(await resolve(undefined, 'sk-xxx')).toBe('singapore');
+  });
+
+  it('keeps an existing resolved region when neither region nor key is given', async () => {
+    expect(await resolve(undefined, undefined, { region: 'us' })).toBe('us');
+    expect(await resolve(undefined, undefined, null)).toBeNull();
+  });
+
+  it('rejects an invalid requested region', async () => {
+    await expect(resolve('mars', undefined)).rejects.toThrow('Qwen region must be one of');
+  });
+
+  it('returns a concrete requested region unchanged', async () => {
+    expect(await resolve('singapore', undefined)).toBe('singapore');
+  });
+
+  it('auto-detects using a decrypted stored key', async () => {
+    detectQwenRegion.mockResolvedValue('beijing');
+    const encrypted = encrypt('stored-key', getEncryptionSecret());
+    expect(await resolve('auto', undefined, { api_key_encrypted: encrypted })).toBe('beijing');
+  });
+
+  it('auto-detect falls back to the existing region when the stored key cannot be decrypted', async () => {
+    expect(await resolve('auto', undefined, { region: 'us', api_key_encrypted: 'garbage' })).toBe(
+      'us',
+    );
+  });
+
+  it('throws when auto-detection yields no region', async () => {
+    detectQwenRegion.mockResolvedValue(null);
+    await expect(resolve('auto', 'sk-xxx')).rejects.toThrow('Could not auto-detect');
+  });
+});

--- a/packages/backend/src/routing/routing-core/__tests__/route-helpers.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/route-helpers.spec.ts
@@ -4,6 +4,7 @@ import {
   readAutoAssignedRoute,
   readFallbackRoutes,
   readOverrideRoute,
+  routeMatches,
   unambiguousRoute,
 } from '../route-helpers';
 import type { ModelRoute } from 'manifest-shared';
@@ -122,6 +123,18 @@ describe('route-helpers', () => {
     it('returns null when matched model has no authType', () => {
       const list = [discovered('gpt-4o', 'openai', undefined as never)];
       expect(unambiguousRoute('gpt-4o', list)).toBeNull();
+    });
+  });
+
+  describe('routeMatches', () => {
+    it('compares key labels case-insensitively after trimming', () => {
+      const base = route('openai', 'api_key', 'gpt-4o');
+      expect(routeMatches({ ...base, keyLabel: ' Work ' }, { ...base, keyLabel: 'work' })).toBe(
+        true,
+      );
+      expect(routeMatches({ ...base, keyLabel: 'Work' }, { ...base, keyLabel: 'Home' })).toBe(
+        false,
+      );
     });
   });
 });

--- a/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
@@ -65,6 +65,16 @@ describe('SpecificityService', () => {
     );
   });
 
+  describe('setResponseMode', () => {
+    it('creates a new specificity row when none exists yet', async () => {
+      const out = await svc.setResponseMode('agent-1', 'coding', 'buffered');
+      expect(repo.insert).toHaveBeenCalledTimes(1);
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+      expect(out.category).toBe('coding');
+      expect(out.response_mode).toBe('buffered');
+    });
+  });
+
   describe('getAssignments', () => {
     it('returns the cached value without touching the repo', async () => {
       const cached = [{ category: 'coding' }] as SpecificityAssignment[];

--- a/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
@@ -78,6 +78,16 @@ describe('TierService', () => {
     );
   });
 
+  describe('setResponseMode', () => {
+    it('creates a new tier row when none exists yet', async () => {
+      const out = await svc.setResponseMode('agent-1', 'standard', 'buffered');
+      expect(tierRepo.insert).toHaveBeenCalledTimes(1);
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+      expect(out.tier).toBe('standard');
+      expect(out.response_mode).toBe('buffered');
+    });
+  });
+
   describe('hasRoutableTier', () => {
     it('returns true when any tier has an override route', async () => {
       tierRepo.find.mockResolvedValue([

--- a/packages/backend/src/routing/specificity.controller.spec.ts
+++ b/packages/backend/src/routing/specificity.controller.spec.ts
@@ -1,0 +1,50 @@
+import { BadRequestException } from '@nestjs/common';
+import { SpecificityController } from './specificity.controller';
+import { SpecificityService } from './routing-core/specificity.service';
+import { ResolveAgentService } from './routing-core/resolve-agent.service';
+import type { TenantContext } from '../common/decorators/tenant-context.decorator';
+
+describe('SpecificityController.setResponseMode', () => {
+  const ctx: TenantContext = { tenantId: 'tenant-1', userId: 'user-1' };
+  const agent = { id: 'agent-1', tenant_id: 'tenant-1' };
+  let specificityService: { setResponseMode: jest.Mock };
+  let resolveAgentService: { resolve: jest.Mock };
+  let controller: SpecificityController;
+
+  beforeEach(() => {
+    specificityService = {
+      setResponseMode: jest
+        .fn()
+        .mockResolvedValue({ category: 'coding', response_mode: 'buffered' }),
+    };
+    resolveAgentService = { resolve: jest.fn().mockResolvedValue(agent) };
+    controller = new SpecificityController(
+      specificityService as unknown as SpecificityService,
+      resolveAgentService as unknown as ResolveAgentService,
+    );
+  });
+
+  it('sets the response mode for a valid category', async () => {
+    const out = await controller.setResponseMode(ctx, 'demo', 'coding', {
+      response_mode: 'buffered',
+    });
+    expect(out).toEqual({ category: 'coding', response_mode: 'buffered' });
+    expect(specificityService.setResponseMode).toHaveBeenCalledWith(
+      'agent-1',
+      'coding',
+      'buffered',
+    );
+  });
+
+  it('rejects an unknown category', async () => {
+    await expect(
+      controller.setResponseMode(ctx, 'demo', 'not-a-category', { response_mode: 'buffered' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects a missing response_mode', async () => {
+    await expect(controller.setResponseMode(ctx, 'demo', 'coding', {})).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+});

--- a/packages/backend/src/routing/tier.controller.spec.ts
+++ b/packages/backend/src/routing/tier.controller.spec.ts
@@ -129,6 +129,23 @@ describe('TierController', () => {
     expect(resolveAgentService.invalidate).toHaveBeenCalledWith('tenant-1', 'demo');
   });
 
+  it('PATCH response-mode sets the mode for a valid tier', async () => {
+    tierService.setResponseMode = jest
+      .fn()
+      .mockResolvedValue({ tier: 'standard', response_mode: 'buffered' });
+    const out = await controller.setResponseMode(ctx, 'demo', 'standard', {
+      response_mode: 'buffered',
+    });
+    expect(out).toEqual({ tier: 'standard', response_mode: 'buffered' });
+    expect(tierService.setResponseMode).toHaveBeenCalledWith('agent-1', 'standard', 'buffered');
+  });
+
+  it('PATCH response-mode rejects a missing response_mode', async () => {
+    await expect(controller.setResponseMode(ctx, 'demo', 'standard', {})).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
   // P1-A: tier write endpoint must 404 for the reserved "Playground" agent
   it('PUT /tiers/:tier throws NotFoundException when resolve rejects the Playground agent', async () => {
     resolveAgentService.resolve.mockRejectedValueOnce(

--- a/packages/backend/src/scoring/__tests__/score-request-advanced.spec.ts
+++ b/packages/backend/src/scoring/__tests__/score-request-advanced.spec.ts
@@ -1,5 +1,25 @@
 import { scoreRequest } from '../index';
 
+describe('scoreRequest — tool floor', () => {
+  it('floors a low-scoring tool-call request up to standard', () => {
+    const result = scoreRequest(
+      {
+        messages: [
+          {
+            role: 'user',
+            content: 'just saying a friendly little hello and checking in with you today',
+          },
+        ],
+        tools: [{ type: 'function', function: { name: 'get_time', parameters: {} } }],
+        tool_choice: 'auto',
+      } as never,
+      { boundaries: { simpleMax: 100, standardMax: 200, complexMax: 300 } },
+    );
+    expect(result.tier).toBe('standard');
+    expect(result.reason).toBe('tool_detected');
+  });
+});
+
 describe('scoreRequest — configOverride', () => {
   it('uses custom boundaries when configOverride is provided', () => {
     const result = scoreRequest(

--- a/packages/backend/test/jest-e2e.json
+++ b/packages/backend/test/jest-e2e.json
@@ -1,7 +1,7 @@
 {
   "moduleFileExtensions": ["js", "json", "ts", "tsx"],
-  "rootDir": ".",
-  "coverageDirectory": "../coverage",
+  "rootDir": "..",
+  "coverageDirectory": "coverage",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
@@ -12,6 +12,16 @@
     "node_modules/(?!(better-auth|better-call|@better-auth)/)"
   ],
   "moduleNameMapper": {
-    "^src/(.*)$": "<rootDir>/../src/$1"
-  }
+    "^src/(.*)$": "<rootDir>/src/$1"
+  },
+  "collectCoverageFrom": [
+    "src/**/*.ts",
+    "!src/**/*.spec.ts",
+    "!src/main.ts",
+    "!src/**/database/migrations/**",
+    "!src/**/database/datasource.ts",
+    "!src/**/*.module.ts",
+    "!src/**/otlp/interfaces/index.ts",
+    "!src/**/otlp/proto/**"
+  ]
 }

--- a/packages/shared/__tests__/model-params-scope.spec.ts
+++ b/packages/shared/__tests__/model-params-scope.spec.ts
@@ -1,0 +1,49 @@
+import {
+  modelParamsScopeForTier,
+  modelParamsScopeForSpecificity,
+  modelParamsScopeForHeaderTier,
+  modelParamsScopeForRouting,
+} from '../src/model-params-scope';
+
+describe('modelParamsScopeForTier', () => {
+  it('prefixes the tier', () => {
+    expect(modelParamsScopeForTier('complex')).toBe('tier:complex');
+  });
+});
+
+describe('modelParamsScopeForSpecificity', () => {
+  it('prefixes the specificity category', () => {
+    expect(modelParamsScopeForSpecificity('coding')).toBe('specificity:coding');
+  });
+});
+
+describe('modelParamsScopeForHeaderTier', () => {
+  it('prefixes the header tier id', () => {
+    expect(modelParamsScopeForHeaderTier('abc-123')).toBe('header:abc-123');
+  });
+});
+
+describe('modelParamsScopeForRouting', () => {
+  it('prefers the header tier when present', () => {
+    expect(
+      modelParamsScopeForRouting({
+        tier: 'standard',
+        specificityCategory: 'coding',
+        headerTierId: 'h1',
+      }),
+    ).toBe('header:h1');
+  });
+
+  it('falls back to specificity when no header tier', () => {
+    expect(
+      modelParamsScopeForRouting({
+        tier: 'standard',
+        specificityCategory: 'trading',
+      }),
+    ).toBe('specificity:trading');
+  });
+
+  it('falls back to the complexity tier when neither header nor specificity is set', () => {
+    expect(modelParamsScopeForRouting({ tier: 'simple' })).toBe('tier:simple');
+  });
+});


### PR DESCRIPTION
### 💭 Why
The e2e Jest config had no `collectCoverageFrom`, so e2e runs reported coverage for a single file. Codecov never saw real e2e coverage, so the combined unit+e2e gate the docs describe was never measured.

### ✨ What changed
- `jest-e2e.json` collects coverage from `src/` (rootDir moved to the package root).
- New and extended specs raise backend merged unit+e2e coverage from 98.01% to 99.51%, shared package to 100%.
- Exported two arch/os switch helpers and two header-tier DTO classes so unit tests can reach them. No behavior change.

### 📝 Notes
- Targets `next`.
- Remaining ~65 backend lines (proxy stream/adapter internals) and the frontend gaps are follow-ups.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports real e2e coverage to Codecov by fixing the e2e Jest config and adding tests to close gaps. Backend merged unit+e2e coverage is 99.51% and `packages/shared` is 100%, and we fixed DTO validation tests to assert zero errors.

- **Bug Fixes**
  - Fixed `packages/backend/test/jest-e2e.json` to collect coverage from `src/**` (moved `rootDir` to the package root, updated `coverageDirectory`, `moduleNameMapper`, and added `collectCoverageFrom`) so e2e coverage is included in Codecov.
  - Updated DTO validation specs to use `expect(await validate(dto)).toHaveLength(0)` to properly verify valid payloads.

- **Refactors**
  - Exported `claudeCodeStainlessArch`, `claudeCodeStainlessOs`, `OverrideBody`, and `FallbacksBody` for test access; no runtime behavior changes.

<sup>Written for commit 01a0a964ffb772dd8bc43c5c2c259614684f877d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

