### PR TITLE
Fix the e2e test broken by moving the backfill out-of-band

### DIFF
--- a/packages/backend/test/user-provider-backfill-migrations.e2e-spec.ts
+++ b/packages/backend/test/user-provider-backfill-migrations.e2e-spec.ts
@@ -2,34 +2,35 @@ import { DataSource } from 'typeorm';
 import { LiftProvidersToUserLevel1791000000000 } from '../src/database/migrations/1791000000000-LiftProvidersToUserLevel';
 import { RenameProviderAccessToEnabledProviders1791800000000 } from '../src/database/migrations/1791800000000-RenameProviderAccessToEnabledProviders';
 import { AddUserProviderIdToAgentMessages1792000000000 } from '../src/database/migrations/1792000000000-AddUserProviderIdToAgentMessages';
-// origin/next's tenant-canonical rename sits on top of this migration
-// (user_providers → tenant_providers, agent_messages.user_provider_id →
-// tenant_provider_id). This pre-lift reproduction operates in the
-// user_providers world, so we unwind that rename first before rewinding our
-// own migrations back to the pre-lift shape.
 import { TenantOwnerColumn1792400000000 } from '../src/database/migrations/1792400000000-TenantOwnerColumn';
 import { TenantProviders1792500000000 } from '../src/database/migrations/1792500000000-TenantProviders';
 import { TenantScopedConfigs1792600000000 } from '../src/database/migrations/1792600000000-TenantScopedConfigs';
 import { DropUserScopeFromRouting1792700000000 } from '../src/database/migrations/1792700000000-DropUserScopeFromRouting';
+import { runMessageProviderBackfill } from '../src/database/backfills/backfill-message-providers';
+import { TypeOrmBackfillGateway } from '../src/database/backfills/backfill-message-providers.gateway';
 
 const DB_URL =
   process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/manifest_duprepro';
 
 /**
- * Live-upgrade reproduction for the user_provider_id backfill. A real
- * pre-lift database has the SAME provider connected on multiple agents, all
- * labeled 'Default'. LiftProvidersToUserLevel then RELABELS the colliding
- * rows ('Default' → 'from <agent>'), so the original single-pass user-level
+ * Live-upgrade reproduction for the message → connection attribution backfill.
+ * A real pre-lift database has the SAME provider connected on multiple agents,
+ * all labeled 'Default'. LiftProvidersToUserLevel then RELABELS the colliding
+ * rows ('Default' → 'from <agent>'), so a naive single-pass user-level
  * (provider, auth_type, label) backfill matched NOTHING for those users and
  * left every pre-upgrade message NULL. The three-pass backfill must instead
- * anchor on user_providers.agent_id (kept by the lift) and stamp each message
+ * anchor on the connection's agent_id (kept by the lift) and stamp each message
  * with the RIGHT connection.
  *
- * The spec builds the migrated schema, reverts back to the pre-lift shape
- * (AddUserProviderId.down → Rename.down → Lift.down), seeds pre-lift data,
- * then replays the real chain (Lift.up → Rename.up → AddUserProviderId.up).
+ * That backfill no longer runs inside the migration (it would lock
+ * agent_messages for the whole deploy); it runs post-deploy via
+ * runMessageProviderBackfill, against the FINAL schema (user_providers →
+ * tenant_providers, user_provider_id → tenant_provider_id). So this spec builds
+ * the migrated schema, rewinds to the pre-lift shape, seeds pre-lift data,
+ * replays the real upgrade chain THROUGH the tenant rename, then runs the
+ * out-of-band backfill and asserts the stamping.
  */
-describe('AddUserProviderIdToAgentMessages backfill after provider lift (e2e)', () => {
+describe('agent-message attribution backfill after provider lift (e2e)', () => {
   let ds: DataSource;
 
   beforeAll(async () => {
@@ -55,9 +56,6 @@ describe('AddUserProviderIdToAgentMessages backfill after provider lift (e2e)', 
     await ds.query(`DELETE FROM "tenants"`);
 
     const rewindQr = ds.createQueryRunner();
-    // First unwind next's tenant-canonical layer so the schema is back in the
-    // user_providers world (tenant_providers → user_providers, tenant_provider_id
-    // → user_provider_id), then rewind our own migrations to the pre-lift shape.
     await new DropUserScopeFromRouting1792700000000().down(rewindQr);
     await new TenantScopedConfigs1792600000000().down(rewindQr);
     await new TenantProviders1792500000000().down(rewindQr);
@@ -92,7 +90,7 @@ describe('AddUserProviderIdToAgentMessages backfill after provider lift (e2e)', 
          ('up-a3-gemini','u-1','a3','gemini','enc-5','api_key','Default',0,true, now(), now())`,
     );
 
-    // Pre-upgrade messages (user_provider_id column does not exist yet).
+    // Pre-upgrade messages (the attribution column does not exist yet).
     await ds.query(
       `INSERT INTO "agent_messages"
          ("id","tenant_id","agent_id","timestamp","provider","auth_type","provider_key_label")
@@ -104,12 +102,20 @@ describe('AddUserProviderIdToAgentMessages backfill after provider lift (e2e)', 
          ('msg-deleted-agent','t1',NULL, now(),'gemini','api_key','Default')`,
     );
 
-    // Replay the real upgrade chain.
+    // Replay the real upgrade chain, including the tenant rename that turns
+    // user_provider_id into tenant_provider_id.
     const upgradeQr = ds.createQueryRunner();
     await new LiftProvidersToUserLevel1791000000000().up(upgradeQr);
     await new RenameProviderAccessToEnabledProviders1791800000000().up(upgradeQr);
     await new AddUserProviderIdToAgentMessages1792000000000().up(upgradeQr);
+    await new TenantOwnerColumn1792400000000().up(upgradeQr);
+    await new TenantProviders1792500000000().up(upgradeQr);
     await upgradeQr.release();
+
+    // The migration leaves the column NULL; the historical stamping runs
+    // post-deploy, against the renamed schema. This is the exact code the
+    // boot task and `npm run backfill:message-providers` invoke.
+    await runMessageProviderBackfill(new TypeOrmBackfillGateway(ds), { throttleMs: 0 });
   }, 60000);
 
   afterAll(async () => {
@@ -118,7 +124,7 @@ describe('AddUserProviderIdToAgentMessages backfill after provider lift (e2e)', 
 
   it('sanity: the lift relabeled both colliding anthropic connections away from Default', async () => {
     const rows: { id: string; label: string }[] = await ds.query(
-      `SELECT "id","label" FROM "user_providers"
+      `SELECT "id","label" FROM "tenant_providers"
         WHERE "id" IN ('up-a1-anthropic','up-a2-anthropic') ORDER BY "id"`,
     );
     expect(rows).toEqual([
@@ -129,43 +135,43 @@ describe('AddUserProviderIdToAgentMessages backfill after provider lift (e2e)', 
 
   it('pass 2 stamps relabeled single-key-per-agent messages with the RIGHT connection per agent', async () => {
     // Both messages carry label 'Default', which no anthropic connection has
-    // anymore — the old user-level backfill left BOTH NULL. The agent anchor
+    // anymore — a user-level backfill would leave BOTH NULL. The agent anchor
     // resolves each to its own agent's key.
-    const rows: { id: string; user_provider_id: string | null }[] = await ds.query(
-      `SELECT "id","user_provider_id" FROM "agent_messages"
+    const rows: { id: string; tenant_provider_id: string | null }[] = await ds.query(
+      `SELECT "id","tenant_provider_id" FROM "agent_messages"
         WHERE "id" IN ('msg-a1-anthropic','msg-a2-anthropic') ORDER BY "id"`,
     );
     expect(rows).toEqual([
-      { id: 'msg-a1-anthropic', user_provider_id: 'up-a1-anthropic' },
-      { id: 'msg-a2-anthropic', user_provider_id: 'up-a2-anthropic' },
+      { id: 'msg-a1-anthropic', tenant_provider_id: 'up-a1-anthropic' },
+      { id: 'msg-a2-anthropic', tenant_provider_id: 'up-a2-anthropic' },
     ]);
   });
 
   it('pass 1 stamps a label-exact message even when the agent has multiple keys for the provider', async () => {
-    const rows: { user_provider_id: string | null }[] = await ds.query(
-      `SELECT "user_provider_id" FROM "agent_messages" WHERE "id" = 'msg-a2-openai-work'`,
+    const rows: { tenant_provider_id: string | null }[] = await ds.query(
+      `SELECT "tenant_provider_id" FROM "agent_messages" WHERE "id" = 'msg-a2-openai-work'`,
     );
-    expect(rows).toEqual([{ user_provider_id: 'up-a2-openai-work' }]);
+    expect(rows).toEqual([{ tenant_provider_id: 'up-a2-openai-work' }]);
   });
 
   it('leaves a genuinely ambiguous message NULL (two keys on the agent, no label match)', async () => {
-    const rows: { user_provider_id: string | null }[] = await ds.query(
-      `SELECT "user_provider_id" FROM "agent_messages" WHERE "id" = 'msg-a2-openai-ambiguous'`,
+    const rows: { tenant_provider_id: string | null }[] = await ds.query(
+      `SELECT "tenant_provider_id" FROM "agent_messages" WHERE "id" = 'msg-a2-openai-ambiguous'`,
     );
-    expect(rows).toEqual([{ user_provider_id: null }]);
+    expect(rows).toEqual([{ tenant_provider_id: null }]);
   });
 
   it('pass 3 still resolves deleted-agent (NULL agent_id) messages via the user-level label match', async () => {
-    const rows: { user_provider_id: string | null }[] = await ds.query(
-      `SELECT "user_provider_id" FROM "agent_messages" WHERE "id" = 'msg-deleted-agent'`,
+    const rows: { tenant_provider_id: string | null }[] = await ds.query(
+      `SELECT "tenant_provider_id" FROM "agent_messages" WHERE "id" = 'msg-deleted-agent'`,
     );
-    expect(rows).toEqual([{ user_provider_id: 'up-a3-gemini' }]);
+    expect(rows).toEqual([{ tenant_provider_id: 'up-a3-gemini' }]);
   });
 
-  it('recreates the FK (ON DELETE SET NULL) and the covering index', async () => {
+  it('the migration left the FK (ON DELETE SET NULL) and covering index in place (renamed)', async () => {
     const fks: { confdeltype: string }[] = await ds.query(
       `SELECT confdeltype FROM pg_constraint
-        WHERE conname = 'FK_agent_messages_user_provider'
+        WHERE conname = 'FK_agent_messages_tenant_provider'
           AND conrelid = '"agent_messages"'::regclass`,
     );
     expect(fks).toHaveLength(1);
@@ -174,7 +180,7 @@ describe('AddUserProviderIdToAgentMessages backfill after provider lift (e2e)', 
     const idx: { indexname: string }[] = await ds.query(
       `SELECT indexname FROM pg_indexes
         WHERE tablename = 'agent_messages'
-          AND indexname = 'IDX_agent_messages_user_provider'`,
+          AND indexname = 'IDX_agent_messages_tenant_provider'`,
     );
     expect(idx).toHaveLength(1);
   });


### PR DESCRIPTION
#2264 moved the agent-message attribution backfill out of the `AddUserProviderIdToAgentMessages` migration (so it no longer locks `agent_messages` during deploy). The migration-reproduction e2e (`user-provider-backfill-migrations.e2e-spec.ts`) still asserted the migration stamped the column inline, so its pass-1/2/3 cases failed on `next` (CI: Backend (PostgreSQL) red; Codecov red downstream of the incomplete e2e coverage upload).

This updates the spec to match the new flow: it replays the upgrade chain **through the tenant rename** (so the column becomes `tenant_provider_id`) and then runs the real out-of-band `runMessageProviderBackfill` — the exact code the boot task and CLI invoke — asserting the same per-connection attribution.

Verified locally against PostgreSQL: the spec passes and the **full e2e suite is 35 suites / 301 tests green**, tsc + lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the attribution backfill e2e by aligning it with the out-of-band backfill and the tenant rename. The test now replays the real upgrade path and runs the same backfill used in production to restore green CI.

- **Bug Fixes**
  - Replays the upgrade chain through the tenant rename so the schema is `tenant_providers`/`tenant_provider_id`.
  - Runs the real out-of-band backfill via `runMessageProviderBackfill` using `TypeOrmBackfillGateway` (no inline migration stamping).
  - Updates assertions to target `tenant_provider_id`, `tenant_providers`, and the renamed FK/index, keeping the pass 1/2/3 coverage.

<sup>Written for commit 2fc54669300ff2d0c5658a4741de2e76fb67f03d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

