### PR TITLE
Make the tenant-scoping upgrade safe on large databases

### DIFF
--- a/.changeset/tenant-refactor-deploy-safety.md
+++ b/.changeset/tenant-refactor-deploy-safety.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Harden the tenant-scoping upgrade for large production databases. The provider-lift migration now skips rows whose agent was already deleted instead of aborting the whole upgrade with a foreign-key error, and the multi-million-row agent-message attribution backfill runs as a throttled, resumable post-deploy job (`npm run backfill:message-providers`) instead of inside the boot transaction — so upgrading no longer holds a long lock on `agent_messages`.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,9 @@
     "migration:run": "typeorm-ts-node-commonjs migration:run -d src/database/datasource.ts",
     "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/database/datasource.ts",
     "migration:show": "typeorm-ts-node-commonjs migration:show -d src/database/datasource.ts",
-    "migration:create": "typeorm-ts-node-commonjs migration:create"
+    "migration:create": "typeorm-ts-node-commonjs migration:create",
+    "backfill:message-providers": "ts-node -T src/database/backfills/backfill-message-providers.cli.ts",
+    "backfill:message-providers:prod": "node dist/database/backfills/backfill-message-providers.cli.js"
   },
   "dependencies": {
     "manifest-shared": "*",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { ApiKeyGuard } from './common/guards/api-key.guard';
 import { ApiKey } from './entities/api-key.entity';
 import { SessionGuard } from './auth/session.guard';
 import { DatabaseModule } from './database/database.module';
+import { BackfillModule } from './database/backfills/backfill.module';
 import { AuthModule } from './auth/auth.module';
 import { HealthModule } from './health/health.module';
 import { AnalyticsModule } from './analytics/analytics.module';
@@ -78,6 +79,7 @@ const serveStaticImports = frontendPath
     SetupModule,
     FreeModelsModule,
     TelemetryModule,
+    BackfillModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: SessionGuard },

--- a/packages/backend/src/database/backfills/backfill-message-providers.cli.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.cli.spec.ts
@@ -1,0 +1,121 @@
+import { DataSource } from 'typeorm';
+
+import {
+  createBackfillDataSource,
+  main,
+  readBackfillOptions,
+} from './backfill-message-providers.cli';
+import { WINDOW_END_SQL } from './backfill-message-providers.gateway';
+
+describe('readBackfillOptions', () => {
+  it('parses numeric env knobs', () => {
+    expect(
+      readBackfillOptions({
+        BACKFILL_BATCH_SIZE: '5000',
+        BACKFILL_THROTTLE_MS: '100',
+        BACKFILL_LOCK_TIMEOUT_MS: '3000',
+        BACKFILL_STATEMENT_TIMEOUT_MS: '90000',
+        BACKFILL_MAX_RETRIES: '8',
+        BACKFILL_RETRY_BACKOFF_MS: '2000',
+      }),
+    ).toEqual({
+      batchSize: 5000,
+      throttleMs: 100,
+      lockTimeoutMs: 3000,
+      statementTimeoutMs: 90000,
+      maxRetries: 8,
+      retryBackoffMs: 2000,
+    });
+  });
+
+  it('leaves knobs undefined when absent, blank, or non-numeric', () => {
+    expect(readBackfillOptions({ BACKFILL_BATCH_SIZE: '', BACKFILL_THROTTLE_MS: 'abc' })).toEqual({
+      batchSize: undefined,
+      throttleMs: undefined,
+      lockTimeoutMs: undefined,
+      statementTimeoutMs: undefined,
+      maxRetries: undefined,
+      retryBackoffMs: undefined,
+    });
+    expect(readBackfillOptions({})).toEqual({
+      batchSize: undefined,
+      throttleMs: undefined,
+      lockTimeoutMs: undefined,
+      statementTimeoutMs: undefined,
+      maxRetries: undefined,
+      retryBackoffMs: undefined,
+    });
+  });
+});
+
+describe('createBackfillDataSource', () => {
+  const url = (ds: DataSource): unknown => (ds.options as { url?: string }).url;
+
+  it('prefers MIGRATION_DATABASE_URL, then DATABASE_URL, then a local default', () => {
+    expect(
+      url(
+        createBackfillDataSource({
+          MIGRATION_DATABASE_URL: 'postgres://m/x',
+          DATABASE_URL: 'postgres://d/y',
+        }),
+      ),
+    ).toBe('postgres://m/x');
+    expect(url(createBackfillDataSource({ DATABASE_URL: 'postgres://d/y' }))).toBe(
+      'postgres://d/y',
+    );
+    expect(url(createBackfillDataSource({}))).toContain('localhost:5432');
+  });
+});
+
+describe('main', () => {
+  function fakeDataSource(): DataSource & { initialize: jest.Mock; destroy: jest.Mock } {
+    const query = jest.fn(async (sql: string) => {
+      if (sql === WINDOW_END_SQL) {
+        return [{ end_id: null }];
+      }
+      return undefined;
+    });
+    return {
+      initialize: jest.fn(async () => undefined),
+      destroy: jest.fn(async () => undefined),
+      query,
+      createQueryRunner: jest.fn(),
+    } as unknown as DataSource & { initialize: jest.Mock; destroy: jest.Mock };
+  }
+
+  it('initializes, runs the backfill, logs the summary, and destroys the data source', async () => {
+    const dataSource = fakeDataSource();
+    const logger = { log: jest.fn(), error: jest.fn() };
+
+    const result = await main({ env: {}, logger, dataSource });
+
+    expect(result).toEqual({ windows: 0, stamped: 0 });
+    expect(dataSource.initialize).toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      'Backfill complete: stamped 0 message(s) across 0 window(s).',
+    );
+    expect(dataSource.destroy).toHaveBeenCalled();
+  });
+
+  it('destroys the data source even when the backfill throws', async () => {
+    const dataSource = fakeDataSource();
+    (dataSource.query as jest.Mock).mockRejectedValue(new Error('connection lost'));
+    const logger = { log: jest.fn(), error: jest.fn() };
+
+    await expect(main({ env: {}, logger, dataSource })).rejects.toThrow('connection lost');
+    expect(dataSource.destroy).toHaveBeenCalled();
+  });
+
+  it('defaults env and logger when not supplied', async () => {
+    const dataSource = fakeDataSource();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    try {
+      await main({ dataSource });
+      expect(logSpy).toHaveBeenCalledWith(
+        'Backfill complete: stamped 0 message(s) across 0 window(s).',
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/packages/backend/src/database/backfills/backfill-message-providers.cli.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.cli.ts
@@ -1,0 +1,69 @@
+import 'dotenv/config';
+import { DataSource } from 'typeorm';
+
+import {
+  BackfillOptions,
+  BackfillResult,
+  runMessageProviderBackfill,
+} from './backfill-message-providers';
+import { TypeOrmBackfillGateway } from './backfill-message-providers.gateway';
+
+const DEFAULT_DATABASE_URL = 'postgresql://myuser:mypassword@localhost:5432/mydatabase';
+
+/** Tunable knobs, read from the environment (all optional). */
+export function readBackfillOptions(env: NodeJS.ProcessEnv): BackfillOptions {
+  const num = (raw: string | undefined): number | undefined => {
+    if (raw === undefined || raw.trim() === '') {
+      return undefined;
+    }
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  };
+  return {
+    batchSize: num(env['BACKFILL_BATCH_SIZE']),
+    throttleMs: num(env['BACKFILL_THROTTLE_MS']),
+    lockTimeoutMs: num(env['BACKFILL_LOCK_TIMEOUT_MS']),
+    statementTimeoutMs: num(env['BACKFILL_STATEMENT_TIMEOUT_MS']),
+    maxRetries: num(env['BACKFILL_MAX_RETRIES']),
+    retryBackoffMs: num(env['BACKFILL_RETRY_BACKOFF_MS']),
+  };
+}
+
+/** A no-entity DataSource — the backfill is raw SQL, so it needs no metadata. */
+export function createBackfillDataSource(env: NodeJS.ProcessEnv): DataSource {
+  const url = env['MIGRATION_DATABASE_URL'] ?? env['DATABASE_URL'] ?? DEFAULT_DATABASE_URL;
+  return new DataSource({ type: 'postgres', url });
+}
+
+export interface MainDeps {
+  env?: NodeJS.ProcessEnv;
+  logger?: { log: (message: string) => void; error: (message: unknown) => void };
+  dataSource?: DataSource;
+}
+
+export async function main(deps: MainDeps = {}): Promise<BackfillResult> {
+  const env = deps.env ?? process.env;
+  const logger = deps.logger ?? console;
+  const dataSource = deps.dataSource ?? createBackfillDataSource(env);
+  await dataSource.initialize();
+  try {
+    const result = await runMessageProviderBackfill(new TypeOrmBackfillGateway(dataSource), {
+      ...readBackfillOptions(env),
+      logger,
+    });
+    logger.log(
+      `Backfill complete: stamped ${result.stamped} message(s) across ${result.windows} window(s).`,
+    );
+    return result;
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+/* istanbul ignore next -- thin process entrypoint, exercised on staging/prod, not in unit tests */
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/backend/src/database/backfills/backfill-message-providers.gateway.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.gateway.spec.ts
@@ -1,0 +1,114 @@
+import { DataSource } from 'typeorm';
+
+import {
+  PASS_1_SQL,
+  PASS_2_SQL,
+  PASS_3_SQL,
+  TypeOrmBackfillGateway,
+  WINDOW_END_SQL,
+} from './backfill-message-providers.gateway';
+
+function mockQueryRunner() {
+  return {
+    connect: jest.fn(async () => undefined),
+    startTransaction: jest.fn(async () => undefined),
+    commitTransaction: jest.fn(async () => undefined),
+    rollbackTransaction: jest.fn(async () => undefined),
+    release: jest.fn(async () => undefined),
+    query: jest.fn(),
+  };
+}
+
+describe('backfill SQL constants', () => {
+  it('target the post-rename schema and apply identical matching logic, scoped to a keyset window', () => {
+    for (const sql of [PASS_1_SQL, PASS_2_SQL, PASS_3_SQL]) {
+      expect(sql).toContain('SET "tenant_provider_id" = m.tp_id'); // renamed target column
+      expect(sql).toContain('JOIN "tenant_providers" tp'); // renamed source table
+      expect(sql).toContain('am2.id > $1 AND am2.id <= $2'); // keyset window
+      expect(sql).toContain('am2.tenant_provider_id IS NULL');
+      expect(sql).toContain('GROUP BY am2.id');
+      expect(sql).toContain('HAVING COUNT(*) = 1');
+      expect(sql).toContain('MIN(tp.id) AS tp_id');
+    }
+    // pass 1 matches the exact label; pass 2 ignores it; pass 3 joins via tenants
+    // using the renamed created_by_user_id (== original user_id).
+    expect(PASS_1_SQL).toContain("LOWER(COALESCE(am2.provider_key_label, 'Default'))");
+    expect(PASS_2_SQL).not.toContain('provider_key_label');
+    expect(PASS_3_SQL).toContain('JOIN "tenants" t ON t.id = am2.tenant_id');
+    expect(PASS_3_SQL).toContain('tp.created_by_user_id = t.name');
+    expect(WINDOW_END_SQL).toContain('ORDER BY id LIMIT $2');
+  });
+});
+
+describe('TypeOrmBackfillGateway', () => {
+  describe('nextWindowEnd', () => {
+    it('returns the window end id', async () => {
+      const query = jest.fn(async () => [{ end_id: 'id-9' }]);
+      const gw = new TypeOrmBackfillGateway({ query } as unknown as DataSource);
+      expect(await gw.nextWindowEnd('id-0', 100)).toBe('id-9');
+      expect(query).toHaveBeenCalledWith(WINDOW_END_SQL, ['id-0', 100]);
+    });
+
+    it('returns null when the window is empty or end_id is null', async () => {
+      const nullEnd = new TypeOrmBackfillGateway({
+        query: jest.fn(async () => [{ end_id: null }]),
+      } as unknown as DataSource);
+      expect(await nullEnd.nextWindowEnd('z', 100)).toBeNull();
+
+      const emptyRows = new TypeOrmBackfillGateway({
+        query: jest.fn(async () => []),
+      } as unknown as DataSource);
+      expect(await emptyRows.nextWindowEnd('z', 100)).toBeNull();
+    });
+  });
+
+  describe('stampWindow', () => {
+    it('runs the three passes in one timeout-guarded transaction and totals the stamped rows', async () => {
+      const qr = mockQueryRunner();
+      qr.query
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([{ n: 3 }])
+        .mockResolvedValueOnce([{ n: 2 }])
+        .mockResolvedValueOnce([{ n: 1 }]);
+      const ds = { createQueryRunner: jest.fn(() => qr) } as unknown as DataSource;
+
+      const stamped = await new TypeOrmBackfillGateway(ds).stampWindow('a', 'b', {
+        lockTimeoutMs: 5000,
+        statementTimeoutMs: 60000,
+      });
+
+      expect(stamped).toBe(6);
+      expect(qr.connect).toHaveBeenCalled();
+      expect(qr.startTransaction).toHaveBeenCalled();
+      expect(qr.query).toHaveBeenCalledWith("SET LOCAL lock_timeout = '5000ms'");
+      expect(qr.query).toHaveBeenCalledWith("SET LOCAL statement_timeout = '60000ms'");
+      expect(qr.query).toHaveBeenCalledWith(PASS_1_SQL, ['a', 'b']);
+      expect(qr.query).toHaveBeenCalledWith(PASS_2_SQL, ['a', 'b']);
+      expect(qr.query).toHaveBeenCalledWith(PASS_3_SQL, ['a', 'b']);
+      expect(qr.commitTransaction).toHaveBeenCalled();
+      expect(qr.rollbackTransaction).not.toHaveBeenCalled();
+      expect(qr.release).toHaveBeenCalled();
+    });
+
+    it('rolls back, releases, and rethrows on failure', async () => {
+      const qr = mockQueryRunner();
+      const boom = new Error('deadlock detected');
+      qr.query
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(boom);
+      const ds = { createQueryRunner: jest.fn(() => qr) } as unknown as DataSource;
+
+      await expect(
+        new TypeOrmBackfillGateway(ds).stampWindow('a', 'b', {
+          lockTimeoutMs: 1,
+          statementTimeoutMs: 1,
+        }),
+      ).rejects.toThrow('deadlock detected');
+      expect(qr.rollbackTransaction).toHaveBeenCalled();
+      expect(qr.commitTransaction).not.toHaveBeenCalled();
+      expect(qr.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/database/backfills/backfill-message-providers.gateway.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.gateway.ts
@@ -1,0 +1,115 @@
+import { DataSource } from 'typeorm';
+
+import { BackfillGateway, BackfillTimeouts } from './backfill-message-providers';
+
+/**
+ * Next keyset window upper bound: the largest id among the next `batchSize`
+ * ids strictly greater than `afterId`. Walks the PK index, never OFFSET.
+ */
+export const WINDOW_END_SQL = `
+  SELECT max(id) AS end_id
+  FROM (
+    SELECT id FROM "agent_messages" WHERE id > $1 ORDER BY id LIMIT $2
+  ) w
+`;
+
+/**
+ * The three stamping passes — identical matching logic to the original
+ * in-migration backfill, translated to the post-rename schema
+ * (tenant_provider_id / tenant_providers / created_by_user_id) and with ONLY
+ * the keyset window `am2.id > $1 AND am2.id <= $2` added. Wrapped in a CTE so
+ * each returns how many rows it stamped without shipping every updated row.
+ */
+function stampingPass(joinAndMatch: string): string {
+  return `
+    WITH upd AS (
+      UPDATE "agent_messages" am
+      SET "tenant_provider_id" = m.tp_id
+      FROM (
+        SELECT am2.id AS msg_id, MIN(tp.id) AS tp_id
+        ${joinAndMatch}
+        GROUP BY am2.id
+        HAVING COUNT(*) = 1
+      ) m
+      WHERE am.id = m.msg_id
+      RETURNING 1
+    )
+    SELECT count(*)::int AS n FROM upd
+  `;
+}
+
+// Pass 1 (agent-exact): agent_id + provider + auth_type + label.
+export const PASS_1_SQL = stampingPass(`
+  FROM "agent_messages" am2
+  JOIN "tenant_providers" tp
+    ON tp.agent_id = am2.agent_id
+   AND LOWER(tp.provider) = LOWER(am2.provider)
+   AND tp.auth_type = am2.auth_type
+   AND LOWER(tp.label) = LOWER(COALESCE(am2.provider_key_label, 'Default'))
+  WHERE am2.tenant_provider_id IS NULL
+    AND am2.provider IS NOT NULL
+    AND am2.agent_id IS NOT NULL
+    AND am2.id > $1 AND am2.id <= $2
+`);
+
+// Pass 2 (agent-unique): same agent anchor, ignore label.
+export const PASS_2_SQL = stampingPass(`
+  FROM "agent_messages" am2
+  JOIN "tenant_providers" tp
+    ON tp.agent_id = am2.agent_id
+   AND LOWER(tp.provider) = LOWER(am2.provider)
+   AND tp.auth_type = am2.auth_type
+  WHERE am2.tenant_provider_id IS NULL
+    AND am2.provider IS NOT NULL
+    AND am2.agent_id IS NOT NULL
+    AND am2.id > $1 AND am2.id <= $2
+`);
+
+// Pass 3 (user-level): match via tenants.name = tenant_providers.created_by_user_id
+// (created_by_user_id is the renamed, value-preserved user_id).
+export const PASS_3_SQL = stampingPass(`
+  FROM "agent_messages" am2
+  JOIN "tenants" t ON t.id = am2.tenant_id
+  JOIN "tenant_providers" tp
+    ON tp.created_by_user_id = t.name
+   AND LOWER(tp.provider) = LOWER(am2.provider)
+   AND tp.auth_type = am2.auth_type
+   AND LOWER(tp.label) = LOWER(COALESCE(am2.provider_key_label, 'Default'))
+  WHERE am2.tenant_provider_id IS NULL
+    AND am2.provider IS NOT NULL
+    AND am2.id > $1 AND am2.id <= $2
+`);
+
+/** DataSource-backed gateway. The orchestrator stays database-agnostic. */
+export class TypeOrmBackfillGateway implements BackfillGateway {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async nextWindowEnd(afterId: string, batchSize: number): Promise<string | null> {
+    const rows = (await this.dataSource.query(WINDOW_END_SQL, [afterId, batchSize])) as {
+      end_id: string | null;
+    }[];
+    return rows[0]?.end_id ?? null;
+  }
+
+  async stampWindow(afterId: string, endId: string, timeouts: BackfillTimeouts): Promise<number> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      // SET LOCAL is transaction-scoped and PgBouncer-transaction-pool safe.
+      await queryRunner.query(`SET LOCAL lock_timeout = '${timeouts.lockTimeoutMs}ms'`);
+      await queryRunner.query(`SET LOCAL statement_timeout = '${timeouts.statementTimeoutMs}ms'`);
+      const params = [afterId, endId];
+      const [{ n: n1 }] = (await queryRunner.query(PASS_1_SQL, params)) as { n: number }[];
+      const [{ n: n2 }] = (await queryRunner.query(PASS_2_SQL, params)) as { n: number }[];
+      const [{ n: n3 }] = (await queryRunner.query(PASS_3_SQL, params)) as { n: number }[];
+      await queryRunner.commitTransaction();
+      return n1 + n2 + n3;
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}

--- a/packages/backend/src/database/backfills/backfill-message-providers.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.spec.ts
@@ -1,0 +1,158 @@
+import {
+  BackfillGateway,
+  BackfillTimeouts,
+  DEFAULT_BACKFILL_OPTIONS,
+  isRetryableBackfillError,
+  runMessageProviderBackfill,
+} from './backfill-message-providers';
+
+function gatewayWith(ends: (string | null)[], stampPerWindow = 5): jest.Mocked<BackfillGateway> {
+  let call = 0;
+  return {
+    nextWindowEnd: jest.fn(async (_afterId: string, _batchSize: number) => ends[call++] ?? null),
+    stampWindow: jest.fn(
+      async (_afterId: string, _endId: string, _timeouts: BackfillTimeouts) => stampPerWindow,
+    ),
+  };
+}
+
+describe('runMessageProviderBackfill', () => {
+  it('walks keyset windows until nextWindowEnd returns null, summing stamped counts', async () => {
+    const gateway = gatewayWith(['id-10', 'id-20', null]);
+    const sleep = jest.fn(async () => undefined);
+
+    const result = await runMessageProviderBackfill(gateway, { sleep, throttleMs: 10 });
+
+    expect(result).toEqual({ windows: 2, stamped: 10 });
+    expect(gateway.nextWindowEnd).toHaveBeenNthCalledWith(
+      1,
+      '',
+      DEFAULT_BACKFILL_OPTIONS.batchSize,
+    );
+    expect(gateway.nextWindowEnd).toHaveBeenNthCalledWith(
+      2,
+      'id-10',
+      DEFAULT_BACKFILL_OPTIONS.batchSize,
+    );
+    expect(gateway.stampWindow).toHaveBeenNthCalledWith(1, '', 'id-10', expect.any(Object));
+    expect(gateway.stampWindow).toHaveBeenNthCalledWith(2, 'id-10', 'id-20', expect.any(Object));
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(10);
+  });
+
+  it('does nothing but report zero when there are no rows to stamp', async () => {
+    const gateway = gatewayWith([null]);
+
+    const result = await runMessageProviderBackfill(gateway, { throttleMs: 0 });
+
+    expect(result).toEqual({ windows: 0, stamped: 0 });
+    expect(gateway.stampWindow).not.toHaveBeenCalled();
+  });
+
+  it('passes configured timeouts through to each window and skips sleep when throttle is 0', async () => {
+    const gateway = gatewayWith(['id-10', null]);
+    const sleep = jest.fn(async () => undefined);
+
+    await runMessageProviderBackfill(gateway, {
+      sleep,
+      throttleMs: 0,
+      lockTimeoutMs: 1234,
+      statementTimeoutMs: 5678,
+    });
+
+    expect(gateway.stampWindow).toHaveBeenCalledWith('', 'id-10', {
+      lockTimeoutMs: 1234,
+      statementTimeoutMs: 5678,
+    });
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('emits a progress log every 25 windows', async () => {
+    const ends: (string | null)[] = Array.from({ length: 25 }, (_, i) => `id-${i}`);
+    ends.push(null);
+    const gateway = gatewayWith(ends, 1);
+    const logger = { log: jest.fn() };
+
+    await runMessageProviderBackfill(gateway, { sleep: jest.fn(async () => undefined), logger });
+
+    expect(logger.log).toHaveBeenCalledWith(
+      'backfill: 25 window(s) processed, 25 message(s) stamped so far',
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      'backfill: done — stamped 25 message(s) across 25 window(s)',
+    );
+  });
+
+  it('falls back to a real timer-based sleep when none is injected', async () => {
+    const gateway = gatewayWith(['id-10', null], 2);
+
+    const result = await runMessageProviderBackfill(gateway, { throttleMs: 1 });
+
+    expect(result).toEqual({ windows: 1, stamped: 2 });
+  });
+
+  it('retries a window that hits a transient error, then continues', async () => {
+    const gateway = gatewayWith(['id-10', null]);
+    gateway.stampWindow
+      .mockRejectedValueOnce(new Error('canceling statement due to statement timeout'))
+      .mockResolvedValueOnce(7);
+    const sleep = jest.fn(async () => undefined);
+    const logger = { log: jest.fn() };
+
+    const result = await runMessageProviderBackfill(gateway, {
+      sleep,
+      throttleMs: 0,
+      retryBackoffMs: 10,
+      logger,
+    });
+
+    expect(result).toEqual({ windows: 1, stamped: 7 });
+    expect(gateway.stampWindow).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(10); // retryBackoffMs * attempt 1
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('retrying'));
+  });
+
+  it('gives up after maxRetries consecutive transient failures', async () => {
+    const gateway = gatewayWith(['id-10', null]);
+    gateway.stampWindow.mockRejectedValue(new Error('deadlock detected'));
+
+    await expect(
+      runMessageProviderBackfill(gateway, {
+        sleep: jest.fn(async () => undefined),
+        maxRetries: 2,
+        retryBackoffMs: 1,
+      }),
+    ).rejects.toThrow('deadlock detected');
+    expect(gateway.stampWindow).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it('does not retry a non-retryable error', async () => {
+    const gateway = gatewayWith(['id-10', null]);
+    gateway.stampWindow.mockRejectedValue(new Error('column "x" does not exist'));
+
+    await expect(
+      runMessageProviderBackfill(gateway, { sleep: jest.fn(async () => undefined) }),
+    ).rejects.toThrow('does not exist');
+    expect(gateway.stampWindow).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isRetryableBackfillError', () => {
+  it('flags transient database errors as retryable', () => {
+    for (const message of [
+      'canceling statement due to statement timeout',
+      'deadlock detected',
+      'canceling statement due to lock timeout',
+      'connection terminated unexpectedly',
+      'read ECONNRESET',
+    ]) {
+      expect(isRetryableBackfillError(new Error(message))).toBe(true);
+    }
+  });
+
+  it('treats logic/schema errors and non-Error values as non-retryable', () => {
+    expect(isRetryableBackfillError(new Error('column "x" does not exist'))).toBe(false);
+    expect(isRetryableBackfillError('some string')).toBe(false);
+    expect(isRetryableBackfillError(null)).toBe(false);
+  });
+});

--- a/packages/backend/src/database/backfills/backfill-message-providers.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.ts
@@ -1,0 +1,177 @@
+/**
+ * Post-deploy backfill for `agent_messages.tenant_provider_id`.
+ *
+ * The tenant-refactor migrations add the column (+ FK + covering index) but
+ * deliberately do NOT stamp pre-upgrade history inline: on a multi-million-row
+ * table that held an ACCESS EXCLUSIVE lock on `agent_messages` for the whole
+ * (12–30+ min) backfill, locking the live app out of its main table. This runs
+ * that stamping OUT of the boot transaction, in throttled keyset batches.
+ *
+ * It runs AFTER the full migration batch, so it targets the FINAL schema names:
+ * `agent_messages.tenant_provider_id` (was user_provider_id) matched against
+ * `tenant_providers` (was user_providers), whose `created_by_user_id` (was
+ * user_id) carries the original user id. Those are pure RENAMEs, so the values
+ * are unchanged and the matching is identical to the original in-migration
+ * backfill — proven row-for-row against it on a production-data replica.
+ *
+ * Equivalence: the three passes are the original matching logic, in precedence
+ * order, with ONLY a keyset window `am2.id > $1 AND am2.id <= $2` added. Each
+ * message's assignment depends only on its own columns and the (static)
+ * tenant_providers table, so windowing cannot change any per-row result. Passes
+ * run in one short transaction per window; an earlier (more precise) stamp
+ * excludes the row from later passes via `am2.tenant_provider_id IS NULL`.
+ *
+ * Refs: ankane/strong_migrations (backfill in batches), GitLab batched
+ * background migrations (batch sizing + throttle), Sequin (keyset cursors).
+ */
+
+export const DEFAULT_BACKFILL_OPTIONS = {
+  /** Rows per keyset window (one short transaction). */
+  batchSize: 10_000,
+  /** Pause between windows to spare the primary and read replicas. */
+  throttleMs: 50,
+  /** Per-window lock wait ceiling — fail fast instead of queueing behind app load. */
+  lockTimeoutMs: 5_000,
+  /** Per-statement runtime ceiling inside a window. */
+  statementTimeoutMs: 60_000,
+  /** Retries for a window that hits a transient error (timeout/deadlock/conn). */
+  maxRetries: 5,
+  /** Base backoff between retries (multiplied by the attempt number). */
+  retryBackoffMs: 1_000,
+} as const;
+
+// A window rolls back cleanly on failure, so these transient conditions are
+// safe to retry: a slow window (autovacuum/IO spike) tripping statement_timeout,
+// brief lock contention, a deadlock, or a dropped connection.
+const RETRYABLE_ERROR =
+  /statement timeout|lock timeout|deadlock|connection terminated|connection closed|ECONNRESET|ETIMEDOUT|server closed the connection/i;
+
+export function isRetryableBackfillError(error: unknown): boolean {
+  return RETRYABLE_ERROR.test(error instanceof Error ? error.message : String(error));
+}
+
+export interface BackfillTimeouts {
+  lockTimeoutMs: number;
+  statementTimeoutMs: number;
+}
+
+export interface BackfillOptions {
+  batchSize?: number;
+  throttleMs?: number;
+  lockTimeoutMs?: number;
+  statementTimeoutMs?: number;
+  maxRetries?: number;
+  retryBackoffMs?: number;
+  logger?: { log: (message: string) => void };
+  /** Injectable for tests; defaults to a real setTimeout-based sleep. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface BackfillResult {
+  windows: number;
+  stamped: number;
+}
+
+/**
+ * Database operations the backfill needs. Kept narrow so the orchestrator is
+ * pure logic over a gateway and unit-testable without a database.
+ */
+export interface BackfillGateway {
+  /**
+   * Upper bound (inclusive) of the next keyset window of size `batchSize`
+   * containing ids strictly greater than `afterId`, or null when no rows remain.
+   */
+  nextWindowEnd(afterId: string, batchSize: number): Promise<string | null>;
+  /**
+   * Run the three stamping passes for ids in `(afterId, endId]` inside one
+   * short, timeout-guarded transaction. Returns the number of rows stamped.
+   */
+  stampWindow(afterId: string, endId: string, timeouts: BackfillTimeouts): Promise<number>;
+}
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/** Stamp one window, retrying transient failures (the window rolls back cleanly). */
+async function stampWindowWithRetry(
+  gateway: BackfillGateway,
+  afterId: string,
+  endId: string,
+  timeouts: BackfillTimeouts,
+  maxRetries: number,
+  retryBackoffMs: number,
+  sleep: (ms: number) => Promise<void>,
+  log: (message: string) => void,
+): Promise<number> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await gateway.stampWindow(afterId, endId, timeouts);
+    } catch (error) {
+      attempt += 1;
+      if (attempt > maxRetries || !isRetryableBackfillError(error)) {
+        throw error;
+      }
+      const reason = error instanceof Error ? error.message : String(error);
+      log(
+        `backfill: window after "${afterId}" failed (attempt ${attempt}/${maxRetries}: ${reason}); retrying`,
+      );
+      await sleep(retryBackoffMs * attempt);
+    }
+  }
+}
+
+/**
+ * Stamp every keyset window in id order. Idempotent and resumable — re-running
+ * only re-touches rows still NULL (new messages are already stamped at proxy
+ * time), so an interrupted run is safe to restart from the beginning.
+ */
+export async function runMessageProviderBackfill(
+  gateway: BackfillGateway,
+  options: BackfillOptions = {},
+): Promise<BackfillResult> {
+  const batchSize = options.batchSize ?? DEFAULT_BACKFILL_OPTIONS.batchSize;
+  const throttleMs = options.throttleMs ?? DEFAULT_BACKFILL_OPTIONS.throttleMs;
+  const timeouts: BackfillTimeouts = {
+    lockTimeoutMs: options.lockTimeoutMs ?? DEFAULT_BACKFILL_OPTIONS.lockTimeoutMs,
+    statementTimeoutMs: options.statementTimeoutMs ?? DEFAULT_BACKFILL_OPTIONS.statementTimeoutMs,
+  };
+  const sleep = options.sleep ?? realSleep;
+  const maxRetries = options.maxRetries ?? DEFAULT_BACKFILL_OPTIONS.maxRetries;
+  const retryBackoffMs = options.retryBackoffMs ?? DEFAULT_BACKFILL_OPTIONS.retryBackoffMs;
+  const log = (message: string): void => options.logger?.log(message);
+
+  let afterId = '';
+  let windows = 0;
+  let stamped = 0;
+
+  for (;;) {
+    const endId = await gateway.nextWindowEnd(afterId, batchSize);
+    if (endId === null) {
+      break;
+    }
+    stamped += await stampWindowWithRetry(
+      gateway,
+      afterId,
+      endId,
+      timeouts,
+      maxRetries,
+      retryBackoffMs,
+      sleep,
+      log,
+    );
+    windows += 1;
+    afterId = endId;
+    if (windows % 25 === 0) {
+      log(`backfill: ${windows} window(s) processed, ${stamped} message(s) stamped so far`);
+    }
+    if (throttleMs > 0) {
+      await sleep(throttleMs);
+    }
+  }
+
+  log(`backfill: done — stamped ${stamped} message(s) across ${windows} window(s)`);
+  return { windows, stamped };
+}

--- a/packages/backend/src/database/backfills/backfill.module.ts
+++ b/packages/backend/src/database/backfills/backfill.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { BackfillState } from '../../entities/backfill-state.entity';
+import { MessageProviderBackfillBootService } from './message-provider-backfill.boot.service';
+
+/**
+ * Wires the post-deploy backfill boot task. The DataSource is provided globally
+ * by DatabaseModule; this only needs the BackfillState marker repository.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([BackfillState])],
+  providers: [MessageProviderBackfillBootService],
+})
+export class BackfillModule {}

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
@@ -1,0 +1,176 @@
+import { Logger } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+
+import { BackfillState } from '../../entities/backfill-state.entity';
+import {
+  MESSAGE_PROVIDER_BACKFILL_LOCK_KEY,
+  MESSAGE_PROVIDER_BACKFILL_NAME,
+  MessageProviderBackfillBootService,
+} from './message-provider-backfill.boot.service';
+
+function makeLock(locked: boolean) {
+  return {
+    connect: jest.fn(async () => undefined),
+    release: jest.fn(async () => undefined),
+    query: jest.fn(async (sql: string) =>
+      sql.includes('pg_try_advisory_lock') ? [{ locked }] : undefined,
+    ),
+  };
+}
+
+function makeState(completed: boolean) {
+  const execute = jest.fn(async () => undefined);
+  const orIgnore = jest.fn(() => ({ execute }));
+  const values = jest.fn(() => ({ orIgnore }));
+  const into = jest.fn(() => ({ values }));
+  const insert = jest.fn(() => ({ into }));
+  const createQueryBuilder = jest.fn(() => ({ insert }));
+  const countBy = jest.fn(async () => (completed ? 1 : 0));
+  const repo = { countBy, createQueryBuilder } as unknown as Repository<BackfillState>;
+  return { repo, countBy, createQueryBuilder, insert, into, values, orIgnore, execute };
+}
+
+const UNLOCK = 'SELECT pg_advisory_unlock($1)';
+const TRYLOCK = 'SELECT pg_try_advisory_lock($1) AS locked';
+
+describe('MessageProviderBackfillBootService', () => {
+  let logSpy: jest.SpyInstance;
+  let errSpy: jest.SpyInstance;
+  const originalEnv = process.env['NODE_ENV'];
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    errSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    process.env['NODE_ENV'] = originalEnv;
+  });
+
+  describe('onApplicationBootstrap', () => {
+    it('does nothing outside production', () => {
+      process.env['NODE_ENV'] = 'test';
+      const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
+      new MessageProviderBackfillBootService(ds, makeState(false).repo).onApplicationBootstrap();
+      expect(ds.createQueryRunner).not.toHaveBeenCalled();
+    });
+
+    it('fires the backfill in production and logs (not throws) on failure', async () => {
+      process.env['NODE_ENV'] = 'production';
+      const state = makeState(false);
+      state.countBy.mockRejectedValue(new Error('db down'));
+      const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
+
+      new MessageProviderBackfillBootService(ds, state.repo).onApplicationBootstrap();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('post-deploy backfill failed'));
+    });
+  });
+
+  describe('runOnce', () => {
+    it('returns immediately when already marked complete', async () => {
+      const state = makeState(true);
+      const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
+      const runner = jest.fn();
+      await new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner);
+      expect(ds.createQueryRunner).not.toHaveBeenCalled();
+      expect(runner).not.toHaveBeenCalled();
+    });
+
+    it('skips (without unlocking) when another instance holds the advisory lock', async () => {
+      const lock = makeLock(false);
+      const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+      const runner = jest.fn();
+      await new MessageProviderBackfillBootService(ds, makeState(false).repo).runOnce(runner);
+      expect(lock.query).toHaveBeenCalledWith(TRYLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
+      expect(runner).not.toHaveBeenCalled();
+      expect(lock.query).not.toHaveBeenCalledWith(UNLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
+      expect(lock.release).toHaveBeenCalled();
+    });
+
+    it('runs the backfill under the lock, marks complete, then unlocks and releases', async () => {
+      const lock = makeLock(true);
+      const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+      const state = makeState(false);
+      const runner = jest.fn(async () => ({ windows: 3, stamped: 42 }));
+
+      await new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner);
+
+      expect(runner).toHaveBeenCalledWith(
+        ds,
+        expect.objectContaining({ logger: expect.anything() }),
+      );
+      expect(state.values).toHaveBeenCalledWith({ name: MESSAGE_PROVIDER_BACKFILL_NAME });
+      expect(state.execute).toHaveBeenCalled();
+      expect(lock.query).toHaveBeenCalledWith(UNLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
+      expect(lock.release).toHaveBeenCalled();
+    });
+
+    it('re-checks under the lock and skips the run if a peer finished first', async () => {
+      const lock = makeLock(true);
+      const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+      const state = makeState(false);
+      state.countBy.mockResolvedValueOnce(0).mockResolvedValueOnce(1); // free, then taken
+      const runner = jest.fn();
+
+      await new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner);
+
+      expect(runner).not.toHaveBeenCalled();
+      expect(lock.query).toHaveBeenCalledWith(UNLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
+      expect(lock.release).toHaveBeenCalled();
+    });
+
+    it('unlocks and releases even if the backfill throws', async () => {
+      const lock = makeLock(true);
+      const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+      const runner = jest.fn(async () => {
+        throw new Error('boom');
+      });
+
+      await expect(
+        new MessageProviderBackfillBootService(ds, makeState(false).repo).runOnce(runner),
+      ).rejects.toThrow('boom');
+      expect(lock.query).toHaveBeenCalledWith(UNLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
+      expect(lock.release).toHaveBeenCalled();
+    });
+
+    it('swallows an unlock failure in the finally block (still releases, no throw)', async () => {
+      const lock = {
+        connect: jest.fn(async () => undefined),
+        release: jest.fn(async () => undefined),
+        query: jest.fn(async (sql: string) => {
+          if (sql.includes('pg_try_advisory_lock')) {
+            return [{ locked: true }];
+          }
+          throw new Error('unlock failed');
+        }),
+      };
+      const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+      const runner = jest.fn(async () => ({ windows: 1, stamped: 1 }));
+
+      await expect(
+        new MessageProviderBackfillBootService(ds, makeState(false).repo).runOnce(runner),
+      ).resolves.toBeUndefined();
+      expect(lock.release).toHaveBeenCalled();
+    });
+
+    it('defaults to the real backfill runner when none is injected', async () => {
+      const lock = makeLock(true);
+      const ds = {
+        createQueryRunner: jest.fn(() => lock),
+        // gateway.nextWindowEnd → no rows → backfill completes with zero windows
+        query: jest.fn(async (sql: string) =>
+          sql.includes('FROM "agent_messages"') ? [{ end_id: null }] : undefined,
+        ),
+      } as unknown as DataSource;
+      const state = makeState(false);
+
+      await new MessageProviderBackfillBootService(ds, state.repo).runOnce();
+
+      expect(state.execute).toHaveBeenCalled(); // ran to completion → marked done
+      expect(lock.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
@@ -1,0 +1,114 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+
+import { BackfillState } from '../../entities/backfill-state.entity';
+import {
+  BackfillOptions,
+  BackfillResult,
+  runMessageProviderBackfill,
+} from './backfill-message-providers';
+import { TypeOrmBackfillGateway } from './backfill-message-providers.gateway';
+
+/** Marker name in `backfill_state`; presence == this backfill has finished. */
+export const MESSAGE_PROVIDER_BACKFILL_NAME = 'agent_message_provider_attribution';
+/** Stable advisory-lock key so only one app instance runs the backfill at once. */
+export const MESSAGE_PROVIDER_BACKFILL_LOCK_KEY = 1792000000;
+
+export type BackfillRunner = (
+  dataSource: DataSource,
+  options: BackfillOptions,
+) => Promise<BackfillResult>;
+
+const defaultRunner: BackfillRunner = (dataSource, options) =>
+  runMessageProviderBackfill(new TypeOrmBackfillGateway(dataSource), options);
+
+/**
+ * Runs the post-deploy agent-message attribution backfill automatically, once,
+ * after the app is up — so operators never have to invoke the CLI by hand.
+ *
+ * - Production only (like telemetry); dev/test never auto-run it.
+ * - Fire-and-forget from onApplicationBootstrap: never blocks readiness/health
+ *   and never crashes boot.
+ * - Single-runner across replicas via a Postgres advisory lock.
+ * - Exactly once per install via the `backfill_state` marker. The backfill is
+ *   idempotent + resumable, so a crash mid-run simply re-runs on the next boot
+ *   (the marker is only written on success).
+ *
+ * It calls the same `runMessageProviderBackfill` as `npm run
+ * backfill:message-providers`, so the data it writes is identical either way.
+ */
+@Injectable()
+export class MessageProviderBackfillBootService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(MessageProviderBackfillBootService.name);
+
+  constructor(
+    private readonly dataSource: DataSource,
+    @InjectRepository(BackfillState)
+    private readonly stateRepo: Repository<BackfillState>,
+  ) {}
+
+  onApplicationBootstrap(): void {
+    // Only on real deploys, and never await — boot must not wait on the backfill.
+    if (process.env['NODE_ENV'] !== 'production') {
+      return;
+    }
+    void this.runOnce().catch((error) => {
+      this.logger.error(
+        `post-deploy backfill failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  }
+
+  /** `runner` is injectable for tests; production uses the real backfill. */
+  async runOnce(runner: BackfillRunner = defaultRunner): Promise<void> {
+    if (await this.isCompleted()) {
+      return;
+    }
+    const lock = this.dataSource.createQueryRunner();
+    await lock.connect();
+    let acquired = false;
+    try {
+      const rows = (await lock.query('SELECT pg_try_advisory_lock($1) AS locked', [
+        MESSAGE_PROVIDER_BACKFILL_LOCK_KEY,
+      ])) as { locked: boolean }[];
+      acquired = rows[0]?.locked === true;
+      if (!acquired) {
+        this.logger.log('another instance is running the backfill; skipping');
+        return;
+      }
+      // Re-check under the lock: a peer may have finished between the first
+      // check and acquiring the lock.
+      if (await this.isCompleted()) {
+        return;
+      }
+      this.logger.log('running post-deploy agent-message attribution backfill…');
+      const result = await runner(this.dataSource, { logger: this.logger });
+      await this.markCompleted();
+      this.logger.log(
+        `post-deploy backfill complete: stamped ${result.stamped} message(s) across ${result.windows} window(s)`,
+      );
+    } finally {
+      if (acquired) {
+        await lock
+          .query('SELECT pg_advisory_unlock($1)', [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY])
+          .catch(() => undefined);
+      }
+      await lock.release();
+    }
+  }
+
+  private async isCompleted(): Promise<boolean> {
+    return (await this.stateRepo.countBy({ name: MESSAGE_PROVIDER_BACKFILL_NAME })) > 0;
+  }
+
+  private async markCompleted(): Promise<void> {
+    await this.stateRepo
+      .createQueryBuilder()
+      .insert()
+      .into(BackfillState)
+      .values({ name: MESSAGE_PROVIDER_BACKFILL_NAME })
+      .orIgnore()
+      .execute();
+  }
+}

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -19,6 +19,7 @@ import { CustomProvider } from '../entities/custom-provider.entity';
 import { SpecificityAssignment } from '../entities/specificity-assignment.entity';
 import { HeaderTier } from '../entities/header-tier.entity';
 import { InstallMetadata } from '../entities/install-metadata.entity';
+import { BackfillState } from '../entities/backfill-state.entity';
 import { MessageRecording } from '../entities/message-recording.entity';
 import { AgentModelParams } from '../entities/agent-model-params.entity';
 import { PlaygroundRun } from '../entities/playground-run.entity';
@@ -125,6 +126,7 @@ import { TenantOwnerColumn1792400000000 } from './migrations/1792400000000-Tenan
 import { TenantProviders1792500000000 } from './migrations/1792500000000-TenantProviders';
 import { TenantScopedConfigs1792600000000 } from './migrations/1792600000000-TenantScopedConfigs';
 import { DropUserScopeFromRouting1792700000000 } from './migrations/1792700000000-DropUserScopeFromRouting';
+import { AddBackfillStateTable1792800000000 } from './migrations/1792800000000-AddBackfillStateTable';
 
 const entities = [
   AgentMessage,
@@ -150,6 +152,7 @@ const entities = [
   PlaygroundColumn,
   ReasoningContentCacheEntry,
   AgentEnabledProvider,
+  BackfillState,
 ];
 
 const migrations = [
@@ -250,6 +253,7 @@ const migrations = [
   TenantProviders1792500000000,
   TenantScopedConfigs1792600000000,
   DropUserScopeFromRouting1792700000000,
+  AddBackfillStateTable1792800000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
@@ -22,6 +22,21 @@ describe('LiftProvidersToUserLevel1791000000000', () => {
       ),
     ).toBe(true);
     expect(queries.some((q) => q.includes('ALTER COLUMN "agent_id" DROP NOT NULL'))).toBe(true);
+  });
+
+  it('only attaches providers whose agent still exists so the FK cannot abort the backfill', async () => {
+    // Legacy user_providers can carry a dangling agent_id (no FK existed before
+    // this migration); without this guard the agent FK rejects the row and rolls
+    // back the entire tenant-refactor migration on real data.
+    await migration.up(queryRunner);
+    const backfill = queries.find(
+      (q) =>
+        q.includes('INSERT INTO "agent_provider_access"') && q.includes('FROM "user_providers"'),
+    );
+    expect(backfill).toBeDefined();
+    expect(backfill).toContain(
+      'AND EXISTS (SELECT 1 FROM "agents" a WHERE a."id" = "user_providers"."agent_id")',
+    );
     const relabel = queries.find((q) => q.includes('WITH colliding_labels AS'));
     expect(relabel).toBeDefined();
     expect(relabel).toContain('WITH colliding_labels AS');

--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
@@ -34,11 +34,17 @@ export class LiftProvidersToUserLevel1791000000000 implements MigrationInterface
   `);
 
     // 2. Backfill each old agent-scoped provider row as an explicit attachment.
+    //    Skip rows whose agent was hard-deleted: legacy user_providers can still
+    //    carry a dangling agent_id (no FK existed before this migration), and
+    //    FK_agent_provider_access_agent above would reject it and abort the whole
+    //    migration. The provider row itself survives as a user-global connection;
+    //    only the grant to the now-missing agent is dropped.
     await queryRunner.query(`
     INSERT INTO "agent_provider_access" ("agent_id", "user_provider_id")
     SELECT "agent_id", "id"
     FROM "user_providers"
     WHERE "agent_id" IS NOT NULL
+      AND EXISTS (SELECT 1 FROM "agents" a WHERE a."id" = "user_providers"."agent_id")
     ON CONFLICT DO NOTHING
   `);
 

--- a/packages/backend/src/database/migrations/1792000000000-AddUserProviderIdToAgentMessages.spec.ts
+++ b/packages/backend/src/database/migrations/1792000000000-AddUserProviderIdToAgentMessages.spec.ts
@@ -1,145 +1,66 @@
-import { Logger } from '@nestjs/common';
 import { QueryRunner } from 'typeorm';
+
 import { AddUserProviderIdToAgentMessages1792000000000 } from './1792000000000-AddUserProviderIdToAgentMessages';
 
 describe('AddUserProviderIdToAgentMessages1792000000000', () => {
-  let migration: AddUserProviderIdToAgentMessages1792000000000;
+  const migration = new AddUserProviderIdToAgentMessages1792000000000();
   let queries: string[];
-  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
-  let logSpy: jest.SpyInstance;
+  let queryRunner: QueryRunner;
 
   beforeEach(() => {
-    migration = new AddUserProviderIdToAgentMessages1792000000000();
     queries = [];
     queryRunner = {
-      query: jest.fn(async (sql: string): Promise<unknown> => {
+      query: jest.fn(async (sql: string) => {
         queries.push(sql);
-        if (sql.includes('FILTER (WHERE user_provider_id IS NOT NULL)')) {
-          return [{ matched: 7, remaining: 3 }];
-        }
-        return undefined;
-      }) as unknown as jest.Mocked<Pick<QueryRunner, 'query'>>['query'],
-    };
-    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    logSpy.mockRestore();
+      }),
+    } as unknown as QueryRunner;
   });
 
   describe('up', () => {
     it('adds the nullable column first, with IF NOT EXISTS', async () => {
-      await migration.up(queryRunner as unknown as QueryRunner);
+      await migration.up(queryRunner);
 
       expect(queries[0]).toContain(
         'ALTER TABLE "agent_messages" ADD COLUMN IF NOT EXISTS "user_provider_id" varchar',
       );
     });
 
-    it('runs three separate backfill UPDATEs, each guarded by user_provider_id IS NULL so earlier stamps exclude rows from later passes', async () => {
-      await migration.up(queryRunner as unknown as QueryRunner);
+    it('adds the FK with ON DELETE SET NULL (validated — trivial against an all-NULL column)', async () => {
+      await migration.up(queryRunner);
 
-      const updates = queries.filter((q) => q.includes('UPDATE "agent_messages" am'));
-      expect(updates).toHaveLength(3);
-      for (const update of updates) {
-        expect(update).toContain('WHERE am2.user_provider_id IS NULL');
-        expect(update).toContain('AND am2.provider IS NOT NULL');
-        expect(update).toContain('MIN(up.id) AS up_id');
-        expect(update).toContain('GROUP BY am2.id');
-        expect(update).toContain('HAVING COUNT(*) = 1');
-        expect(update).toContain('WHERE am.id = m.msg_id');
-      }
-    });
-
-    it('pass 1 anchors on the agent and matches the exact (provider, auth_type, label) tuple', async () => {
-      await migration.up(queryRunner as unknown as QueryRunner);
-
-      const pass1 = queries.filter((q) => q.includes('UPDATE "agent_messages" am'))[0];
-      expect(pass1).toContain('ON up.agent_id = am2.agent_id');
-      expect(pass1).toContain('LOWER(up.provider) = LOWER(am2.provider)');
-      expect(pass1).toContain('up.auth_type = am2.auth_type');
-      expect(pass1).toContain(
-        `LOWER(up.label) = LOWER(COALESCE(am2.provider_key_label, 'Default'))`,
-      );
-      expect(pass1).toContain('AND am2.agent_id IS NOT NULL');
-      // Agent-anchored: must not detour through tenants.
-      expect(pass1).not.toContain('JOIN "tenants"');
-    });
-
-    it('pass 2 anchors on the agent but ignores the label (covers lift-relabeled rows)', async () => {
-      await migration.up(queryRunner as unknown as QueryRunner);
-
-      const pass2 = queries.filter((q) => q.includes('UPDATE "agent_messages" am'))[1];
-      expect(pass2).toContain('ON up.agent_id = am2.agent_id');
-      expect(pass2).toContain('LOWER(up.provider) = LOWER(am2.provider)');
-      expect(pass2).toContain('up.auth_type = am2.auth_type');
-      expect(pass2).toContain('AND am2.agent_id IS NOT NULL');
-      expect(pass2).not.toContain('provider_key_label');
-      expect(pass2).not.toContain('up.label');
-      expect(pass2).not.toContain('JOIN "tenants"');
-    });
-
-    it('pass 3 keeps the user-level label match via tenants for deleted-agent / NULL agent_id messages', async () => {
-      await migration.up(queryRunner as unknown as QueryRunner);
-
-      const pass3 = queries.filter((q) => q.includes('UPDATE "agent_messages" am'))[2];
-      expect(pass3).toContain('JOIN "tenants" t ON t.id = am2.tenant_id');
-      expect(pass3).toContain('ON up.user_id = t.name');
-      expect(pass3).toContain('LOWER(up.provider) = LOWER(am2.provider)');
-      expect(pass3).toContain('up.auth_type = am2.auth_type');
-      expect(pass3).toContain(
-        `LOWER(up.label) = LOWER(COALESCE(am2.provider_key_label, 'Default'))`,
-      );
-      // User-level: must not require an agent anchor.
-      expect(pass3).not.toContain('up.agent_id = am2.agent_id');
-      expect(pass3).not.toContain('am2.agent_id IS NOT NULL');
-    });
-
-    it('logs the backfill outcome with matched/remaining counts and the pass summary', async () => {
-      await migration.up(queryRunner as unknown as QueryRunner);
-
-      const countSql = queries.find((q) =>
-        q.includes('FILTER (WHERE user_provider_id IS NOT NULL)'),
-      );
-      expect(countSql).toBeDefined();
-      expect(countSql).toContain('FILTER (WHERE user_provider_id IS NULL)');
-      expect(logSpy).toHaveBeenCalledTimes(1);
-      const message = logSpy.mock.calls[0][0] as string;
-      expect(message).toContain('Backfilled user_provider_id on 7 message(s)');
-      expect(message).toContain('three passes');
-      expect(message).toContain('agent-exact label, agent-unique key, user-level label');
-      expect(message).toContain('3 left NULL');
-    });
-
-    it('adds the FK with ON DELETE SET NULL and the covering index, after the backfill', async () => {
-      await migration.up(queryRunner as unknown as QueryRunner);
-
-      const fkIdx = queries.findIndex((q) =>
+      const fk = queries.find((q) =>
         q.includes('ADD CONSTRAINT "FK_agent_messages_user_provider"'),
       );
-      const indexIdx = queries.findIndex((q) =>
+      expect(fk).toBeDefined();
+      expect(fk).toContain('FOREIGN KEY ("user_provider_id") REFERENCES "user_providers"("id")');
+      expect(fk).toContain('ON DELETE SET NULL ON UPDATE NO ACTION');
+      // Validated, not NOT VALID — the column is empty so there is nothing to scan.
+      expect(fk).not.toContain('NOT VALID');
+    });
+
+    it('builds the covering index in the migration (TenantProviders later renames it)', async () => {
+      await migration.up(queryRunner);
+
+      const idx = queries.find((q) =>
         q.includes('CREATE INDEX "IDX_agent_messages_user_provider"'),
       );
-      const lastUpdateIdx = queries
-        .map((q, i) => (q.includes('UPDATE "agent_messages" am') ? i : -1))
-        .filter((i) => i >= 0)
-        .pop() as number;
+      expect(idx).toBeDefined();
+      expect(idx).toContain('"user_provider_id", "tenant_id", "timestamp" DESC');
+    });
 
-      expect(queries[fkIdx]).toContain(
-        'FOREIGN KEY ("user_provider_id") REFERENCES "user_providers"("id")',
-      );
-      expect(queries[fkIdx]).toContain('ON DELETE SET NULL ON UPDATE NO ACTION');
-      expect(queries[indexIdx]).toContain('("user_provider_id", "tenant_id", "timestamp" DESC)');
-      expect(fkIdx).toBeGreaterThan(lastUpdateIdx);
-      expect(indexIdx).toBeGreaterThan(fkIdx);
+    it('does no inline historical backfill — that runs post-deploy', async () => {
+      await migration.up(queryRunner);
+
+      expect(queries.some((q) => q.includes('UPDATE "agent_messages"'))).toBe(false);
+      // add column, add FK, create index — nothing else.
+      expect(queries).toHaveLength(3);
     });
   });
 
   describe('down', () => {
     it('drops the index, then the FK, then the column', async () => {
-      await migration.down(queryRunner as unknown as QueryRunner);
+      await migration.down(queryRunner);
 
-      expect(queries).toHaveLength(3);
       expect(queries[0]).toContain('DROP INDEX IF EXISTS "IDX_agent_messages_user_provider"');
       expect(queries[1]).toContain('DROP CONSTRAINT IF EXISTS "FK_agent_messages_user_provider"');
       expect(queries[2]).toContain('DROP COLUMN IF EXISTS "user_provider_id"');

--- a/packages/backend/src/database/migrations/1792000000000-AddUserProviderIdToAgentMessages.ts
+++ b/packages/backend/src/database/migrations/1792000000000-AddUserProviderIdToAgentMessages.ts
@@ -1,4 +1,3 @@
-import { Logger } from '@nestjs/common';
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 /**
@@ -9,16 +8,23 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * added key showed a sibling key's usage. We add a nullable `user_provider_id`
  * stamped at proxy time and filter per-connection views on it instead.
  *
- * The whole migration runs inside the single boot transaction
- * (migrationsTransactionMode: 'all'), so CREATE INDEX CONCURRENTLY is not
- * usable here — a plain index build briefly locks `agent_messages` writes.
- * Fine at current scale; large self-hosted installs should expect a short
- * write stall the first time this migration runs.
+ * This migration does ONLY metadata-only / structural work that is safe inside
+ * the single boot transaction: add the nullable column, add the FK (trivially
+ * valid — every row is NULL at this point), and build the covering index. The
+ * index must exist here because a later migration (TenantProviders) renames it
+ * along with the column and FK; it cannot be deferred out-of-band.
+ *
+ * The historical backfill of `user_provider_id` is NOT done here. On a
+ * multi-million-row `agent_messages` table it stamps most rows, and inside the
+ * boot transaction it held an ACCESS EXCLUSIVE lock for 12–30+ minutes,
+ * locking the live app out of its main table for the whole deploy. It now runs
+ * post-deploy, batched and throttled, against the FINAL (post-rename) schema —
+ * see packages/backend/src/database/backfills/backfill-message-providers.ts and
+ * `npm run backfill:message-providers`. New messages are stamped at proxy time,
+ * so only pre-upgrade history relies on the backfill.
  */
 export class AddUserProviderIdToAgentMessages1792000000000 implements MigrationInterface {
   name = 'AddUserProviderIdToAgentMessages1792000000000';
-
-  private readonly logger = new Logger(AddUserProviderIdToAgentMessages1792000000000.name);
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Nullable add → metadata-only, no table rewrite even on a large table.
@@ -26,104 +32,9 @@ export class AddUserProviderIdToAgentMessages1792000000000 implements MigrationI
       `ALTER TABLE "agent_messages" ADD COLUMN IF NOT EXISTS "user_provider_id" varchar`,
     );
 
-    // Best-effort backfill of pre-upgrade history, in three passes. Each pass
-    // only touches rows still NULL, so an earlier (more precise) stamp excludes
-    // the message from every later pass. Where 0 or >1 keys match within a
-    // pass, the row falls through — and if no pass resolves it, it stays NULL:
-    // ambiguous history correctly stays out of every per-connection view.
-    //
-    // Pass 1 (agent-exact): match on the message's own agent via
-    // user_providers.agent_id — the legacy column LiftProvidersToUserLevel
-    // deliberately kept (nullable, values intact) — plus provider, auth_type,
-    // and label. Pre-lift, (agent_id, provider, auth_type, LOWER(label)) was
-    // unique, so this is precise wherever the lift did not relabel the row.
-    await queryRunner.query(`
-      UPDATE "agent_messages" am
-      SET "user_provider_id" = m.up_id
-      FROM (
-        SELECT am2.id AS msg_id, MIN(up.id) AS up_id
-        FROM "agent_messages" am2
-        JOIN "user_providers" up
-          ON up.agent_id = am2.agent_id
-         AND LOWER(up.provider) = LOWER(am2.provider)
-         AND up.auth_type = am2.auth_type
-         AND LOWER(up.label) = LOWER(COALESCE(am2.provider_key_label, 'Default'))
-        WHERE am2.user_provider_id IS NULL
-          AND am2.provider IS NOT NULL
-          AND am2.agent_id IS NOT NULL
-        GROUP BY am2.id
-        HAVING COUNT(*) = 1
-      ) m
-      WHERE am.id = m.msg_id
-    `);
-
-    // Pass 2 (agent-unique): same agent_id anchor but ignore the label. When
-    // an agent had exactly ONE key for that provider + auth_type, the label is
-    // irrelevant — this covers rows the lift relabeled (e.g. 'Default' →
-    // 'from Agent One'), where the stored provider_key_label no longer matches.
-    await queryRunner.query(`
-      UPDATE "agent_messages" am
-      SET "user_provider_id" = m.up_id
-      FROM (
-        SELECT am2.id AS msg_id, MIN(up.id) AS up_id
-        FROM "agent_messages" am2
-        JOIN "user_providers" up
-          ON up.agent_id = am2.agent_id
-         AND LOWER(up.provider) = LOWER(am2.provider)
-         AND up.auth_type = am2.auth_type
-        WHERE am2.user_provider_id IS NULL
-          AND am2.provider IS NOT NULL
-          AND am2.agent_id IS NOT NULL
-        GROUP BY am2.id
-        HAVING COUNT(*) = 1
-      ) m
-      WHERE am.id = m.msg_id
-    `);
-
-    // Pass 3 (user-level): stamp a message only when exactly ONE key matches
-    // its (provider, auth_type, label) tuple for the owning user. The user is
-    // reached via tenants.name = user_providers.user_id (tenant.name holds the
-    // user id). This catches messages from deleted agents / NULL agent_id that
-    // the agent-anchored passes cannot reach.
-    await queryRunner.query(`
-      UPDATE "agent_messages" am
-      SET "user_provider_id" = m.up_id
-      FROM (
-        SELECT am2.id AS msg_id, MIN(up.id) AS up_id
-        FROM "agent_messages" am2
-        JOIN "tenants" t ON t.id = am2.tenant_id
-        JOIN "user_providers" up
-          ON up.user_id = t.name
-         AND LOWER(up.provider) = LOWER(am2.provider)
-         AND up.auth_type = am2.auth_type
-         AND LOWER(up.label) = LOWER(COALESCE(am2.provider_key_label, 'Default'))
-        WHERE am2.user_provider_id IS NULL
-          AND am2.provider IS NOT NULL
-        GROUP BY am2.id
-        HAVING COUNT(*) = 1
-      ) m
-      WHERE am.id = m.msg_id
-    `);
-
-    // Surface the backfill outcome so operators can see the pre-upgrade history
-    // gap. Everything still NULL is ambiguous, local/Ollama, blind-proxy, or
-    // simply had no matching connection — all expected.
-    const [{ matched, remaining }] = (await queryRunner.query(`
-      SELECT
-        COUNT(*) FILTER (WHERE user_provider_id IS NOT NULL)::int AS matched,
-        COUNT(*) FILTER (WHERE user_provider_id IS NULL)::int AS remaining
-      FROM "agent_messages"
-    `)) as { matched: number; remaining: number }[];
-    this.logger.log(
-      `Backfilled user_provider_id on ${matched} message(s) across the three passes ` +
-        `(agent-exact label, agent-unique key, user-level label); ${remaining} left NULL ` +
-        `(ambiguous, local/Ollama, or no matching connection).`,
-    );
-
     // ON DELETE SET NULL, not CASCADE: disconnecting a provider must never
-    // delete its billing/usage history. Disconnect is a soft delete today
-    // (is_active = false), so this fires only on a true hard delete such as an
-    // account purge — and then the rows survive with a NULL connection.
+    // delete its billing/usage history. The column is entirely NULL here, so
+    // validation is instant — no scan of agent_messages.
     await queryRunner.query(`
       ALTER TABLE "agent_messages"
       ADD CONSTRAINT "FK_agent_messages_user_provider"
@@ -133,9 +44,9 @@ export class AddUserProviderIdToAgentMessages1792000000000 implements MigrationI
 
     // user_provider_id leads so this one index serves both the connection-detail
     // reads (WHERE user_provider_id = X AND tenant_id = Y ORDER BY timestamp DESC)
-    // and the FK's ON DELETE SET NULL lookup (WHERE user_provider_id = X). An
-    // index leading with tenant_id would leave the parent-delete cleanup to a
-    // sequential scan of agent_messages.
+    // and the FK's ON DELETE SET NULL lookup (WHERE user_provider_id = X). Built
+    // here against an all-NULL column (cheap) before the post-deploy backfill
+    // populates it; TenantProviders later renames it to IDX_agent_messages_tenant_provider.
     await queryRunner.query(
       `CREATE INDEX "IDX_agent_messages_user_provider" ON "agent_messages" ("user_provider_id", "tenant_id", "timestamp" DESC)`,
     );

--- a/packages/backend/src/database/migrations/1792800000000-AddBackfillStateTable.spec.ts
+++ b/packages/backend/src/database/migrations/1792800000000-AddBackfillStateTable.spec.ts
@@ -1,0 +1,29 @@
+import { QueryRunner } from 'typeorm';
+
+import { AddBackfillStateTable1792800000000 } from './1792800000000-AddBackfillStateTable';
+
+describe('AddBackfillStateTable1792800000000', () => {
+  const migration = new AddBackfillStateTable1792800000000();
+  let queries: string[];
+  let queryRunner: QueryRunner;
+
+  beforeEach(() => {
+    queries = [];
+    queryRunner = {
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+      }),
+    } as unknown as QueryRunner;
+  });
+
+  it('creates the backfill_state marker table, keyed by name', async () => {
+    await migration.up(queryRunner);
+    expect(queries[0]).toContain('CREATE TABLE IF NOT EXISTS "backfill_state"');
+    expect(queries[0]).toContain('PRIMARY KEY ("name")');
+  });
+
+  it('drops the table on down', async () => {
+    await migration.down(queryRunner);
+    expect(queries[0]).toContain('DROP TABLE IF EXISTS "backfill_state"');
+  });
+});

--- a/packages/backend/src/database/migrations/1792800000000-AddBackfillStateTable.ts
+++ b/packages/backend/src/database/migrations/1792800000000-AddBackfillStateTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Marker table for one-time post-deploy backfills. A row is written when a
+ * named backfill finishes so the boot task that runs it does so exactly once
+ * per install. Metadata-only CREATE — instant, no impact on the lock window.
+ */
+export class AddBackfillStateTable1792800000000 implements MigrationInterface {
+  name = 'AddBackfillStateTable1792800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS "backfill_state" (
+        "name" varchar NOT NULL,
+        "completed_at" timestamp NOT NULL DEFAULT NOW(),
+        CONSTRAINT "PK_backfill_state" PRIMARY KEY ("name")
+      )`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "backfill_state"`);
+  }
+}

--- a/packages/backend/src/entities/backfill-state.entity.ts
+++ b/packages/backend/src/entities/backfill-state.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryColumn, Column } from 'typeorm';
+
+import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
+
+/**
+ * One row per completed one-time data backfill, keyed by a stable name. The
+ * post-deploy backfill boot task inserts its row when finished, so the backfill
+ * runs exactly once per install instead of on every boot.
+ */
+@Entity('backfill_state')
+export class BackfillState {
+  @PrimaryColumn('varchar')
+  name!: string;
+
+  @Column(timestampType(), { default: timestampDefault() })
+  completed_at!: string;
+}

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -40,6 +40,7 @@ import { PlaygroundRun } from '../src/entities/playground-run.entity';
 import { PlaygroundColumn } from '../src/entities/playground-column.entity';
 import { ReasoningContentCacheEntry } from '../src/entities/reasoning-content-cache-entry.entity';
 import { AgentEnabledProvider } from '../src/entities/agent-enabled-provider.entity';
+import { BackfillState } from '../src/entities/backfill-state.entity';
 import { HealthModule } from '../src/health/health.module';
 import { AnalyticsModule } from '../src/analytics/analytics.module';
 import { OtlpModule } from '../src/otlp/otlp.module';
@@ -82,6 +83,7 @@ const entities = [
   PlaygroundColumn,
   ReasoningContentCacheEntry,
   AgentEnabledProvider,
+  BackfillState,
 ];
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 const OPENROUTER_MODELS_FIXTURE = {


### PR DESCRIPTION
## Why

Rehearsing the tenant-scoping migration batch against a **restore of the production database** (3.6M `agent_messages`, ~10k providers) surfaced two deploy blockers that an empty staging DB hides completely:

1. **The upgrade aborts on real data.** `LiftProvidersToUserLevel` builds `agent_provider_access` with a strict FK to `agents`, then backfills it from `user_providers`. Hundreds of provider rows reference already-deleted agents, so the first orphan trips the FK and rolls back the whole batch. Empty staging has no orphans, so it passes — and lies.
2. **The upgrade locks the live app for 12–30+ minutes.** `AddUserProviderIdToAgentMessages` stamped attribution on every historical row inside the single boot transaction. The `ADD COLUMN` takes an `ACCESS EXCLUSIVE` lock held until commit, so for the entire backfill the app can't read or write `agent_messages` (observed: a query blocked behind it for 27 minutes).

## What

**1. Skip orphaned providers** — the lift backfill skips rows whose agent no longer exists; the provider survives as a user-global connection.

**2. Move the historical backfill out of the boot transaction.** The migration now only adds the column, FK, and covering index (the index must stay here — `TenantProviders` renames it in the same batch). That drops the boot lock window from 12–30+ min to **~38s** (the index build).

**3. The backfill runs itself after deploy.** A production-only, fire-and-forget boot task (`MessageProviderBackfillBootService`) runs the attribution backfill automatically once the app is up — **no manual step**. It's:
- guarded by a Postgres **advisory lock** (one replica at a time) and a `backfill_state` marker (**exactly once** per install; idempotent + resumable),
- **non-blocking** — never delays readiness/health or crashes boot,
- throttled keyset batches with `lock_timeout`/`statement_timeout` guards + transient-error retries.

The same logic is also runnable by hand: `npm run backfill:message-providers` (env-tunable: `BACKFILL_BATCH_SIZE`, `BACKFILL_THROTTLE_MS`, …). New messages are stamped at proxy time, so only pre-upgrade history relies on this.

## Validation (on the production-data replica)

| | before | after |
|---|---|---|
| Upgrade outcome | ❌ aborts on FK | ✅ all migrations apply |
| Boot lock window | 12–30+ min | **~38s** (index build) |
| Historical backfill | inside boot txn — locks the table | post-deploy, **non-blocking**, **auto-run** |

- **Data is byte-identical to the original inline backfill** — verified two ways: a full diff of the batched backfill vs. the original 3-pass logic (**0 differing rows / 3,641,842 messages**), and a scoped diff of the **auto-triggered** output on the live replica (**0 differing**).
- End-to-end on staging: app boots with the new wiring, `AddBackfillStateTable` migration runs, and the boot task fires + stamps automatically.
- Non-blocking confirmed (concurrent reads stayed instant during the backfill). Backend unit suite green (6,651 tests); 100% line coverage on the backfill module; `tsc` + lint clean.

## Operational notes

- **The ~38s boot lock is the index build** on 3.6M rows — unavoidable in-transaction because `TenantProviders` renames that index in the same batch. Deploy off-peak.
- **Nothing to run by hand** — the backfill auto-starts post-deploy and finishes in the background (fast on the internal network; only pre-upgrade history depends on it).
- Patterns follow ankane/strong_migrations (index/FK handling, batched backfill), GitLab batched background migrations (batch sizing + throttle + retry), and Sequin (keyset cursors).
