### PR TITLE
fix: support Kiro IAM Identity Center login

### DIFF
--- a/.changeset/kiro-identity-center.md
+++ b/.changeset/kiro-identity-center.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add Kiro IAM Identity Center start URL and region options to the subscription login flow.

--- a/packages/backend/src/routing/kiro-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/kiro-oauth.controller.spec.ts
@@ -42,10 +42,7 @@ describe('KiroOauthController', () => {
       const result = await controller.start('my-agent', { id: 'user-1' } as never);
 
       expect(resolveAgent.resolve).toHaveBeenCalledWith('user-1', 'my-agent');
-      expect(oauthService.startAuthorization).toHaveBeenCalledWith('agent-id-1', 'user-1', {
-        startUrl: undefined,
-        region: undefined,
-      });
+      expect(oauthService.startAuthorization).toHaveBeenCalledWith('agent-id-1', 'user-1');
       expect(result.flowId).toBe('flow-1');
     });
 

--- a/packages/backend/src/routing/kiro-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/kiro-oauth.controller.spec.ts
@@ -1,6 +1,7 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { KiroOauthController } from './oauth/kiro-oauth.controller';
 import { KiroOauthService } from './oauth/kiro-oauth.service';
+import { KiroAuthorizationOptionsError } from './oauth/kiro-oidc';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
 import { ProviderService } from './routing-core/provider.service';
 
@@ -41,8 +42,34 @@ describe('KiroOauthController', () => {
       const result = await controller.start('my-agent', { id: 'user-1' } as never);
 
       expect(resolveAgent.resolve).toHaveBeenCalledWith('user-1', 'my-agent');
-      expect(oauthService.startAuthorization).toHaveBeenCalledWith('agent-id-1', 'user-1');
+      expect(oauthService.startAuthorization).toHaveBeenCalledWith('agent-id-1', 'user-1', {
+        startUrl: undefined,
+        region: undefined,
+      });
       expect(result.flowId).toBe('flow-1');
+    });
+
+    it('passes optional IAM Identity Center options to the device flow', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+      oauthService.startAuthorization.mockResolvedValue({
+        flowId: 'flow-1',
+        userCode: 'AAAA-BBBB',
+        verificationUri: 'https://verify',
+        expiresAt: 123,
+        pollIntervalMs: 5000,
+      });
+
+      await controller.start(
+        'my-agent',
+        { id: 'user-1' } as never,
+        ' https://org.awsapps.com/start ',
+        ' eu-west-1 ',
+      );
+
+      expect(oauthService.startAuthorization).toHaveBeenCalledWith('agent-id-1', 'user-1', {
+        startUrl: 'https://org.awsapps.com/start',
+        region: 'eu-west-1',
+      });
     });
 
     it('throws 400 when agentName is missing', async () => {
@@ -55,6 +82,17 @@ describe('KiroOauthController', () => {
       await expect(controller.start('my-agent', { id: 'user-1' } as never)).rejects.toMatchObject({
         message: 'Failed to start Kiro login',
         status: HttpStatus.SERVICE_UNAVAILABLE,
+      });
+    });
+
+    it('maps invalid IAM Identity Center options to 400', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+      oauthService.startAuthorization.mockRejectedValue(
+        new KiroAuthorizationOptionsError('bad Kiro option'),
+      );
+      await expect(controller.start('my-agent', { id: 'user-1' } as never)).rejects.toMatchObject({
+        message: 'bad Kiro option',
+        status: HttpStatus.BAD_REQUEST,
       });
     });
 

--- a/packages/backend/src/routing/oauth/kiro-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, HttpException, HttpStatus, Post, Query } from '@nestjs
 import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 import { KiroOauthService } from './kiro-oauth.service';
-import { KiroAuthorizationOptionsError } from './kiro-oidc';
+import { KiroAuthorizationOptionsError, type KiroAuthorizationOptions } from './kiro-oidc';
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
 import { ProviderService } from '../routing-core/provider.service';
 import { optionalTrimmedStringQuery } from './query-params';
@@ -25,13 +25,21 @@ export class KiroOauthController {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
-    const options = {
-      startUrl: optionalTrimmedStringQuery(startUrl, 'startUrl'),
-      region: optionalTrimmedStringQuery(region, 'region'),
-    };
+    const options: KiroAuthorizationOptions = {};
+    const trimmedStartUrl = optionalTrimmedStringQuery(startUrl, 'startUrl');
+    const trimmedRegion = optionalTrimmedStringQuery(region, 'region');
+    if (trimmedStartUrl !== undefined) {
+      options.startUrl = trimmedStartUrl;
+    }
+    if (trimmedRegion !== undefined) {
+      options.region = trimmedRegion;
+    }
     const agent = await this.resolveAgent.resolve(user.id, agentName);
     try {
-      return await this.oauthService.startAuthorization(agent.id, user.id, options);
+      if (options.startUrl !== undefined || options.region !== undefined) {
+        return await this.oauthService.startAuthorization(agent.id, user.id, options);
+      }
+      return await this.oauthService.startAuthorization(agent.id, user.id);
     } catch (err) {
       if (err instanceof KiroAuthorizationOptionsError) {
         throw new HttpException(err.message, HttpStatus.BAD_REQUEST);

--- a/packages/backend/src/routing/oauth/kiro-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, HttpException, HttpStatus, Post, Query } from '@nestjs
 import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 import { KiroOauthService } from './kiro-oauth.service';
+import { KiroAuthorizationOptionsError } from './kiro-oidc';
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
 import { ProviderService } from '../routing-core/provider.service';
 import { optionalTrimmedStringQuery } from './query-params';
@@ -15,14 +16,26 @@ export class KiroOauthController {
   ) {}
 
   @Post('start')
-  async start(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+  async start(
+    @Query('agentName') agentName: string,
+    @CurrentUser() user: AuthUser,
+    @Query('startUrl') startUrl?: string | string[],
+    @Query('region') region?: string | string[],
+  ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
+    const options = {
+      startUrl: optionalTrimmedStringQuery(startUrl, 'startUrl'),
+      region: optionalTrimmedStringQuery(region, 'region'),
+    };
     const agent = await this.resolveAgent.resolve(user.id, agentName);
     try {
-      return await this.oauthService.startAuthorization(agent.id, user.id);
+      return await this.oauthService.startAuthorization(agent.id, user.id, options);
     } catch (err) {
+      if (err instanceof KiroAuthorizationOptionsError) {
+        throw new HttpException(err.message, HttpStatus.BAD_REQUEST);
+      }
       const message = err instanceof Error ? err.message : 'Failed to start Kiro login';
       throw new HttpException(message, HttpStatus.SERVICE_UNAVAILABLE);
     }

--- a/packages/backend/src/routing/oauth/kiro-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.service.spec.ts
@@ -136,6 +136,55 @@ describe('KiroOauthService', () => {
       expect(service.getPendingCount()).toBe(1);
     });
 
+    it('uses per-flow IAM Identity Center start URL and region options', async () => {
+      const service = makeService();
+      fetchMock
+        .mockResolvedValueOnce(REGISTER_OK)
+        .mockResolvedValueOnce(DEVICE_OK)
+        .mockResolvedValueOnce(
+          jsonResponse(200, {
+            accessToken: 'aoa-token',
+            refreshToken: 'aor-token',
+            expiresIn: 3600,
+          }),
+        );
+
+      const { flowId } = await service.startAuthorization('agent-1', 'user-1', {
+        startUrl: ' https://org.awsapps.com/start ',
+        region: 'EU-WEST-1',
+      });
+      await service.pollAuthorization(flowId, 'user-1');
+
+      const [registerUrl] = fetchMock.mock.calls[0];
+      expect(registerUrl).toBe('https://oidc.eu-west-1.amazonaws.com/client/register');
+      const [, deviceInit] = fetchMock.mock.calls[1];
+      expect(JSON.parse((deviceInit as RequestInit).body as string).startUrl).toBe(
+        'https://org.awsapps.com/start',
+      );
+      const [tokenUrl] = fetchMock.mock.calls[2];
+      expect(tokenUrl).toBe('https://oidc.eu-west-1.amazonaws.com/token');
+      const saved = parseKiroOAuthTokenBlob(provider.upsertProvider.mock.calls[0][3] as string);
+      expect(saved?.region).toBe('eu-west-1');
+    });
+
+    it('rejects invalid IAM Identity Center options before registering a client', async () => {
+      const service = makeService();
+
+      await expect(
+        service.startAuthorization('agent-1', 'user-1', {
+          startUrl: 'http://org.awsapps.com/start',
+          region: 'eu-west-1',
+        }),
+      ).rejects.toThrow('must use HTTPS');
+      await expect(
+        service.startAuthorization('agent-1', 'user-1', {
+          startUrl: 'https://org.awsapps.com/start',
+          region: 'eu-west-1.example',
+        }),
+      ).rejects.toThrow('region is invalid');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it('sweeps expired pending flows when a new flow starts', async () => {
       const service = makeService();
       await startFlow(service);

--- a/packages/backend/src/routing/oauth/kiro-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.service.spec.ts
@@ -2,7 +2,11 @@ import { ConfigService } from '@nestjs/config';
 import { KiroOauthService } from './kiro-oauth.service';
 import { ProviderService } from '../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
-import { parseKiroOAuthTokenBlob, serializeKiroOAuthTokenBlob } from './kiro-oidc';
+import {
+  KiroAuthorizationOptionsError,
+  parseKiroOAuthTokenBlob,
+  serializeKiroOAuthTokenBlob,
+} from './kiro-oidc';
 
 const originalFetch = global.fetch;
 
@@ -183,6 +187,13 @@ describe('KiroOauthService', () => {
         }),
       ).rejects.toThrow('region is invalid');
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('names IAM Identity Center option errors for diagnostics', () => {
+      const error = new KiroAuthorizationOptionsError('bad option');
+
+      expect(error.name).toBe('KiroAuthorizationOptionsError');
+      expect(error.message).toBe('bad option');
     });
 
     it('sweeps expired pending flows when a new flow starts', async () => {

--- a/packages/backend/src/routing/oauth/kiro-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.service.ts
@@ -14,10 +14,13 @@ import {
   KIRO_OIDC_DEFAULT_REGION,
   KIRO_REFRESH_GRANT,
   KIRO_REGISTER_GRANT_TYPES,
+  KiroAuthorizationOptions,
   buildKiroDeviceAuthorizationUrl,
   buildKiroRegisterUrl,
   buildKiroTokenUrl,
   getKiroOidcBaseUrl,
+  normalizeKiroRegion,
+  normalizeKiroStartUrl,
   parseKiroOAuthTokenBlob,
   serializeKiroOAuthTokenBlob,
   toAbsoluteExpiryTimestamp,
@@ -31,6 +34,7 @@ interface PendingKiroOAuth {
   deviceCode: string;
   agentId: string;
   userId: string;
+  region: string;
   expiresAt: number;
   pollIntervalMs: number;
 }
@@ -104,11 +108,16 @@ export class KiroOauthService {
       : KIRO_DEFAULT_SCOPES;
   }
 
-  async startAuthorization(agentId: string, userId: string): Promise<KiroOAuthStartResult> {
+  async startAuthorization(
+    agentId: string,
+    userId: string,
+    options: KiroAuthorizationOptions = {},
+  ): Promise<KiroOAuthStartResult> {
     this.cleanupExpired();
-    const baseUrl = getKiroOidcBaseUrl(this.region);
+    const { region, startUrl } = this.resolveAuthorizationOptions(options);
+    const baseUrl = getKiroOidcBaseUrl(region);
     const { clientId, clientSecret } = await this.registerClient(baseUrl);
-    const device = await this.startDeviceAuthorization(baseUrl, clientId, clientSecret);
+    const device = await this.startDeviceAuthorization(baseUrl, clientId, clientSecret, startUrl);
 
     const flowId = randomBytes(16).toString('base64url');
     const expiresAt = toAbsoluteExpiryTimestamp(device.expiresIn);
@@ -119,6 +128,7 @@ export class KiroOauthService {
       deviceCode: device.deviceCode,
       agentId,
       userId,
+      region,
       expiresAt,
       pollIntervalMs,
     });
@@ -148,7 +158,7 @@ export class KiroOauthService {
       return { status: 'error', message: 'Kiro login expired. Start again.' };
     }
 
-    const baseUrl = getKiroOidcBaseUrl(this.region);
+    const baseUrl = getKiroOidcBaseUrl(pending.region);
     const response = await fetch(buildKiroTokenUrl(baseUrl), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
@@ -195,7 +205,7 @@ export class KiroOauthService {
       e: toAbsoluteExpiryTimestamp(payload.expiresIn),
       cid: pending.clientId,
       cs: pending.clientSecret,
-      region: this.region,
+      region: pending.region,
     };
     const label = await this.providerService.nextOAuthLabel(pending.agentId, 'kiro');
     const { provider: savedProvider } = await this.providerService.upsertProvider(
@@ -288,6 +298,7 @@ export class KiroOauthService {
     baseUrl: string,
     clientId: string,
     clientSecret: string,
+    startUrl: string,
   ): Promise<
     Required<Pick<KiroDeviceAuthorizationResponse, 'deviceCode' | 'userCode' | 'expiresIn'>> &
       KiroDeviceAuthorizationResponse
@@ -295,7 +306,7 @@ export class KiroOauthService {
     const response = await fetch(buildKiroDeviceAuthorizationUrl(baseUrl), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify({ clientId, clientSecret, startUrl: this.startUrl }),
+      body: JSON.stringify({ clientId, clientSecret, startUrl }),
     });
     if (!response.ok) {
       const text = await response.text();
@@ -315,6 +326,15 @@ export class KiroOauthService {
       Pick<KiroDeviceAuthorizationResponse, 'deviceCode' | 'userCode' | 'expiresIn'>
     > &
       KiroDeviceAuthorizationResponse;
+  }
+
+  private resolveAuthorizationOptions(
+    options: KiroAuthorizationOptions,
+  ): Required<KiroAuthorizationOptions> {
+    return {
+      region: normalizeKiroRegion(options.region ?? this.region),
+      startUrl: normalizeKiroStartUrl(options.startUrl ?? this.startUrl),
+    };
   }
 
   private async refreshAccessToken(blob: KiroOAuthTokenBlob): Promise<KiroOAuthTokenBlob> {

--- a/packages/backend/src/routing/oauth/kiro-oidc.ts
+++ b/packages/backend/src/routing/oauth/kiro-oidc.ts
@@ -68,7 +68,12 @@ export interface KiroAuthorizationOptions {
   region?: string;
 }
 
-export class KiroAuthorizationOptionsError extends Error {}
+export class KiroAuthorizationOptionsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'KiroAuthorizationOptionsError';
+  }
+}
 
 export function normalizeKiroRegion(region: string): string {
   const normalized = region.trim().toLowerCase();

--- a/packages/backend/src/routing/oauth/kiro-oidc.ts
+++ b/packages/backend/src/routing/oauth/kiro-oidc.ts
@@ -45,6 +45,7 @@ export const KIRO_REGISTER_GRANT_TYPES: readonly string[] = Object.freeze([
 
 const ABSOLUTE_TIME_THRESHOLD_MS = 10_000_000_000;
 export const KIRO_DEFAULT_POLL_INTERVAL_MS = 5000;
+const KIRO_REGION_PATTERN = /^[a-z]{2}(?:-[a-z0-9]+)+-\d$/;
 
 export function getKiroOidcBaseUrl(region: string = KIRO_OIDC_DEFAULT_REGION): string {
   return `https://oidc.${region}.amazonaws.com`;
@@ -60,6 +61,35 @@ export function buildKiroDeviceAuthorizationUrl(baseUrl: string): string {
 
 export function buildKiroTokenUrl(baseUrl: string): string {
   return `${baseUrl}/token`;
+}
+
+export interface KiroAuthorizationOptions {
+  startUrl?: string;
+  region?: string;
+}
+
+export class KiroAuthorizationOptionsError extends Error {}
+
+export function normalizeKiroRegion(region: string): string {
+  const normalized = region.trim().toLowerCase();
+  if (!KIRO_REGION_PATTERN.test(normalized)) {
+    throw new KiroAuthorizationOptionsError('Kiro IAM Identity Center region is invalid.');
+  }
+  return normalized;
+}
+
+export function normalizeKiroStartUrl(startUrl: string): string {
+  const trimmed = startUrl.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new KiroAuthorizationOptionsError('Kiro IAM Identity Center start URL is invalid.');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new KiroAuthorizationOptionsError('Kiro IAM Identity Center start URL must use HTTPS.');
+  }
+  return parsed.toString();
 }
 
 /** SSO OIDC returns `expiresIn` as a relative seconds value; store absolute ms. */

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -39,6 +39,7 @@ interface Props {
 
 const MAX_LABEL_LENGTH = 50;
 const KIRO_DEFAULT_REGION = 'us-east-1';
+const KIRO_CUSTOM_REGION_VALUE = 'custom';
 const KIRO_REGION_OPTIONS = [
   'us-east-1',
   'us-east-2',
@@ -68,6 +69,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [selectedRegion, setSelectedRegion] = createSignal<MinimaxOAuthRegion>('global');
   const [kiroStartUrl, setKiroStartUrl] = createSignal('');
   const [kiroRegion, setKiroRegion] = createSignal(KIRO_DEFAULT_REGION);
+  const [kiroCustomRegion, setKiroCustomRegion] = createSignal('');
   const [kiroConfigError, setKiroConfigError] = createSignal<string | null>(null);
   const [altToken, setAltToken] = createSignal('');
   const [altError, setAltError] = createSignal<string | null>(null);
@@ -135,7 +137,9 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     }
 
     const startUrl = kiroStartUrl().trim();
-    const region = kiroRegion().trim().toLowerCase();
+    const selectedKiroRegion =
+      kiroRegion() === KIRO_CUSTOM_REGION_VALUE ? kiroCustomRegion() : kiroRegion();
+    const region = selectedKiroRegion.trim().toLowerCase();
     if (!/^[a-z]{2}(?:-[a-z0-9]+)+-\d$/.test(region)) {
       setKiroConfigError('Enter a valid AWS region, such as us-east-1.');
       return null;
@@ -390,26 +394,46 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
                     <label class="provider-detail__label" for="kiro-region">
                       Region
                     </label>
-                    <input
+                    <select
                       id="kiro-region"
                       class="provider-detail__input"
                       classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
-                      type="text"
-                      list="kiro-region-options"
-                      autocomplete="off"
-                      placeholder={KIRO_DEFAULT_REGION}
                       value={kiroRegion()}
                       disabled={props.busy()}
                       aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
-                      onInput={(e) => {
+                      onChange={(e) => {
                         setKiroRegion(e.currentTarget.value);
                         setKiroConfigError(null);
                       }}
-                    />
-                    <datalist id="kiro-region-options">
-                      <For each={KIRO_REGION_OPTIONS}>{(region) => <option value={region} />}</For>
-                    </datalist>
+                    >
+                      <For each={KIRO_REGION_OPTIONS}>
+                        {(region) => <option value={region}>{region}</option>}
+                      </For>
+                      <option value={KIRO_CUSTOM_REGION_VALUE}>Other region...</option>
+                    </select>
                   </div>
+                  <Show when={kiroRegion() === KIRO_CUSTOM_REGION_VALUE}>
+                    <div class="provider-detail__field">
+                      <label class="provider-detail__label" for="kiro-custom-region">
+                        Custom region
+                      </label>
+                      <input
+                        id="kiro-custom-region"
+                        class="provider-detail__input"
+                        classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
+                        type="text"
+                        autocomplete="off"
+                        placeholder={KIRO_DEFAULT_REGION}
+                        value={kiroCustomRegion()}
+                        disabled={props.busy()}
+                        aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
+                        onInput={(e) => {
+                          setKiroCustomRegion(e.currentTarget.value);
+                          setKiroConfigError(null);
+                        }}
+                      />
+                    </div>
+                  </Show>
                   <div class="provider-detail__field">
                     <label class="provider-detail__label" for="kiro-start-url">
                       Start URL <span class="provider-detail__label-muted">(optional)</span>

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -53,6 +53,10 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [flow, setFlow] = createSignal<DeviceCodeFlow | null>(null);
   const [statusMessage, setStatusMessage] = createSignal<string | null>(null);
   const [selectedRegion, setSelectedRegion] = createSignal<MinimaxOAuthRegion>('global');
+  const [useKiroIdentityCenter, setUseKiroIdentityCenter] = createSignal(false);
+  const [kiroStartUrl, setKiroStartUrl] = createSignal('');
+  const [kiroRegion, setKiroRegion] = createSignal('');
+  const [kiroConfigError, setKiroConfigError] = createSignal<string | null>(null);
   const [altToken, setAltToken] = createSignal('');
   const [altError, setAltError] = createSignal<string | null>(null);
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
@@ -60,6 +64,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [addingAccount, setAddingAccount] = createSignal(false);
 
   const api = () => getDeviceCodeApi(props.provId);
+  const isKiro = () => props.provId === 'kiro';
   const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
   const activeKeyLabels = () => (props.activeKeys?.() ?? []).map((k) => k.label);
   const showConnectFlow = () => !props.connected() || addingAccount();
@@ -108,6 +113,38 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   let pollTimer: number | undefined;
   let isDisposed = false;
   let activeFlowGeneration = 0;
+
+  const buildStartOptions = () => {
+    if (api().hasRegion) {
+      return { region: selectedRegion() };
+    }
+    if (!isKiro() || !useKiroIdentityCenter()) {
+      return undefined;
+    }
+
+    const startUrl = kiroStartUrl().trim();
+    const region = kiroRegion().trim().toLowerCase();
+    if (!startUrl || !region) {
+      setKiroConfigError('Enter your IAM Identity Center Start URL and region.');
+      return null;
+    }
+    try {
+      const parsed = new URL(startUrl);
+      if (parsed.protocol !== 'https:') {
+        setKiroConfigError('Start URL must use HTTPS.');
+        return null;
+      }
+    } catch {
+      setKiroConfigError('Enter a valid IAM Identity Center Start URL.');
+      return null;
+    }
+    if (!/^[a-z]{2}(?:-[a-z0-9]+)+-\d$/.test(region)) {
+      setKiroConfigError('Enter a valid AWS region, such as us-east-1.');
+      return null;
+    }
+    setKiroConfigError(null);
+    return { startUrl, region };
+  };
 
   const clearPollTimer = () => {
     if (pollTimer !== undefined) {
@@ -243,6 +280,8 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   };
 
   const handleStart = async () => {
+    const startOptions = buildStartOptions();
+    if (startOptions === null) return;
     // Open the popup synchronously inside the click handler to keep the
     // user-gesture flag alive; without this, browsers block the post-await
     // window.open as a "programmatic popup". noopener can't be used here
@@ -263,10 +302,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     setStatusMessage(null);
     try {
       const current = api();
-      const nextFlow = await current.start(
-        props.agentName,
-        current.hasRegion ? selectedRegion() : undefined,
-      );
+      const nextFlow = await current.start(props.agentName, startOptions);
       if (isDisposed || flowGeneration !== activeFlowGeneration) {
         popup.close();
         return;
@@ -334,6 +370,74 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
                       <option value="cn">China Mainland (api.minimaxi.com)</option>
                     </select>
                   </div>
+                </Show>
+                <Show when={isKiro()}>
+                  <div class="provider-detail__field">
+                    <label
+                      for="kiro-identity-center"
+                      style="display: flex; align-items: center; gap: 8px; font-size: var(--font-size-sm); color: hsl(var(--foreground));"
+                    >
+                      <input
+                        id="kiro-identity-center"
+                        type="checkbox"
+                        checked={useKiroIdentityCenter()}
+                        disabled={props.busy()}
+                        onChange={(e) => {
+                          setUseKiroIdentityCenter(e.currentTarget.checked);
+                          setKiroConfigError(null);
+                        }}
+                      />
+                      Sign in with AWS IAM Identity Center
+                    </label>
+                  </div>
+                  <Show when={useKiroIdentityCenter()}>
+                    <div class="provider-detail__field">
+                      <label class="provider-detail__label" for="kiro-start-url">
+                        Start URL
+                      </label>
+                      <input
+                        id="kiro-start-url"
+                        class="provider-detail__input"
+                        classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
+                        type="url"
+                        inputmode="url"
+                        autocomplete="off"
+                        placeholder="https://your-domain.awsapps.com/start"
+                        value={kiroStartUrl()}
+                        disabled={props.busy()}
+                        aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
+                        onInput={(e) => {
+                          setKiroStartUrl(e.currentTarget.value);
+                          setKiroConfigError(null);
+                        }}
+                      />
+                    </div>
+                    <div class="provider-detail__field">
+                      <label class="provider-detail__label" for="kiro-region">
+                        Region
+                      </label>
+                      <input
+                        id="kiro-region"
+                        class="provider-detail__input"
+                        classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
+                        type="text"
+                        autocomplete="off"
+                        placeholder="us-east-1"
+                        value={kiroRegion()}
+                        disabled={props.busy()}
+                        aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
+                        onInput={(e) => {
+                          setKiroRegion(e.currentTarget.value);
+                          setKiroConfigError(null);
+                        }}
+                      />
+                    </div>
+                    <Show when={kiroConfigError()}>
+                      <div id="kiro-identity-error" class="provider-detail__error">
+                        {kiroConfigError()}
+                      </div>
+                    </Show>
+                  </Show>
                 </Show>
                 <button
                   class="btn btn--primary subscription-detail__btn"

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -422,6 +422,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
                       disabled={props.busy()}
                       portal
                       maxDropdownHeight={240}
+                      ariaDescribedBy={kiroConfigError() ? 'kiro-identity-error' : undefined}
                       onChange={(value) => {
                         setKiroRegion(value);
                         setKiroConfigError(null);

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -38,6 +38,19 @@ interface Props {
 }
 
 const MAX_LABEL_LENGTH = 50;
+const KIRO_DEFAULT_REGION = 'us-east-1';
+const KIRO_REGION_OPTIONS = [
+  'us-east-1',
+  'us-east-2',
+  'us-west-2',
+  'eu-west-1',
+  'eu-west-2',
+  'eu-central-1',
+  'ap-south-1',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'ap-northeast-1',
+];
 
 interface DeviceCodeFlow {
   flowId: string;
@@ -53,9 +66,8 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [flow, setFlow] = createSignal<DeviceCodeFlow | null>(null);
   const [statusMessage, setStatusMessage] = createSignal<string | null>(null);
   const [selectedRegion, setSelectedRegion] = createSignal<MinimaxOAuthRegion>('global');
-  const [useKiroIdentityCenter, setUseKiroIdentityCenter] = createSignal(false);
   const [kiroStartUrl, setKiroStartUrl] = createSignal('');
-  const [kiroRegion, setKiroRegion] = createSignal('');
+  const [kiroRegion, setKiroRegion] = createSignal(KIRO_DEFAULT_REGION);
   const [kiroConfigError, setKiroConfigError] = createSignal<string | null>(null);
   const [altToken, setAltToken] = createSignal('');
   const [altError, setAltError] = createSignal<string | null>(null);
@@ -118,32 +130,40 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     if (api().hasRegion) {
       return { region: selectedRegion() };
     }
-    if (!isKiro() || !useKiroIdentityCenter()) {
+    if (!isKiro()) {
       return undefined;
     }
 
     const startUrl = kiroStartUrl().trim();
     const region = kiroRegion().trim().toLowerCase();
-    if (!startUrl || !region) {
-      setKiroConfigError('Enter your IAM Identity Center Start URL and region.');
-      return null;
-    }
-    try {
-      const parsed = new URL(startUrl);
-      if (parsed.protocol !== 'https:') {
-        setKiroConfigError('Start URL must use HTTPS.');
-        return null;
-      }
-    } catch {
-      setKiroConfigError('Enter a valid IAM Identity Center Start URL.');
-      return null;
-    }
     if (!/^[a-z]{2}(?:-[a-z0-9]+)+-\d$/.test(region)) {
       setKiroConfigError('Enter a valid AWS region, such as us-east-1.');
       return null;
     }
+    if (startUrl) {
+      try {
+        const parsed = new URL(startUrl);
+        if (parsed.protocol !== 'https:') {
+          setKiroConfigError('Start URL must use HTTPS.');
+          return null;
+        }
+      } catch {
+        setKiroConfigError('Enter a valid IAM Identity Center Start URL.');
+        return null;
+      }
+    }
     setKiroConfigError(null);
-    return { startUrl, region };
+    return startUrl ? { startUrl, region } : { region };
+  };
+
+  const connectHint = () => {
+    if (api().hasRegion) {
+      return 'Choose your MiniMax region, then open the authorization page in your browser to sign in and approve access.';
+    }
+    if (isKiro()) {
+      return 'Choose the AWS region for Kiro sign-in. Add a Start URL only if your organization uses IAM Identity Center.';
+    }
+    return 'Open the authorization page in your browser to sign in and approve access.';
   };
 
   const clearPollTimer = () => {
@@ -344,13 +364,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
             <>
               <div class="subscription-detail__primary">
                 <p class="provider-detail__hint" style="margin-bottom: 0;">
-                  <Show
-                    when={api().hasRegion}
-                    fallback="Open the authorization page in your browser to sign in and approve access."
-                  >
-                    Choose your MiniMax region, then open the authorization page in your browser to
-                    sign in and approve access.
-                  </Show>
+                  {connectHint()}
                 </p>
                 <Show when={api().hasRegion}>
                   <div class="provider-detail__field">
@@ -373,70 +387,54 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
                 </Show>
                 <Show when={isKiro()}>
                   <div class="provider-detail__field">
-                    <label
-                      for="kiro-identity-center"
-                      style="display: flex; align-items: center; gap: 8px; font-size: var(--font-size-sm); color: hsl(var(--foreground));"
-                    >
-                      <input
-                        id="kiro-identity-center"
-                        type="checkbox"
-                        checked={useKiroIdentityCenter()}
-                        disabled={props.busy()}
-                        onChange={(e) => {
-                          setUseKiroIdentityCenter(e.currentTarget.checked);
-                          setKiroConfigError(null);
-                        }}
-                      />
-                      Sign in with AWS IAM Identity Center
+                    <label class="provider-detail__label" for="kiro-region">
+                      Region
                     </label>
+                    <input
+                      id="kiro-region"
+                      class="provider-detail__input"
+                      classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
+                      type="text"
+                      list="kiro-region-options"
+                      autocomplete="off"
+                      placeholder={KIRO_DEFAULT_REGION}
+                      value={kiroRegion()}
+                      disabled={props.busy()}
+                      aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
+                      onInput={(e) => {
+                        setKiroRegion(e.currentTarget.value);
+                        setKiroConfigError(null);
+                      }}
+                    />
+                    <datalist id="kiro-region-options">
+                      <For each={KIRO_REGION_OPTIONS}>{(region) => <option value={region} />}</For>
+                    </datalist>
                   </div>
-                  <Show when={useKiroIdentityCenter()}>
-                    <div class="provider-detail__field">
-                      <label class="provider-detail__label" for="kiro-start-url">
-                        Start URL
-                      </label>
-                      <input
-                        id="kiro-start-url"
-                        class="provider-detail__input"
-                        classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
-                        type="url"
-                        inputmode="url"
-                        autocomplete="off"
-                        placeholder="https://your-domain.awsapps.com/start"
-                        value={kiroStartUrl()}
-                        disabled={props.busy()}
-                        aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
-                        onInput={(e) => {
-                          setKiroStartUrl(e.currentTarget.value);
-                          setKiroConfigError(null);
-                        }}
-                      />
+                  <div class="provider-detail__field">
+                    <label class="provider-detail__label" for="kiro-start-url">
+                      Start URL <span class="provider-detail__label-muted">(optional)</span>
+                    </label>
+                    <input
+                      id="kiro-start-url"
+                      class="provider-detail__input"
+                      classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
+                      type="url"
+                      inputmode="url"
+                      autocomplete="off"
+                      placeholder="https://your-domain.awsapps.com/start"
+                      value={kiroStartUrl()}
+                      disabled={props.busy()}
+                      aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
+                      onInput={(e) => {
+                        setKiroStartUrl(e.currentTarget.value);
+                        setKiroConfigError(null);
+                      }}
+                    />
+                  </div>
+                  <Show when={kiroConfigError()}>
+                    <div id="kiro-identity-error" class="provider-detail__error">
+                      {kiroConfigError()}
                     </div>
-                    <div class="provider-detail__field">
-                      <label class="provider-detail__label" for="kiro-region">
-                        Region
-                      </label>
-                      <input
-                        id="kiro-region"
-                        class="provider-detail__input"
-                        classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
-                        type="text"
-                        autocomplete="off"
-                        placeholder="us-east-1"
-                        value={kiroRegion()}
-                        disabled={props.busy()}
-                        aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
-                        onInput={(e) => {
-                          setKiroRegion(e.currentTarget.value);
-                          setKiroConfigError(null);
-                        }}
-                      />
-                    </div>
-                    <Show when={kiroConfigError()}>
-                      <div id="kiro-identity-error" class="provider-detail__error">
-                        {kiroConfigError()}
-                      </div>
-                    </Show>
                   </Show>
                 </Show>
                 <button

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -20,6 +20,7 @@ import {
 import { suggestNextProviderKeyLabel } from '../services/provider-key-labels.js';
 import { validateSubscriptionKey } from '../services/provider-utils.js';
 import { toast } from '../services/toast-store.js';
+import Select from './Select.jsx';
 
 interface Props {
   provDef: ProviderDef;
@@ -41,16 +42,17 @@ const MAX_LABEL_LENGTH = 50;
 const KIRO_DEFAULT_REGION = 'us-east-1';
 const KIRO_CUSTOM_REGION_VALUE = 'custom';
 const KIRO_REGION_OPTIONS = [
-  'us-east-1',
-  'us-east-2',
-  'us-west-2',
-  'eu-west-1',
-  'eu-west-2',
-  'eu-central-1',
-  'ap-south-1',
-  'ap-southeast-1',
-  'ap-southeast-2',
-  'ap-northeast-1',
+  { value: 'us-east-1', label: 'us-east-1' },
+  { value: 'us-east-2', label: 'us-east-2' },
+  { value: 'us-west-2', label: 'us-west-2' },
+  { value: 'eu-west-1', label: 'eu-west-1' },
+  { value: 'eu-west-2', label: 'eu-west-2' },
+  { value: 'eu-central-1', label: 'eu-central-1' },
+  { value: 'ap-south-1', label: 'ap-south-1' },
+  { value: 'ap-southeast-1', label: 'ap-southeast-1' },
+  { value: 'ap-southeast-2', label: 'ap-southeast-2' },
+  { value: 'ap-northeast-1', label: 'ap-northeast-1' },
+  { value: KIRO_CUSTOM_REGION_VALUE, label: 'Other region...' },
 ];
 
 interface DeviceCodeFlow {
@@ -391,26 +393,17 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
                 </Show>
                 <Show when={isKiro()}>
                   <div class="provider-detail__field">
-                    <label class="provider-detail__label" for="kiro-region">
-                      Region
-                    </label>
-                    <select
-                      id="kiro-region"
-                      class="provider-detail__input"
-                      classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
+                    <span class="provider-detail__label">Region</span>
+                    <Select
+                      label="Region"
+                      options={KIRO_REGION_OPTIONS}
                       value={kiroRegion()}
                       disabled={props.busy()}
-                      aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
-                      onChange={(e) => {
-                        setKiroRegion(e.currentTarget.value);
+                      onChange={(value) => {
+                        setKiroRegion(value);
                         setKiroConfigError(null);
                       }}
-                    >
-                      <For each={KIRO_REGION_OPTIONS}>
-                        {(region) => <option value={region}>{region}</option>}
-                      </For>
-                      <option value={KIRO_CUSTOM_REGION_VALUE}>Other region...</option>
-                    </select>
+                    />
                   </div>
                   <Show when={kiroRegion() === KIRO_CUSTOM_REGION_VALUE}>
                     <div class="provider-detail__field">

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -20,6 +20,7 @@ import {
 import { suggestNextProviderKeyLabel } from '../services/provider-key-labels.js';
 import { validateSubscriptionKey } from '../services/provider-utils.js';
 import { toast } from '../services/toast-store.js';
+import Select from './Select.jsx';
 
 interface Props {
   provDef: ProviderDef;
@@ -39,6 +40,44 @@ interface Props {
 
 const MAX_LABEL_LENGTH = 50;
 const KIRO_DEFAULT_REGION = 'us-east-1';
+const KIRO_REGION_OPTIONS = [
+  { value: 'us-east-2', label: 'us-east-2' },
+  { value: 'us-east-1', label: 'us-east-1' },
+  { value: 'us-west-1', label: 'us-west-1' },
+  { value: 'us-west-2', label: 'us-west-2' },
+  { value: 'af-south-1', label: 'af-south-1' },
+  { value: 'ap-east-1', label: 'ap-east-1' },
+  { value: 'ap-south-2', label: 'ap-south-2' },
+  { value: 'ap-southeast-3', label: 'ap-southeast-3' },
+  { value: 'ap-southeast-5', label: 'ap-southeast-5' },
+  { value: 'ap-southeast-4', label: 'ap-southeast-4' },
+  { value: 'ap-south-1', label: 'ap-south-1' },
+  { value: 'ap-southeast-6', label: 'ap-southeast-6' },
+  { value: 'ap-northeast-3', label: 'ap-northeast-3' },
+  { value: 'ap-northeast-2', label: 'ap-northeast-2' },
+  { value: 'ap-southeast-1', label: 'ap-southeast-1' },
+  { value: 'ap-southeast-2', label: 'ap-southeast-2' },
+  { value: 'ap-east-2', label: 'ap-east-2' },
+  { value: 'ap-southeast-7', label: 'ap-southeast-7' },
+  { value: 'ap-northeast-1', label: 'ap-northeast-1' },
+  { value: 'ca-central-1', label: 'ca-central-1' },
+  { value: 'ca-west-1', label: 'ca-west-1' },
+  { value: 'eu-central-1', label: 'eu-central-1' },
+  { value: 'eu-west-1', label: 'eu-west-1' },
+  { value: 'eu-west-2', label: 'eu-west-2' },
+  { value: 'eu-south-1', label: 'eu-south-1' },
+  { value: 'eu-west-3', label: 'eu-west-3' },
+  { value: 'eu-south-2', label: 'eu-south-2' },
+  { value: 'eu-north-1', label: 'eu-north-1' },
+  { value: 'eu-central-2', label: 'eu-central-2' },
+  { value: 'il-central-1', label: 'il-central-1' },
+  { value: 'mx-central-1', label: 'mx-central-1' },
+  { value: 'me-south-1', label: 'me-south-1' },
+  { value: 'me-central-1', label: 'me-central-1' },
+  { value: 'sa-east-1', label: 'sa-east-1' },
+  { value: 'us-gov-east-1', label: 'us-gov-east-1' },
+  { value: 'us-gov-west-1', label: 'us-gov-west-1' },
+];
 
 interface DeviceCodeFlow {
   flowId: string;
@@ -375,21 +414,16 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
                 </Show>
                 <Show when={isKiro()}>
                   <div class="provider-detail__field">
-                    <label class="provider-detail__label" for="kiro-region">
-                      Region
-                    </label>
-                    <input
-                      id="kiro-region"
-                      class="provider-detail__input"
-                      classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
-                      type="text"
-                      autocomplete="off"
-                      placeholder={KIRO_DEFAULT_REGION}
+                    <span class="provider-detail__label">Region</span>
+                    <Select
+                      label="Region"
+                      options={KIRO_REGION_OPTIONS}
                       value={kiroRegion()}
                       disabled={props.busy()}
-                      aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
-                      onInput={(e) => {
-                        setKiroRegion(e.currentTarget.value);
+                      portal
+                      maxDropdownHeight={240}
+                      onChange={(value) => {
+                        setKiroRegion(value);
                         setKiroConfigError(null);
                       }}
                     />

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -20,7 +20,6 @@ import {
 import { suggestNextProviderKeyLabel } from '../services/provider-key-labels.js';
 import { validateSubscriptionKey } from '../services/provider-utils.js';
 import { toast } from '../services/toast-store.js';
-import Select from './Select.jsx';
 
 interface Props {
   provDef: ProviderDef;
@@ -40,20 +39,6 @@ interface Props {
 
 const MAX_LABEL_LENGTH = 50;
 const KIRO_DEFAULT_REGION = 'us-east-1';
-const KIRO_CUSTOM_REGION_VALUE = 'custom';
-const KIRO_REGION_OPTIONS = [
-  { value: 'us-east-1', label: 'us-east-1' },
-  { value: 'us-east-2', label: 'us-east-2' },
-  { value: 'us-west-2', label: 'us-west-2' },
-  { value: 'eu-west-1', label: 'eu-west-1' },
-  { value: 'eu-west-2', label: 'eu-west-2' },
-  { value: 'eu-central-1', label: 'eu-central-1' },
-  { value: 'ap-south-1', label: 'ap-south-1' },
-  { value: 'ap-southeast-1', label: 'ap-southeast-1' },
-  { value: 'ap-southeast-2', label: 'ap-southeast-2' },
-  { value: 'ap-northeast-1', label: 'ap-northeast-1' },
-  { value: KIRO_CUSTOM_REGION_VALUE, label: 'Other region...' },
-];
 
 interface DeviceCodeFlow {
   flowId: string;
@@ -71,7 +56,6 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [selectedRegion, setSelectedRegion] = createSignal<MinimaxOAuthRegion>('global');
   const [kiroStartUrl, setKiroStartUrl] = createSignal('');
   const [kiroRegion, setKiroRegion] = createSignal(KIRO_DEFAULT_REGION);
-  const [kiroCustomRegion, setKiroCustomRegion] = createSignal('');
   const [kiroConfigError, setKiroConfigError] = createSignal<string | null>(null);
   const [altToken, setAltToken] = createSignal('');
   const [altError, setAltError] = createSignal<string | null>(null);
@@ -139,9 +123,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     }
 
     const startUrl = kiroStartUrl().trim();
-    const selectedKiroRegion =
-      kiroRegion() === KIRO_CUSTOM_REGION_VALUE ? kiroCustomRegion() : kiroRegion();
-    const region = selectedKiroRegion.trim().toLowerCase();
+    const region = kiroRegion().trim().toLowerCase();
     if (!/^[a-z]{2}(?:-[a-z0-9]+)+-\d$/.test(region)) {
       setKiroConfigError('Enter a valid AWS region, such as us-east-1.');
       return null;
@@ -393,40 +375,25 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
                 </Show>
                 <Show when={isKiro()}>
                   <div class="provider-detail__field">
-                    <span class="provider-detail__label">Region</span>
-                    <Select
-                      label="Region"
-                      options={KIRO_REGION_OPTIONS}
+                    <label class="provider-detail__label" for="kiro-region">
+                      Region
+                    </label>
+                    <input
+                      id="kiro-region"
+                      class="provider-detail__input"
+                      classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
+                      type="text"
+                      autocomplete="off"
+                      placeholder={KIRO_DEFAULT_REGION}
                       value={kiroRegion()}
                       disabled={props.busy()}
-                      onChange={(value) => {
-                        setKiroRegion(value);
+                      aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
+                      onInput={(e) => {
+                        setKiroRegion(e.currentTarget.value);
                         setKiroConfigError(null);
                       }}
                     />
                   </div>
-                  <Show when={kiroRegion() === KIRO_CUSTOM_REGION_VALUE}>
-                    <div class="provider-detail__field">
-                      <label class="provider-detail__label" for="kiro-custom-region">
-                        Custom region
-                      </label>
-                      <input
-                        id="kiro-custom-region"
-                        class="provider-detail__input"
-                        classList={{ 'provider-detail__input--error': !!kiroConfigError() }}
-                        type="text"
-                        autocomplete="off"
-                        placeholder={KIRO_DEFAULT_REGION}
-                        value={kiroCustomRegion()}
-                        disabled={props.busy()}
-                        aria-describedby={kiroConfigError() ? 'kiro-identity-error' : undefined}
-                        onInput={(e) => {
-                          setKiroCustomRegion(e.currentTarget.value);
-                          setKiroConfigError(null);
-                        }}
-                      />
-                    </div>
-                  </Show>
                   <div class="provider-detail__field">
                     <label class="provider-detail__label" for="kiro-start-url">
                       Start URL <span class="provider-detail__label-muted">(optional)</span>

--- a/packages/frontend/src/components/Select.tsx
+++ b/packages/frontend/src/components/Select.tsx
@@ -16,6 +16,7 @@ interface SelectProps {
   disabled?: boolean;
   portal?: boolean;
   maxDropdownHeight?: number;
+  ariaDescribedBy?: string;
 }
 
 const Select: Component<SelectProps> = (props) => {
@@ -136,6 +137,7 @@ const Select: Component<SelectProps> = (props) => {
         aria-haspopup="listbox"
         aria-expanded={open()}
         aria-label={props.label ?? selectedLabel()}
+        aria-describedby={props.ariaDescribedBy}
       >
         <span class="custom-select__value">{props.displayValue ?? selectedLabel()}</span>
         <svg

--- a/packages/frontend/src/components/Select.tsx
+++ b/packages/frontend/src/components/Select.tsx
@@ -1,4 +1,5 @@
 import { createSignal, For, Show, onCleanup, type Component } from 'solid-js';
+import { Portal } from 'solid-js/web';
 
 interface SelectOption {
   label: string;
@@ -13,11 +14,51 @@ interface SelectProps {
   label?: string;
   displayValue?: string;
   disabled?: boolean;
+  portal?: boolean;
+  maxDropdownHeight?: number;
 }
 
 const Select: Component<SelectProps> = (props) => {
   const [open, setOpen] = createSignal(false);
+  const [dropdownStyle, setDropdownStyle] = createSignal('');
   let ref: HTMLDivElement | undefined;
+  let dropdownRef: HTMLDivElement | undefined;
+
+  const updateDropdownPosition = () => {
+    if (!props.portal || !ref || typeof window === 'undefined') return;
+
+    const gap = 4;
+    const viewportMargin = 8;
+    const minHeight = 96;
+    const maxHeight = props.maxDropdownHeight ?? 320;
+    const rect = ref.getBoundingClientRect();
+    const availableBelow = window.innerHeight - rect.bottom - gap - viewportMargin;
+    const availableAbove = rect.top - gap - viewportMargin;
+    const opensAbove = availableBelow < minHeight && availableAbove > availableBelow;
+    const availableHeight = opensAbove ? availableAbove : availableBelow;
+    const constrainedLeft = Math.min(
+      Math.max(rect.left, viewportMargin),
+      Math.max(viewportMargin, window.innerWidth - rect.width - viewportMargin),
+    );
+
+    setDropdownStyle(
+      [
+        `left: ${constrainedLeft}px`,
+        `top: ${opensAbove ? rect.top - gap : rect.bottom + gap}px`,
+        `width: ${rect.width}px`,
+        `max-height: ${Math.max(minHeight, Math.min(maxHeight, availableHeight))}px`,
+        `transform: ${opensAbove ? 'translateY(-100%)' : 'none'}`,
+      ].join('; '),
+    );
+  };
+
+  const openDropdown = () => {
+    updateDropdownPosition();
+    setOpen(true);
+    if (props.portal && typeof window !== 'undefined') {
+      window.requestAnimationFrame?.(updateDropdownPosition);
+    }
+  };
 
   const selectedLabel = () => {
     const opt = props.options.find((o) => o.value === props.value);
@@ -25,7 +66,8 @@ const Select: Component<SelectProps> = (props) => {
   };
 
   const handleClickOutside = (e: MouseEvent) => {
-    if (ref && !ref.contains(e.target as Node)) {
+    const target = e.target as Node;
+    if (ref && !ref.contains(target) && !dropdownRef?.contains(target)) {
       setOpen(false);
     }
   };
@@ -34,14 +76,50 @@ const Select: Component<SelectProps> = (props) => {
     if (e.key === 'Escape') setOpen(false);
   };
 
+  const handleViewportChange = () => {
+    if (open()) updateDropdownPosition();
+  };
+
   if (typeof document !== 'undefined') {
     document.addEventListener('click', handleClickOutside);
     document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('resize', handleViewportChange);
+    window.addEventListener('scroll', handleViewportChange, true);
     onCleanup(() => {
       document.removeEventListener('click', handleClickOutside);
       document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('resize', handleViewportChange);
+      window.removeEventListener('scroll', handleViewportChange, true);
     });
   }
+
+  const dropdown = () => (
+    <div
+      class="custom-select__dropdown"
+      classList={{ 'custom-select__dropdown--portal': props.portal }}
+      ref={dropdownRef}
+      role="listbox"
+      style={props.portal ? dropdownStyle() : undefined}
+    >
+      <For each={props.options}>
+        {(opt) => (
+          <button
+            class="custom-select__option"
+            classList={{ 'custom-select__option--selected': props.value === opt.value }}
+            onClick={() => {
+              props.onChange(opt.value);
+              setOpen(false);
+            }}
+            type="button"
+            role="option"
+            aria-selected={props.value === opt.value}
+          >
+            {opt.label}
+          </button>
+        )}
+      </For>
+    </div>
+  );
 
   return (
     <div class="custom-select" ref={ref}>
@@ -49,7 +127,9 @@ const Select: Component<SelectProps> = (props) => {
         class="custom-select__trigger"
         classList={{ 'custom-select__trigger--open': open() }}
         onClick={() => {
-          if (!props.disabled) setOpen(!open());
+          if (props.disabled) return;
+          if (open()) setOpen(false);
+          else openDropdown();
         }}
         disabled={props.disabled}
         type="button"
@@ -73,27 +153,7 @@ const Select: Component<SelectProps> = (props) => {
           <path d="m6 9 6 6 6-6" />
         </svg>
       </button>
-      <Show when={open()}>
-        <div class="custom-select__dropdown" role="listbox">
-          <For each={props.options}>
-            {(opt) => (
-              <button
-                class="custom-select__option"
-                classList={{ 'custom-select__option--selected': props.value === opt.value }}
-                onClick={() => {
-                  props.onChange(opt.value);
-                  setOpen(false);
-                }}
-                type="button"
-                role="option"
-                aria-selected={props.value === opt.value}
-              >
-                {opt.label}
-              </button>
-            )}
-          </For>
-        </div>
-      </Show>
+      <Show when={open()}>{props.portal ? <Portal>{dropdown()}</Portal> : dropdown()}</Show>
     </div>
   );
 };

--- a/packages/frontend/src/services/api/oauth.ts
+++ b/packages/frontend/src/services/api/oauth.ts
@@ -2,6 +2,11 @@ import { fetchJson, fetchMutate } from './core.js';
 
 export type MinimaxOAuthRegion = 'global' | 'cn';
 
+export interface KiroOAuthStartOptions {
+  startUrl?: string;
+  region?: string;
+}
+
 export interface MinimaxOAuthStartResponse {
   flowId: string;
   userCode: string;
@@ -84,11 +89,15 @@ export function revokeMinimaxOAuth(agentName: string, label?: string) {
   );
 }
 
-export function startKiroOAuth(agentName: string) {
-  return fetchMutate<MinimaxOAuthStartResponse>(
-    `/oauth/kiro/start?agentName=${encodeURIComponent(agentName)}`,
-    { method: 'POST' },
-  );
+export function startKiroOAuth(agentName: string, options: KiroOAuthStartOptions = {}) {
+  const params = new URLSearchParams({ agentName });
+  const startUrl = options.startUrl?.trim();
+  const region = options.region?.trim();
+  if (startUrl) params.set('startUrl', startUrl);
+  if (region) params.set('region', region);
+  return fetchMutate<MinimaxOAuthStartResponse>(`/oauth/kiro/start?${params.toString()}`, {
+    method: 'POST',
+  });
 }
 
 export function pollKiroOAuth(flowId: string) {
@@ -206,7 +215,10 @@ export function getPopupOauthApi(providerId: string): PopupOauthApi {
  * region argument.
  */
 export interface DeviceCodeApi {
-  start: (agentName: string, region?: MinimaxOAuthRegion) => Promise<MinimaxOAuthStartResponse>;
+  start: (
+    agentName: string,
+    options?: { region?: MinimaxOAuthRegion | string; startUrl?: string },
+  ) => Promise<MinimaxOAuthStartResponse>;
   poll: (flowId: string) => Promise<MinimaxOAuthPollResponse>;
   revoke: (agentName: string, label?: string) => Promise<{ ok: boolean; notifications?: string[] }>;
   hasRegion: boolean;
@@ -214,13 +226,23 @@ export interface DeviceCodeApi {
 
 const DEVICE_CODE_PROVIDERS: Record<string, DeviceCodeApi> = {
   minimax: {
-    start: (agentName, region) => startMinimaxOAuth(agentName, region ?? 'global'),
+    start: (agentName, options) =>
+      startMinimaxOAuth(agentName, (options?.region as MinimaxOAuthRegion | undefined) ?? 'global'),
     poll: pollMinimaxOAuth,
     revoke: revokeMinimaxOAuth,
     hasRegion: true,
   },
   kiro: {
-    start: (agentName) => startKiroOAuth(agentName),
+    start: (agentName, options) => {
+      const kiroOptions = {
+        startUrl: options?.startUrl,
+        region: typeof options?.region === 'string' ? options.region : undefined,
+      };
+      return startKiroOAuth(
+        agentName,
+        kiroOptions.startUrl || kiroOptions.region ? kiroOptions : undefined,
+      );
+    },
     poll: pollKiroOAuth,
     revoke: revokeKiroOAuth,
     hasRegion: false,

--- a/packages/frontend/src/styles/custom-select.css
+++ b/packages/frontend/src/styles/custom-select.css
@@ -59,6 +59,17 @@
   animation: fadeInUp 100ms ease-out;
 }
 
+.custom-select__dropdown--portal {
+  position: fixed;
+  top: auto;
+  left: auto;
+  min-width: 140px;
+  box-sizing: border-box;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  z-index: 200;
+}
+
 .custom-select__option {
   display: block;
   width: 100%;

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -433,16 +433,6 @@
   font-weight: 400;
 }
 
-.provider-detail__field > .custom-select {
-  display: block;
-  width: 100%;
-}
-
-.provider-detail__field > .custom-select .custom-select__trigger {
-  width: 100%;
-  height: 2.25rem;
-}
-
 .provider-detail__input {
   width: 100%;
   height: 2.25rem;

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -428,6 +428,11 @@
   margin-bottom: 6px;
 }
 
+.provider-detail__label-muted {
+  color: hsl(var(--muted-foreground));
+  font-weight: 400;
+}
+
 .provider-detail__input {
   width: 100%;
   height: 2.25rem;

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -433,6 +433,16 @@
   font-weight: 400;
 }
 
+.provider-detail__field > .custom-select {
+  display: block;
+  width: 100%;
+}
+
+.provider-detail__field > .custom-select .custom-select__trigger {
+  width: 100%;
+  height: 2.25rem;
+}
+
 .provider-detail__input {
   width: 100%;
   height: 2.25rem;

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -633,4 +633,29 @@ describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () =
     expect(startKiroOAuth).not.toHaveBeenCalled();
     openSpy.mockRestore();
   });
+
+  it.each([
+    ['Start URL must use HTTPS.', 'http://org.awsapps.com/start', 'us-east-1'],
+    ['Enter a valid IAM Identity Center Start URL.', 'not-a-url', 'us-east-1'],
+    [
+      'Enter a valid AWS region, such as us-east-1.',
+      'https://org.awsapps.com/start',
+      'eu-west-1.example',
+    ],
+  ])('validates %s before opening the Kiro popup', async (message, startUrl, region) => {
+    const api = await import('../../src/services/api.js');
+    const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
+    const openSpy = vi.spyOn(window, 'open');
+
+    renderKiro();
+    fireEvent.click(screen.getByLabelText('Sign in with AWS IAM Identity Center'));
+    fireEvent.input(screen.getByLabelText('Start URL'), { target: { value: startUrl } });
+    fireEvent.input(screen.getByLabelText('Region'), { target: { value: region } });
+    fireEvent.click(screen.getByText('Connect with Kiro'));
+
+    expect(screen.getByText(message)).toBeDefined();
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(startKiroOAuth).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
 });

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -540,22 +540,15 @@ function renderKiro() {
   return { ...render(() => <DeviceCodeDetailView {...props} />), props };
 }
 
-async function selectKiroRegion(value: string) {
-  await fireEvent.click(screen.getByLabelText('Region'));
-  await fireEvent.click(screen.getByRole('option', { name: value }));
-}
-
 describe('DeviceCodeDetailView — Kiro', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('shows the region selector, optional Start URL, and Kiro hint', () => {
+  it('shows the editable region, optional Start URL, and Kiro hint', () => {
     renderKiro();
-    expect(screen.getByLabelText('Region').textContent).toContain('us-east-1');
-    fireEvent.click(screen.getByLabelText('Region'));
-    expect(screen.getByRole('option', { name: 'eu-west-1' })).toBeDefined();
-    expect(screen.getByRole('option', { name: 'Other region...' })).toBeDefined();
+    expect((screen.getByLabelText('Region') as HTMLInputElement).value).toBe('us-east-1');
+    expect(screen.queryByRole('option', { name: 'Other region...' })).toBeNull();
     expect((screen.getByLabelText(/Start URL/) as HTMLInputElement).value).toBe('');
     expect(
       screen.getByText(
@@ -615,7 +608,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
     fireEvent.input(screen.getByLabelText(/Start URL/), {
       target: { value: 'https://org.awsapps.com/start' },
     });
-    await selectKiroRegion('eu-west-1');
+    fireEvent.input(screen.getByLabelText('Region'), { target: { value: 'eu-west-1' } });
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     await waitFor(() => {
@@ -633,7 +626,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
     const openSpy = vi.spyOn(window, 'open');
 
     renderKiro();
-    await selectKiroRegion('Other region...');
+    fireEvent.input(screen.getByLabelText('Region'), { target: { value: '' } });
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     expect(screen.getByText('Enter a valid AWS region, such as us-east-1.')).toBeDefined();
@@ -642,7 +635,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
     openSpy.mockRestore();
   });
 
-  it('passes a custom AWS region when selected', async () => {
+  it('passes an edited AWS region', async () => {
     const api = await import('../../src/services/api.js');
     const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
     startKiroOAuth.mockResolvedValue({
@@ -659,8 +652,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
     } as unknown as Window);
 
     renderKiro();
-    await selectKiroRegion('Other region...');
-    fireEvent.input(screen.getByLabelText('Custom region'), {
+    fireEvent.input(screen.getByLabelText('Region'), {
       target: { value: 'CA-CENTRAL-1' },
     });
     fireEvent.click(screen.getByText('Connect with Kiro'));
@@ -686,12 +678,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
 
     renderKiro();
     fireEvent.input(screen.getByLabelText(/Start URL/), { target: { value: startUrl } });
-    if (region === 'us-east-1') {
-      await selectKiroRegion(region);
-    } else {
-      await selectKiroRegion('Other region...');
-      fireEvent.input(screen.getByLabelText('Custom region'), { target: { value: region } });
-    }
+    fireEvent.input(screen.getByLabelText('Region'), { target: { value: region } });
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     expect(screen.getByText(message)).toBeDefined();

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -540,20 +540,21 @@ function renderKiro() {
   return { ...render(() => <DeviceCodeDetailView {...props} />), props };
 }
 
-describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () => {
+describe('DeviceCodeDetailView — Kiro', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('hides the region selector and shows the generic hint', () => {
+  it('shows the region selector, optional Start URL, and Kiro hint', () => {
     renderKiro();
-    expect(screen.queryByLabelText('Region')).toBeNull();
+    expect((screen.getByLabelText('Region') as HTMLInputElement).value).toBe('us-east-1');
+    expect((screen.getByLabelText(/Start URL/) as HTMLInputElement).value).toBe('');
     expect(
       screen.getByText(
-        'Open the authorization page in your browser to sign in and approve access.',
+        'Choose the AWS region for Kiro sign-in. Add a Start URL only if your organization uses IAM Identity Center.',
       ),
     ).toBeDefined();
-    expect(screen.getByLabelText('Sign in with AWS IAM Identity Center')).toBeDefined();
+    expect(screen.queryByLabelText('Sign in with AWS IAM Identity Center')).toBeNull();
   });
 
   it('does not render the MiniMax token-paste alternative', () => {
@@ -561,7 +562,7 @@ describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () =
     expect(screen.queryByText('Connect with token')).toBeNull();
   });
 
-  it('starts the device flow without a region argument', async () => {
+  it('starts the device flow with the default Kiro region', async () => {
     const api = await import('../../src/services/api.js');
     const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
     startKiroOAuth.mockResolvedValue({
@@ -581,12 +582,12 @@ describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () =
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     await waitFor(() => {
-      expect(startKiroOAuth).toHaveBeenCalledWith('test-agent', undefined);
+      expect(startKiroOAuth).toHaveBeenCalledWith('test-agent', { region: 'us-east-1' });
     });
     openSpy.mockRestore();
   });
 
-  it('passes IAM Identity Center start URL and region when enabled', async () => {
+  it('passes optional IAM Identity Center start URL and selected region', async () => {
     const api = await import('../../src/services/api.js');
     const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
     startKiroOAuth.mockResolvedValue({
@@ -603,8 +604,7 @@ describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () =
     } as unknown as Window);
 
     renderKiro();
-    fireEvent.click(screen.getByLabelText('Sign in with AWS IAM Identity Center'));
-    fireEvent.input(screen.getByLabelText('Start URL'), {
+    fireEvent.input(screen.getByLabelText(/Start URL/), {
       target: { value: 'https://org.awsapps.com/start' },
     });
     fireEvent.input(screen.getByLabelText('Region'), { target: { value: 'EU-WEST-1' } });
@@ -619,16 +619,16 @@ describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () =
     openSpy.mockRestore();
   });
 
-  it('requires IAM Identity Center fields before opening the Kiro popup', async () => {
+  it('requires a valid region before opening the Kiro popup', async () => {
     const api = await import('../../src/services/api.js');
     const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
     const openSpy = vi.spyOn(window, 'open');
 
     renderKiro();
-    fireEvent.click(screen.getByLabelText('Sign in with AWS IAM Identity Center'));
+    fireEvent.input(screen.getByLabelText('Region'), { target: { value: '' } });
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
-    expect(screen.getByText('Enter your IAM Identity Center Start URL and region.')).toBeDefined();
+    expect(screen.getByText('Enter a valid AWS region, such as us-east-1.')).toBeDefined();
     expect(openSpy).not.toHaveBeenCalled();
     expect(startKiroOAuth).not.toHaveBeenCalled();
     openSpy.mockRestore();
@@ -648,8 +648,7 @@ describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () =
     const openSpy = vi.spyOn(window, 'open');
 
     renderKiro();
-    fireEvent.click(screen.getByLabelText('Sign in with AWS IAM Identity Center'));
-    fireEvent.input(screen.getByLabelText('Start URL'), { target: { value: startUrl } });
+    fireEvent.input(screen.getByLabelText(/Start URL/), { target: { value: startUrl } });
     fireEvent.input(screen.getByLabelText('Region'), { target: { value: region } });
     fireEvent.click(screen.getByText('Connect with Kiro'));
 

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -540,14 +540,25 @@ function renderKiro() {
   return { ...render(() => <DeviceCodeDetailView {...props} />), props };
 }
 
+async function selectKiroRegion(value: string) {
+  await fireEvent.click(screen.getByLabelText('Region'));
+  await fireEvent.click(screen.getByRole('option', { name: value }));
+}
+
 describe('DeviceCodeDetailView — Kiro', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('shows the editable region, optional Start URL, and Kiro hint', () => {
+  it('shows all supported regions without an Other region option', async () => {
     renderKiro();
-    expect((screen.getByLabelText('Region') as HTMLInputElement).value).toBe('us-east-1');
+    expect(screen.getByLabelText('Region').textContent).toContain('us-east-1');
+    await fireEvent.click(screen.getByLabelText('Region'));
+    expect(screen.getByRole('option', { name: 'eu-west-1' })).toBeDefined();
+    expect(screen.getByRole('option', { name: 'ap-east-2' })).toBeDefined();
+    expect(screen.getByRole('option', { name: 'eu-central-2' })).toBeDefined();
+    expect(screen.getByRole('option', { name: 'mx-central-1' })).toBeDefined();
+    expect(screen.getByRole('option', { name: 'us-gov-west-1' })).toBeDefined();
     expect(screen.queryByRole('option', { name: 'Other region...' })).toBeNull();
     expect((screen.getByLabelText(/Start URL/) as HTMLInputElement).value).toBe('');
     expect(
@@ -608,7 +619,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
     fireEvent.input(screen.getByLabelText(/Start URL/), {
       target: { value: 'https://org.awsapps.com/start' },
     });
-    fireEvent.input(screen.getByLabelText('Region'), { target: { value: 'eu-west-1' } });
+    await selectKiroRegion('eu-west-1');
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     await waitFor(() => {
@@ -620,28 +631,13 @@ describe('DeviceCodeDetailView — Kiro', () => {
     openSpy.mockRestore();
   });
 
-  it('requires a valid region before opening the Kiro popup', async () => {
-    const api = await import('../../src/services/api.js');
-    const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
-    const openSpy = vi.spyOn(window, 'open');
-
-    renderKiro();
-    fireEvent.input(screen.getByLabelText('Region'), { target: { value: '' } });
-    fireEvent.click(screen.getByText('Connect with Kiro'));
-
-    expect(screen.getByText('Enter a valid AWS region, such as us-east-1.')).toBeDefined();
-    expect(openSpy).not.toHaveBeenCalled();
-    expect(startKiroOAuth).not.toHaveBeenCalled();
-    openSpy.mockRestore();
-  });
-
-  it('passes an edited AWS region', async () => {
+  it('passes a selected opt-in AWS region', async () => {
     const api = await import('../../src/services/api.js');
     const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
     startKiroOAuth.mockResolvedValue({
       flowId: 'f1',
       userCode: 'AAAA-BBBB',
-      verificationUri: 'https://device.sso.ca-central-1.amazonaws.com/?user_code=AAAA-BBBB',
+      verificationUri: 'https://device.sso.ap-east-2.amazonaws.com/?user_code=AAAA-BBBB',
       expiresAt: Date.now() + 60000,
       pollIntervalMs: 5000,
     });
@@ -652,13 +648,11 @@ describe('DeviceCodeDetailView — Kiro', () => {
     } as unknown as Window);
 
     renderKiro();
-    fireEvent.input(screen.getByLabelText('Region'), {
-      target: { value: 'CA-CENTRAL-1' },
-    });
+    await selectKiroRegion('ap-east-2');
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     await waitFor(() => {
-      expect(startKiroOAuth).toHaveBeenCalledWith('test-agent', { region: 'ca-central-1' });
+      expect(startKiroOAuth).toHaveBeenCalledWith('test-agent', { region: 'ap-east-2' });
     });
     openSpy.mockRestore();
   });
@@ -666,11 +660,6 @@ describe('DeviceCodeDetailView — Kiro', () => {
   it.each([
     ['Start URL must use HTTPS.', 'http://org.awsapps.com/start', 'us-east-1'],
     ['Enter a valid IAM Identity Center Start URL.', 'not-a-url', 'us-east-1'],
-    [
-      'Enter a valid AWS region, such as us-east-1.',
-      'https://org.awsapps.com/start',
-      'eu-west-1.example',
-    ],
   ])('validates %s before opening the Kiro popup', async (message, startUrl, region) => {
     const api = await import('../../src/services/api.js');
     const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
@@ -678,7 +667,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
 
     renderKiro();
     fireEvent.input(screen.getByLabelText(/Start URL/), { target: { value: startUrl } });
-    fireEvent.input(screen.getByLabelText('Region'), { target: { value: region } });
+    await selectKiroRegion(region);
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     expect(screen.getByText(message)).toBeDefined();

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -671,6 +671,12 @@ describe('DeviceCodeDetailView — Kiro', () => {
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     expect(screen.getByText(message)).toBeDefined();
+    expect(screen.getByLabelText('Region').getAttribute('aria-describedby')).toBe(
+      'kiro-identity-error',
+    );
+    expect(screen.getByLabelText(/Start URL/).getAttribute('aria-describedby')).toBe(
+      'kiro-identity-error',
+    );
     expect(openSpy).not.toHaveBeenCalled();
     expect(startKiroOAuth).not.toHaveBeenCalled();
     openSpy.mockRestore();

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -435,7 +435,7 @@ describe('DeviceCodeDetailView — addKeyOpen effect', () => {
     renderConnectedWithAddKeyOpen();
 
     await waitFor(() => {
-      expect(startMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
+      expect(startMinimaxOAuth).toHaveBeenCalledWith('test-agent', { region: 'global' });
     });
     expect(screen.getByText(/A new tab opened with the MiniMax authorization page/)).toBeDefined();
     openSpy.mockRestore();
@@ -468,7 +468,7 @@ describe('DeviceCodeDetailView — addKeyOpen effect', () => {
       renderConnectedWithAddKeyOpen();
 
       await waitFor(() => {
-        expect(startMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
+        expect(startMinimaxOAuth).toHaveBeenCalledWith('test-agent', { region: 'global' });
       });
       await vi.advanceTimersByTimeAsync(2000);
 
@@ -553,6 +553,7 @@ describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () =
         'Open the authorization page in your browser to sign in and approve access.',
       ),
     ).toBeDefined();
+    expect(screen.getByLabelText('Sign in with AWS IAM Identity Center')).toBeDefined();
   });
 
   it('does not render the MiniMax token-paste alternative', () => {
@@ -570,13 +571,11 @@ describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () =
       expiresAt: Date.now() + 60000,
       pollIntervalMs: 5000,
     });
-    const openSpy = vi
-      .spyOn(window, 'open')
-      .mockReturnValue({
-        closed: false,
-        opener: null,
-        location: { replace: vi.fn() },
-      } as unknown as Window);
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({
+      closed: false,
+      opener: null,
+      location: { replace: vi.fn() },
+    } as unknown as Window);
 
     renderKiro();
     fireEvent.click(screen.getByText('Connect with Kiro'));
@@ -584,6 +583,54 @@ describe('DeviceCodeDetailView — Kiro (no region, no token alternative)', () =
     await waitFor(() => {
       expect(startKiroOAuth).toHaveBeenCalledWith('test-agent', undefined);
     });
+    openSpy.mockRestore();
+  });
+
+  it('passes IAM Identity Center start URL and region when enabled', async () => {
+    const api = await import('../../src/services/api.js');
+    const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
+    startKiroOAuth.mockResolvedValue({
+      flowId: 'f1',
+      userCode: 'AAAA-BBBB',
+      verificationUri: 'https://device.sso.eu-west-1.amazonaws.com/?user_code=AAAA-BBBB',
+      expiresAt: Date.now() + 60000,
+      pollIntervalMs: 5000,
+    });
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({
+      closed: false,
+      opener: null,
+      location: { replace: vi.fn() },
+    } as unknown as Window);
+
+    renderKiro();
+    fireEvent.click(screen.getByLabelText('Sign in with AWS IAM Identity Center'));
+    fireEvent.input(screen.getByLabelText('Start URL'), {
+      target: { value: 'https://org.awsapps.com/start' },
+    });
+    fireEvent.input(screen.getByLabelText('Region'), { target: { value: 'EU-WEST-1' } });
+    fireEvent.click(screen.getByText('Connect with Kiro'));
+
+    await waitFor(() => {
+      expect(startKiroOAuth).toHaveBeenCalledWith('test-agent', {
+        startUrl: 'https://org.awsapps.com/start',
+        region: 'eu-west-1',
+      });
+    });
+    openSpy.mockRestore();
+  });
+
+  it('requires IAM Identity Center fields before opening the Kiro popup', async () => {
+    const api = await import('../../src/services/api.js');
+    const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
+    const openSpy = vi.spyOn(window, 'open');
+
+    renderKiro();
+    fireEvent.click(screen.getByLabelText('Sign in with AWS IAM Identity Center'));
+    fireEvent.click(screen.getByText('Connect with Kiro'));
+
+    expect(screen.getByText('Enter your IAM Identity Center Start URL and region.')).toBeDefined();
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(startKiroOAuth).not.toHaveBeenCalled();
     openSpy.mockRestore();
   });
 });

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -547,7 +547,9 @@ describe('DeviceCodeDetailView — Kiro', () => {
 
   it('shows the region selector, optional Start URL, and Kiro hint', () => {
     renderKiro();
-    expect((screen.getByLabelText('Region') as HTMLInputElement).value).toBe('us-east-1');
+    expect((screen.getByLabelText('Region') as HTMLSelectElement).value).toBe('us-east-1');
+    expect(screen.getByText('eu-west-1')).toBeDefined();
+    expect(screen.getByText('Other region...')).toBeDefined();
     expect((screen.getByLabelText(/Start URL/) as HTMLInputElement).value).toBe('');
     expect(
       screen.getByText(
@@ -607,7 +609,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
     fireEvent.input(screen.getByLabelText(/Start URL/), {
       target: { value: 'https://org.awsapps.com/start' },
     });
-    fireEvent.input(screen.getByLabelText('Region'), { target: { value: 'EU-WEST-1' } });
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'eu-west-1' } });
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     await waitFor(() => {
@@ -625,12 +627,41 @@ describe('DeviceCodeDetailView — Kiro', () => {
     const openSpy = vi.spyOn(window, 'open');
 
     renderKiro();
-    fireEvent.input(screen.getByLabelText('Region'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'custom' } });
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     expect(screen.getByText('Enter a valid AWS region, such as us-east-1.')).toBeDefined();
     expect(openSpy).not.toHaveBeenCalled();
     expect(startKiroOAuth).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it('passes a custom AWS region when selected', async () => {
+    const api = await import('../../src/services/api.js');
+    const startKiroOAuth = api.startKiroOAuth as ReturnType<typeof vi.fn>;
+    startKiroOAuth.mockResolvedValue({
+      flowId: 'f1',
+      userCode: 'AAAA-BBBB',
+      verificationUri: 'https://device.sso.ca-central-1.amazonaws.com/?user_code=AAAA-BBBB',
+      expiresAt: Date.now() + 60000,
+      pollIntervalMs: 5000,
+    });
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({
+      closed: false,
+      opener: null,
+      location: { replace: vi.fn() },
+    } as unknown as Window);
+
+    renderKiro();
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'custom' } });
+    fireEvent.input(screen.getByLabelText('Custom region'), {
+      target: { value: 'CA-CENTRAL-1' },
+    });
+    fireEvent.click(screen.getByText('Connect with Kiro'));
+
+    await waitFor(() => {
+      expect(startKiroOAuth).toHaveBeenCalledWith('test-agent', { region: 'ca-central-1' });
+    });
     openSpy.mockRestore();
   });
 
@@ -649,7 +680,12 @@ describe('DeviceCodeDetailView — Kiro', () => {
 
     renderKiro();
     fireEvent.input(screen.getByLabelText(/Start URL/), { target: { value: startUrl } });
-    fireEvent.input(screen.getByLabelText('Region'), { target: { value: region } });
+    if (region === 'us-east-1') {
+      fireEvent.change(screen.getByLabelText('Region'), { target: { value: region } });
+    } else {
+      fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'custom' } });
+      fireEvent.input(screen.getByLabelText('Custom region'), { target: { value: region } });
+    }
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     expect(screen.getByText(message)).toBeDefined();

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -540,6 +540,11 @@ function renderKiro() {
   return { ...render(() => <DeviceCodeDetailView {...props} />), props };
 }
 
+async function selectKiroRegion(value: string) {
+  await fireEvent.click(screen.getByLabelText('Region'));
+  await fireEvent.click(screen.getByRole('option', { name: value }));
+}
+
 describe('DeviceCodeDetailView — Kiro', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -547,9 +552,10 @@ describe('DeviceCodeDetailView — Kiro', () => {
 
   it('shows the region selector, optional Start URL, and Kiro hint', () => {
     renderKiro();
-    expect((screen.getByLabelText('Region') as HTMLSelectElement).value).toBe('us-east-1');
-    expect(screen.getByText('eu-west-1')).toBeDefined();
-    expect(screen.getByText('Other region...')).toBeDefined();
+    expect(screen.getByLabelText('Region').textContent).toContain('us-east-1');
+    fireEvent.click(screen.getByLabelText('Region'));
+    expect(screen.getByRole('option', { name: 'eu-west-1' })).toBeDefined();
+    expect(screen.getByRole('option', { name: 'Other region...' })).toBeDefined();
     expect((screen.getByLabelText(/Start URL/) as HTMLInputElement).value).toBe('');
     expect(
       screen.getByText(
@@ -609,7 +615,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
     fireEvent.input(screen.getByLabelText(/Start URL/), {
       target: { value: 'https://org.awsapps.com/start' },
     });
-    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'eu-west-1' } });
+    await selectKiroRegion('eu-west-1');
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     await waitFor(() => {
@@ -627,7 +633,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
     const openSpy = vi.spyOn(window, 'open');
 
     renderKiro();
-    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'custom' } });
+    await selectKiroRegion('Other region...');
     fireEvent.click(screen.getByText('Connect with Kiro'));
 
     expect(screen.getByText('Enter a valid AWS region, such as us-east-1.')).toBeDefined();
@@ -653,7 +659,7 @@ describe('DeviceCodeDetailView — Kiro', () => {
     } as unknown as Window);
 
     renderKiro();
-    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'custom' } });
+    await selectKiroRegion('Other region...');
     fireEvent.input(screen.getByLabelText('Custom region'), {
       target: { value: 'CA-CENTRAL-1' },
     });
@@ -681,9 +687,9 @@ describe('DeviceCodeDetailView — Kiro', () => {
     renderKiro();
     fireEvent.input(screen.getByLabelText(/Start URL/), { target: { value: startUrl } });
     if (region === 'us-east-1') {
-      fireEvent.change(screen.getByLabelText('Region'), { target: { value: region } });
+      await selectKiroRegion(region);
     } else {
-      fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'custom' } });
+      await selectKiroRegion('Other region...');
       fireEvent.input(screen.getByLabelText('Custom region'), { target: { value: region } });
     }
     fireEvent.click(screen.getByText('Connect with Kiro'));

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1367,7 +1367,7 @@ describe('ProviderSelectModal', () => {
       expect(popup.opener).toBeNull();
 
       await waitFor(() => {
-        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', { region: 'global' });
       });
       await waitFor(() => {
         expect(popup.location.replace).toHaveBeenCalledWith('https://www.minimax.io/verify');
@@ -1423,7 +1423,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'cn');
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', { region: 'cn' });
       });
 
       vi.restoreAllMocks();
@@ -1656,7 +1656,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', { region: 'global' });
       });
       expect(screen.queryByText(/A new tab opened with the MiniMax/)).toBeNull();
       expect(screen.getByText('Connect with MiniMax')).toBeDefined();

--- a/packages/frontend/tests/components/Select.test.tsx
+++ b/packages/frontend/tests/components/Select.test.tsx
@@ -125,9 +125,12 @@ describe('Select', () => {
   });
 
   it('has correct aria attributes', () => {
-    render(() => <Select options={options} value="a" onChange={() => {}} />);
+    render(() => (
+      <Select options={options} value="a" onChange={() => {}} ariaDescribedBy="select-help" />
+    ));
     const trigger = screen.getByRole('button');
     expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger.getAttribute('aria-describedby')).toBe('select-help');
   });
 });

--- a/packages/frontend/tests/components/Select.test.tsx
+++ b/packages/frontend/tests/components/Select.test.tsx
@@ -1,99 +1,133 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
-import Select from "../../src/components/Select";
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
+import Select from '../../src/components/Select';
 
-describe("Select", () => {
+describe('Select', () => {
   const options = [
-    { label: "Option A", value: "a" },
-    { label: "Option B", value: "b" },
-    { label: "Option C", value: "c" },
+    { label: 'Option A', value: 'a' },
+    { label: 'Option B', value: 'b' },
+    { label: 'Option C', value: 'c' },
   ];
 
-  it("renders with selected value label", () => {
+  it('renders with selected value label', () => {
     render(() => <Select options={options} value="b" onChange={() => {}} />);
-    expect(screen.getByText("Option B")).toBeDefined();
+    expect(screen.getByText('Option B')).toBeDefined();
   });
 
-  it("shows placeholder when no match", () => {
+  it('shows placeholder when no match', () => {
     render(() => <Select options={options} value="" onChange={() => {}} placeholder="Pick one" />);
-    expect(screen.getByText("Pick one")).toBeDefined();
+    expect(screen.getByText('Pick one')).toBeDefined();
   });
 
-  it("opens dropdown on click", async () => {
+  it('opens dropdown on click', async () => {
     render(() => <Select options={options} value="a" onChange={() => {}} />);
-    const trigger = screen.getByRole("button", { name: /Option A/i });
+    const trigger = screen.getByRole('button', { name: /Option A/i });
     await fireEvent.click(trigger);
-    expect(screen.getByRole("listbox")).toBeDefined();
+    expect(screen.getByRole('listbox')).toBeDefined();
   });
 
-  it("calls onChange when option selected", async () => {
+  it('calls onChange when option selected', async () => {
     const onChange = vi.fn();
     render(() => <Select options={options} value="a" onChange={onChange} />);
-    const trigger = screen.getByRole("button", { name: /Option A/i });
+    const trigger = screen.getByRole('button', { name: /Option A/i });
     await fireEvent.click(trigger);
-    const optB = screen.getByText("Option B");
+    const optB = screen.getByText('Option B');
     await fireEvent.click(optB);
-    expect(onChange).toHaveBeenCalledWith("b");
+    expect(onChange).toHaveBeenCalledWith('b');
   });
 
-  it("closes on Escape key", async () => {
+  it('closes on Escape key', async () => {
     render(() => <Select options={options} value="a" onChange={() => {}} />);
-    const trigger = screen.getByRole("button", { name: /Option A/i });
+    const trigger = screen.getByRole('button', { name: /Option A/i });
     await fireEvent.click(trigger);
-    expect(screen.getByRole("listbox")).toBeDefined();
-    expect(trigger.getAttribute("aria-expanded")).toBe("true");
-    await fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.getByRole('listbox')).toBeDefined();
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    await fireEvent.keyDown(document, { key: 'Escape' });
     await waitFor(() => {
-      expect(trigger.getAttribute("aria-expanded")).toBe("false");
+      expect(trigger.getAttribute('aria-expanded')).toBe('false');
     });
-    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.queryByRole('listbox')).toBeNull();
   });
 
-  it("does not close on non-Escape keys", async () => {
+  it('does not close on non-Escape keys', async () => {
     render(() => <Select options={options} value="a" onChange={() => {}} />);
-    const trigger = screen.getByRole("button", { name: /Option A/i });
+    const trigger = screen.getByRole('button', { name: /Option A/i });
     await fireEvent.click(trigger);
-    expect(screen.getByRole("listbox")).toBeDefined();
-    await fireEvent.keyDown(document, { key: "Enter" });
-    await fireEvent.keyDown(document, { key: "ArrowDown" });
-    await fireEvent.keyDown(document, { key: "a" });
-    expect(trigger.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.queryByRole("listbox")).not.toBeNull();
+    expect(screen.getByRole('listbox')).toBeDefined();
+    await fireEvent.keyDown(document, { key: 'Enter' });
+    await fireEvent.keyDown(document, { key: 'ArrowDown' });
+    await fireEvent.keyDown(document, { key: 'a' });
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.queryByRole('listbox')).not.toBeNull();
   });
 
-  it("closes dropdown when clicking outside", async () => {
+  it('closes dropdown when clicking outside', async () => {
     render(() => <Select options={options} value="a" onChange={() => {}} />);
-    const trigger = screen.getByRole("button", { name: /Option A/i });
+    const trigger = screen.getByRole('button', { name: /Option A/i });
     await fireEvent.click(trigger);
-    expect(screen.getByRole("listbox")).toBeDefined();
-    expect(trigger.getAttribute("aria-expanded")).toBe("true");
-    const outsideElement = document.createElement("div");
+    expect(screen.getByRole('listbox')).toBeDefined();
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    const outsideElement = document.createElement('div');
     document.body.appendChild(outsideElement);
     await fireEvent.click(outsideElement);
     await waitFor(() => {
-      expect(trigger.getAttribute("aria-expanded")).toBe("false");
+      expect(trigger.getAttribute('aria-expanded')).toBe('false');
     });
-    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.queryByRole('listbox')).toBeNull();
     document.body.removeChild(outsideElement);
   });
 
-  it("does not close when clicking inside the dropdown options", async () => {
+  it('does not close when clicking inside the dropdown options', async () => {
     render(() => <Select options={options} value="a" onChange={() => {}} />);
-    const trigger = screen.getByRole("button", { name: /Option A/i });
+    const trigger = screen.getByRole('button', { name: /Option A/i });
     await fireEvent.click(trigger);
-    const listbox = screen.getByRole("listbox");
+    const listbox = screen.getByRole('listbox');
     expect(listbox).toBeDefined();
     // Click on the listbox container itself (not an option) — should remain open
     // because the ref contains it.
     await fireEvent.click(listbox);
-    expect(trigger.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.queryByRole("listbox")).not.toBeNull();
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.queryByRole('listbox')).not.toBeNull();
   });
 
-  it("has correct aria attributes", () => {
+  it('can render the dropdown in a capped portal', async () => {
+    const innerHeight = vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(180);
+    const innerWidth = vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(320);
+
+    render(() => (
+      <Select options={options} value="a" onChange={() => {}} portal maxDropdownHeight={120} />
+    ));
+    const root = document.querySelector('.custom-select') as HTMLDivElement;
+    vi.spyOn(root, 'getBoundingClientRect').mockReturnValue({
+      x: 12,
+      y: 40,
+      top: 40,
+      left: 12,
+      right: 252,
+      bottom: 72,
+      width: 240,
+      height: 32,
+      toJSON: () => ({}),
+    });
+
+    const trigger = screen.getByRole('button', { name: /Option A/i });
+    await fireEvent.click(trigger);
+
+    const listbox = screen.getByRole('listbox');
+    expect(root.contains(listbox)).toBe(false);
+    expect(listbox.classList.contains('custom-select__dropdown--portal')).toBe(true);
+    expect((listbox as HTMLElement).style.top).toBe('76px');
+    expect((listbox as HTMLElement).style.width).toBe('240px');
+    expect((listbox as HTMLElement).style.maxHeight).toBe('96px');
+
+    innerHeight.mockRestore();
+    innerWidth.mockRestore();
+  });
+
+  it('has correct aria attributes', () => {
     render(() => <Select options={options} value="a" onChange={() => {}} />);
-    const trigger = screen.getByRole("button");
-    expect(trigger.getAttribute("aria-haspopup")).toBe("listbox");
-    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    const trigger = screen.getByRole('button');
+    expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 });

--- a/packages/frontend/tests/services/api/oauth.test.ts
+++ b/packages/frontend/tests/services/api/oauth.test.ts
@@ -144,8 +144,27 @@ describe('oauth API client', () => {
     const out = await oauth.startKiroOAuth('my agent');
     expect(out.flowId).toBe('f1');
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toContain('/api/v1/oauth/kiro/start?agentName=my%20agent');
+    expect(url).toContain('/api/v1/oauth/kiro/start?agentName=my+agent');
     expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('startKiroOAuth includes IAM Identity Center options when provided', async () => {
+    const fetchMock = setupFetch({
+      flowId: 'f1',
+      userCode: 'AAAA-BBBB',
+      verificationUri: 'https://verify',
+      expiresAt: 0,
+      pollIntervalMs: 5000,
+    });
+    await oauth.startKiroOAuth('demo', {
+      startUrl: ' https://org.awsapps.com/start ',
+      region: ' eu-west-1 ',
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/oauth/kiro/start?');
+    expect(url).toContain('agentName=demo');
+    expect(url).toContain('startUrl=https%3A%2F%2Forg.awsapps.com%2Fstart');
+    expect(url).toContain('region=eu-west-1');
   });
 
   it('pollKiroOAuth GETs /poll with the flowId', async () => {
@@ -184,7 +203,7 @@ describe('oauth API client', () => {
       });
       const api = oauth.getDeviceCodeApi('minimax');
       expect(api.hasRegion).toBe(true);
-      await api.start('demo', 'cn');
+      await api.start('demo', { region: 'cn' });
       expect(fetchMock.mock.calls[0][0] as string).toContain('region=cn');
     });
 
@@ -200,7 +219,7 @@ describe('oauth API client', () => {
       expect(fetchMock.mock.calls[0][0] as string).toContain('region=global');
     });
 
-    it('routes kiro through its region-less start endpoint', async () => {
+    it('routes kiro through its default start endpoint without options', async () => {
       const fetchMock = setupFetch({
         flowId: 'f1',
         userCode: 'C',
@@ -210,10 +229,27 @@ describe('oauth API client', () => {
       });
       const api = oauth.getDeviceCodeApi('kiro');
       expect(api.hasRegion).toBe(false);
-      await api.start('demo', 'cn');
+      await api.start('demo');
       const url = fetchMock.mock.calls[0][0] as string;
       expect(url).toContain('/api/v1/oauth/kiro/start');
       expect(url).not.toContain('region=');
+    });
+
+    it('routes kiro IAM Identity Center options through its start endpoint', async () => {
+      const fetchMock = setupFetch({
+        flowId: 'f1',
+        userCode: 'C',
+        verificationUri: 'https://v',
+        expiresAt: 0,
+        pollIntervalMs: 5000,
+      });
+      await oauth.getDeviceCodeApi('kiro').start('demo', {
+        startUrl: 'https://org.awsapps.com/start',
+        region: 'eu-west-1',
+      });
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain('startUrl=https%3A%2F%2Forg.awsapps.com%2Fstart');
+      expect(url).toContain('region=eu-west-1');
     });
 
     it('throws for a provider without a device-code flow', () => {

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -653,7 +653,7 @@ describe('PROVIDERS', () => {
     expect(getRoutingProviderApiKeyUrl('opencode-zen')).toBe('https://opencode.ai/auth');
   });
 
-  it('Kiro is subscription-only with CLI OAuth flow and dynamic models', () => {
+  it('Kiro is subscription-only with device-code OAuth flow and dynamic models', () => {
     const kiro = PROVIDERS.find((p) => p.id === 'kiro')!;
     expect(kiro).toBeDefined();
     expect(kiro.name).toBe('Kiro');


### PR DESCRIPTION
### ✨ What changed
- Added a Kiro IAM Identity Center option to subscription login.
- Sent Start URL and selected region through the Kiro OAuth flow.
- Added all AWS IAM Identity Center OIDC regions to the dropdown.
- Kept the region dropdown scrollable inside the connect modal.

### 💭 Why
Kiro org accounts require an IAM Identity Center Start URL and region.
Manifest only opened the default Builder ID flow.

### 👤 For users
Kiro setup now supports AWS IAM Identity Center and region selection.

### 📝 Notes
Closes #2245.
No live Kiro org-account smoke was run.