### PR TITLE
fix: clarify Xiaomi Basic API key setup

### DIFF
--- a/.changeset/xiaomi-basic-api-key.md
+++ b/.changeset/xiaomi-basic-api-key.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Clarify Xiaomi MiMo Basic API-key setup by linking directly to the API Keys console and validating the documented `sk-xxxxx` pay-as-you-go key shape separately from Token Plan `tp-` credentials.

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -17,7 +17,7 @@ export const ROUTING_PROVIDER_API_KEY_URLS: Record<string, string> = {
   'opencode-zen': 'https://opencode.ai/auth',
   openrouter: 'https://openrouter.ai/keys',
   qwen: 'https://www.alibabacloud.com/help/en/model-studio/developer-reference/get-api-key',
-  xiaomi: 'https://platform.xiaomimimo.com/console',
+  xiaomi: 'https://platform.xiaomimimo.com/console/api-keys',
   xai: 'https://docs.x.ai/docs/api-reference',
   zai: 'https://z.ai/manage-apikey/apikey-list',
 };

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -145,6 +145,7 @@ describe('validateApiKey', () => {
 
   it('validates Xiaomi MiMo API key prefix and length', () => {
     const xiaomi = getProvider('xiaomi')!;
+    expect(xiaomi.keyPlaceholder).toBe('sk-xxxxx');
     expect(validateApiKey(xiaomi, '')).toEqual({
       valid: false,
       error: 'API key is required',
@@ -155,9 +156,9 @@ describe('validateApiKey', () => {
     });
     expect(validateApiKey(xiaomi, 'sk-short')).toEqual({
       valid: false,
-      error: 'Key is too short (minimum 10 characters)',
+      error: 'Key is too short (minimum 50 characters)',
     });
-    expect(validateApiKey(xiaomi, 'sk-mimo-valid')).toEqual({ valid: true });
+    expect(validateApiKey(xiaomi, `sk-${'a'.repeat(47)}`)).toEqual({ valid: true });
   });
 
   it('validates NVIDIA NIM key length without enforcing an undocumented prefix', () => {
@@ -600,7 +601,9 @@ describe('PROVIDERS', () => {
   });
 
   it('provides API-key and subscription-key URLs for Xiaomi MiMo', () => {
-    expect(getRoutingProviderApiKeyUrl('xiaomi')).toBe('https://platform.xiaomimimo.com/console');
+    expect(getRoutingProviderApiKeyUrl('xiaomi')).toBe(
+      'https://platform.xiaomimimo.com/console/api-keys',
+    );
     expect(getSubscriptionProviderKeyUrl('xiaomi')).toBe(
       'https://platform.xiaomimimo.com/token-plan',
     );

--- a/packages/shared/__tests__/providers.spec.ts
+++ b/packages/shared/__tests__/providers.spec.ts
@@ -178,7 +178,8 @@ describe('SHARED_PROVIDER_BY_ID', () => {
     expect(xiaomi!.displayName).toBe('Xiaomi MiMo');
     expect(xiaomi!.openRouterPrefixes).toEqual(['xiaomi']);
     expect(xiaomi!.keyPrefix).toBe('sk-');
-    expect(xiaomi!.minKeyLength).toBe(10);
+    expect(xiaomi!.minKeyLength).toBe(50);
+    expect(xiaomi!.keyPlaceholder).toBe('sk-xxxxx');
   });
 });
 

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -216,8 +216,8 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     localOnly: false,
     color: '#FF6900',
     keyPrefix: 'sk-',
-    minKeyLength: 10,
-    keyPlaceholder: 'sk-...',
+    minKeyLength: 50,
+    keyPlaceholder: 'sk-xxxxx',
   },
   {
     id: 'mistral',


### PR DESCRIPTION
## Summary

Clarifies Xiaomi MiMo's pay-as-you-go Basic API-key path separately from the existing Token Plan path.

- Link the API Key tab directly to Xiaomi MiMo's API Keys console.
- Update Xiaomi API-key placeholder and validation to match the documented `sk-xxxxx` key shape.
- Keep Token Plan `tp-` credentials and `token-plan-*` endpoints unchanged.

## Validation

- [x] `npm run build --workspace=packages/shared`
- [x] `npm test --workspace=packages/shared -- providers.spec.ts`
- [x] `npm test --workspace=packages/frontend -- providers.test.ts`
- [x] `npm test --workspace=packages/backend -- provider-endpoints.spec.ts provider-model-fetcher.service.spec.ts`
- [x] `npx prettier --check .changeset/xiaomi-basic-api-key.md packages/shared/src/providers.ts packages/shared/__tests__/providers.spec.ts packages/frontend/src/services/provider-api-key-urls.ts packages/frontend/tests/services/providers.test.ts`
- [x] `npx changeset status --since=upstream/main` (exits 0; no package bump listed because `manifest` is private in this workspace)
- [x] `git diff --check`

## Live smoke

- [x] Xiaomi MiMo pay-as-you-go `/v1/models` with a Basic `sk-` key returned HTTP 200 and 10 models.
- [x] Xiaomi MiMo pay-as-you-go `/v1/chat/completions` with `mimo-v2.5-pro` returned HTTP 200, `MIMO_SMOKE_OK`, and usage metadata.

The smoke key was passed only to one-off local processes and was not written to repository files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Xiaomi MiMo Basic API key setup for pay-as-you-go users to reduce setup errors. Updates validation and placeholder, and links directly to the API Keys console; Token Plan behavior is unchanged.

- **Bug Fixes**
  - Validate Xiaomi Basic keys as `sk-` with minimum length 50; placeholder `sk-xxxxx`.
  - Link API Key tab to `https://platform.xiaomimimo.com/console/api-keys`.
  - Keep Token Plan `tp-` credentials and `token-plan-*` endpoints unchanged.

<sup>Written for commit ca62d7b323058bf2a50462e76b0a4bb99d83a8a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

