### PR TITLE
feat: add what's-new dialog announcing global providers

### DIFF
--- a/.changeset/whats-new-global-providers.md
+++ b/.changeset/whats-new-global-providers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add a one-time "What we just shipped" dialog for existing users that announces global providers: connect a provider once across all harnesses, scope access per harness, and track subscription vs usage-based spend per provider and harness. Dismissal is remembered locally.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Header from './components/Header.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import AuthGuard from './components/AuthGuard.jsx';
 import VersionIndicator from './components/VersionIndicator.jsx';
+import WhatsNewModal from './components/WhatsNewModal.jsx';
 import { connectSse } from './services/sse.js';
 import { RightSidebarProvider, useRightSidebar } from './services/right-sidebar.jsx';
 
@@ -84,6 +85,7 @@ const AppInner: ParentComponent = (props) => {
         {rightSidebar()}
       </div>
       <VersionIndicator />
+      <WhatsNewModal />
       {__DEV_MODE__ && WingmanDevTools && (
         <Suspense fallback={null}>
           <WingmanDevTools />

--- a/packages/frontend/src/components/WhatsNewModal.tsx
+++ b/packages/frontend/src/components/WhatsNewModal.tsx
@@ -33,10 +33,13 @@ function markSeen(): void {
 
 export default function WhatsNewModal(): JSX.Element {
   const [open, setOpen] = createSignal(false);
+  // Remember what had focus so we can hand it back when the modal closes.
+  let previouslyFocused: HTMLElement | null = null;
 
   function dismiss() {
     markSeen();
     setOpen(false);
+    previouslyFocused?.focus();
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -44,7 +47,10 @@ export default function WhatsNewModal(): JSX.Element {
   }
 
   onMount(() => {
-    if (!hasSeen()) setOpen(true);
+    if (!hasSeen()) {
+      previouslyFocused = document.activeElement as HTMLElement | null;
+      setOpen(true);
+    }
     document.addEventListener('keydown', onKeyDown);
   });
   onCleanup(() => document.removeEventListener('keydown', onKeyDown));
@@ -65,6 +71,7 @@ export default function WhatsNewModal(): JSX.Element {
         >
           <button
             class="modal__close whatsnew-modal__close"
+            ref={(el) => requestAnimationFrame(() => el.focus())}
             onClick={dismiss}
             aria-label="Close"
             type="button"

--- a/packages/frontend/src/components/WhatsNewModal.tsx
+++ b/packages/frontend/src/components/WhatsNewModal.tsx
@@ -1,0 +1,149 @@
+import { createSignal, For, Show, onMount, onCleanup, type JSX } from 'solid-js';
+
+// Bump this id when there's a new announcement worth re-surfacing to everyone.
+// Keyed on a fixed announcement id (not the app version) so routine patch
+// bumps don't re-trigger the same popup.
+const ANNOUNCEMENT_ID = 'global-providers-v1';
+const STORAGE_KEY = `manifest:whatsnew:${ANNOUNCEMENT_ID}`;
+
+const HIGHLIGHTS = [
+  'One unified place to connect and manage every provider across all your harnesses.',
+  'Connect a provider once — it now works across every harness.',
+  'Need isolation? Scope it — disconnect a provider from specific harnesses.',
+  'Track consumption — subscription vs usage-based, per provider and harness.',
+] as const;
+
+function hasSeen(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== null;
+  } catch {
+    // localStorage can throw in private mode / blocked storage — fail open
+    // and just show the popup rather than crash.
+    return false;
+  }
+}
+
+function markSeen(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, new Date().toISOString());
+  } catch {
+    // ignore — worst case the user sees it again next load.
+  }
+}
+
+export default function WhatsNewModal(): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+
+  function dismiss() {
+    markSeen();
+    setOpen(false);
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && open()) dismiss();
+  }
+
+  onMount(() => {
+    if (!hasSeen()) setOpen(true);
+    document.addEventListener('keydown', onKeyDown);
+  });
+  onCleanup(() => document.removeEventListener('keydown', onKeyDown));
+
+  return (
+    <Show when={open()}>
+      <div
+        class="modal-backdrop"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) dismiss();
+        }}
+      >
+        <div
+          class="modal whatsnew-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label="What's new in Manifest"
+        >
+          <button
+            class="modal__close whatsnew-modal__close"
+            onClick={dismiss}
+            aria-label="Close"
+            type="button"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+
+          <div class="whatsnew-modal__body">
+            <h2 class="whatsnew-modal__headline">What we just shipped</h2>
+            <p class="whatsnew-modal__lead">
+              There&rsquo;s now a single, unified UI to connect and manage your providers across all
+              your harnesses. Your existing connected providers have been migrated to global
+              automatically.
+            </p>
+            <ul class="whatsnew-modal__list">
+              <For each={HIGHLIGHTS as unknown as string[]}>
+                {(item) => (
+                  <li class="whatsnew-modal__item">
+                    <svg
+                      class="whatsnew-modal__check"
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                    <span>{item}</span>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </div>
+
+          <div class="whatsnew-modal__footer">
+            <p class="whatsnew-modal__help">
+              Questions or a problem?{' '}
+              <a
+                href="https://github.com/mnfst/manifest/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open an issue
+              </a>{' '}
+              or{' '}
+              <a
+                href="https://discord.com/invite/FepAked3W7"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                join our Discord
+              </a>
+              .
+            </p>
+            <button type="button" class="btn btn--primary" onClick={dismiss}>
+              Got it
+            </button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -19,6 +19,7 @@
 @import './agent-type-select.css';
 @import './action-menu.css';
 @import './feedback.css';
+@import './whatsnew.css';
 
 /*
  * Route-scoped stylesheets are intentionally NOT imported here. They are

--- a/packages/frontend/src/styles/whatsnew.css
+++ b/packages/frontend/src/styles/whatsnew.css
@@ -1,0 +1,80 @@
+/* ── What's New announcement modal ─────────────────── */
+.whatsnew-modal {
+  position: relative;
+  max-width: 480px;
+}
+
+.whatsnew-modal__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 1;
+}
+
+.whatsnew-modal__body {
+  padding: var(--gap-lg);
+}
+
+.whatsnew-modal__headline {
+  margin: 0 0 8px;
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.whatsnew-modal__lead {
+  margin: 0 0 20px;
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+  color: hsl(var(--muted-foreground));
+}
+
+.whatsnew-modal__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.whatsnew-modal__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+  color: hsl(var(--foreground));
+}
+
+.whatsnew-modal__check {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: hsl(var(--success));
+}
+
+.whatsnew-modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 var(--gap-lg) var(--gap-lg);
+}
+
+.whatsnew-modal__help {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  line-height: 1.45;
+  color: hsl(var(--muted-foreground));
+}
+
+.whatsnew-modal__help a {
+  color: hsl(var(--foreground));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  white-space: nowrap;
+}
+
+.whatsnew-modal__help a:hover {
+  color: hsl(var(--primary));
+}

--- a/packages/frontend/tests/components/WhatsNewModal.test.tsx
+++ b/packages/frontend/tests/components/WhatsNewModal.test.tsx
@@ -95,6 +95,18 @@ describe('WhatsNewModal', () => {
     expect(screen.queryByText(HEADLINE)).toBeNull();
   });
 
+  it('moves focus into the modal on open and restores it on close', async () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    render(() => <WhatsNewModal />);
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    expect(document.activeElement).toBe(screen.getByLabelText('Close'));
+    fireEvent.click(screen.getByText('Got it'));
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+
   it('removes the keydown listener on unmount', () => {
     const removeSpy = vi.spyOn(document, 'removeEventListener');
     const { unmount } = render(() => <WhatsNewModal />);

--- a/packages/frontend/tests/components/WhatsNewModal.test.tsx
+++ b/packages/frontend/tests/components/WhatsNewModal.test.tsx
@@ -98,13 +98,16 @@ describe('WhatsNewModal', () => {
   it('moves focus into the modal on open and restores it on close', async () => {
     const trigger = document.createElement('button');
     document.body.appendChild(trigger);
-    trigger.focus();
-    render(() => <WhatsNewModal />);
-    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
-    expect(document.activeElement).toBe(screen.getByLabelText('Close'));
-    fireEvent.click(screen.getByText('Got it'));
-    expect(document.activeElement).toBe(trigger);
-    trigger.remove();
+    try {
+      trigger.focus();
+      render(() => <WhatsNewModal />);
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      expect(document.activeElement).toBe(screen.getByLabelText('Close'));
+      fireEvent.click(screen.getByText('Got it'));
+      expect(document.activeElement).toBe(trigger);
+    } finally {
+      trigger.remove();
+    }
   });
 
   it('removes the keydown listener on unmount', () => {

--- a/packages/frontend/tests/components/WhatsNewModal.test.tsx
+++ b/packages/frontend/tests/components/WhatsNewModal.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@solidjs/testing-library';
+
+import WhatsNewModal from '../../src/components/WhatsNewModal';
+
+const STORAGE_KEY = 'manifest:whatsnew:global-providers-v1';
+const HEADLINE = 'What we just shipped';
+
+describe('WhatsNewModal', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens on first load when never dismissed', () => {
+    render(() => <WhatsNewModal />);
+    expect(screen.getByText(HEADLINE)).toBeDefined();
+    expect(screen.getByRole('dialog')).toBeDefined();
+  });
+
+  it('stays hidden when already dismissed', () => {
+    localStorage.setItem(STORAGE_KEY, new Date().toISOString());
+    render(() => <WhatsNewModal />);
+    expect(screen.queryByText(HEADLINE)).toBeNull();
+  });
+
+  it('renders every highlight bullet', () => {
+    render(() => <WhatsNewModal />);
+    expect(screen.getByText(/One unified place to connect and manage/)).toBeDefined();
+    expect(screen.getByText(/Connect a provider once/)).toBeDefined();
+    expect(screen.getByText(/Need isolation\?/)).toBeDefined();
+    expect(screen.getByText(/Track consumption/)).toBeDefined();
+  });
+
+  it('links out to GitHub issues and Discord in a new tab', () => {
+    render(() => <WhatsNewModal />);
+    const issue = screen.getByText('Open an issue') as HTMLAnchorElement;
+    const discord = screen.getByText('join our Discord') as HTMLAnchorElement;
+    expect(issue.getAttribute('href')).toBe('https://github.com/mnfst/manifest/issues');
+    expect(issue.getAttribute('target')).toBe('_blank');
+    expect(issue.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(discord.getAttribute('href')).toBe('https://discord.com/invite/FepAked3W7');
+  });
+
+  it('dismisses via the "Got it" button and persists the dismissal', () => {
+    render(() => <WhatsNewModal />);
+    fireEvent.click(screen.getByText('Got it'));
+    expect(screen.queryByText(HEADLINE)).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('dismisses via the close button', () => {
+    render(() => <WhatsNewModal />);
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(screen.queryByText(HEADLINE)).toBeNull();
+  });
+
+  it('dismisses on Escape but ignores other keys', () => {
+    render(() => <WhatsNewModal />);
+    fireEvent.keyDown(document, { key: 'a' });
+    expect(screen.getByText(HEADLINE)).toBeDefined();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText(HEADLINE)).toBeNull();
+    // Escape after close is a no-op (open() short-circuits) and must not throw.
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText(HEADLINE)).toBeNull();
+  });
+
+  it('closes when clicking the backdrop but not the modal body', () => {
+    render(() => <WhatsNewModal />);
+    fireEvent.click(screen.getByRole('dialog'));
+    expect(screen.getByText(HEADLINE)).toBeDefined();
+    fireEvent.click(document.querySelector('.modal-backdrop') as HTMLElement);
+    expect(screen.queryByText(HEADLINE)).toBeNull();
+  });
+
+  it('fails open and still shows when localStorage reads throw', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    render(() => <WhatsNewModal />);
+    expect(screen.getByText(HEADLINE)).toBeDefined();
+  });
+
+  it('still dismisses cleanly when localStorage writes throw', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    render(() => <WhatsNewModal />);
+    fireEvent.click(screen.getByText('Got it'));
+    expect(screen.queryByText(HEADLINE)).toBeNull();
+  });
+
+  it('removes the keydown listener on unmount', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = render(() => <WhatsNewModal />);
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+  });
+});


### PR DESCRIPTION
### ✨ What changed
- New `WhatsNewModal`, shown once per user on the dashboard (gated by a localStorage announcement id, not the app version, so patch bumps don't re-trigger it).
- Reuses the existing modal design system. Floating close button, Esc / backdrop / "Got it" all dismiss.
- Copy covers global providers: connect once across all harnesses, per-harness scoping, per-provider/per-harness consumption, and the auto-migration of existing providers.
- Footer links to GitHub issues and Discord (new tab, `rel="noopener noreferrer"`).
- 100% covered unit test, including the localStorage fail-open/fail-closed paths.

### 💭 Why
Existing users land on a reorganized dashboard after the tenant refactor (providers lifted to account level). This tells them what moved without a docs trip.

### 👤 For users
A one-time popup on first load after the upgrade. Dismiss it and it stays gone on that browser.

### 📝 Notes
- No backend, no migration. Pure frontend plus localStorage.
- Content is static for now. A follow-up could source it remotely (server-side fetch to respect the self-only CSP) if we want to change announcements without a deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-time “What’s New” modal announcing global providers after the dashboard reorg. It shows once per browser and stays hidden after dismissal.

- **New Features**
  - New `WhatsNewModal` mounted in `App.tsx`; uses existing modal UI; dismiss via Esc, backdrop, close button, or “Got it”.
  - Dismissal stored in `localStorage` with id `manifest:whatsnew:global-providers-v1`; fails open if storage is blocked.
  - Highlights global providers and links to GitHub issues/Discord; added styles and unit tests for normal and storage edge cases.

- **Bug Fixes**
  - Focus and cleanup: modal focuses on open, restores focus on close, and removes the keydown listener on unmount; tests ensure DOM nodes are cleaned up even if assertions fail.

<sup>Written for commit 97870d37a479c8ecc6ab521d6a3d40c45018a24c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

