### PR TITLE
Fix backfill statement-timeouts on large message tables

### DIFF
--- a/packages/backend/src/database/backfills/backfill-message-providers.gateway.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.gateway.spec.ts
@@ -41,6 +41,15 @@ describe('backfill SQL constants', () => {
 });
 
 describe('TypeOrmBackfillGateway', () => {
+  describe('analyze', () => {
+    it('refreshes statistics on the stamped table and its join target', async () => {
+      const query = jest.fn(async () => undefined);
+      await new TypeOrmBackfillGateway({ query } as unknown as DataSource).analyze();
+      expect(query).toHaveBeenCalledWith('ANALYZE "agent_messages"');
+      expect(query).toHaveBeenCalledWith('ANALYZE "tenant_providers"');
+    });
+  });
+
   describe('nextWindowEnd', () => {
     it('returns the window end id', async () => {
       const query = jest.fn(async () => [{ end_id: 'id-9' }]);

--- a/packages/backend/src/database/backfills/backfill-message-providers.gateway.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.gateway.ts
@@ -84,6 +84,14 @@ export const PASS_3_SQL = stampingPass(`
 export class TypeOrmBackfillGateway implements BackfillGateway {
   constructor(private readonly dataSource: DataSource) {}
 
+  async analyze(): Promise<void> {
+    // Refresh stats for the stamping passes: agent_messages (its
+    // tenant_provider_id column was just added and is ~100% NULL) and the
+    // tenant_providers join target.
+    await this.dataSource.query('ANALYZE "agent_messages"');
+    await this.dataSource.query('ANALYZE "tenant_providers"');
+  }
+
   async nextWindowEnd(afterId: string, batchSize: number): Promise<string | null> {
     const rows = (await this.dataSource.query(WINDOW_END_SQL, [afterId, batchSize])) as {
       end_id: string | null;

--- a/packages/backend/src/database/backfills/backfill-message-providers.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.spec.ts
@@ -9,6 +9,7 @@ import {
 function gatewayWith(ends: (string | null)[], stampPerWindow = 5): jest.Mocked<BackfillGateway> {
   let call = 0;
   return {
+    analyze: jest.fn(async () => undefined),
     nextWindowEnd: jest.fn(async (_afterId: string, _batchSize: number) => ends[call++] ?? null),
     stampWindow: jest.fn(
       async (_afterId: string, _endId: string, _timeouts: BackfillTimeouts) => stampPerWindow,
@@ -17,6 +18,23 @@ function gatewayWith(ends: (string | null)[], stampPerWindow = 5): jest.Mocked<B
 }
 
 describe('runMessageProviderBackfill', () => {
+  it('refreshes planner statistics once, before stamping the first window', async () => {
+    const gateway = gatewayWith(['id-10', null]);
+    const order: string[] = [];
+    gateway.analyze.mockImplementation(async () => {
+      order.push('analyze');
+    });
+    gateway.stampWindow.mockImplementation(async () => {
+      order.push('stamp');
+      return 1;
+    });
+
+    await runMessageProviderBackfill(gateway, { throttleMs: 0 });
+
+    expect(gateway.analyze).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['analyze', 'stamp']); // ANALYZE precedes any stamping
+  });
+
   it('walks keyset windows until nextWindowEnd returns null, summing stamped counts', async () => {
     const gateway = gatewayWith(['id-10', 'id-20', null]);
     const sleep = jest.fn(async () => undefined);

--- a/packages/backend/src/database/backfills/backfill-message-providers.ts
+++ b/packages/backend/src/database/backfills/backfill-message-providers.ts
@@ -78,6 +78,11 @@ export interface BackfillResult {
  */
 export interface BackfillGateway {
   /**
+   * Refresh planner statistics on the tables the stamping passes read. Called
+   * once before the first window (see runMessageProviderBackfill).
+   */
+  analyze(): Promise<void>;
+  /**
    * Upper bound (inclusive) of the next keyset window of size `batchSize`
    * containing ids strictly greater than `afterId`, or null when no rows remain.
    */
@@ -142,6 +147,14 @@ export async function runMessageProviderBackfill(
   const maxRetries = options.maxRetries ?? DEFAULT_BACKFILL_OPTIONS.maxRetries;
   const retryBackoffMs = options.retryBackoffMs ?? DEFAULT_BACKFILL_OPTIONS.retryBackoffMs;
   const log = (message: string): void => options.logger?.log(message);
+
+  // Refresh planner statistics before the first window. The migration just
+  // added tenant_provider_id (≈100% NULL) and autovacuum's analyze has not run
+  // yet, so the planner mis-estimates `tenant_provider_id IS NULL` as highly
+  // selective and builds a full-table bitmap on it every window — turning a
+  // sub-second keyset window into a statement_timeout. ANALYZE lets it cost the
+  // NULL filter correctly and drive each window off the PK id-range instead.
+  await gateway.analyze();
 
   let afterId = '';
   let windows = 0;


### PR DESCRIPTION
## Problem
The post-deploy `agent_messages.tenant_provider_id` backfill stalled on a large production table: every 10k keyset window tripped the 60s `statement_timeout` and retried, making no progress.

## Cause
The tenant-refactor migration adds `tenant_provider_id` (≈100% NULL) immediately before the backfill runs — before autovacuum's analyze. With stale stats the planner estimates `tenant_provider_id IS NULL` as highly selective and `BitmapAnd`s a **full-table** bitmap of that column into every window. `EXPLAIN` showed a trivially-low cost while the actual scan read all ~3.7M NULL index entries per window.

## Fix
`ANALYZE` `agent_messages` and `tenant_providers` once, before the first window. With fresh stats the planner costs the NULL filter correctly and drives each window off the PK id-range alone — windows drop from >60s to sub-second.

## Notes
- Same fix applied by hand to production to unstick the live backfill; this bakes it in so self-hosted installs (and any re-run) never hit it.
- New `analyze()` on the backfill gateway, called once by the orchestrator. Unit + migration-e2e covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Analyze `agent_messages` and `tenant_providers` before the message-provider backfill to prevent statement timeouts and keep windows fast on large tables.

- **Bug Fixes**
  - Added `analyze()` to `TypeOrmBackfillGateway` to run `ANALYZE "agent_messages"` and `ANALYZE "tenant_providers"` once before the first window.
  - Hooked `analyze()` into `runMessageProviderBackfill` so windows drive off the PK range instead of a full-table bitmap.
  - Added tests for the analyze SQL and for calling order (analyze before first stamp).

<sup>Written for commit a6459bc99a8570789ac4258fa315bca03b5a5bb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

