### PR TITLE
fix: support recent Claude Code Anthropic requests

### DIFF
--- a/.changeset/claude-code-subscription-compat.md
+++ b/.changeset/claude-code-subscription-compat.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix Claude Code subscription routing for Anthropic Messages requests by capping Manifest-added `cache_control` markers at Anthropic's four-block limit, enabling the `context_management` beta header expected by recent Claude Code clients, and downgrading `output_config.effort: "xhigh"` when routing resolves to Sonnet.

--- a/packages/backend/src/common/constants/subscription-clients.ts
+++ b/packages/backend/src/common/constants/subscription-clients.ts
@@ -20,7 +20,12 @@ export const CODEX_CLI_USER_AGENT = 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unk
 export const CLAUDE_CODE_USER_AGENT = 'claude-cli/2.1.92 (external, sdk-cli)';
 export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.80.0';
 export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v24.14.0';
-export const CLAUDE_CODE_BETA_FLAGS = ['claude-code-20250219', 'oauth-2025-04-20'].join(',');
+export const CLAUDE_CODE_BETA_FLAGS = [
+  'claude-code-20250219',
+  'oauth-2025-04-20',
+  'context-management-2025-06-27',
+  'effort-2025-11-24',
+].join(',');
 
 function claudeCodeStainlessArch(arch = process.arch): string {
   switch (arch) {

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -8,6 +8,14 @@ import {
 } from '../anthropic-adapter';
 import { injectOpenRouterCacheControl } from '../cache-injection';
 
+function countCacheControls(value: unknown): number {
+  if (!value || typeof value !== 'object') return 0;
+
+  const children = Array.isArray(value) ? value : Object.values(value as Record<string, unknown>);
+  const self = !Array.isArray(value) && 'cache_control' in value ? 1 : 0;
+  return self + children.reduce((sum, child) => sum + countCacheControls(child), 0);
+}
+
 describe('Anthropic Adapter', () => {
   describe('toAnthropicRequest', () => {
     it('converts basic user message', () => {
@@ -562,8 +570,9 @@ describe('Anthropic Adapter', () => {
       }>;
       expect(system).toHaveLength(2);
       expect(system[0].text).toContain('Claude agent');
-      expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
+      expect(system[0].cache_control).toBeUndefined();
       expect(system[1].text).toBe('You are helpful.');
+      expect(system[1].cache_control).toEqual({ type: 'ephemeral' });
     });
 
     it('adds subscription identity as sole system block when no user system prompt', () => {
@@ -2078,6 +2087,7 @@ describe('Anthropic Adapter', () => {
       const system = result.system as Array<Record<string, unknown>>;
       expect(system).toHaveLength(2);
       expect(system[0].text).toMatch(/Claude agent/);
+      expect(system[0].cache_control).toBeUndefined();
       expect(system[1].text).toBe('You are Manifest.');
       expect(system[1].cache_control).toEqual({ type: 'ephemeral' });
     });
@@ -2090,6 +2100,7 @@ describe('Anthropic Adapter', () => {
       const system = result.system as Array<Record<string, unknown>>;
       expect(system).toHaveLength(1);
       expect(system[0].text).toMatch(/Claude agent/);
+      expect(system[0].cache_control).toBeUndefined();
     });
 
     it('drops system when input has none and no mutations need it', () => {
@@ -2120,6 +2131,68 @@ describe('Anthropic Adapter', () => {
       expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
       const tools = result.tools as Array<Record<string, unknown>>;
       expect(tools[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+
+    it('caps Manifest cache_control injection when Claude Code already supplies three breakpoints', () => {
+      const cache = { type: 'ephemeral' };
+      const inbound = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'uncached' },
+              { type: 'text', text: 'cached', cache_control: cache },
+            ],
+          },
+        ],
+        system: [
+          { type: 'text', text: 'context', cache_control: cache },
+          { type: 'text', text: 'instructions', cache_control: cache },
+        ],
+        tools: [{ type: 'web_search_20250305', name: 'web_search' }],
+      };
+
+      const result = applyAnthropicMessagesMutations(inbound, {
+        injectSubscriptionIdentity: true,
+      });
+
+      expect(countCacheControls(result)).toBe(4);
+      const system = result.system as Array<Record<string, unknown>>;
+      expect(system[0].text).toMatch(/Claude agent/);
+      expect(system[0].cache_control).toBeUndefined();
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools[0].cache_control).toEqual(cache);
+      expect((inbound.tools[0] as Record<string, unknown>).cache_control).toBeUndefined();
+    });
+
+    it('does not add cache_control when the inbound Messages request is already at the Anthropic cap', () => {
+      const cache = { type: 'ephemeral' };
+      const result = applyAnthropicMessagesMutations(
+        {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'cached 1', cache_control: cache },
+                { type: 'text', text: 'cached 2', cache_control: cache },
+              ],
+            },
+          ],
+          system: [
+            { type: 'text', text: 'cached 3', cache_control: cache },
+            { type: 'text', text: 'cached 4', cache_control: cache },
+          ],
+          tools: [{ type: 'web_search_20250305', name: 'web_search' }],
+        },
+        { injectSubscriptionIdentity: true },
+      );
+
+      expect(countCacheControls(result)).toBe(4);
+      const system = result.system as Array<Record<string, unknown>>;
+      expect(system[0].text).toMatch(/Claude agent/);
+      expect(system[0].cache_control).toBeUndefined();
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools[0].cache_control).toBeUndefined();
     });
 
     it('defaults max_tokens to 4096 when not provided', () => {
@@ -2255,6 +2328,30 @@ describe('Anthropic Adapter', () => {
         metadata: { user_id: 'u' },
         tool_choice: { type: 'auto' },
       });
+    });
+
+    it('downgrades Opus/Fable xhigh effort when Manifest resolves the request to Sonnet', () => {
+      const result = applyAnthropicMessagesMutations(
+        {
+          messages: [{ role: 'user', content: 'hi' }],
+          output_config: { effort: 'xhigh', style: 'unchanged' },
+        },
+        { targetModel: 'claude-sonnet-4-6' },
+      );
+
+      expect(result.output_config).toEqual({ effort: 'high', style: 'unchanged' });
+    });
+
+    it('keeps xhigh effort when the resolved Anthropic model supports it', () => {
+      const result = applyAnthropicMessagesMutations(
+        {
+          messages: [{ role: 'user', content: 'hi' }],
+          output_config: { effort: 'xhigh' },
+        },
+        { targetModel: 'claude-opus-4-8' },
+      );
+
+      expect(result.output_config).toEqual({ effort: 'xhigh' });
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
@@ -83,6 +83,8 @@ describe('ProviderClient — strict header contract on auth-critical paths', () 
       'x-stainless-timeout': '600',
     });
     expect(sentHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
+    expect(sentHeaders['anthropic-beta']).toContain('context-management-2025-06-27');
+    expect(sentHeaders['anthropic-beta']).toContain('effort-2025-11-24');
     expect(sentHeaders['anthropic-beta']).not.toContain('prompt-caching-scope-2026-01-05');
     expect(sentHeaders).not.toHaveProperty('x-api-key');
   });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -712,7 +712,7 @@ describe('ProviderClient', () => {
       const system = sentBody.system as Array<{ text?: string; cache_control?: unknown }>;
       // First system block is the subscription identity prompt
       expect(system[0].text).toContain('Claude agent');
-      expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
+      expect(system[0].cache_control).toBeUndefined();
       // The OAuth API accepts cache_control (the #1193 400s were caused by the
       // missing identity block, not caching), so subscription auth gets the
       // same breakpoints as API-key auth.

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -318,6 +318,8 @@ describe('PROVIDER_ENDPOINTS', () => {
     expect(headers['Authorization']).toBe('Bearer skst-token');
     expect(headers['anthropic-beta']).toContain('claude-code-20250219');
     expect(headers['anthropic-beta']).toContain('oauth-2025-04-20');
+    expect(headers['anthropic-beta']).toContain('context-management-2025-06-27');
+    expect(headers['anthropic-beta']).toContain('effort-2025-11-24');
     expect(headers['anthropic-dangerous-direct-browser-access']).toBe('true');
     expect(headers['user-agent']).toContain('claude-cli/');
     expect(headers['x-app']).toBe('cli');

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -33,6 +33,7 @@ interface AnthropicTool {
 }
 
 const CACHE = { type: 'ephemeral' } as const;
+const MAX_CACHE_CONTROL_BLOCKS = 4;
 const ANTHROPIC_PREFIX = 'anthropic/';
 const DATA_IMAGE_URL_RE = /^data:([^;,]+)(?:;[^,]*)?;base64,(.*)$/is;
 
@@ -66,7 +67,6 @@ function shouldForwardAnthropicThinking(thinking: unknown, model: string): boole
 const SUBSCRIPTION_IDENTITY_BLOCK: ContentBlock = {
   type: 'text',
   text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
-  cache_control: { type: 'ephemeral' },
 };
 
 function safeParseArgs(args: string | undefined): unknown {
@@ -79,6 +79,35 @@ function safeParseArgs(args: string | undefined): unknown {
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function countCacheControlBlocks(value: unknown): number {
+  if (!value || typeof value !== 'object') return 0;
+
+  let count = !Array.isArray(value) && 'cache_control' in value ? 1 : 0;
+  const children = Array.isArray(value) ? value : Object.values(value);
+  for (const child of children) count += countCacheControlBlocks(child);
+  return count;
+}
+
+function tryAddCacheControl(
+  block: { cache_control?: unknown } | undefined,
+  budget: { remaining: number },
+): void {
+  if (!block || block.cache_control || budget.remaining <= 0) return;
+  block.cache_control = CACHE;
+  budget.remaining -= 1;
+}
+
+function isClaudeSonnetModel(model: string | undefined): boolean {
+  if (!model) return false;
+  return bareAnthropicModel(model).replace(/\./g, '-').startsWith('claude-sonnet-');
+}
+
+function normalizeOutputConfigForModel(outputConfig: unknown, model: string | undefined): unknown {
+  if (!isObjectRecord(outputConfig)) return outputConfig;
+  if (outputConfig.effort !== 'xhigh' || !isClaudeSonnetModel(model)) return outputConfig;
+  return { ...outputConfig, effort: 'high' };
 }
 
 /* ── Request helpers ── */
@@ -242,6 +271,8 @@ export interface AnthropicRequestOptions {
   injectSubscriptionIdentity?: boolean;
   /** Lookup for re-injecting cached extended-thinking blocks. */
   thinkingLookup?: ThinkingBlockLookup;
+  /** Resolved Anthropic upstream model, used for model-specific body normalization. */
+  targetModel?: string;
 }
 
 export function toAnthropicRequest(
@@ -348,6 +379,9 @@ export function applyAnthropicMessagesMutations(
   options?: AnthropicRequestOptions,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = { ...body };
+  const cacheBudget = {
+    remaining: Math.max(0, MAX_CACHE_CONTROL_BLOCKS - countCacheControlBlocks(body)),
+  };
 
   // Normalize `system` to a content-block array so cache_control + identity
   // injection have a uniform target. Anthropic accepts either a bare string
@@ -363,9 +397,7 @@ export function applyAnthropicMessagesMutations(
     } else if (Array.isArray(body.system)) {
       systemBlocks = (body.system as ContentBlock[]).map((b) => ({ ...b }));
     }
-    if (systemBlocks.length > 0) {
-      systemBlocks[systemBlocks.length - 1].cache_control = CACHE;
-    }
+    tryAddCacheControl(systemBlocks[systemBlocks.length - 1], cacheBudget);
     if (options?.injectSubscriptionIdentity) {
       systemBlocks.unshift({ ...SUBSCRIPTION_IDENTITY_BLOCK });
     }
@@ -381,13 +413,17 @@ export function applyAnthropicMessagesMutations(
   // custom tools' `input_schema` both survive unchanged.
   if (Array.isArray(body.tools)) {
     const tools = (body.tools as Array<Record<string, unknown>>).map((t) => ({ ...t }));
-    if (tools.length > 0) {
-      tools[tools.length - 1].cache_control = CACHE;
-    }
+    tryAddCacheControl(tools[tools.length - 1], cacheBudget);
     result.tools = tools;
   }
 
   if (result.max_tokens === undefined) result.max_tokens = 4096;
+  if (result.output_config !== undefined) {
+    result.output_config = normalizeOutputConfigForModel(
+      result.output_config,
+      options?.targetModel,
+    );
+  }
 
   const thinkingLookup = options?.thinkingLookup;
   if (thinkingLookup && Array.isArray(body.messages)) {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -399,6 +399,7 @@ export class ProviderClient {
           ? applyAnthropicMessagesMutations(body, {
               injectSubscriptionIdentity,
               thinkingLookup: ctx.thinkingLookup,
+              targetModel: bareModel,
             })
           : toAnthropicRequest(requestSource, bareModel, {
               injectSubscriptionIdentity,


### PR DESCRIPTION
### ✨ What changed
- Added Claude Code `context_management` and effort beta headers.
- Capped Manifest-added Anthropic `cache_control` markers at four total.
- Kept the injected Claude Code identity block uncached.
- Downgraded `xhigh` effort when Manifest resolves the request to Sonnet.
- Added regressions for cache budgeting, beta headers, and effort normalization.

### 💭 Why
Recent Claude Code sends native Anthropic Messages fields that need beta headers.
Manifest also added cache breakpoints on top of Claude Code's three, which could exceed Anthropic's four-block cap.

### 👤 For users
Claude Code subscription routes should stop failing on `context_management`, cache-control, and Sonnet `xhigh` errors.

### 📝 Notes
Fixes #2253.
Verified with Claude Code 2.1.177 against a local fake Anthropic endpoint.
Local checks passed: backend build, full backend Jest (6205 tests), backend lint (0 errors), Prettier, changeset, diff check.
Docker smoke was not run because the local Docker daemon is unavailable.