### PR TITLE
Make coverage checks non-blocking on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,10 +6,14 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        # Coverage is reported on every PR but does not block merges.
+        informational: true
     patch:
       default:
         target: auto
         threshold: 5%
+        # Coverage is reported on every PR but does not block merges.
+        informational: true
 flags:
   backend:
     paths:


### PR DESCRIPTION
## What
Sets `informational: true` on both codecov status checks (`project` and `patch`).

## Why
Coverage stays reported on every PR — the codecov comment and both status lines still appear — but they no longer **block** merges. Recent `next → main` release cuts were gated by these checks on coverage-merge artifacts rather than genuine regressions, forcing manual bypasses. Reporting-without-blocking keeps the signal while removing the friction.

## Tradeoff
This disables coverage *enforcement* repo-wide: a PR can drop coverage without failing CI. Revert by removing the two `informational: true` lines if stricter gating is wanted later.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make coverage checks non-blocking on PRs by setting `informational: true` for both `codecov` project and patch statuses. Coverage still appears on PRs (status lines and comment), but drops no longer fail CI or block merges.

<sup>Written for commit f452c6a0a8c7b035e14ba2e8eeea6f04c342ecd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

