### PR TITLE
fix: stop "Tenant not found" on first provider connect

### DIFF
--- a/.changeset/first-run-tenant-resolution.md
+++ b/.changeset/first-run-tenant-resolution.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Connecting a provider right after creating your first agent no longer fails with "Tenant not found" for several minutes — newly created workspaces are now visible to the dashboard immediately. When a database migration fails on startup, the logs now show the real migration error instead of a misleading "Unable to connect to the database" retry loop.

--- a/packages/backend/src/common/services/tenant-cache.service.spec.ts
+++ b/packages/backend/src/common/services/tenant-cache.service.spec.ts
@@ -41,6 +41,22 @@ describe('TenantCacheService', () => {
     expect(mockFindOne).toHaveBeenCalledTimes(1);
   });
 
+  it('does NOT cache a missing tenant — re-queries until one exists (first-run 404 regression)', async () => {
+    // First resolve: the user has no tenant yet (e.g. the create-agent guard
+    // runs before its handler creates the tenant).
+    mockFindOne.mockResolvedValueOnce(null);
+    expect(await service.resolve('user-1')).toBeNull();
+
+    // The tenant is created between the two calls.
+    mockFindOne.mockResolvedValueOnce({ id: 'tenant-created' });
+    expect(await service.resolve('user-1')).toBe('tenant-created');
+
+    // The null was never cached, so the second call had to re-hit the DB —
+    // otherwise the freshly created tenant would stay invisible for the TTL and
+    // provider/routing endpoints would 404 "Tenant not found".
+    expect(mockFindOne).toHaveBeenCalledTimes(2);
+  });
+
   it('invalidate() forces the next resolve() to re-hit the DB', async () => {
     // First resolve populates the cache.
     mockFindOne.mockResolvedValueOnce({ id: 'tenant-abc' });

--- a/packages/backend/src/common/services/tenant-cache.service.ts
+++ b/packages/backend/src/common/services/tenant-cache.service.ts
@@ -23,10 +23,22 @@ export class TenantCacheService {
   ) {}
 
   async resolve(userId: string): Promise<string | null> {
-    return this.cache.resolve(userId, async (uid) => {
-      const tenant = await this.tenantRepo.findOne({ where: { owner_user_id: uid } });
-      return tenant?.id ?? null;
-    });
+    // Memoize only a real tenant id, never the "no tenant yet" (null) result.
+    // Tenants are created lazily (first agent / playground / provider), and the
+    // create-agent request's own guard resolves the tenant BEFORE its handler
+    // creates it. Caching that null for the full TTL made every tenant-lookup
+    // endpoint — notably connecting a provider — return 404 "Tenant not found"
+    // for up to 5 minutes after a user created their first agent. Skipping the
+    // negative cache keeps the hot path fast while letting the very next request
+    // observe a freshly created tenant.
+    return this.cache.resolve(
+      userId,
+      async (uid) => {
+        const tenant = await this.tenantRepo.findOne({ where: { owner_user_id: uid } });
+        return tenant?.id ?? null;
+      },
+      (tenantId) => tenantId !== null,
+    );
   }
 
   /**

--- a/packages/backend/src/common/utils/db-retry.spec.ts
+++ b/packages/backend/src/common/utils/db-retry.spec.ts
@@ -1,0 +1,35 @@
+import { shouldRetryDbConnection } from './db-retry';
+
+describe('shouldRetryDbConnection', () => {
+  it('retries genuine connectivity failures (DB not ready yet)', () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), {
+      code: 'ECONNREFUSED',
+    });
+    expect(shouldRetryDbConnection(err)).toBe(true);
+  });
+
+  it('retries a generic non-migration error rather than masking a transient blip', () => {
+    expect(shouldRetryDbConnection(new Error('socket hang up'))).toBe(true);
+  });
+
+  it('does NOT retry a QueryFailedError (a failed migration/query statement)', () => {
+    const err = new Error('relation "tenant_providers" does not exist');
+    err.name = 'QueryFailedError';
+    expect(shouldRetryDbConnection(err)).toBe(false);
+  });
+
+  it('does NOT retry our explicit re-scope migration abort', () => {
+    const err = new Error(
+      'TenantProviders migration: 1 user_providers row(s) reference a user with no tenant and cannot be re-scoped.',
+    );
+    expect(shouldRetryDbConnection(err)).toBe(false);
+  });
+
+  it('retries when the error has no usable name/message (unknown shape)', () => {
+    expect(shouldRetryDbConnection(null)).toBe(true);
+    expect(shouldRetryDbConnection(undefined)).toBe(true);
+    expect(shouldRetryDbConnection({})).toBe(true);
+    // Non-string name/message must not throw and should default to retrying.
+    expect(shouldRetryDbConnection({ name: 123, message: { nested: true } })).toBe(true);
+  });
+});

--- a/packages/backend/src/common/utils/db-retry.spec.ts
+++ b/packages/backend/src/common/utils/db-retry.spec.ts
@@ -1,35 +1,34 @@
 import { shouldRetryDbConnection } from './db-retry';
 
 describe('shouldRetryDbConnection', () => {
-  it('retries genuine connectivity failures (DB not ready yet)', () => {
-    const err = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), {
-      code: 'ECONNREFUSED',
-    });
-    expect(shouldRetryDbConnection(err)).toBe(true);
+  it('retries transport-level connection codes (DB not reachable yet)', () => {
+    // code present (string) → matched; no message exercises the empty-message path.
+    expect(shouldRetryDbConnection({ code: 'ECONNREFUSED' })).toBe(true);
   });
 
-  it('retries a generic non-migration error rather than masking a transient blip', () => {
-    expect(shouldRetryDbConnection(new Error('socket hang up'))).toBe(true);
+  it('retries transport failures pg reports as a message without a code', () => {
+    expect(shouldRetryDbConnection(new Error('Connection terminated unexpectedly'))).toBe(true);
   });
 
-  it('does NOT retry a QueryFailedError (a failed migration/query statement)', () => {
-    const err = new Error('relation "tenant_providers" does not exist');
-    err.name = 'QueryFailedError';
-    expect(shouldRetryDbConnection(err)).toBe(false);
+  it('does NOT retry a failed migration / query error (not transport-level)', () => {
+    const queryErr = new Error('relation "tenant_providers" does not exist');
+    queryErr.name = 'QueryFailedError';
+    expect(shouldRetryDbConnection(queryErr)).toBe(false);
+
+    expect(
+      shouldRetryDbConnection(
+        new Error(
+          'TenantProviders migration: 1 user_providers row(s) reference a user with no tenant and cannot be re-scoped.',
+        ),
+      ),
+    ).toBe(false);
   });
 
-  it('does NOT retry our explicit re-scope migration abort', () => {
-    const err = new Error(
-      'TenantProviders migration: 1 user_providers row(s) reference a user with no tenant and cannot be re-scoped.',
-    );
-    expect(shouldRetryDbConnection(err)).toBe(false);
-  });
-
-  it('retries when the error has no usable name/message (unknown shape)', () => {
-    expect(shouldRetryDbConnection(null)).toBe(true);
-    expect(shouldRetryDbConnection(undefined)).toBe(true);
-    expect(shouldRetryDbConnection({})).toBe(true);
-    // Non-string name/message must not throw and should default to retrying.
-    expect(shouldRetryDbConnection({ name: 123, message: { nested: true } })).toBe(true);
+  it('does NOT retry unknown / shapeless errors (fail fast rather than mask)', () => {
+    expect(shouldRetryDbConnection(null)).toBe(false);
+    expect(shouldRetryDbConnection(undefined)).toBe(false);
+    expect(shouldRetryDbConnection({})).toBe(false);
+    // Non-string code/message must not throw and must not count as transport.
+    expect(shouldRetryDbConnection({ code: 123, message: { nested: true } })).toBe(false);
   });
 });

--- a/packages/backend/src/common/utils/db-retry.ts
+++ b/packages/backend/src/common/utils/db-retry.ts
@@ -1,31 +1,44 @@
+// Transport-level failures that mean "the database isn't reachable yet" — the
+// only class of error worth retrying at boot (e.g. Postgres still starting).
+const TRANSPORT_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPIPE',
+]);
+
+// pg sometimes surfaces transport/startup failures as a message without a code.
+const TRANSPORT_MESSAGES = [
+  'connection terminated',
+  'connection refused',
+  'timeout expired',
+  'the database system is starting up',
+  'terminating connection',
+  'server closed the connection',
+];
+
 /**
  * Decides whether a failed TypeORM DataSource initialization is worth retrying.
  *
- * Migrations run on connect (`migrationsRun: true`), so a failed migration
- * surfaces through @nestjs/typeorm's connection-retry path. Retrying never
- * fixes a bad migration — it just spams the misleading "Unable to connect to
- * the database. Retrying (N)..." line and buries the real
- * "Migration X failed, error: ..." cause the operator needs to see. So we fail
- * fast on migration/query errors and keep retrying only genuine connectivity
- * failures (e.g. the database not being ready yet at boot).
+ * Retry ONLY transport-level connection failures (the DB not being reachable
+ * yet). Everything else — a failed migration, a query error, or any unexpected
+ * error — fails fast: retrying never fixes it and just buries the real cause
+ * under repeated "Unable to connect to the database. Retrying (N)..." lines.
+ * Migrations run on connect (`migrationsRun: true`), so this is what stops a
+ * failed migration from looping. @nestjs/typeorm checks this predicate BEFORE
+ * logging, so returning false also suppresses the misleading retry message.
  *
- * Used as the `toRetry` predicate in database.module.ts; @nestjs/typeorm
- * checks it BEFORE logging the retry line, so returning false both suppresses
- * the misleading message and stops the retry loop.
+ * Used as the `toRetry` predicate in database.module.ts.
  */
 export function shouldRetryDbConnection(err: unknown): boolean {
-  const e = (err ?? {}) as { name?: unknown; message?: unknown };
-  const name = typeof e.name === 'string' ? e.name : '';
+  const e = (err ?? {}) as { code?: unknown; message?: unknown };
+  const code = typeof e.code === 'string' ? e.code : '';
   const message = typeof e.message === 'string' ? e.message.toLowerCase() : '';
 
-  // QueryFailedError = a SQL statement failed after connecting (a migration or
-  // query problem), never "database unreachable".
-  if (name === 'QueryFailedError') return false;
-
-  // The tenant re-scope migrations throw plain Errors whose message names the
-  // migration (e.g. "TenantProviders migration: N row(s) ... cannot be
-  // re-scoped").
-  if (message.includes('migration')) return false;
-
-  return true;
+  if (TRANSPORT_CODES.has(code)) return true;
+  return TRANSPORT_MESSAGES.some((m) => message.includes(m));
 }

--- a/packages/backend/src/common/utils/db-retry.ts
+++ b/packages/backend/src/common/utils/db-retry.ts
@@ -1,0 +1,31 @@
+/**
+ * Decides whether a failed TypeORM DataSource initialization is worth retrying.
+ *
+ * Migrations run on connect (`migrationsRun: true`), so a failed migration
+ * surfaces through @nestjs/typeorm's connection-retry path. Retrying never
+ * fixes a bad migration — it just spams the misleading "Unable to connect to
+ * the database. Retrying (N)..." line and buries the real
+ * "Migration X failed, error: ..." cause the operator needs to see. So we fail
+ * fast on migration/query errors and keep retrying only genuine connectivity
+ * failures (e.g. the database not being ready yet at boot).
+ *
+ * Used as the `toRetry` predicate in database.module.ts; @nestjs/typeorm
+ * checks it BEFORE logging the retry line, so returning false both suppresses
+ * the misleading message and stops the retry loop.
+ */
+export function shouldRetryDbConnection(err: unknown): boolean {
+  const e = (err ?? {}) as { name?: unknown; message?: unknown };
+  const name = typeof e.name === 'string' ? e.name : '';
+  const message = typeof e.message === 'string' ? e.message.toLowerCase() : '';
+
+  // QueryFailedError = a SQL statement failed after connecting (a migration or
+  // query problem), never "database unreachable".
+  if (name === 'QueryFailedError') return false;
+
+  // The tenant re-scope migrations throw plain Errors whose message names the
+  // migration (e.g. "TenantProviders migration: N row(s) ... cannot be
+  // re-scoped").
+  if (message.includes('migration')) return false;
+
+  return true;
+}

--- a/packages/backend/src/common/utils/ttl-fifo-cache.spec.ts
+++ b/packages/backend/src/common/utils/ttl-fifo-cache.spec.ts
@@ -80,6 +80,26 @@ describe('TtlFifoCache', () => {
     expect(await cache.resolve('k', loader)).toBe('v2');
   });
 
+  it('does not cache a value rejected by shouldCache (loader re-runs until cacheable)', async () => {
+    const loader = jest
+      .fn<Promise<number | null>, [string]>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(99);
+    const cache = new TtlFifoCache<string, number | null>({ maxEntries: 10, ttlMs: 1_000_000 });
+    const keepRealOnly = (v: number | null) => v !== null;
+
+    // null is returned but never stored, so each call re-runs the loader.
+    expect(await cache.resolve('k', loader, keepRealOnly)).toBeNull();
+    expect(await cache.resolve('k', loader, keepRealOnly)).toBeNull();
+    expect(loader).toHaveBeenCalledTimes(2);
+
+    // The first cacheable value IS memoized — no further loader calls.
+    expect(await cache.resolve('k', loader, keepRealOnly)).toBe(99);
+    expect(await cache.resolve('k', loader, keepRealOnly)).toBe(99);
+    expect(loader).toHaveBeenCalledTimes(3);
+  });
+
   it('defaults to Date.now when no clock is injected', async () => {
     const cache = new TtlFifoCache<string, number>({ maxEntries: 10, ttlMs: 1000 });
     const loader = jest.fn<Promise<number>, [string]>().mockResolvedValue(7);

--- a/packages/backend/src/common/utils/ttl-fifo-cache.ts
+++ b/packages/backend/src/common/utils/ttl-fifo-cache.ts
@@ -21,12 +21,24 @@ export class TtlFifoCache<K, V> {
     this.now = opts.now ?? Date.now;
   }
 
-  async resolve(key: K, loader: (key: K) => Promise<V>): Promise<V> {
+  /**
+   * `shouldCache` lets a caller skip memoizing a result it considers transient
+   * (e.g. a "not found yet" sentinel). Such values are returned to the caller
+   * but never stored, so the next resolve() re-runs the loader. Defaults to
+   * caching every value.
+   */
+  async resolve(
+    key: K,
+    loader: (key: K) => Promise<V>,
+    shouldCache: (value: V) => boolean = () => true,
+  ): Promise<V> {
     const cached = this.entries.get(key);
     if (cached && cached.expiresAt > this.now()) return cached.value;
     if (cached) this.entries.delete(key);
 
     const value = await loader(key);
+
+    if (!shouldCache(value)) return value;
 
     if (this.entries.size >= this.maxEntries && !this.entries.has(key)) {
       const firstKey = this.entries.keys().next().value;

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -27,6 +27,7 @@ import { ReasoningContentCacheEntry } from '../entities/reasoning-content-cache-
 import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { DatabaseSeederService } from './database-seeder.service';
 import { ModelPricesModule } from '../model-prices/model-prices.module';
+import { shouldRetryDbConnection } from '../common/utils/db-retry';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -270,6 +271,12 @@ const migrations = [
         migrationsRun: true,
         migrationsTransactionMode: 'all' as const,
         migrations,
+        // A failed migration must not go through the connection-retry loop:
+        // @nestjs/typeorm checks toRetry before logging, so returning false
+        // here suppresses the misleading "Unable to connect to the database.
+        // Retrying" line and fails fast with the real migration error. Genuine
+        // connectivity failures (DB not ready yet) still retry.
+        toRetry: shouldRetryDbConnection,
         logging: false,
         extra: {
           // app.config.ts always resolves dbPoolMax (default 20), so there is no

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -225,5 +225,18 @@ export async function bootstrap() {
 
 // Only auto-start when run directly (not when embedded)
 if (!process.env['MANIFEST_EMBEDDED']) {
-  bootstrap();
+  bootstrap().catch((err) => {
+    // The server never came up. The most common cause is a failed database
+    // migration — TypeORM logs the specific "Migration X failed, error: ..."
+    // line just above this. Surface a clear, intentional fatal message and
+    // exit non-zero, rather than leaving an unhandled rejection (or, before
+    // the toRetry change, a misleading "Unable to connect to the database").
+    new Logger('Bootstrap').fatal(
+      'Manifest failed to start — see the error above. A failed database migration is the most ' +
+        'common cause; if it reports provider/config rows that "cannot be re-scoped", back up your ' +
+        'database and re-run with MANIFEST_MIGRATION_FORCE=1.',
+      err instanceof Error ? err.stack : String(err),
+    );
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
### 💭 Why
A new self-hosted user who created their first agent and then connected a provider hit "Tenant not found" for up to 5 minutes. The tenant cache stored the "no tenant yet" result before the agent's tenant existed, and nothing refreshed it until the 5-minute TTL expired.

### ✨ What changed
- Tenant cache now memoizes only a real tenant id, never the "no tenant yet" null, so a freshly created tenant is visible on the next request.
- A failed startup migration now fails fast with the real error plus a clear fatal line, instead of a misleading "Unable to connect to the database" retry loop.

### 👤 For users
Connecting a provider works right after creating your first agent. No more 5-minute "Tenant not found" wait.

### 🔧 For operators
When a migration fails on boot, the logs show the actual cause (e.g. rows it cannot re-scope) and a clear fatal message, not repeated database-connection errors.

### 📝 Notes
Backend-only. Upgraders were never affected (their tenant already exists); this is a first-run fix.
Two pre-existing frontend test failures on `next` (RoutingTierCard / FallbackList "Thinking mode") are unrelated; `packages/frontend` is unchanged here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a first-run bug that returned "Tenant not found" when connecting a provider right after creating the first agent. Also makes startup fail fast on migrations and only retries real connection issues, with a clear fatal log.

- **Bug Fixes**
  - Tenant cache only memoizes real tenant IDs (never null), so a new tenant is visible on the next request.
  - On boot, we retry only transport-level DB connection failures (e.g. ECONNREFUSED, connection terminated). Migration, query, and unknown errors fail fast and surface the real error, without the misleading "Unable to connect to the database" retry loop.

<sup>Written for commit c4792983d547a072abe0e6ac182a12605a5242e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

