### PR TITLE
feat: add AWS Bedrock provider

### DIFF
--- a/.changeset/bedrock-provider.md
+++ b/.changeset/bedrock-provider.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add AWS Bedrock as an API-key provider using Bedrock Mantle's OpenAI-compatible endpoints. Bedrock vendor-prefixed model IDs now resolve model parameters, pricing, and capabilities through the underlying provider metadata while keeping the original Bedrock ID for inference.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -183,6 +183,66 @@ const MOCK_API_RESPONSE = {
       },
     },
   },
+  'amazon-bedrock': {
+    id: 'amazon-bedrock',
+    name: 'Amazon Bedrock',
+    models: {
+      'mistral.magistral-small-2509': {
+        id: 'mistral.magistral-small-2509',
+        name: 'Magistral Small 1.2',
+        cost: { input: 0.5, output: 1.5 },
+        limit: { context: 128000, output: 40000 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'qwen.qwen3-32b-v1:0': {
+        id: 'qwen.qwen3-32b-v1:0',
+        name: 'Qwen3 32B (dense)',
+        cost: { input: 0.15, output: 0.6 },
+        limit: { context: 131072, output: 32768 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'qwen.qwen3-coder-30b-a3b-v1:0': {
+        id: 'qwen.qwen3-coder-30b-a3b-v1:0',
+        name: 'Qwen3 Coder 30B A3B Instruct',
+        cost: { input: 0.15, output: 0.6 },
+        limit: { context: 262144, output: 65536 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'qwen.qwen3-next-80b-a3b': {
+        id: 'qwen.qwen3-next-80b-a3b',
+        name: 'Qwen3 Next 80B A3B Instruct',
+        cost: { input: 0.14, output: 1.4 },
+        limit: { context: 262144, output: 65536 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'moonshot.kimi-k2-thinking': {
+        id: 'moonshot.kimi-k2-thinking',
+        name: 'Kimi K2 Thinking',
+        cost: { input: 0.6, output: 2.5 },
+        limit: { context: 262144, output: 32768 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'deepseek.v3-v1:0': {
+        id: 'deepseek.v3-v1:0',
+        name: 'DeepSeek-V3.1',
+        cost: { input: 0.58, output: 1.68 },
+        limit: { context: 64000, output: 8192 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'qwen.qwen3-version-test-20260101': {
+        id: 'qwen.qwen3-version-test-20260101',
+        name: 'Dated Qwen snapshot',
+        cost: { input: 9, output: 9 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'qwen.qwen3-version-test-v2:0': {
+        id: 'qwen.qwen3-version-test-v2:0',
+        name: 'Versioned Qwen snapshot',
+        cost: { input: 0.21, output: 0.42 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
   kilo: {
     id: 'kilo',
     name: 'Kilo Gateway',
@@ -243,8 +303,8 @@ describe('ModelsDevSyncService', () => {
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
       // anthropic: 2, google: 1 (audio excluded), openai: 1, deepseek: 1,
-      // fireworks: 1, mistral: 6, xai: 3, groq: 2, nvidia: 1 = 18
-      expect(count).toBe(18);
+      // fireworks: 1, mistral: 6, xai: 3, bedrock: 8, groq: 2, nvidia: 1 = 26
+      expect(count).toBe(26);
     });
 
     it('should filter out non-text-output models', async () => {
@@ -331,6 +391,48 @@ describe('ModelsDevSyncService', () => {
       expect(prefixed!.inputPricePerToken).toBe(0.29 / 1_000_000);
     });
 
+    it('should find Amazon Bedrock models via our bedrock provider ID', () => {
+      const model = service.lookupModel('bedrock', 'mistral.magistral-small-2509');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Magistral Small 1.2');
+      expect(model!.inputPricePerToken).toBe(0.5 / 1_000_000);
+      expect(model!.outputPricePerToken).toBe(1.5 / 1_000_000);
+      expect(model!.contextWindow).toBe(128000);
+      expect(model!.maxOutputTokens).toBe(40000);
+    });
+
+    it('should match Amazon Bedrock versioned and alias model IDs', () => {
+      const qwenDense = service.lookupModel('bedrock', 'qwen.qwen3-32b');
+      expect(qwenDense).not.toBeNull();
+      expect(qwenDense!.name).toBe('Qwen3 32B (dense)');
+      expect(qwenDense!.inputPricePerToken).toBe(0.15 / 1_000_000);
+
+      const qwenCoder = service.lookupModel('bedrock', 'qwen.qwen3-coder-30b-a3b-instruct');
+      expect(qwenCoder).not.toBeNull();
+      expect(qwenCoder!.name).toBe('Qwen3 Coder 30B A3B Instruct');
+      expect(qwenCoder!.outputPricePerToken).toBe(0.6 / 1_000_000);
+
+      const qwenNext = service.lookupModel('bedrock', 'qwen.qwen3-next-80b-a3b-instruct');
+      expect(qwenNext).not.toBeNull();
+      expect(qwenNext!.name).toBe('Qwen3 Next 80B A3B Instruct');
+      expect(qwenNext!.outputPricePerToken).toBe(1.4 / 1_000_000);
+
+      const moonshot = service.lookupModel('bedrock', 'moonshotai.kimi-k2-thinking');
+      expect(moonshot).not.toBeNull();
+      expect(moonshot!.name).toBe('Kimi K2 Thinking');
+      expect(moonshot!.inputPricePerToken).toBe(0.6 / 1_000_000);
+
+      const deepseek = service.lookupModel('bedrock', 'deepseek.v3.1');
+      expect(deepseek).not.toBeNull();
+      expect(deepseek!.name).toBe('DeepSeek-V3.1');
+      expect(deepseek!.inputPricePerToken).toBe(0.58 / 1_000_000);
+
+      const versioned = service.lookupModel('bedrock', 'qwen.qwen3-version-test');
+      expect(versioned).not.toBeNull();
+      expect(versioned!.name).toBe('Versioned Qwen snapshot');
+      expect(versioned!.inputPricePerToken).toBe(0.21 / 1_000_000);
+    });
+
     it('should find NVIDIA NIM models via our nvidia provider ID', () => {
       const model = service.lookupModel('nvidia', 'nvidia/nemotron-3-super-120b-a12b');
       expect(model).not.toBeNull();
@@ -352,6 +454,10 @@ describe('ModelsDevSyncService', () => {
 
     it('should return null for unknown model', () => {
       expect(service.lookupModel('anthropic', 'nonexistent')).toBeNull();
+    });
+
+    it('should not strip instruction-tuned suffixes outside Bedrock', () => {
+      expect(service.lookupModel('mistral', 'mistral-nemo-instruct')).toBeNull();
     });
 
     it('should return null for unmapped provider', () => {
@@ -533,6 +639,7 @@ describe('ModelsDevSyncService', () => {
       expect(service.isProviderSupported('nvidia')).toBe(true);
       expect(service.isProviderSupported('qwen')).toBe(true);
       expect(service.isProviderSupported('fireworks')).toBe(true);
+      expect(service.isProviderSupported('bedrock')).toBe(true);
     });
 
     it('should return false for unmapped providers', () => {

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -20,6 +20,7 @@ const PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
   fireworks: 'fireworks-ai',
   mistral: 'mistral',
   xai: 'xai',
+  bedrock: 'amazon-bedrock',
   minimax: 'minimax',
   moonshot: 'moonshotai',
   nvidia: 'nvidia',
@@ -98,6 +99,12 @@ const LEGACY_NAME_ALIASES: ReadonlyMap<string, string> = new Map([
   ['open-mistral-nemo', 'mistral-nemo'], // Mistral renamed open-mistral-nemo → mistral-nemo
   ['mistral-tiny', 'open-mistral-7b'], // mistral-tiny was the internal codename for Mistral 7B
 ]);
+/** AWS sometimes returns an API owner namespace that differs from models.dev's Bedrock key. */
+const MODEL_ID_PREFIX_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['moonshotai.', 'moonshot.'],
+]);
+/** Matches instruction-tuned suffixes that models.dev sometimes omits on Bedrock keys. */
+const INSTRUCT_SUFFIX_RE = /-instruct$/;
 
 @Injectable()
 export class ModelsDevSyncService implements OnModuleInit {
@@ -192,9 +199,10 @@ export class ModelsDevSyncService implements OnModuleInit {
    *   8. Strip 4-digit short date suffix (-0709 MMDD format)
    */
   lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null {
-    const providerModels = this.cache.get(resolveProviderId(providerId));
+    const resolvedProviderId = resolveProviderId(providerId);
+    const providerModels = this.cache.get(resolvedProviderId);
     if (!providerModels) return null;
-    return this.lookupModelInProvider(providerModels, modelId);
+    return this.lookupModelInProvider(providerModels, modelId, resolvedProviderId);
   }
 
   /**
@@ -218,8 +226,8 @@ export class ModelsDevSyncService implements OnModuleInit {
     const providerScoped = this.lookupProviderScopedModel(modelId);
     if (providerScoped) return providerScoped;
 
-    for (const providerModels of this.cache.values()) {
-      const found = this.lookupModelInProvider(providerModels, modelId);
+    for (const [providerId, providerModels] of this.cache) {
+      const found = this.lookupModelInProvider(providerModels, modelId, providerId);
       if (found) return found;
     }
 
@@ -242,10 +250,16 @@ export class ModelsDevSyncService implements OnModuleInit {
   private lookupModelInProvider(
     providerModels: Map<string, ModelsDevModelEntry>,
     modelId: string,
+    providerId?: string,
   ): ModelsDevModelEntry | null {
     // 1. Exact match
     const exact = providerModels.get(modelId);
     if (exact) return exact;
+
+    // 1a. Provider APIs can omit Bedrock-style version suffixes present in models.dev
+    //     (e.g., qwen.qwen3-32b → qwen.qwen3-32b-v1:0).
+    const versioned = this.lookupVersionedModelVariant(providerModels, modelId);
+    if (versioned) return versioned;
 
     // 1b. Legacy name alias (e.g., open-mistral-nemo → mistral-nemo)
     //     Strip date, short-date, and -latest suffixes to find the base name for alias lookup.
@@ -260,6 +274,16 @@ export class ModelsDevSyncService implements OnModuleInit {
     if (aliasTarget) {
       const found = providerModels.get(aliasTarget);
       if (found) return found;
+    }
+
+    // 1c. Provider prefix aliases inside provider-native IDs
+    //     (e.g., moonshotai.kimi-k2-thinking → moonshot.kimi-k2-thinking).
+    const prefixAlias = this.applyModelIdPrefixAlias(modelId);
+    if (prefixAlias) {
+      const found = providerModels.get(prefixAlias);
+      if (found) return found;
+      const aliasVersioned = this.lookupVersionedModelVariant(providerModels, prefixAlias);
+      if (aliasVersioned) return aliasVersioned;
     }
 
     // 2. Strip 3-digit version suffix (e.g., gemini-2.0-flash-001 → gemini-2.0-flash)
@@ -303,6 +327,18 @@ export class ModelsDevSyncService implements OnModuleInit {
       if (found) return found;
     }
 
+    if (providerId === 'bedrock') {
+      // 7b. Strip instruction-tuned suffix when models.dev stores the same Bedrock
+      //     model under its shorter base name.
+      const noInstruct = modelId.replace(INSTRUCT_SUFFIX_RE, '');
+      if (noInstruct !== modelId) {
+        const found = providerModels.get(noInstruct);
+        if (found) return found;
+        const versionedBase = this.lookupVersionedModelVariant(providerModels, noInstruct);
+        if (versionedBase) return versionedBase;
+      }
+    }
+
     // 8. Strip 4-digit short date suffix (xAI: grok-4-0709 → grok-4)
     const noShortDate = modelId.replace(SHORT_DATE_SUFFIX_RE, '');
     if (noShortDate !== modelId) {
@@ -329,6 +365,36 @@ export class ModelsDevSyncService implements OnModuleInit {
       if (baseMatch) return baseMatch;
     }
 
+    return null;
+  }
+
+  private lookupVersionedModelVariant(
+    providerModels: Map<string, ModelsDevModelEntry>,
+    modelId: string,
+  ): ModelsDevModelEntry | null {
+    for (const suffix of ['-v1:0', '-v1', '-1:0', '-1']) {
+      const found = providerModels.get(`${modelId}${suffix}`);
+      if (found) return found;
+    }
+
+    const dottedVersion = modelId.replace(/^(.*\.[A-Za-z0-9-]*\d)\.(\d+)$/, '$1-v$2:0');
+    if (dottedVersion !== modelId) {
+      const found = providerModels.get(dottedVersion);
+      if (found) return found;
+    }
+
+    const escaped = modelId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const variantRe = new RegExp(`^${escaped}-(?:v\\d+(?::\\d+)?|\\d+:\\d+)$`);
+    for (const [key, entry] of providerModels) {
+      if (variantRe.test(key)) return entry;
+    }
+    return null;
+  }
+
+  private applyModelIdPrefixAlias(modelId: string): string | null {
+    for (const [from, to] of MODEL_ID_PREFIX_ALIASES) {
+      if (modelId.startsWith(from)) return `${to}${modelId.slice(from.length)}`;
+    }
     return null;
   }
 

--- a/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
+++ b/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
@@ -361,6 +361,18 @@ describe('filterNonChatModels', () => {
     });
   });
 
+  describe('Bedrock-specific patterns', () => {
+    it('filters Voxtral models returned through Bedrock while keeping other Mistral Bedrock models', () => {
+      const models = [
+        makeModel('mistral.voxtral-mini-3b-2507'),
+        makeModel('mistral.voxtral-small-24b-2507'),
+        makeModel('mistral.ministral-3-8b-instruct'),
+      ];
+      const result = filterNonChatModels(models, 'bedrock');
+      expect(result.map((m) => m.id)).toEqual(['mistral.ministral-3-8b-instruct']);
+    });
+  });
+
   describe('PROVIDER_NON_CHAT registry', () => {
     it('has entries for openai, openai-subscription, fireworks, gemini, mistral, and xai', () => {
       expect(PROVIDER_NON_CHAT).toHaveProperty('openai');
@@ -369,6 +381,7 @@ describe('filterNonChatModels', () => {
       expect(PROVIDER_NON_CHAT).toHaveProperty('gemini');
       expect(PROVIDER_NON_CHAT).toHaveProperty('mistral');
       expect(PROVIDER_NON_CHAT).toHaveProperty('xai');
+      expect(PROVIDER_NON_CHAT).toHaveProperty('bedrock');
     });
   });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -218,6 +218,72 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].displayName).toBe('GPT-4 via OR');
     });
 
+    it('does not use underlying provider pricing for Bedrock models', async () => {
+      mockPricingSync.lookupPricing.mockImplementation((key: string) => {
+        if (key === 'anthropic/claude-opus-4.8') {
+          return {
+            input: 0.000015,
+            output: 0.000075,
+            contextWindow: 200000,
+            displayName: 'Claude Opus 4.8',
+          };
+        }
+        return null;
+      });
+
+      fetcher.fetch.mockResolvedValue([
+        makeModel({ id: 'us.anthropic.claude-opus-4.8', provider: 'bedrock' }),
+      ]);
+
+      const result = await service.discoverModels(
+        makeProvider({ provider: 'bedrock', region: 'us-east-1' } as Partial<UserProvider>),
+      );
+
+      expect(result[0].id).toBe('us.anthropic.claude-opus-4.8');
+      expect(result[0].provider).toBe('bedrock');
+      expect(mockPricingSync.lookupPricing).not.toHaveBeenCalledWith('anthropic/claude-opus-4.8');
+      expect(result[0].inputPricePerToken).toBeNull();
+      expect(result[0].outputPricePerToken).toBeNull();
+    });
+
+    it('uses exact Bedrock models.dev pricing for AWS model ids', async () => {
+      mockModelsDevSync.lookupModel.mockImplementation((providerId: string, modelId: string) => {
+        if (providerId === 'anthropic' && modelId === 'claude-opus-4.8') {
+          return {
+            name: 'Claude Opus 4.8',
+            inputPricePerToken: 0.000015,
+            outputPricePerToken: 0.000075,
+            contextWindow: 200000,
+          };
+        }
+        if (providerId === 'bedrock' && modelId === 'us.anthropic.claude-opus-4.8') {
+          return {
+            name: 'AWS Claude Opus 4.8',
+            inputPricePerToken: 0.000016,
+            outputPricePerToken: 0.00008,
+            contextWindow: 200000,
+          };
+        }
+        return null;
+      });
+
+      fetcher.fetch.mockResolvedValue([
+        makeModel({ id: 'us.anthropic.claude-opus-4.8', provider: 'bedrock' }),
+      ]);
+
+      const result = await service.discoverModels(
+        makeProvider({ provider: 'bedrock', region: 'us-east-1' } as Partial<UserProvider>),
+      );
+
+      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith(
+        'bedrock',
+        'us.anthropic.claude-opus-4.8',
+      );
+      expect(result[0].inputPricePerToken).toBe(0.000016);
+      expect(result[0].outputPricePerToken).toBe(0.00008);
+      expect(result[0].displayName).toBe('Claude Opus 4.8');
+    });
+
     it('should use model contextWindow when openRouter has no contextWindow', async () => {
       mockPricingSync.lookupPricing.mockImplementation((key: string) => {
         if (key === 'openai/gpt-4') {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, Inject, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import type { AuthType } from 'manifest-shared';
+import { resolveProviderMetadataIdentity, type AuthType } from 'manifest-shared';
 import { UserProvider } from '../entities/user-provider.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { ProviderModelFetcherService, filterNonChatModels } from './provider-model-fetcher.service';
@@ -13,6 +13,11 @@ import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { parseOAuthTokenBlob } from '../routing/oauth/openai-oauth.types';
 import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../routing/qwen-region';
+import {
+  getBedrockMantleBaseUrl,
+  isBedrockProvider,
+  isBedrockRegion,
+} from '../routing/bedrock-region';
 import { MINIMAX_BASE_URLS } from '../routing/oauth/minimax-oauth-helpers';
 import {
   getXiaomiTokenPlanBaseUrl,
@@ -137,6 +142,9 @@ export class ModelDiscoveryService {
     if (isQwenProvider(provider.provider) && isQwenResolvedRegion(provider.region)) {
       endpointOverride = getQwenCompatibleBaseUrl(provider.region);
     }
+    if (isBedrockProvider(provider.provider) && isBedrockRegion(provider.region)) {
+      endpointOverride = getBedrockMantleBaseUrl(provider.region);
+    }
     if (
       provider.provider.toLowerCase() === 'zai' &&
       provider.auth_type === 'subscription' &&
@@ -236,7 +244,9 @@ export class ModelDiscoveryService {
     // unusable. Only filter when models.dev has data — if no entry exists we
     // keep the model (we don't know its capabilities).
     const filtered = enriched.filter((model) => {
-      const mdEntry = this.modelsDevSync?.lookupModel(provider.provider, model.id);
+      const metadata = resolveProviderMetadataIdentity(provider.provider, model.id);
+      const metadataProvider = metadata.provider ?? provider.provider;
+      const mdEntry = this.modelsDevSync?.lookupModel(metadataProvider, metadata.model);
       if (mdEntry && mdEntry.toolCall === false) return false;
       return true;
     });
@@ -477,12 +487,23 @@ export class ModelDiscoveryService {
     // capability flags (reasoning / tool-call) — those drive tier auto-
     // assignment quality scoring and shouldn't be lost just because we
     // overrode the price. Mirrors the price-already-set branch above.
-    const known = lookupKnownPrice(model.id);
+    const metadata = resolveProviderMetadataIdentity(providerId, model.id);
+    const metadataProvider = metadata.provider ?? providerId;
+    const metadataModel = metadata.model;
+    const isBedrock = providerId.toLowerCase() === 'bedrock';
+    const metadataEntry = this.modelsDevSync?.lookupModel(metadataProvider, metadataModel) ?? null;
+    const modelWithMetadataName =
+      metadataEntry?.name && metadataEntry.name !== model.id
+        ? { ...model, displayName: metadataEntry.name }
+        : model;
+    const pricingProvider = isBedrock ? providerId : metadataProvider;
+    const pricingModel = isBedrock ? model.id : metadataModel;
+    const known = lookupKnownPrice(pricingModel) ?? lookupKnownPrice(model.id);
     if (known) {
       return this.computeScore(
         this.applyCapabilities(
           {
-            ...model,
+            ...modelWithMetadataName,
             inputPricePerToken: known.input,
             outputPricePerToken: known.output,
           },
@@ -491,63 +512,76 @@ export class ModelDiscoveryService {
       );
     }
 
-    // Priority 2: models.dev — uses native provider IDs, no normalization needed
+    // Priority 2: models.dev — uses native provider IDs. Bedrock pricing must
+    // come from a Bedrock/AWS entry keyed by the AWS model ID; underlying
+    // vendor metadata may still provide the display name/capabilities.
     if (this.modelsDevSync) {
-      const mdEntry = this.modelsDevSync.lookupModel(providerId, model.id);
+      const mdEntry =
+        pricingProvider === metadataProvider && pricingModel === metadataModel
+          ? metadataEntry
+          : this.modelsDevSync.lookupModel(pricingProvider, pricingModel);
       if (mdEntry && mdEntry.inputPricePerToken !== null) {
+        const capabilityEntry = metadataEntry ?? mdEntry;
         return this.computeScore({
-          ...model,
+          ...modelWithMetadataName,
           inputPricePerToken: mdEntry.inputPricePerToken,
           outputPricePerToken: mdEntry.outputPricePerToken,
-          contextWindow: mdEntry.contextWindow ?? model.contextWindow,
-          displayName: mdEntry.name || model.displayName,
-          capabilityReasoning: mdEntry.reasoning ?? model.capabilityReasoning,
-          capabilityCode: mdEntry.toolCall ?? model.capabilityCode,
-          ...(mdEntry.inputModalities ? { inputModalities: mdEntry.inputModalities } : {}),
-          ...(mdEntry.outputModalities ? { outputModalities: mdEntry.outputModalities } : {}),
+          contextWindow:
+            mdEntry.contextWindow ?? capabilityEntry.contextWindow ?? model.contextWindow,
+          displayName: capabilityEntry.name || mdEntry.name || modelWithMetadataName.displayName,
+          capabilityReasoning: capabilityEntry.reasoning ?? model.capabilityReasoning,
+          capabilityCode: capabilityEntry.toolCall ?? model.capabilityCode,
+          ...(capabilityEntry.inputModalities
+            ? { inputModalities: capabilityEntry.inputModalities }
+            : {}),
+          ...(capabilityEntry.outputModalities
+            ? { outputModalities: capabilityEntry.outputModalities }
+            : {}),
           capabilities: mergeModelCapabilities(
             model.capabilities,
-            mdEntry.capabilities,
-            modelSupportsStreaming(providerId, model.id) ? ['stream'] : undefined,
+            capabilityEntry.capabilities,
+            modelSupportsStreaming(metadataProvider, metadataModel) ? ['stream'] : undefined,
           ),
         });
       }
     }
 
     // Priority 3: OpenRouter cache — broader coverage, needs prefix + variant matching
-    if (this.pricingSync) {
-      const orPrefix = findOpenRouterPrefix(providerId);
+    if (this.pricingSync && !isBedrock) {
+      const orPrefix = findOpenRouterPrefix(metadataProvider);
       if (orPrefix) {
-        const orPricing = lookupWithVariants(this.pricingSync, orPrefix, model.id);
+        const orPricing = lookupWithVariants(this.pricingSync, orPrefix, metadataModel);
         if (orPricing) {
           return this.computeScore({
-            ...model,
+            ...modelWithMetadataName,
             inputPricePerToken: orPricing.input,
             outputPricePerToken: orPricing.output,
-            contextWindow: orPricing.contextWindow ?? model.contextWindow,
-            displayName: orPricing.displayName || model.displayName,
+            contextWindow: orPricing.contextWindow ?? modelWithMetadataName.contextWindow,
+            displayName: orPricing.displayName || modelWithMetadataName.displayName,
           });
         }
       }
       const exactPricing = this.pricingSync.lookupPricing(model.id);
       if (exactPricing) {
         return this.computeScore({
-          ...model,
+          ...modelWithMetadataName,
           inputPricePerToken: exactPricing.input,
           outputPricePerToken: exactPricing.output,
-          contextWindow: exactPricing.contextWindow ?? model.contextWindow,
-          displayName: exactPricing.displayName || model.displayName,
+          contextWindow: exactPricing.contextWindow ?? modelWithMetadataName.contextWindow,
+          displayName: exactPricing.displayName || modelWithMetadataName.displayName,
         });
       }
     }
 
-    return this.computeScore(model);
+    return this.computeScore(modelWithMetadataName);
   }
 
   /** Merge capability flags from models.dev without touching pricing or display name. */
   private applyCapabilities(model: DiscoveredModel, providerId: string): DiscoveredModel {
     if (!this.modelsDevSync) return model;
-    const mdEntry = this.modelsDevSync.lookupModel(providerId, model.id);
+    const metadata = resolveProviderMetadataIdentity(providerId, model.id);
+    const metadataProvider = metadata.provider ?? providerId;
+    const mdEntry = this.modelsDevSync.lookupModel(metadataProvider, metadata.model);
     if (!mdEntry) return model;
     return {
       ...model,
@@ -558,7 +592,7 @@ export class ModelDiscoveryService {
       capabilities: mergeModelCapabilities(
         model.capabilities,
         mdEntry.capabilities,
-        modelSupportsStreaming(providerId, model.id) ? ['stream'] : undefined,
+        modelSupportsStreaming(metadataProvider, metadata.model) ? ['stream'] : undefined,
       ),
     };
   }

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -174,6 +174,14 @@ describe('lookupWithVariants', () => {
     expect(result).toEqual({ input: 0.01, output: 0.02 });
   });
 
+  it('should try provider-prefixed model names', () => {
+    const cache = new Map([['deepseek/deepseek-v3.2', { input: 0.01, output: 0.02 }]]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'deepseek', 'v3.2');
+
+    expect(result).toEqual({ input: 0.01, output: 0.02 });
+  });
+
   it('should try dot variant', () => {
     const cache = new Map([['anthropic/claude-sonnet-4.6', { input: 0.01, output: 0.02 }]]);
 

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -84,12 +84,6 @@ export function lookupWithVariants(
     }
   }
 
-  const prefixedModel = providerPrefixedModelId(prefix, modelId);
-  if (prefixedModel) {
-    const prefixedResult = pricingSync.lookupPricing(`${prefix}/${prefixedModel}`);
-    if (prefixedResult) return prefixedResult;
-  }
-
   const dotVariant = modelId.replace(/-(\d+)-(\d)/g, '-$1.$2');
   if (dotVariant !== modelId) {
     const dotResult = pricingSync.lookupPricing(`${prefix}/${dotVariant}`);
@@ -100,6 +94,12 @@ export function lookupWithVariants(
   if (dashVariant !== modelId) {
     const dashResult = pricingSync.lookupPricing(`${prefix}/${dashVariant}`);
     if (dashResult) return dashResult;
+  }
+
+  const prefixedModel = providerPrefixedModelId(prefix, modelId);
+  if (prefixedModel) {
+    const prefixedResult = pricingSync.lookupPricing(`${prefix}/${prefixedModel}`);
+    if (prefixedResult) return prefixedResult;
   }
 
   const noDate = modelId.replace(/-\d{8}$/, '');

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -84,6 +84,12 @@ export function lookupWithVariants(
     }
   }
 
+  const prefixedModel = providerPrefixedModelId(prefix, modelId);
+  if (prefixedModel) {
+    const prefixedResult = pricingSync.lookupPricing(`${prefix}/${prefixedModel}`);
+    if (prefixedResult) return prefixedResult;
+  }
+
   const dotVariant = modelId.replace(/-(\d+)-(\d)/g, '-$1.$2');
   if (dotVariant !== modelId) {
     const dotResult = pricingSync.lookupPricing(`${prefix}/${dotVariant}`);
@@ -133,6 +139,12 @@ export function lookupWithVariants(
   }
 
   return null;
+}
+
+function providerPrefixedModelId(prefix: string, modelId: string): string | null {
+  const normalizedPrefix = prefix.toLowerCase();
+  if (modelId.toLowerCase().startsWith(`${normalizedPrefix}-`)) return null;
+  return `${prefix}-${modelId}`;
 }
 
 /**

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -19,6 +19,7 @@ describe('ProviderModelFetcherService', () => {
     const expected = [
       'openai',
       'openai-subscription',
+      'bedrock',
       'deepseek',
       'byteplus',
       'commandcode',
@@ -47,6 +48,32 @@ describe('ProviderModelFetcherService', () => {
     for (const id of expected) {
       expect(PROVIDER_CONFIGS[id]).toBeDefined();
     }
+  });
+
+  it('should fetch AWS Bedrock models from the selected Mantle region', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'mistral.ministral-3-8b-instruct' }, { id: 'amazon.titan-embed-text-v2:0' }],
+      }),
+    });
+
+    const result = await service.fetch(
+      'bedrock',
+      'bedrock-api-key-test',
+      'api_key',
+      'https://bedrock-mantle.eu-west-1.api.aws',
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://bedrock-mantle.eu-west-1.api.aws/v1/models',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer bedrock-api-key-test',
+        }),
+      }),
+    );
+    expect(result.map((m) => m.id)).toEqual(['mistral.ministral-3-8b-instruct']);
   });
 
   /* ── Unknown provider ── */

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -54,7 +54,11 @@ describe('ProviderModelFetcherService', () => {
     fetchSpy.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [{ id: 'mistral.ministral-3-8b-instruct' }, { id: 'amazon.titan-embed-text-v2:0' }],
+        data: [
+          { id: 'mistral.ministral-3-8b-instruct' },
+          { id: 'mistral.voxtral-small-24b-2507' },
+          { id: 'amazon.titan-embed-text-v2:0' },
+        ],
       }),
     });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -11,6 +11,7 @@ import {
 } from '../common/constants/subscription-clients';
 import { normalizeMinimaxSubscriptionBaseUrl } from '../routing/provider-base-url';
 import { getQwenCompatibleBaseUrl, normalizeQwenCompatibleBaseUrl } from '../routing/qwen-region';
+import { getBedrockMantleBaseUrl, normalizeBedrockMantleBaseUrl } from '../routing/bedrock-region';
 import {
   getXiaomiTokenPlanBaseUrl,
   normalizeXiaomiTokenPlanBaseUrl,
@@ -645,6 +646,11 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     },
     parse: parseAnthropic,
   },
+  bedrock: {
+    endpoint: `${getBedrockMantleBaseUrl()}/v1/models`,
+    buildHeaders: bearerHeaders,
+    parse: parseOpenAI,
+  },
   gemini: {
     endpoint: (key: string) =>
       `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}`,
@@ -745,6 +751,13 @@ export class ProviderModelFetcherService {
         url = `${minimaxBaseUrl}/v1/models?limit=100`;
       } else {
         this.logger.warn('Ignoring invalid MiniMax subscription endpoint override');
+      }
+    } else if (endpointOverride && configKey === 'bedrock') {
+      const bedrockBaseUrl = normalizeBedrockMantleBaseUrl(endpointOverride);
+      if (bedrockBaseUrl) {
+        url = `${bedrockBaseUrl}/v1/models`;
+      } else {
+        this.logger.warn('Ignoring invalid AWS Bedrock endpoint override');
       }
     } else if (endpointOverride && (configKey === 'qwen' || configKey === 'qwen-subscription')) {
       const qwenBaseUrl = normalizeQwenCompatibleBaseUrl(endpointOverride);

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -231,6 +231,7 @@ export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
   'qwen-subscription': /(?:^qwen-image-|^wan.*image)/i,
   xai: /imagine/i,
   copilot: /accounts\/[^/]+\/routers\//i,
+  bedrock: /(?:^|[./])voxtral-/i,
 };
 
 /**

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -222,6 +222,53 @@ describe('ModelPricingCacheService', () => {
       expect(result!.provider).toBe('Anthropic');
     });
 
+    it('does not resolve Bedrock vendor-prefixed model ids through underlying pricing aliases', async () => {
+      const orMap = new Map<string, OpenRouterPricingEntry>([
+        ['anthropic/claude-opus-4-6', makeEntry(0.015, 0.075)],
+      ]);
+      mockGetAll.mockReturnValue(orMap);
+      await service.reload();
+
+      const direct = service.getByModel('anthropic.claude-opus-4.6');
+      const crossRegion = service.getByModel('us.anthropic.claude-opus-4.6');
+
+      expect(direct).toBeUndefined();
+      expect(crossRegion).toBeUndefined();
+    });
+
+    it('does not resolve Bedrock short vendor model ids through provider-prefixed pricing aliases', async () => {
+      const orMap = new Map<string, OpenRouterPricingEntry>([
+        ['deepseek/deepseek-v3.2', makeEntry(0.0000002, 0.0000008)],
+      ]);
+      mockGetAll.mockReturnValue(orMap);
+      await service.reload();
+
+      const result = service.getByModel('deepseek.v3.2');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('uses exact Bedrock models.dev pricing entries when present', async () => {
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId !== 'bedrock') return [];
+        return [
+          {
+            id: 'us.anthropic.claude-opus-4.6',
+            name: 'AWS Claude Opus 4.6',
+            inputPricePerToken: 0.000016,
+            outputPricePerToken: 0.00008,
+          },
+        ];
+      });
+      await service.reload();
+
+      const result = service.getByModel('us.anthropic.claude-opus-4.6');
+
+      expect(result).toBeDefined();
+      expect(result!.provider).toBe('AWS Bedrock');
+      expect(result!.input_price_per_token).toBe(0.000016);
+    });
+
     it('should resolve dash-variant when cached Anthropic model uses dots', async () => {
       const orMap = new Map<string, OpenRouterPricingEntry>([
         ['anthropic/claude-opus-4.6', makeEntry(0.015, 0.075)],

--- a/packages/backend/src/routing/__tests__/bedrock-fixtures.ts
+++ b/packages/backend/src/routing/__tests__/bedrock-fixtures.ts
@@ -1,0 +1,6 @@
+export function makeShortTermBedrockKey(region: string): string {
+  const payload =
+    'bedrock.amazonaws.com/?Action=CallWithBearerToken&' +
+    `X-Amz-Credential=ASIAEXAMPLE%2F20260612%2F${region}%2Fbedrock%2Faws4_request`;
+  return `bedrock-api-key-${Buffer.from(payload).toString('base64')}`;
+}

--- a/packages/backend/src/routing/bedrock-region.spec.ts
+++ b/packages/backend/src/routing/bedrock-region.spec.ts
@@ -6,13 +6,7 @@ import {
   isBedrockRegion,
   normalizeBedrockMantleBaseUrl,
 } from './bedrock-region';
-
-function makeShortTermKey(region: string): string {
-  const payload =
-    'bedrock.amazonaws.com/?Action=CallWithBearerToken&' +
-    `X-Amz-Credential=ASIAEXAMPLE%2F20260612%2F${region}%2Fbedrock%2Faws4_request`;
-  return `bedrock-api-key-${Buffer.from(payload).toString('base64')}`;
-}
+import { makeShortTermBedrockKey } from './__tests__/bedrock-fixtures';
 
 describe('bedrock-region', () => {
   it('recognizes Bedrock provider aliases', () => {
@@ -43,18 +37,28 @@ describe('bedrock-region', () => {
     );
     expect(normalizeBedrockMantleBaseUrl('https://evil.example/v1')).toBeNull();
     expect(normalizeBedrockMantleBaseUrl('http://bedrock-mantle.eu-west-1.api.aws')).toBe(null);
+    expect(normalizeBedrockMantleBaseUrl('https://bedrock-mantle.eu-west-1.api.aws:8443')).toBe(
+      null,
+    );
+    expect(
+      normalizeBedrockMantleBaseUrl('https://bedrock-mantle.eu-west-1.api.aws?x=1'),
+    ).toBeNull();
+    expect(
+      normalizeBedrockMantleBaseUrl('https://bedrock-mantle.eu-west-1.api.aws#fragment'),
+    ).toBeNull();
   });
 
   it('extracts the region from short-term Bedrock API keys', () => {
-    expect(detectBedrockRegionFromApiKey(makeShortTermKey('eu-west-1'))).toBe('eu-west-1');
+    expect(detectBedrockRegionFromApiKey(makeShortTermBedrockKey('eu-west-1'))).toBe('eu-west-1');
   });
 
   it('ignores short-term Bedrock API key regions that Mantle does not support', () => {
-    expect(detectBedrockRegionFromApiKey(makeShortTermKey('eu-west-3'))).toBeNull();
+    expect(detectBedrockRegionFromApiKey(makeShortTermBedrockKey('eu-west-3'))).toBeNull();
   });
 
   it('returns null for opaque or malformed keys', () => {
     expect(detectBedrockRegionFromApiKey('bedrock-api-key-not-base64')).toBeNull();
+    expect(detectBedrockRegionFromApiKey('ABSKTWFudGxlQXBpS2V5LWV4YW1wbGU=')).toBeNull();
     expect(detectBedrockRegionFromApiKey('sk-test')).toBeNull();
   });
 });

--- a/packages/backend/src/routing/bedrock-region.spec.ts
+++ b/packages/backend/src/routing/bedrock-region.spec.ts
@@ -1,0 +1,60 @@
+import {
+  DEFAULT_BEDROCK_REGION,
+  detectBedrockRegionFromApiKey,
+  getBedrockMantleBaseUrl,
+  isBedrockProvider,
+  isBedrockRegion,
+  normalizeBedrockMantleBaseUrl,
+} from './bedrock-region';
+
+function makeShortTermKey(region: string): string {
+  const payload =
+    'bedrock.amazonaws.com/?Action=CallWithBearerToken&' +
+    `X-Amz-Credential=ASIAEXAMPLE%2F20260612%2F${region}%2Fbedrock%2Faws4_request`;
+  return `bedrock-api-key-${Buffer.from(payload).toString('base64')}`;
+}
+
+describe('bedrock-region', () => {
+  it('recognizes Bedrock provider aliases', () => {
+    expect(isBedrockProvider('bedrock')).toBe(true);
+    expect(isBedrockProvider('aws-bedrock')).toBe(true);
+    expect(isBedrockProvider('amazon-bedrock')).toBe(true);
+    expect(isBedrockProvider('openai')).toBe(false);
+  });
+
+  it('accepts Bedrock Mantle-supported AWS regions', () => {
+    expect(isBedrockRegion('us-east-1')).toBe(true);
+    expect(isBedrockRegion('eu-west-1')).toBe(true);
+    expect(isBedrockRegion('eu-west-3')).toBe(false);
+    expect(isBedrockRegion('global')).toBe(false);
+    expect(isBedrockRegion('https://example.com')).toBe(false);
+  });
+
+  it('builds Bedrock Mantle base URLs from safe regions', () => {
+    expect(getBedrockMantleBaseUrl('eu-west-1')).toBe('https://bedrock-mantle.eu-west-1.api.aws');
+    expect(getBedrockMantleBaseUrl('bad-region')).toBe(
+      `https://bedrock-mantle.${DEFAULT_BEDROCK_REGION}.api.aws`,
+    );
+  });
+
+  it('normalizes Bedrock Mantle base URLs only', () => {
+    expect(normalizeBedrockMantleBaseUrl('https://bedrock-mantle.eu-west-1.api.aws/v1')).toBe(
+      'https://bedrock-mantle.eu-west-1.api.aws',
+    );
+    expect(normalizeBedrockMantleBaseUrl('https://evil.example/v1')).toBeNull();
+    expect(normalizeBedrockMantleBaseUrl('http://bedrock-mantle.eu-west-1.api.aws')).toBe(null);
+  });
+
+  it('extracts the region from short-term Bedrock API keys', () => {
+    expect(detectBedrockRegionFromApiKey(makeShortTermKey('eu-west-1'))).toBe('eu-west-1');
+  });
+
+  it('ignores short-term Bedrock API key regions that Mantle does not support', () => {
+    expect(detectBedrockRegionFromApiKey(makeShortTermKey('eu-west-3'))).toBeNull();
+  });
+
+  it('returns null for opaque or malformed keys', () => {
+    expect(detectBedrockRegionFromApiKey('bedrock-api-key-not-base64')).toBeNull();
+    expect(detectBedrockRegionFromApiKey('sk-test')).toBeNull();
+  });
+});

--- a/packages/backend/src/routing/bedrock-region.ts
+++ b/packages/backend/src/routing/bedrock-region.ts
@@ -25,7 +25,8 @@ const BEDROCK_PROVIDER = PROVIDER_BY_ID_OR_ALIAS.get(BEDROCK_PROVIDER_ID);
 if (!BEDROCK_PROVIDER) {
   throw new Error('AWS Bedrock provider is missing from the shared provider registry');
 }
-const BEDROCK_API_KEY_PREFIX = BEDROCK_PROVIDER.keyPrefix;
+const LEGACY_BEDROCK_API_KEY_PREFIX = 'bedrock-api-key-';
+const AWS_BEARER_TOKEN_PREFIX = 'ABSK';
 
 export function isBedrockProvider(provider: string): boolean {
   return PROVIDER_BY_ID_OR_ALIAS.get(provider.toLowerCase().trim())?.id === BEDROCK_PROVIDER_ID;
@@ -49,7 +50,15 @@ export function normalizeBedrockMantleBaseUrl(baseUrl: string): string | null {
   try {
     const url = new URL(normalized);
     const match = /^bedrock-mantle\.([a-z0-9-]+)\.api\.aws$/.exec(url.hostname);
-    if (url.protocol !== 'https:' || url.username || url.password || url.pathname !== '/') {
+    if (
+      url.protocol !== 'https:' ||
+      url.username ||
+      url.password ||
+      url.port ||
+      url.pathname !== '/' ||
+      url.search ||
+      url.hash
+    ) {
       return null;
     }
     if (!match || !isBedrockRegion(match[1])) return null;
@@ -61,10 +70,11 @@ export function normalizeBedrockMantleBaseUrl(baseUrl: string): string | null {
 
 export function detectBedrockRegionFromApiKey(apiKey: string | undefined): string | null {
   const compact = apiKey?.replace(/\s/g, '') ?? '';
-  if (!compact.startsWith(BEDROCK_API_KEY_PREFIX)) return null;
+  if (compact.startsWith(AWS_BEARER_TOKEN_PREFIX)) return null;
+  if (!compact.startsWith(LEGACY_BEDROCK_API_KEY_PREFIX)) return null;
 
   try {
-    const encoded = compact.slice(BEDROCK_API_KEY_PREFIX.length);
+    const encoded = compact.slice(LEGACY_BEDROCK_API_KEY_PREFIX.length);
     const decoded = Buffer.from(encoded, 'base64').toString('utf8');
     const query = decoded.includes('?') ? decoded.slice(decoded.indexOf('?') + 1) : decoded;
     const credential = new URLSearchParams(query).get('X-Amz-Credential');

--- a/packages/backend/src/routing/bedrock-region.ts
+++ b/packages/backend/src/routing/bedrock-region.ts
@@ -1,0 +1,76 @@
+import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
+import { normalizeProviderBaseUrl } from './provider-base-url';
+
+export const DEFAULT_BEDROCK_REGION = 'us-east-1';
+
+export const BEDROCK_ENDPOINT_REGIONS = [
+  'us-east-1',
+  'us-east-2',
+  'us-west-2',
+  'eu-west-1',
+  'eu-west-2',
+  'eu-central-1',
+  'eu-south-1',
+  'eu-north-1',
+  'ap-south-1',
+  'ap-southeast-2',
+  'ap-southeast-3',
+  'ap-northeast-1',
+  'sa-east-1',
+] as const;
+
+const AWS_REGION_RE = /^[a-z]{2}(?:-gov)?-[a-z]+-\d+$/;
+const BEDROCK_PROVIDER_ID = 'bedrock';
+const BEDROCK_PROVIDER = PROVIDER_BY_ID_OR_ALIAS.get(BEDROCK_PROVIDER_ID);
+if (!BEDROCK_PROVIDER) {
+  throw new Error('AWS Bedrock provider is missing from the shared provider registry');
+}
+const BEDROCK_API_KEY_PREFIX = BEDROCK_PROVIDER.keyPrefix;
+
+export function isBedrockProvider(provider: string): boolean {
+  return PROVIDER_BY_ID_OR_ALIAS.get(provider.toLowerCase().trim())?.id === BEDROCK_PROVIDER_ID;
+}
+
+export function isBedrockRegion(value: string | null | undefined): value is string {
+  return (
+    typeof value === 'string' &&
+    AWS_REGION_RE.test(value) &&
+    BEDROCK_ENDPOINT_REGIONS.includes(value as (typeof BEDROCK_ENDPOINT_REGIONS)[number])
+  );
+}
+
+export function getBedrockMantleBaseUrl(region?: string | null): string {
+  const resolved = isBedrockRegion(region) ? region : DEFAULT_BEDROCK_REGION;
+  return `https://bedrock-mantle.${resolved}.api.aws`;
+}
+
+export function normalizeBedrockMantleBaseUrl(baseUrl: string): string | null {
+  const normalized = normalizeProviderBaseUrl(baseUrl);
+  try {
+    const url = new URL(normalized);
+    const match = /^bedrock-mantle\.([a-z0-9-]+)\.api\.aws$/.exec(url.hostname);
+    if (url.protocol !== 'https:' || url.username || url.password || url.pathname !== '/') {
+      return null;
+    }
+    if (!match || !isBedrockRegion(match[1])) return null;
+    return normalized.replace(/\/$/, '');
+  } catch {
+    return null;
+  }
+}
+
+export function detectBedrockRegionFromApiKey(apiKey: string | undefined): string | null {
+  const compact = apiKey?.replace(/\s/g, '') ?? '';
+  if (!compact.startsWith(BEDROCK_API_KEY_PREFIX)) return null;
+
+  try {
+    const encoded = compact.slice(BEDROCK_API_KEY_PREFIX.length);
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+    const query = decoded.includes('?') ? decoded.slice(decoded.indexOf('?') + 1) : decoded;
+    const credential = new URLSearchParams(query).get('X-Amz-Credential');
+    const region = credential?.split('/')[2];
+    return isBedrockRegion(region) ? region : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -418,6 +418,40 @@ describe('ModelController', () => {
       expect(result[0].display_name).toBeNull();
     });
 
+    it('uses underlying models.dev names for cached Bedrock raw ids', async () => {
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([
+        makeDiscovered({
+          id: 'mistral.magistral-small-2509',
+          provider: 'bedrock',
+          displayName: 'mistral.magistral-small-2509',
+        }),
+      ]);
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        name: 'Magistral Small',
+      });
+
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
+
+      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith('mistral', 'magistral-small-2509');
+      expect(result[0].model_name).toBe('mistral.magistral-small-2509');
+      expect(result[0].display_name).toBe('Magistral Small');
+    });
+
+    it('formats Bedrock raw ids when no metadata name is available', async () => {
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([
+        makeDiscovered({
+          id: 'us.anthropic.claude-opus-4.6',
+          provider: 'bedrock',
+          displayName: 'us.anthropic.claude-opus-4.6',
+        }),
+      ]);
+
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
+
+      expect(result[0].model_name).toBe('us.anthropic.claude-opus-4.6');
+      expect(result[0].display_name).toBe('Claude Opus 4.6');
+    });
+
     it('should include models from multiple providers', async () => {
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([
         makeDiscovered({ id: 'gpt-4o', provider: 'openai' }),

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -22,6 +22,35 @@ import {
   RemoveProviderQueryDto,
 } from './dto/routing.dto';
 
+function formatModelSlug(slug: string): string {
+  return slug.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function displayNameForModel(
+  provider: string,
+  modelId: string,
+  displayName: string | null | undefined,
+  metadataName: string | null | undefined,
+): string | null {
+  const trimmedDisplay = displayName?.trim();
+  if (trimmedDisplay && trimmedDisplay !== modelId) return trimmedDisplay;
+
+  const trimmedMetadata = metadataName?.trim();
+  if (trimmedMetadata && trimmedMetadata !== modelId) return trimmedMetadata;
+
+  const metadata = resolveProviderMetadataIdentity(provider, modelId);
+  if (
+    provider.toLowerCase() === 'bedrock' &&
+    metadata.provider &&
+    metadata.provider !== provider &&
+    metadata.model !== modelId
+  ) {
+    return formatModelSlug(metadata.model);
+  }
+
+  return trimmedDisplay || null;
+}
+
 @Controller('api/v1/routing')
 export class ModelController {
   constructor(
@@ -143,7 +172,9 @@ export class ModelController {
           input_modalities: inputModalities,
           output_modalities: ['text'],
           quality_score: m.qualityScore,
-          display_name: isCustom ? CustomProviderService.rawModelName(m.id) : m.displayName || null,
+          display_name: isCustom
+            ? CustomProviderService.rawModelName(m.id)
+            : displayNameForModel(m.provider, m.id, m.displayName, modelsDevEntry?.name),
           ...(isCustom && {
             provider_display_name: cpNameMap.get(m.provider) ?? m.provider,
           }),

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -10,7 +10,7 @@ import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
-import { resolveUnderlyingModelIdentity } from 'manifest-shared';
+import { resolveProviderMetadataIdentity } from 'manifest-shared';
 import {
   inputModalitiesFromCapabilities,
   mergeModelCapabilities,
@@ -106,12 +106,10 @@ export class ModelController {
           authType,
           m.id,
         );
-        // Gateway models (e.g. `opencode-go/glm-5.1`) proxy another provider's
-        // API, so their capabilities live under the underlying provider on
-        // models.dev. Resolve the provenance before the metadata lookups; this
-        // is gateway-generic, not OpenCode Go-specific. `getCapabilities` (MPS)
-        // already unwraps gateways internally, so it keeps the raw identity.
-        const capId = resolveUnderlyingModelIdentity(m.provider, m.id);
+        // Some routable ids proxy another provider's model namespace (gateway
+        // ids, Bedrock vendor-prefixed ids). Resolve that provenance for
+        // metadata only; the routable provider/model below stay unchanged.
+        const capId = resolveProviderMetadataIdentity(m.provider, m.id);
         const capProvider = capId.provider ?? m.provider;
         const modelsDevEntry = this.modelsDevSync.lookupModel(capProvider, capId.model);
         const modelsDevCapabilities = modelsDevEntry?.capabilities;

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -533,6 +533,48 @@ describe('ProviderController', () => {
       ).rejects.toThrow('Z.ai subscription region must be one of: global, cn');
     });
 
+    it('should accept a valid AWS Bedrock region for API-key auth', async () => {
+      mockProviderService.upsertProvider.mockResolvedValue({
+        provider: {
+          id: 'p1',
+          provider: 'bedrock',
+          is_active: true,
+          auth_type: 'api_key',
+          region: 'eu-west-1',
+        },
+        isNew: true,
+      });
+
+      const result = await controller.upsertProvider(mockUser, mockAgentName, {
+        provider: 'bedrock',
+        apiKey: 'bedrock-api-key-test',
+        authType: 'api_key',
+        region: 'eu-west-1',
+      });
+
+      expect(mockProviderService.upsertProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'user-1',
+        'bedrock',
+        'bedrock-api-key-test',
+        'api_key',
+        'eu-west-1',
+        undefined,
+      );
+      expect(result.region).toBe('eu-west-1');
+    });
+
+    it('should reject invalid AWS Bedrock regions', async () => {
+      await expect(
+        controller.upsertProvider(mockUser, mockAgentName, {
+          provider: 'bedrock',
+          apiKey: 'bedrock-api-key-test',
+          authType: 'api_key',
+          region: 'global',
+        }),
+      ).rejects.toThrow('AWS Bedrock region must be a valid AWS region code');
+    });
+
     it('should reject region when MiniMax is connected with api_key auth', async () => {
       await expect(
         controller.upsertProvider(mockUser, mockAgentName, {
@@ -542,7 +584,7 @@ describe('ProviderController', () => {
           region: 'cn',
         }),
       ).rejects.toThrow(
-        'region is only supported for Alibaba/Qwen providers, MiniMax subscriptions, Xiaomi MiMo Token Plan, and Z.ai subscriptions',
+        'region is only supported for Alibaba/Qwen providers, AWS Bedrock, MiniMax subscriptions, Xiaomi MiMo Token Plan, and Z.ai subscriptions',
       );
     });
   });

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -29,6 +29,7 @@ import {
 } from './dto/routing.dto';
 import { isQwenRegion } from './qwen-region';
 import { getSubscriptionEndpointRegionConfig } from './subscription-region';
+import { isBedrockProvider, isBedrockRegion } from './bedrock-region';
 
 @Controller('api/v1/routing')
 export class ProviderController {
@@ -106,13 +107,17 @@ export class ProviderController {
         if (!isQwenRegion(body.region)) {
           throw new BadRequestException('region must be one of: auto, singapore, us, beijing');
         }
+      } else if (isBedrockProvider(lowerProvider) && (body.authType ?? 'api_key') === 'api_key') {
+        if (!isBedrockRegion(body.region)) {
+          throw new BadRequestException('AWS Bedrock region must be a valid AWS region code');
+        }
       } else if (subscriptionRegionConfig) {
         if (!subscriptionRegionConfig.isRegion(body.region)) {
           throw new BadRequestException(subscriptionRegionConfig.validationMessage);
         }
       } else {
         throw new BadRequestException(
-          'region is only supported for Alibaba/Qwen providers, MiniMax subscriptions, Xiaomi MiMo Token Plan, and Z.ai subscriptions',
+          'region is only supported for Alibaba/Qwen providers, AWS Bedrock, MiniMax subscriptions, Xiaomi MiMo Token Plan, and Z.ai subscriptions',
         );
       }
     }

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -111,6 +111,35 @@ describe('ProviderClient', () => {
       );
     });
 
+    it('builds Bedrock Mantle chat completions requests with bearer API-key auth', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'bedrock',
+        apiKey: 'bedrock-api-key-test',
+        model: 'mistral.ministral-3-8b-instruct',
+        body,
+        stream: false,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer bedrock-api-key-test',
+            'Content-Type': 'application/json',
+          },
+        }),
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('mistral.ministral-3-8b-instruct');
+      expect(sentBody.stream).toBe(false);
+      expect(result.isAnthropic).toBe(false);
+      expect(result.isGoogle).toBe(false);
+    });
+
     it('builds correct URL for moonshot', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -66,6 +66,7 @@ describe('resolveEndpointKey', () => {
   it('resolves known providers directly', () => {
     expect(resolveEndpointKey('openai')).toBe('openai');
     expect(resolveEndpointKey('anthropic')).toBe('anthropic');
+    expect(resolveEndpointKey('bedrock')).toBe('bedrock');
     expect(resolveEndpointKey('google')).toBe('google');
     expect(resolveEndpointKey('byteplus')).toBe('byteplus');
     expect(resolveEndpointKey('deepseek')).toBe('deepseek');
@@ -114,6 +115,11 @@ describe('resolveEndpointKey', () => {
     expect(resolveEndpointKey('Xiaomi MiMo')).toBe('xiaomi');
   });
 
+  it('resolves AWS Bedrock aliases to bedrock', () => {
+    expect(resolveEndpointKey('aws-bedrock')).toBe('bedrock');
+    expect(resolveEndpointKey('amazon-bedrock')).toBe('bedrock');
+  });
+
   it('resolves qwen and alibaba to qwen', () => {
     expect(resolveEndpointKey('qwen')).toBe('qwen');
     expect(resolveEndpointKey('alibaba')).toBe('qwen');
@@ -133,6 +139,7 @@ describe('resolveEndpointKey', () => {
     const known = Object.keys(PROVIDER_ENDPOINTS);
     expect(known).toContain('openai');
     expect(known).toContain('anthropic');
+    expect(known).toContain('bedrock');
     expect(known).toContain('google');
     expect(known).toContain('qwen');
     expect(known).toContain('copilot');
@@ -210,6 +217,17 @@ describe('PROVIDER_ENDPOINTS', () => {
 
   it('zai uses openai format', () => {
     expect(PROVIDER_ENDPOINTS['zai'].format).toBe('openai');
+  });
+
+  it('bedrock uses the OpenAI-compatible Bedrock Mantle endpoint', () => {
+    const ep = PROVIDER_ENDPOINTS['bedrock'];
+    expect(ep.baseUrl).toBe('https://bedrock-mantle.us-east-1.api.aws');
+    expect(ep.format).toBe('openai');
+    expect(ep.buildPath('mistral.ministral-3-8b-instruct')).toBe('/v1/chat/completions');
+    expect(ep.buildHeaders('bedrock-api-key-test')).toEqual({
+      Authorization: 'Bearer bedrock-api-key-test',
+      'Content-Type': 'application/json',
+    });
   });
 
   it('groq uses OpenAI-compatible format at api.groq.com/openai', () => {
@@ -622,6 +640,7 @@ describe('PROVIDER_ENDPOINTS', () => {
       'xiaomi',
       'moonshot',
       'nvidia',
+      'bedrock',
       'qwen',
       'qwen-subscription',
       'xiaomi-subscription',

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
@@ -146,6 +146,17 @@ describe('resolveForwardEndpoint', () => {
     expect(out.customEndpoint).toBeDefined();
   });
 
+  it('builds the AWS Bedrock Mantle endpoint for a selected region', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'bedrock',
+      authType: 'api_key',
+      model: 'mistral.ministral-3-8b-instruct',
+      providerRegion: 'eu-west-1',
+    });
+    expect(out.forwardModel).toBe('mistral.ministral-3-8b-instruct');
+    expect(out.customEndpoint?.baseUrl).toBe('https://bedrock-mantle.eu-west-1.api.aws');
+  });
+
   it('sets no qwen override for an unresolved region', () => {
     const out = resolveForwardEndpoint({
       provider: 'qwen',

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
@@ -20,6 +20,7 @@ import {
 } from './provider-endpoints';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
 import { normalizeMinimaxSubscriptionBaseUrl } from '../provider-base-url';
+import { getBedrockMantleBaseUrl, isBedrockRegion } from '../bedrock-region';
 import { MINIMAX_BASE_URLS } from '../oauth/minimax-oauth-helpers';
 import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../qwen-region';
 import {
@@ -115,6 +116,8 @@ export function resolveForwardEndpoint(
       );
       forwardModel = CustomProviderService.rawModelName(model);
     }
+  } else if (resolveEndpointKey(provider) === 'bedrock' && isBedrockRegion(providerRegion)) {
+    customEndpoint = buildEndpointOverride(getBedrockMantleBaseUrl(providerRegion), 'bedrock');
   } else if (resolveEndpointKey(provider) === 'qwen' && isQwenResolvedRegion(providerRegion)) {
     customEndpoint = buildEndpointOverride(getQwenCompatibleBaseUrl(providerRegion), 'qwen');
   } else if (authType === 'subscription' && lower === 'minimax') {

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -8,6 +8,7 @@ import {
   buildClaudeCodeSubscriptionHeaders,
 } from '../../common/constants/subscription-clients';
 import { normalizeProviderBaseUrl } from '../provider-base-url';
+import { getBedrockMantleBaseUrl } from '../bedrock-region';
 import { getQwenCompatibleBaseUrl } from '../qwen-region';
 import { getXiaomiTokenPlanBaseUrl } from '../xiaomi-region';
 import { getZaiCodingPlanBaseUrl } from '../zai-region';
@@ -146,6 +147,13 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildHeaders: anthropicHeaders,
     buildPath: () => '/v1/messages',
     format: 'anthropic',
+  },
+  bedrock: {
+    baseUrl: getBedrockMantleBaseUrl(),
+    buildHeaders: openaiHeaders,
+    buildPath: openaiPath,
+    format: 'openai',
+    ...openaiStreamUsage,
   },
   deepseek: {
     baseUrl: 'https://api.deepseek.com',

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -228,6 +228,60 @@ describe('ProviderParamSpecService', () => {
     expect(specs.map((spec) => spec.path)).toEqual(['reasoning.effort']);
   });
 
+  it('resolves Bedrock Claude model ids through the underlying Anthropic provider for params', async () => {
+    mockProviderlessParams({
+      'claude-opus-4-8': [reasoningEffortParam],
+    });
+    const service = new ProviderParamSpecService();
+
+    const specs = await service.getSpecs('bedrock', 'api_key', 'us.anthropic.claude-opus-4.8');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://modelparams.dev/api/v1/params/claude-opus-4-8.json',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      'https://modelparams.dev/api/v1/params/us.anthropic.claude-opus-4.8.json',
+      expect.anything(),
+    );
+    expect(specs).toEqual([
+      expect.objectContaining({
+        provider: 'bedrock',
+        authType: 'api_key',
+        model: 'us.anthropic.claude-opus-4.8',
+        path: 'reasoning.effort',
+      }),
+    ]);
+  });
+
+  it('strips dated Bedrock model ids for providerless params while preserving the route identity', async () => {
+    mockProviderlessParams({
+      'gpt-5.4': [reasoningEffortParam],
+    });
+    const service = new ProviderParamSpecService();
+
+    const specs = await service.getSpecs('bedrock', 'api_key', 'openai.gpt-5.4-2026-03-05');
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      'https://modelparams.dev/api/v1/params/gpt-5.4-2026-03-05.json',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      'https://modelparams.dev/api/v1/params/gpt-5.4.json',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(specs).toEqual([
+      expect.objectContaining({
+        provider: 'bedrock',
+        authType: 'api_key',
+        model: 'openai.gpt-5.4-2026-03-05',
+        path: 'reasoning.effort',
+      }),
+    ]);
+  });
+
   it('falls back to the providerless API-key slug for subscription routes', async () => {
     mockProviderlessParams({
       'gpt-4o-mini': [temperatureParam],

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -69,6 +69,64 @@ describe('ProviderService — route-only cleanup paths', () => {
     );
   });
 
+  describe('upsertProvider — Bedrock region', () => {
+    let originalSecret: string | undefined;
+
+    const makeShortTermKey = (region: string) => {
+      const payload =
+        'bedrock.amazonaws.com/?Action=CallWithBearerToken&' +
+        `X-Amz-Credential=ASIAEXAMPLE%2F20260612%2F${region}%2Fbedrock%2Faws4_request`;
+      return `bedrock-api-key-${Buffer.from(payload).toString('base64')}`;
+    };
+
+    beforeEach(() => {
+      originalSecret = process.env.BETTER_AUTH_SECRET;
+      process.env.BETTER_AUTH_SECRET = 'a'.repeat(48);
+    });
+
+    afterEach(() => {
+      if (originalSecret === undefined) {
+        delete process.env.BETTER_AUTH_SECRET;
+      } else {
+        process.env.BETTER_AUTH_SECRET = originalSecret;
+      }
+    });
+
+    it('infers the region from a short-term Bedrock API key', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+
+      await svc.upsertProvider('agent-1', 'user-1', 'bedrock', makeShortTermKey('eu-west-1'));
+
+      const inserted = providerRepo.insert.mock.calls[0][0] as UserProvider;
+      expect(inserted.region).toBe('eu-west-1');
+    });
+
+    it('falls back to the default region when a short-term Bedrock key uses an unsupported Mantle region', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+
+      await svc.upsertProvider('agent-1', 'user-1', 'bedrock', makeShortTermKey('eu-west-3'));
+
+      const inserted = providerRepo.insert.mock.calls[0][0] as UserProvider;
+      expect(inserted.region).toBe('us-east-1');
+    });
+
+    it('uses an explicitly selected Bedrock region over key inference', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+
+      await svc.upsertProvider(
+        'agent-1',
+        'user-1',
+        'bedrock',
+        makeShortTermKey('eu-west-3'),
+        'api_key',
+        'us-west-2',
+      );
+
+      const inserted = providerRepo.insert.mock.calls[0][0] as UserProvider;
+      expect(inserted.region).toBe('us-west-2');
+    });
+  });
+
   describe('removeProvider — cleanupProviderReferences', () => {
     it('clears tier override_route when its provider matches removed provider (case-insensitive)', async () => {
       providerRepo.findOne.mockResolvedValue({

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -9,6 +9,7 @@ import type { TierAutoAssignService } from '../tier-auto-assign.service';
 import type { RoutingCacheService } from '../routing-cache.service';
 import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import { encrypt, getEncryptionSecret } from '../../../common/utils/crypto.util';
+import { makeShortTermBedrockKey } from '../../__tests__/bedrock-fixtures';
 
 const route = (
   provider: string,
@@ -72,13 +73,6 @@ describe('ProviderService — route-only cleanup paths', () => {
   describe('upsertProvider — Bedrock region', () => {
     let originalSecret: string | undefined;
 
-    const makeShortTermKey = (region: string) => {
-      const payload =
-        'bedrock.amazonaws.com/?Action=CallWithBearerToken&' +
-        `X-Amz-Credential=ASIAEXAMPLE%2F20260612%2F${region}%2Fbedrock%2Faws4_request`;
-      return `bedrock-api-key-${Buffer.from(payload).toString('base64')}`;
-    };
-
     beforeEach(() => {
       originalSecret = process.env.BETTER_AUTH_SECRET;
       process.env.BETTER_AUTH_SECRET = 'a'.repeat(48);
@@ -95,7 +89,12 @@ describe('ProviderService — route-only cleanup paths', () => {
     it('infers the region from a short-term Bedrock API key', async () => {
       providerRepo.findOne.mockResolvedValue(null);
 
-      await svc.upsertProvider('agent-1', 'user-1', 'bedrock', makeShortTermKey('eu-west-1'));
+      await svc.upsertProvider(
+        'agent-1',
+        'user-1',
+        'bedrock',
+        makeShortTermBedrockKey('eu-west-1'),
+      );
 
       const inserted = providerRepo.insert.mock.calls[0][0] as UserProvider;
       expect(inserted.region).toBe('eu-west-1');
@@ -104,7 +103,12 @@ describe('ProviderService — route-only cleanup paths', () => {
     it('falls back to the default region when a short-term Bedrock key uses an unsupported Mantle region', async () => {
       providerRepo.findOne.mockResolvedValue(null);
 
-      await svc.upsertProvider('agent-1', 'user-1', 'bedrock', makeShortTermKey('eu-west-3'));
+      await svc.upsertProvider(
+        'agent-1',
+        'user-1',
+        'bedrock',
+        makeShortTermBedrockKey('eu-west-3'),
+      );
 
       const inserted = providerRepo.insert.mock.calls[0][0] as UserProvider;
       expect(inserted.region).toBe('us-east-1');
@@ -117,13 +121,23 @@ describe('ProviderService — route-only cleanup paths', () => {
         'agent-1',
         'user-1',
         'bedrock',
-        makeShortTermKey('eu-west-3'),
+        makeShortTermBedrockKey('eu-west-3'),
         'api_key',
         'us-west-2',
       );
 
       const inserted = providerRepo.insert.mock.calls[0][0] as UserProvider;
       expect(inserted.region).toBe('us-west-2');
+    });
+
+    it('accepts raw AWS bearer token shaped Bedrock keys without region inference', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+
+      await svc.upsertProvider('agent-1', 'user-1', 'bedrock', 'ABSKTWFudGxlQXBpS2V5LWV4YW1wbGU=');
+
+      const inserted = providerRepo.insert.mock.calls[0][0] as UserProvider;
+      expect(inserted.region).toBe('us-east-1');
+      expect(inserted.key_prefix).toBe('ABSKTWFu');
     });
   });
 

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -10,6 +10,7 @@ import {
   isProviderParamPath,
   normalizeProviderParamProviderId,
   providerParamValueIsValid,
+  resolveProviderMetadataIdentity,
   underlyingGatewayModel,
   type AuthType,
   type JsonValue,
@@ -33,6 +34,7 @@ const BY_MODEL_MISS_CACHE_TTL_MS = 5 * 60 * 1000;
 const SUBSCRIPTION_MODEL_SUFFIX = '-subscription';
 const SHORT_CLAUDE_MODEL_RE = /^claude-(opus|sonnet|haiku)-/i;
 const DOTTED_CLAUDE_MINOR_RE = /-(\d+)\.(\d{1,2})(?=$|-\d{8}$)/g;
+const DATE_SUFFIX_RE = /-\d{4}-?\d{2}-?\d{2}$/;
 const MODEL_PARAM_TYPES: readonly ModelParamType[] = [
   'boolean',
   'enum',
@@ -141,7 +143,16 @@ export class ProviderParamSpecService implements OnModuleInit {
   ): Promise<readonly ProviderParamSpec[]> {
     const providerlessSpecs = await this.getProviderlessSpecs(providerId, authType, model);
     if (providerlessSpecs.length > 0) return providerlessSpecs;
-    return getProviderParamSpecs(this.specs, providerId, authType, model);
+
+    const directSpecs = getProviderParamSpecs(this.specs, providerId, authType, model);
+    if (directSpecs.length > 0) return directSpecs;
+
+    const metadata = providerMetadataIdentity(providerId, model);
+    if (!metadata || metadataMatchesRoute(metadata, providerId, model)) return directSpecs;
+
+    return getProviderParamSpecs(this.specs, metadata.provider, authType, metadata.model).map(
+      (spec) => withRouteIdentity(spec, providerId, authType, model),
+    );
   }
 
   async getCapabilities(
@@ -149,7 +160,12 @@ export class ProviderParamSpecService implements OnModuleInit {
     authType: AuthType | undefined,
     model: string | undefined,
   ): Promise<readonly ModelCapability[] | null> {
-    return getProviderModelCapabilities(this.specs, providerId, authType, model);
+    const direct = getProviderModelCapabilities(this.specs, providerId, authType, model);
+    if (direct) return direct;
+
+    const metadata = providerMetadataIdentity(providerId, model);
+    if (!metadata || metadataMatchesRoute(metadata, providerId, model)) return direct;
+    return getProviderModelCapabilities(this.specs, metadata.provider, authType, metadata.model);
   }
 
   getLastFetchedAt(): Date | null {
@@ -199,7 +215,11 @@ export class ProviderParamSpecService implements OnModuleInit {
     if (!providerId || !authType || !model || authType === 'local') return [];
 
     const provider = normalizeProviderParamProviderId(providerId);
-    const slugs = providerlessModelParamSlugs(provider, authType, model);
+    const metadata = resolveProviderMetadataIdentity(provider, model);
+    const lookupProvider = metadata.provider
+      ? normalizeProviderParamProviderId(metadata.provider)
+      : provider;
+    const slugs = providerlessModelParamSlugs(lookupProvider, authType, metadata.model);
     for (const slug of slugs) {
       const params = await this.fetchProviderlessModelParams(slug);
       if (!params || params.length === 0) continue;
@@ -262,6 +282,39 @@ export class ProviderParamSpecService implements OnModuleInit {
   }
 }
 
+function providerMetadataIdentity(
+  providerId: string | undefined,
+  model: string | undefined,
+): { provider: string | undefined; model: string } | null {
+  if (!model) return null;
+  const normalizedProvider = providerId ? normalizeProviderParamProviderId(providerId) : providerId;
+  return resolveProviderMetadataIdentity(normalizedProvider, model);
+}
+
+function metadataMatchesRoute(
+  metadata: { provider: string | undefined; model: string },
+  providerId: string | undefined,
+  model: string | undefined,
+): boolean {
+  const normalizedProvider = providerId ? normalizeProviderParamProviderId(providerId) : providerId;
+  return metadata.provider === normalizedProvider && metadata.model === model;
+}
+
+function withRouteIdentity(
+  spec: ProviderParamSpec,
+  providerId: string | undefined,
+  authType: AuthType | undefined,
+  model: string | undefined,
+): ProviderParamSpec {
+  if (!providerId || !authType || !model) return spec;
+  return {
+    ...spec,
+    provider: normalizeProviderParamProviderId(providerId),
+    authType,
+    model,
+  };
+}
+
 function providerlessModelParamSlugs(
   providerId: string,
   authType: AuthType,
@@ -302,15 +355,22 @@ function providerlessModelBaseCandidates(providerId: string, model: string): rea
 
 function providerlessModelSlugVariants(model: string): readonly string[] {
   const out: string[] = [];
-  const normalizedClaude = normalizeClaudeProviderlessSlug(model);
-  pushUnique(out, normalizedClaude);
-  pushUnique(out, model);
+  const stableModel = stripProviderlessDateSuffix(model);
+  for (const candidate of [model, stableModel]) {
+    const normalizedClaude = normalizeClaudeProviderlessSlug(candidate);
+    pushUnique(out, normalizedClaude);
+    pushUnique(out, candidate);
+  }
   return out;
 }
 
 function normalizeClaudeProviderlessSlug(model: string): string {
   if (!SHORT_CLAUDE_MODEL_RE.test(model)) return model;
   return model.replace(DOTTED_CLAUDE_MINOR_RE, '-$1-$2');
+}
+
+function stripProviderlessDateSuffix(model: string): string {
+  return model.replace(DATE_SUFFIX_RE, '');
 }
 
 function pushUnique(values: string[], value: string): void {

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -18,6 +18,12 @@ import type { AuthType, ModelRoute } from 'manifest-shared';
 import { TIER_LABELS } from 'manifest-shared';
 import { detectQwenRegion, isQwenRegion, isQwenResolvedRegion } from '../qwen-region';
 import {
+  DEFAULT_BEDROCK_REGION,
+  detectBedrockRegionFromApiKey,
+  isBedrockProvider,
+  isBedrockRegion,
+} from '../bedrock-region';
+import {
   getSubscriptionEndpointRegionConfig,
   SubscriptionEndpointRegionConfig,
 } from '../subscription-region';
@@ -339,6 +345,19 @@ export class ProviderService {
         requestedRegion,
         existing,
       );
+    }
+
+    if (isBedrockProvider(lower) && authType === 'api_key') {
+      if (requestedRegion !== undefined) {
+        if (!isBedrockRegion(requestedRegion)) {
+          throw new BadRequestException('AWS Bedrock region must be a valid AWS region code');
+        }
+        return requestedRegion;
+      }
+
+      const detectedRegion = detectBedrockRegionFromApiKey(apiKey);
+      if (detectedRegion) return detectedRegion;
+      return isBedrockRegion(existing?.region) ? existing.region : DEFAULT_BEDROCK_REGION;
     }
 
     const isQwenProvider = lower === 'qwen' || lower === 'alibaba';

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -143,7 +143,7 @@ const HeaderTierCard: Component<Props> = (props) => {
   const priceLabel = (): string => {
     const info = modelInfo();
     if (!info) return '';
-    return `${pricePerM(Number(info.input_price_per_token ?? 0))} in · ${pricePerM(Number(info.output_price_per_token ?? 0))} out per 1M`;
+    return `${pricePerM(info.input_price_per_token)} in · ${pricePerM(info.output_price_per_token)} out per 1M`;
   };
 
   const effectiveAuth = (): AuthType | null => {

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -35,12 +35,24 @@ interface Props {
 }
 
 /** Resolve a display label for a model name, handling vendor-prefixed IDs. */
-function labelForModel(name: string, labels: Map<string, string>): string {
+function labelForModel(
+  name: string,
+  labels: Map<string, string>,
+  providerIds: Set<string>,
+): string {
   const direct = labels.get(name);
   if (direct) return direct;
   const slash = name.indexOf('/');
   if (slash !== -1) {
     const bare = name.substring(slash + 1);
+    const found = labels.get(bare);
+    if (found) return found;
+    return bare;
+  }
+  const parts = name.split('.');
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    if (!providerIds.has(parts[i]!.toLowerCase())) continue;
+    const bare = parts.slice(i + 1).join('.');
     const found = labels.get(bare);
     if (found) return found;
     return bare;
@@ -141,6 +153,8 @@ const ModelPickerModal: Component<Props> = (props) => {
     return map;
   };
 
+  const providerIdSet = (): Set<string> => new Set(PROVIDERS.map((p) => p.id.toLowerCase()));
+
   const customProviderNameMap = (): Map<string, string> => {
     const map = new Map<string, string>();
     for (const cp of props.customProviders ?? []) {
@@ -165,6 +179,7 @@ const ModelPickerModal: Component<Props> = (props) => {
   const groupedModels = () => {
     const q = search().toLowerCase().trim();
     const labels = providerLabelMap();
+    const providerIds = providerIdSet();
     const cpNames = customProviderNameMap();
     const tab = activeTab();
     const hasConnectedProviders = (props.connectedProviders ?? []).length > 0;
@@ -219,8 +234,15 @@ const ModelPickerModal: Component<Props> = (props) => {
           : (provDef?.name ?? m.provider);
         groupMap.set(provId, { provId, name, models: [] });
       }
-      const label = m.display_name || labelForModel(m.model_name, labels);
-      groupMap.get(provId)!.models.push({ value: m.model_name, label, pricing: m });
+      const label =
+        m.display_name && m.display_name !== m.model_name
+          ? m.display_name
+          : labelForModel(m.model_name, labels, providerIds);
+      groupMap.get(provId)!.models.push({
+        value: m.model_name,
+        label,
+        pricing: m,
+      });
     }
 
     const groups: { provId: string; name: string; models: ModalModel[] }[] = [];

--- a/packages/frontend/src/components/ProviderIcon.tsx
+++ b/packages/frontend/src/components/ProviderIcon.tsx
@@ -38,6 +38,24 @@ export function providerIcon(id: string, size: number = 20): JSX.Element | null 
         </svg>
       );
 
+    /* ── AWS Bedrock ─────────────────────────────── */
+    case 'bedrock':
+      return (
+        <svg
+          style={s}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <rect x="2" y="3" width="20" height="18" rx="3" fill="#232F3E" />
+          <path d="M6.2 9.1 12 5.8l5.8 3.3v6.8L12 19.2l-5.8-3.3V9.1Z" fill="#FF9900" />
+          <path d="M12 5.8v6.6l5.8-3.3L12 5.8Z" fill="#FFC46B" />
+          <path d="M6.2 9.1 12 12.4v6.8l-5.8-3.3V9.1Z" fill="#E07A00" />
+          <path d="M12 12.4v6.8l5.8-3.3V9.1L12 12.4Z" fill="#F28C00" />
+        </svg>
+      );
+
     /* ── BytePlus ─────────────────────────────────── */
     case 'byteplus':
       return (

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -76,7 +76,9 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
       ? (props.provDef.subscriptionKeyPlaceholder ?? 'Paste token')
       : props.provDef.keyPlaceholder;
   const endpointRegions = () =>
-    props.isSubMode() ? (props.provDef.subscriptionEndpointRegions ?? []) : [];
+    props.isSubMode()
+      ? (props.provDef.subscriptionEndpointRegions ?? [])
+      : (props.provDef.apiKeyEndpointRegions ?? []);
   const hasEndpointRegions = () => endpointRegions().length > 0;
   const defaultEndpointRegion = () => endpointRegions()[0]?.value;
   const endpointRegionLabel = (value: string | null | undefined) =>

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -94,7 +94,7 @@ function activeHeaderCount(entries: HeaderEntry[]): number {
 }
 
 function findDisplayName(
-  available: { model_name: string; display_name?: string }[],
+  available: { model_name: string; display_name?: string | null }[],
   modelName: string,
 ): string {
   const match = available.find((m) => m.model_name === modelName);

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -301,8 +301,8 @@ export interface AvailableModel {
   input_modalities?: ModelModality[];
   output_modalities?: ModelModality[];
   quality_score: number;
-  display_name?: string;
-  provider_display_name?: string;
+  display_name?: string | null;
+  provider_display_name?: string | null;
 }
 
 export function getAvailableModels(agentName: string) {

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -1,5 +1,6 @@
 export const ROUTING_PROVIDER_API_KEY_URLS: Record<string, string> = {
   anthropic: 'https://console.anthropic.com/settings/keys',
+  bedrock: 'https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html',
   deepseek: 'https://platform.deepseek.com/api_keys',
   fireworks: 'https://app.fireworks.ai/api-keys',
   gemini: 'https://aistudio.google.com/apikey',

--- a/packages/frontend/src/services/provider-utils.ts
+++ b/packages/frontend/src/services/provider-utils.ts
@@ -1,3 +1,4 @@
+import { resolveProviderMetadataIdentity } from 'manifest-shared';
 import { PROVIDERS, type ProviderDef } from './providers.js';
 
 export function getProvider(id: string): ProviderDef | undefined {
@@ -92,6 +93,14 @@ function formatModelSlug(slug: string): string {
   return slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+function dotPrefixedModel(modelValue: string): { providerId: string; bare: string } | null {
+  const resolved = resolveProviderMetadataIdentity('bedrock', modelValue);
+  if (!resolved.provider || resolved.provider === 'bedrock' || resolved.model === modelValue) {
+    return null;
+  }
+  return { providerId: resolved.provider, bare: resolved.model };
+}
+
 export function getModelLabel(providerId: string, modelValue: string): string {
   if (!modelValue) return '';
   const prov = getProvider(providerId);
@@ -117,6 +126,17 @@ export function getModelLabel(providerId: string, modelValue: string): string {
       if (found) return found.label;
     }
     return formatModelSlug(bare);
+  }
+  if (prov.id === 'bedrock') {
+    // Bedrock/Mantle model IDs are routable AWS IDs like
+    // "us.anthropic.claude-sonnet-4.6"; display the underlying model label.
+    const dotPrefixed = dotPrefixedModel(modelValue);
+    if (dotPrefixed) {
+      const dotProvider = getProvider(dotPrefixed.providerId);
+      const found = dotProvider?.models.find((m) => m.value === dotPrefixed.bare);
+      if (found) return found.label;
+      return formatModelSlug(dotPrefixed.bare);
+    }
   }
   // Fallback: format the model slug as a readable label
   return formatModelSlug(modelValue);

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -43,6 +43,8 @@ export interface ProviderDef {
   subscriptionAuthMode?: 'popup_oauth' | 'popup_paste' | 'device_code' | 'token';
   /** Optional endpoint selector for token-mode subscription providers. */
   subscriptionEndpointRegions?: SubscriptionEndpointRegion[];
+  /** Optional endpoint selector for API-key providers with regional hosts. */
+  apiKeyEndpointRegions?: SubscriptionEndpointRegion[];
   /**
    * Optional secondary subscription path. Lets a provider expose a pasted-token
    * shortcut alongside its primary OAuth/device-code flow — currently used so
@@ -90,6 +92,7 @@ interface ProviderUIOverlay {
   deviceLogin?: boolean;
   subscriptionAuthMode?: 'popup_oauth' | 'popup_paste' | 'device_code' | 'token';
   subscriptionEndpointRegions?: SubscriptionEndpointRegion[];
+  apiKeyEndpointRegions?: SubscriptionEndpointRegion[];
   subscriptionTokenAlternative?: {
     prefix: string;
     placeholder: string;
@@ -122,6 +125,26 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
     supportsSubscription: true,
     subscriptionLabel: 'Claude Max / Pro subscription',
     subscriptionAuthMode: 'popup_paste',
+    models: [],
+  },
+  bedrock: {
+    initial: 'AWS',
+    subtitle: 'Claude, Llama, Mistral, Nova via Amazon Bedrock',
+    apiKeyEndpointRegions: [
+      { value: 'us-east-1', label: 'US East (N. Virginia)' },
+      { value: 'us-east-2', label: 'US East (Ohio)' },
+      { value: 'us-west-2', label: 'US West (Oregon)' },
+      { value: 'eu-west-1', label: 'Europe (Ireland)' },
+      { value: 'eu-west-2', label: 'Europe (London)' },
+      { value: 'eu-central-1', label: 'Europe (Frankfurt)' },
+      { value: 'eu-south-1', label: 'Europe (Milan)' },
+      { value: 'eu-north-1', label: 'Europe (Stockholm)' },
+      { value: 'ap-south-1', label: 'Asia Pacific (Mumbai)' },
+      { value: 'ap-southeast-2', label: 'Asia Pacific (Sydney)' },
+      { value: 'ap-southeast-3', label: 'Asia Pacific (Jakarta)' },
+      { value: 'ap-northeast-1', label: 'Asia Pacific (Tokyo)' },
+      { value: 'sa-east-1', label: 'South America (Sao Paulo)' },
+    ],
     models: [],
   },
   byteplus: {
@@ -384,6 +407,7 @@ export function buildProviderDef(shared: SharedProviderEntry): ProviderDef {
 const PROVIDER_ORDER = [
   'qwen',
   'anthropic',
+  'bedrock',
   'byteplus',
   'commandcode',
   'deepseek',

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -958,12 +958,8 @@ describe('ModelPickerModal', () => {
       />
     ));
 
-    expect(container.querySelector('.routing-modal__group-name')?.textContent).toBe(
-      'AWS Bedrock',
-    );
-    expect(container.querySelector('.routing-modal__model-label')?.textContent).toBe(
-      'Claude Opus',
-    );
+    expect(container.querySelector('.routing-modal__group-name')?.textContent).toBe('AWS Bedrock');
+    expect(container.querySelector('.routing-modal__model-label')?.textContent).toBe('Claude Opus');
   });
 
   it('renders the no-search empty state when search is non-empty and matches nothing', () => {

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -21,6 +21,11 @@ vi.mock('../../src/services/providers.js', () => ({
       name: 'Anthropic',
       models: [{ value: 'claude-opus', label: 'Claude Opus' }],
     },
+    {
+      id: 'bedrock',
+      name: 'AWS Bedrock',
+      models: [],
+    },
   ],
   STAGES: [
     { id: 'simple', label: 'Simple' },
@@ -918,6 +923,47 @@ describe('ModelPickerModal', () => {
     // The icon falls back to a styled letter span ("G").
     const letter = container.querySelector('.provider-card__logo-letter');
     expect(letter?.textContent).toBe('G');
+  });
+
+  it('keeps Bedrock grouped by route provider while cleaning dotted model labels', () => {
+    const bedrockModels: AvailableModel[] = [
+      {
+        ...baseModels[0],
+        model_name: 'us.anthropic.claude-opus',
+        provider: 'bedrock',
+        display_name: 'us.anthropic.claude-opus',
+        input_price_per_token: null,
+        output_price_per_token: null,
+      },
+    ];
+    const bedrockConnected: RoutingProvider[] = [
+      {
+        id: 'p-bedrock',
+        provider: 'bedrock',
+        auth_type: 'api_key',
+        is_active: true,
+        has_api_key: true,
+        connected_at: '2025-01-01',
+      },
+    ];
+
+    const { container } = render(() => (
+      <ModelPickerModal
+        tierId="simple"
+        models={bedrockModels}
+        tiers={[]}
+        connectedProviders={bedrockConnected}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    ));
+
+    expect(container.querySelector('.routing-modal__group-name')?.textContent).toBe(
+      'AWS Bedrock',
+    );
+    expect(container.querySelector('.routing-modal__model-label')?.textContent).toBe(
+      'Claude Opus',
+    );
   });
 
   it('renders the no-search empty state when search is non-empty and matches nothing', () => {

--- a/packages/frontend/tests/components/ProviderIcon.test.tsx
+++ b/packages/frontend/tests/components/ProviderIcon.test.tsx
@@ -5,6 +5,7 @@ import { providerIcon, customProviderLogo } from '../../src/components/ProviderI
 const KNOWN_PROVIDERS = [
   'openai',
   'anthropic',
+  'bedrock',
   'byteplus',
   'copilot',
   'commandcode',

--- a/packages/frontend/tests/components/ProviderKeyForm.test.tsx
+++ b/packages/frontend/tests/components/ProviderKeyForm.test.tsx
@@ -335,6 +335,43 @@ describe('ProviderKeyForm', () => {
         region: 'cn',
       });
     });
+
+    it('sends the selected API-key endpoint region on connect', async () => {
+      const def = makeProviderDef({
+        id: 'bedrock',
+        name: 'AWS Bedrock',
+        keyPlaceholder: 'bedrock-api-key-...',
+        apiKeyEndpointRegions: [
+          { value: 'us-east-1', label: 'US East (N. Virginia)' },
+          { value: 'eu-west-1', label: 'Europe (Ireland)' },
+        ],
+      });
+      const { container } = mount({
+        provDef: def,
+        provId: 'bedrock',
+        isSubMode: false,
+        selectedAuthType: 'api_key',
+        keyInput: 'bedrock-api-key-test',
+      });
+
+      const endpoint = container.querySelector(
+        '#bedrock-subscription-endpoint',
+      ) as HTMLSelectElement;
+      expect(endpoint.value).toBe('us-east-1');
+      fireEvent.change(endpoint, { target: { value: 'eu-west-1' } });
+
+      const connectBtn = container.querySelector('.provider-detail__action') as HTMLButtonElement;
+      fireEvent.click(connectBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'bedrock',
+        apiKey: 'bedrock-api-key-test',
+        authType: 'api_key',
+        region: 'eu-west-1',
+      });
+    });
   });
 
   describe('handleUpdateKey toast labels', () => {

--- a/packages/frontend/tests/components/ProviderKeyForm.test.tsx
+++ b/packages/frontend/tests/components/ProviderKeyForm.test.tsx
@@ -340,7 +340,7 @@ describe('ProviderKeyForm', () => {
       const def = makeProviderDef({
         id: 'bedrock',
         name: 'AWS Bedrock',
-        keyPlaceholder: 'bedrock-api-key-...',
+        keyPlaceholder: 'ABSK...',
         apiKeyEndpointRegions: [
           { value: 'us-east-1', label: 'US East (N. Virginia)' },
           { value: 'eu-west-1', label: 'Europe (Ireland)' },
@@ -351,7 +351,7 @@ describe('ProviderKeyForm', () => {
         provId: 'bedrock',
         isSubMode: false,
         selectedAuthType: 'api_key',
-        keyInput: 'bedrock-api-key-test',
+        keyInput: 'ABSKTWFudGxlQXBpS2V5LWV4YW1wbGU=',
       });
 
       const endpoint = container.querySelector(
@@ -367,7 +367,7 @@ describe('ProviderKeyForm', () => {
 
       expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
         provider: 'bedrock',
-        apiKey: 'bedrock-api-key-test',
+        apiKey: 'ABSKTWFudGxlQXBpS2V5LWV4YW1wbGU=',
         authType: 'api_key',
         region: 'eu-west-1',
       });

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -125,6 +125,23 @@ describe('validateApiKey', () => {
     expect(validateApiKey(fireworks, 'fw_' + 'a'.repeat(20))).toEqual({ valid: true });
   });
 
+  it('validates AWS Bedrock API key prefix and length', () => {
+    const bedrock = getProvider('bedrock')!;
+    expect(validateApiKey(bedrock, '')).toEqual({
+      valid: false,
+      error: 'API key is required',
+    });
+    expect(validateApiKey(bedrock, 'sk-wrong-prefix-that-is-long-enough')).toEqual({
+      valid: false,
+      error: 'AWS Bedrock keys start with "bedrock-api-key-"',
+    });
+    expect(validateApiKey(bedrock, 'bedrock-api-key-short')).toEqual({
+      valid: false,
+      error: 'Key is too short (minimum 50 characters)',
+    });
+    expect(validateApiKey(bedrock, 'bedrock-api-key-' + 'a'.repeat(50))).toEqual({ valid: true });
+  });
+
   it('validates Xiaomi MiMo API key prefix and length', () => {
     const xiaomi = getProvider('xiaomi')!;
     expect(validateApiKey(xiaomi, '')).toEqual({
@@ -422,6 +439,23 @@ describe('PROVIDERS', () => {
     expect(anthropic.subscriptionAuthMode).toBe('popup_paste');
     expect(anthropic.subscriptionCommand).toBeUndefined();
     expect(anthropic.subscriptionKeyPlaceholder).toBeUndefined();
+  });
+
+  it('AWS Bedrock exposes API-key region choices', () => {
+    const bedrock = PROVIDERS.find((p) => p.id === 'bedrock')!;
+    expect(bedrock.name).toBe('AWS Bedrock');
+    expect(bedrock.apiKeyEndpointRegions?.[0]).toEqual({
+      value: 'us-east-1',
+      label: 'US East (N. Virginia)',
+    });
+    expect(bedrock.apiKeyEndpointRegions).toContainEqual({
+      value: 'eu-west-1',
+      label: 'Europe (Ireland)',
+    });
+    expect(bedrock.apiKeyEndpointRegions).not.toContainEqual({
+      value: 'eu-west-3',
+      label: 'Europe (Paris)',
+    });
   });
 
   it('GitHub Copilot is subscription-only', () => {

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -125,21 +125,22 @@ describe('validateApiKey', () => {
     expect(validateApiKey(fireworks, 'fw_' + 'a'.repeat(20))).toEqual({ valid: true });
   });
 
-  it('validates AWS Bedrock API key prefix and length', () => {
+  it('validates AWS Bedrock raw bearer-token and legacy API-key lengths', () => {
     const bedrock = getProvider('bedrock')!;
     expect(validateApiKey(bedrock, '')).toEqual({
       valid: false,
       error: 'API key is required',
     });
-    expect(validateApiKey(bedrock, 'sk-wrong-prefix-that-is-long-enough')).toEqual({
-      valid: false,
-      error: 'AWS Bedrock keys start with "bedrock-api-key-"',
-    });
     expect(validateApiKey(bedrock, 'bedrock-api-key-short')).toEqual({
       valid: false,
-      error: 'Key is too short (minimum 50 characters)',
+      error: 'Key is too short (minimum 100 characters)',
     });
-    expect(validateApiKey(bedrock, 'bedrock-api-key-' + 'a'.repeat(50))).toEqual({ valid: true });
+    expect(validateApiKey(bedrock, 'ABSKTWFudGxlQXBpS2V5LWV4YW1wbGU='.padEnd(100, 'A'))).toEqual({
+      valid: true,
+    });
+    expect(validateApiKey(bedrock, 'bedrock-api-key-' + 'a'.repeat(100))).toEqual({
+      valid: true,
+    });
   });
 
   it('validates Xiaomi MiMo API key prefix and length', () => {
@@ -391,6 +392,12 @@ describe('getModelLabel', () => {
     // "vendor/unknown.model.name" → bare "unknown.model.name" → not found →
     // normalized "unknown-model-name" → still not found → returns bare
     expect(getModelLabel('openrouter', 'vendor/unknown.model.name')).toBe('Unknown.Model.Name');
+  });
+
+  it('strips Bedrock-style dot provider namespaces', () => {
+    expect(getModelLabel('bedrock', 'us.anthropic.claude-opus-4.6')).toBe('Claude Opus 4.6');
+    expect(getModelLabel('bedrock', 'mistral.magistral-small-2509')).toBe('Magistral Small 2509');
+    expect(getModelLabel('bedrock', 'z.ai.glm-4.6')).toBe('Glm 4.6');
   });
 });
 

--- a/packages/shared/__tests__/provider-inference.spec.ts
+++ b/packages/shared/__tests__/provider-inference.spec.ts
@@ -171,6 +171,17 @@ describe('resolveProviderMetadataIdentity', () => {
     });
   });
 
+  it('unwraps Bedrock vendor aliases that contain dots', () => {
+    expect(resolveProviderMetadataIdentity('bedrock', 'z.ai.glm-4.6')).toEqual({
+      provider: 'zai',
+      model: 'glm-4.6',
+    });
+    expect(resolveProviderMetadataIdentity('bedrock', 'us.z.ai.glm-4.6')).toEqual({
+      provider: 'zai',
+      model: 'glm-4.6',
+    });
+  });
+
   it('leaves unknown Bedrock vendors unchanged', () => {
     expect(resolveProviderMetadataIdentity('bedrock', 'amazon.nova-pro-v1:0')).toEqual({
       provider: 'bedrock',

--- a/packages/shared/__tests__/provider-inference.spec.ts
+++ b/packages/shared/__tests__/provider-inference.spec.ts
@@ -1,6 +1,7 @@
 import {
   MODEL_PREFIX_MAP,
   inferProviderFromModel,
+  resolveProviderMetadataIdentity,
   resolveUnderlyingModelIdentity,
   underlyingGatewayModel,
 } from '../src/provider-inference';
@@ -140,6 +141,47 @@ describe('resolveUnderlyingModelIdentity', () => {
     expect(resolveUnderlyingModelIdentity(undefined, 'deepseek-v4-pro')).toEqual({
       provider: undefined,
       model: 'deepseek-v4-pro',
+    });
+  });
+});
+
+describe('resolveProviderMetadataIdentity', () => {
+  it('keeps non-Bedrock route identities unchanged', () => {
+    expect(resolveProviderMetadataIdentity('anthropic', 'claude-opus-4.8')).toEqual({
+      provider: 'anthropic',
+      model: 'claude-opus-4.8',
+    });
+  });
+
+  it('unwraps Bedrock provider-prefixed model ids for metadata lookups', () => {
+    expect(resolveProviderMetadataIdentity('bedrock', 'anthropic.claude-opus-4.8')).toEqual({
+      provider: 'anthropic',
+      model: 'claude-opus-4.8',
+    });
+    expect(resolveProviderMetadataIdentity('bedrock', 'openai.gpt-oss-120b')).toEqual({
+      provider: 'openai',
+      model: 'gpt-oss-120b',
+    });
+  });
+
+  it('unwraps Bedrock cross-region profile prefixes before the vendor segment', () => {
+    expect(resolveProviderMetadataIdentity('bedrock', 'us.anthropic.claude-opus-4.8')).toEqual({
+      provider: 'anthropic',
+      model: 'claude-opus-4.8',
+    });
+  });
+
+  it('leaves unknown Bedrock vendors unchanged', () => {
+    expect(resolveProviderMetadataIdentity('bedrock', 'amazon.nova-pro-v1:0')).toEqual({
+      provider: 'bedrock',
+      model: 'amazon.nova-pro-v1:0',
+    });
+  });
+
+  it('still unwraps gateway models for metadata lookups', () => {
+    expect(resolveProviderMetadataIdentity('opencode-go', 'opencode-go/glm-5.1')).toEqual({
+      provider: 'zai',
+      model: 'glm-5.1',
     });
   });
 });

--- a/packages/shared/__tests__/providers.spec.ts
+++ b/packages/shared/__tests__/providers.spec.ts
@@ -163,12 +163,13 @@ describe('SHARED_PROVIDER_BY_ID', () => {
     expect(byteplus!.keyPlaceholder).toBe('ModelArk Coding Plan API key');
   });
 
-  it('bedrock has no OpenRouter prefixes and uses Bedrock API-key metadata', () => {
+  it('bedrock has no OpenRouter prefixes and accepts raw AWS bearer token metadata', () => {
     const bedrock = SHARED_PROVIDER_BY_ID.get('bedrock');
     expect(bedrock).toBeDefined();
     expect(bedrock!.displayName).toBe('AWS Bedrock');
     expect(bedrock!.openRouterPrefixes).toEqual([]);
-    expect(bedrock!.keyPrefix).toBe('bedrock-api-key-');
+    expect(bedrock!.keyPrefix).toBe('');
+    expect(bedrock!.keyPlaceholder).toBe('ABSK...');
   });
 
   it('xiaomi exposes the MiMo API-key provider metadata', () => {

--- a/packages/shared/__tests__/providers.spec.ts
+++ b/packages/shared/__tests__/providers.spec.ts
@@ -92,6 +92,16 @@ describe('SHARED_PROVIDER_BY_ID_OR_ALIAS', () => {
     }
   });
 
+  it('resolves AWS Bedrock aliases to the canonical provider entry', () => {
+    for (const name of ['bedrock', 'aws-bedrock', 'Amazon Bedrock']) {
+      const normalized = normalizeProviderName(name);
+      const entry =
+        SHARED_PROVIDER_BY_ID_OR_ALIAS.get(normalized) ??
+        SHARED_PROVIDER_BY_ID_OR_ALIAS.get(name.toLowerCase());
+      expect(entry?.id).toBe('bedrock');
+    }
+  });
+
   it('resolves Xiaomi MiMo aliases to the canonical provider entry', () => {
     for (const name of ['xiaomi', 'mimo', 'xiaomi-mimo', 'Xiaomi MiMo']) {
       const normalized = normalizeProviderName(name);
@@ -151,6 +161,14 @@ describe('SHARED_PROVIDER_BY_ID', () => {
     expect(byteplus!.displayName).toBe('BytePlus');
     expect(byteplus!.openRouterPrefixes).toEqual([]);
     expect(byteplus!.keyPlaceholder).toBe('ModelArk Coding Plan API key');
+  });
+
+  it('bedrock has no OpenRouter prefixes and uses Bedrock API-key metadata', () => {
+    const bedrock = SHARED_PROVIDER_BY_ID.get('bedrock');
+    expect(bedrock).toBeDefined();
+    expect(bedrock!.displayName).toBe('AWS Bedrock');
+    expect(bedrock!.openRouterPrefixes).toEqual([]);
+    expect(bedrock!.keyPrefix).toBe('bedrock-api-key-');
   });
 
   it('xiaomi exposes the MiMo API-key provider metadata', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -90,6 +90,7 @@ export {
   inferProviderFromModel,
   underlyingGatewayModel,
   resolveUnderlyingModelIdentity,
+  resolveProviderMetadataIdentity,
 } from './provider-inference';
 export {
   SHARED_PROVIDERS,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -88,6 +88,7 @@ export type { FallbackEntry } from './fallback-encoding';
 export {
   MODEL_PREFIX_MAP,
   inferProviderFromModel,
+  resolveProviderToken,
   underlyingGatewayModel,
   resolveUnderlyingModelIdentity,
   resolveProviderMetadataIdentity,

--- a/packages/shared/src/provider-inference.ts
+++ b/packages/shared/src/provider-inference.ts
@@ -1,3 +1,5 @@
+import { SHARED_PROVIDERS } from './providers';
+
 /**
  * Infer a provider ID from a model name string.
  * This is the unified superset of all regex patterns from backend and frontend.
@@ -32,6 +34,14 @@ export { MODEL_PREFIX_MAP };
  * own model id (e.g. `opencode-go/deepseek-v4-pro` -> `deepseek-v4-pro`).
  */
 const GATEWAY_MODEL_PREFIXES = ['opencode-go/', 'opencode-zen/'] as const;
+
+const BEDROCK_PROVIDER_TOKENS = new Map<string, string>();
+for (const provider of SHARED_PROVIDERS) {
+  const tokens = [provider.id, ...provider.aliases, ...provider.openRouterPrefixes];
+  for (const token of tokens) {
+    BEDROCK_PROVIDER_TOKENS.set(token.toLowerCase(), provider.id);
+  }
+}
 
 /**
  * If `model` is a gateway model id, return the underlying provider's model
@@ -73,4 +83,29 @@ export function resolveUnderlyingModelIdentity(
   const underlying = underlyingGatewayModel(model);
   if (underlying === null) return { provider, model };
   return { provider: inferProviderFromModel(underlying), model: underlying };
+}
+
+/**
+ * Resolve the provider/model identity that owns model metadata. This must not
+ * be used for inference routing: Bedrock still needs the original model id,
+ * but pricing/params/capabilities belong to the underlying model vendor.
+ */
+export function resolveProviderMetadataIdentity(
+  provider: string | undefined,
+  model: string,
+): { provider: string | undefined; model: string } {
+  const gateway = resolveUnderlyingModelIdentity(provider, model);
+  if (gateway.provider !== provider || gateway.model !== model) return gateway;
+
+  if (provider?.toLowerCase() !== 'bedrock') return { provider, model };
+
+  const parts = model.split('.');
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const resolvedProvider = BEDROCK_PROVIDER_TOKENS.get(parts[i].toLowerCase());
+    if (!resolvedProvider || resolvedProvider === 'bedrock') continue;
+    const underlyingModel = parts.slice(i + 1).join('.');
+    if (underlyingModel) return { provider: resolvedProvider, model: underlyingModel };
+  }
+
+  return { provider, model };
 }

--- a/packages/shared/src/provider-inference.ts
+++ b/packages/shared/src/provider-inference.ts
@@ -43,6 +43,10 @@ for (const provider of SHARED_PROVIDERS) {
   }
 }
 
+export function resolveProviderToken(token: string): string | undefined {
+  return BEDROCK_PROVIDER_TOKENS.get(token.toLowerCase());
+}
+
 /**
  * If `model` is a gateway model id, return the underlying provider's model
  * id; otherwise return `null`. Used to resolve gateway models to the
@@ -101,10 +105,12 @@ export function resolveProviderMetadataIdentity(
 
   const parts = model.split('.');
   for (let i = 0; i < parts.length - 1; i += 1) {
-    const resolvedProvider = BEDROCK_PROVIDER_TOKENS.get(parts[i].toLowerCase());
-    if (!resolvedProvider || resolvedProvider === 'bedrock') continue;
-    const underlyingModel = parts.slice(i + 1).join('.');
-    if (underlyingModel) return { provider: resolvedProvider, model: underlyingModel };
+    for (let j = parts.length - 1; j > i; j -= 1) {
+      const resolvedProvider = resolveProviderToken(parts.slice(i, j).join('.'));
+      if (!resolvedProvider || resolvedProvider === 'bedrock') continue;
+      const underlyingModel = parts.slice(j).join('.');
+      if (underlyingModel) return { provider: resolvedProvider, model: underlyingModel };
+    }
   }
 
   return { provider, model };

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -69,6 +69,18 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     keyPlaceholder: 'sk-ant-...',
   },
   {
+    id: 'bedrock',
+    displayName: 'AWS Bedrock',
+    aliases: ['aws-bedrock', 'aws bedrock', 'amazon-bedrock', 'amazon bedrock'],
+    openRouterPrefixes: [],
+    requiresApiKey: true,
+    localOnly: false,
+    color: '#ff9900',
+    keyPrefix: 'bedrock-api-key-',
+    minKeyLength: 50,
+    keyPlaceholder: 'bedrock-api-key-...',
+  },
+  {
     id: 'byteplus',
     displayName: 'BytePlus',
     aliases: ['byteplus-plan', 'byteplus plan', 'modelark', 'modelark-coding-plan'],

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -76,9 +76,9 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     requiresApiKey: true,
     localOnly: false,
     color: '#ff9900',
-    keyPrefix: 'bedrock-api-key-',
-    minKeyLength: 50,
-    keyPlaceholder: 'bedrock-api-key-...',
+    keyPrefix: '',
+    minKeyLength: 100,
+    keyPlaceholder: 'ABSK...',
   },
   {
     id: 'byteplus',


### PR DESCRIPTION
### ✨ What changed
- Adds AWS Bedrock as an API-key provider backed by Mantle.
- Infers Mantle regions from legacy keys and raw bearer tokens.
- Discovers Bedrock models, labels AWS IDs, and prices via models.dev.
- Filters Bedrock Voxtral models from chat routing.

### 💭 Why
Bedrock keys were rejected or shown with raw provider-prefixed model IDs.
Pricing also missed Bedrock-specific model IDs from models.dev.

### 👤 For users
Users can connect Bedrock/Mantle keys, pick readable Bedrock models, and see prices where models.dev has Bedrock entries.

### 📝 Notes
- Local Bedrock refresh: 36 models, 34 priced.
- Unpriced: `writer.palmyra-vision-7b`, `zai.glm-4.6`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS Bedrock as an API‑key provider via Mantle’s OpenAI‑compatible endpoints with regional routing and strict AWS‑ID pricing, while resolving clean vendor names, params, and capabilities from the underlying providers.

- **New Features**
  - New `bedrock` provider with API‑key auth to `https://bedrock-mantle.{region}.api.aws`; supports aliases (`aws-bedrock`, `amazon-bedrock`).
  - Region: validates AWS regions on connect, infers from short‑term `bedrock-api-key-*` keys, accepts raw `ABSK…` tokens; discovery, routing, proxy, and model fetch honor the selected region (with endpoint normalization).
  - Discovery/routing: fetches regional models, filters Bedrock Mistral Voxtral (non‑chat), forwards chat in OpenAI format; display names, params, and capabilities resolve from underlying vendor metadata while preserving AWS IDs (fallback to formatted slug).
  - Pricing: uses only exact Bedrock entries from `models.dev` for AWS IDs; blocks OpenRouter/provider alias fallbacks for Bedrock.
  - Frontend: Bedrock provider card and icon, API‑key region selector, provider docs link, Model Picker label cleanup for dotted vendor namespaces (e.g., `us.anthropic.claude‑…`), and a price label fix.

- **Refactors**
  - Added `resolveProviderMetadataIdentity` to unify metadata lookups (gateways and Bedrock); applied in discovery, controller display names, and param specs (including providerless/date‑stripped lookups).
  - `models.dev` sync: mapped `bedrock`→`amazon-bedrock`; added version/dotted/alias matching (e.g., `-v1:0`, dotted minors, `moonshotai.`→`moonshot.`) and Bedrock‑only instruction‑suffix stripping.
  - Pricing cache/fallbacks: block OpenRouter/provider aliasing for Bedrock; add provider‑prefixed variant matching for non‑Bedrock.
  - New `bedrock-region` helpers for region validation, Mantle base URL building/normalization, and region inference from legacy keys; used in provider connect and forward endpoint resolution.

<sup>Written for commit 8a85ad51c43f4be80d0fac2ededb1716d9022103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

