### PR TITLE
perf(frontend): SWR cache so dashboard navigation stops refetching everything

### DIFF
--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -180,12 +180,12 @@ const GlobalOverview: Component = () => {
 
   // ── Data resources (5 parallel) ──────────────────────────────────────
   const [overview] = createResource(
-    () => chartRange(),
-    (range) => getOverview(range) as Promise<OverviewResponse>,
+    () => ({ range: chartRange(), _ping: messagePing() }),
+    (p) => getOverview(p.range) as Promise<OverviewResponse>,
   );
 
   const [agents] = createResource(
-    () => agentPing(),
+    () => ({ _agentPing: agentPing(), _messagePing: messagePing() }),
     async () => {
       try {
         const data = await getAgents();
@@ -251,12 +251,12 @@ const GlobalOverview: Component = () => {
   };
 
   const [agentTimeseries] = createResource(
-    () => ({ range: chartRange(), group: groupBy() }),
+    () => ({ range: chartRange(), group: groupBy(), _ping: messagePing() }),
     (p) => tokenFetcher(p.range, p.group),
   );
 
   const [agentMessageTimeseries] = createResource(
-    () => ({ range: chartRange(), group: groupBy() }),
+    () => ({ range: chartRange(), group: groupBy(), _ping: messagePing() }),
     (p) => msgFetcher(p.range, p.group),
   );
 
@@ -266,7 +266,7 @@ const GlobalOverview: Component = () => {
   };
 
   const [agentCostTimeseries] = createResource(
-    () => ({ range: chartRange(), group: groupBy() }),
+    () => ({ range: chartRange(), group: groupBy(), _ping: messagePing() }),
     (p) => costFetcher(p.range, p.group),
   );
 

--- a/packages/frontend/src/services/api/cache.ts
+++ b/packages/frontend/src/services/api/cache.ts
@@ -1,0 +1,163 @@
+/**
+ * Transparent stale-while-revalidate (SWR) cache for dashboard GET requests.
+ *
+ * The dashboard router unmounts/remounts every page on navigation, so each page's
+ * `createResource` re-runs from scratch on every tab switch — a full refetch of
+ * Overview → Messages → Subscriptions → back every single time. This module sits
+ * behind the shared GET helper (`fetchJson`) and serves cached payloads keyed by
+ * request URL so navigation feels instant without going stale.
+ *
+ * Design choices (documented per the implementation brief):
+ *
+ * - **Default-on for GETs, explicit deny-list + per-call opt-out.** Caching every
+ *   GET by default is what makes navigation transparently fast (pages don't have
+ *   to opt in). A small deny-list (`isCacheable`) excludes always-fresh/sensitive
+ *   endpoints, and callers can force a bypass with `fetchJson(path, params, { cache: false })`.
+ * - **Short TTL (30s).** Long enough to make back-and-forth navigation feel
+ *   instant, short enough that data is never meaningfully stale even without an
+ *   SSE invalidation. SSE events (`services/sse.ts`) invalidate the relevant key
+ *   groups immediately, so the TTL is just a backstop.
+ * - **Stale-while-revalidate.** A stale-but-present entry is returned immediately
+ *   while a background refetch updates the cache, so the UI never blocks on the
+ *   network for a key it has seen recently.
+ * - **In-flight de-duplication.** Concurrent identical GETs share one promise so a
+ *   page that mounts several resources hitting the same URL only fires one request.
+ * - **Never cache failures.** Only resolved 2xx payloads are stored; a rejected
+ *   fetch leaves the cache untouched so the next call retries.
+ */
+
+/** Default freshness window, in milliseconds. */
+export const DEFAULT_TTL_MS = 30_000;
+
+interface CacheEntry<T> {
+  /** Last successfully-fetched payload, or undefined while the first fetch is in flight. */
+  data?: T;
+  /** Epoch ms after which `data` is considered stale and should be revalidated. */
+  expiresAt: number;
+  /** Shared promise for an in-flight fetch, used to de-dupe concurrent identical GETs. */
+  inflight?: Promise<T>;
+}
+
+// Module-level cache keyed by fully-qualified request URL (path + query string).
+// `unknown` because entries are heterogeneous across endpoints; callers re-assert
+// the type at the `fetchJson<T>` boundary.
+const cache = new Map<string, CacheEntry<unknown>>();
+
+/**
+ * Endpoints that must NEVER be cached — always-fresh or sensitive surfaces. A
+ * match anywhere in the URL is enough (these are unambiguous path fragments):
+ *
+ * - `/auth`          — Better Auth (sessions, login state) must always be live.
+ * - `/key`           — agent API key reveal; never serve a stale/secret value.
+ * - `/rotate-key`    — key rotation is a mutation that returns a fresh secret.
+ * - `/events`        — SSE stream endpoint; not a JSON GET.
+ * - `/health`        — liveness probe must reflect the current instant.
+ */
+const DENY_LIST = ['/auth', '/key', '/rotate-key', '/events', '/health'];
+
+/** True when a URL is eligible for caching (not on the always-fresh deny-list). */
+export function isCacheable(url: string): boolean {
+  return !DENY_LIST.some((fragment) => url.includes(fragment));
+}
+
+/**
+ * Stale-while-revalidate read-through cache for a single GET.
+ *
+ * @param url     Fully-qualified request URL (the cache key).
+ * @param fetcher Performs the actual network fetch. Only its resolved value is cached;
+ *                a rejection is propagated and never stored.
+ * @param ttlMs   Freshness window for a fresh hit.
+ */
+export function cachedFetch<T>(
+  url: string,
+  fetcher: () => Promise<T>,
+  ttlMs = DEFAULT_TTL_MS,
+): Promise<T> {
+  const now = Date.now();
+  const entry = cache.get(url) as CacheEntry<T> | undefined;
+
+  // Fresh hit — serve cached data without touching the network.
+  if (entry && entry.data !== undefined && now < entry.expiresAt) {
+    return Promise.resolve(entry.data);
+  }
+
+  // In-flight de-dupe — a request for this URL is already running; share it.
+  if (entry?.inflight) {
+    // Stale-but-present: still return the cached data immediately rather than
+    // awaiting the revalidation that's already underway.
+    if (entry.data !== undefined) {
+      return Promise.resolve(entry.data);
+    }
+    return entry.inflight;
+  }
+
+  // Kick off a (re)fetch. The promise updates the cache on success and clears the
+  // in-flight marker either way so a failed fetch doesn't wedge the key.
+  const inflight = fetcher()
+    .then((data) => {
+      cache.set(url, { data, expiresAt: Date.now() + ttlMs });
+      return data;
+    })
+    .catch((err) => {
+      const current = cache.get(url) as CacheEntry<T> | undefined;
+      if (current) {
+        // Drop only the in-flight marker; keep any previously-cached data so a
+        // transient failure during background revalidation doesn't evict a good value.
+        current.inflight = undefined;
+        if (current.data === undefined) cache.delete(url);
+      }
+      throw err;
+    });
+
+  if (entry && entry.data !== undefined) {
+    // Stale-while-revalidate: return the stale value now, revalidate in background.
+    entry.inflight = inflight;
+    // Swallow the background rejection so an unhandled-rejection isn't surfaced;
+    // the next caller will retry against a now-empty in-flight slot.
+    inflight.catch(() => undefined);
+    return Promise.resolve(entry.data);
+  }
+
+  // Cache miss with no prior data: store the in-flight promise and await it.
+  cache.set(url, { expiresAt: 0, inflight });
+  return inflight;
+}
+
+/** Drop every cached entry whose URL starts with `prefix`. */
+export function invalidate(prefix: string): void {
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}
+
+/** Drop every cached entry whose URL matches `predicate`. */
+export function invalidatePredicate(predicate: (url: string) => boolean): void {
+  for (const key of cache.keys()) {
+    if (predicate(key)) cache.delete(key);
+  }
+}
+
+/** Drop the entire cache. Used by mutations with broad blast radius and tests. */
+export function invalidateAll(): void {
+  cache.clear();
+}
+
+/**
+ * URL-fragment groups used by SSE-driven invalidation. A cached key is dropped when
+ * its URL contains any fragment in the relevant group. Kept here (next to the cache)
+ * so the matching rules live with the cache they govern.
+ */
+export const INVALIDATION_GROUPS = {
+  // A new/changed message moves every usage-derived chart and the message log.
+  message: ['/messages', '/overview', '/costs', '/tokens', '/usage', '/provider-analytics'],
+  // A routing/provider change moves provider lists and routing config.
+  routing: ['/routing', '/providers', '/provider-analytics'],
+  // An agent create/rename/delete moves the agent list and per-agent views.
+  agent: ['/agents', '/agent/'],
+} as const;
+
+/** Invalidate every cached key belonging to one of the {@link INVALIDATION_GROUPS}. */
+export function invalidateGroup(group: keyof typeof INVALIDATION_GROUPS): void {
+  const fragments = INVALIDATION_GROUPS[group];
+  invalidatePredicate((url) => fragments.some((fragment) => url.includes(fragment)));
+}

--- a/packages/frontend/src/services/api/cache.ts
+++ b/packages/frontend/src/services/api/cache.ts
@@ -196,8 +196,17 @@ export function invalidateAll(): void {
  * so the matching rules live with the cache they govern.
  */
 export const INVALIDATION_GROUPS = {
-  // A new/changed message moves every usage-derived chart and the message log.
-  message: ['/messages', '/overview', '/costs', '/tokens', '/usage', '/provider-analytics'],
+  // A new/changed message moves every usage-derived chart, summary, and table.
+  message: [
+    '/messages',
+    '/overview',
+    '/costs',
+    '/tokens',
+    '/usage',
+    '/provider-analytics',
+    '/providers/usage',
+    '/agents',
+  ],
   // A routing/provider change moves provider lists and routing config.
   routing: ['/routing', '/providers', '/provider-analytics'],
   // An agent create/rename/delete moves the agent list and per-agent views.

--- a/packages/frontend/src/services/api/cache.ts
+++ b/packages/frontend/src/services/api/cache.ts
@@ -43,6 +43,29 @@ interface CacheEntry<T> {
 // the type at the `fetchJson<T>` boundary.
 const cache = new Map<string, CacheEntry<unknown>>();
 
+// Monotonic invalidation generation. Every invalidate* call bumps this counter.
+// A fetch captures the generation when it starts; if the counter advanced before
+// the fetch resolves, an invalidation ran *during* the request and its result is
+// stale — so the success write is suppressed rather than allowed to resurrect a
+// key that was just dropped. This is what keeps the SSE invalidate-before-bump
+// contract sound: a refetch kicked off after invalidation captures the new
+// generation and writes normally, while any request that was already in flight
+// when invalidation happened silently declines to repopulate the cache.
+let generation = 0;
+
+/**
+ * Bound the cache by dropping expired entries that have no in-flight refetch.
+ * Runs on every successful write, so growth is pruned incrementally without a
+ * timer. Entries with a live `inflight` promise are kept (a revalidation is
+ * mid-flight); entries still holding stale-but-usable data within a fresh
+ * window are kept too — only fully-expired, idle keys are swept.
+ */
+function pruneExpired(now: number): void {
+  for (const [key, entry] of cache) {
+    if (!entry.inflight && now >= entry.expiresAt) cache.delete(key);
+  }
+}
+
 /**
  * Endpoints that must NEVER be cached — always-fresh or sensitive surfaces. A
  * match anywhere in the URL is enough (these are unambiguous path fragments):
@@ -74,6 +97,10 @@ export function cachedFetch<T>(
   ttlMs = DEFAULT_TTL_MS,
 ): Promise<T> {
   const now = Date.now();
+  // Generation snapshot for this call. If an invalidation bumps `generation`
+  // before the fetch resolves, the resolved payload is stale and must not be
+  // written back (see the success handler below).
+  const startGeneration = generation;
   const entry = cache.get(url) as CacheEntry<T> | undefined;
 
   // Fresh hit — serve cached data without touching the network.
@@ -95,12 +122,30 @@ export function cachedFetch<T>(
   // in-flight marker either way so a failed fetch doesn't wedge the key.
   const inflight = fetcher()
     .then((data) => {
-      cache.set(url, { data, expiresAt: Date.now() + ttlMs });
+      // Resurrection guard: an invalidation that ran while this fetch was in
+      // flight bumped `generation`. Writing now would repopulate a key that was
+      // deliberately dropped (and possibly already refetched by a newer call),
+      // so suppress the write and just clear our own in-flight marker. The
+      // payload is still returned to this caller — only the cache is left alone.
+      if (generation !== startGeneration) {
+        const current = cache.get(url) as CacheEntry<T> | undefined;
+        if (current?.inflight === inflight) {
+          current.inflight = undefined;
+          if (current.data === undefined) cache.delete(url);
+        }
+        return data;
+      }
+      const settledAt = Date.now();
+      cache.set(url, { data, expiresAt: settledAt + ttlMs });
+      pruneExpired(settledAt);
       return data;
     })
     .catch((err) => {
       const current = cache.get(url) as CacheEntry<T> | undefined;
-      if (current) {
+      // Only act on the slot we actually registered. An invalidation may have
+      // dropped this key and a newer request may now own it; we must not clobber
+      // that newer in-flight marker or its data.
+      if (current && current.inflight === inflight) {
         // Drop only the in-flight marker; keep any previously-cached data so a
         // transient failure during background revalidation doesn't evict a good value.
         current.inflight = undefined;
@@ -125,6 +170,7 @@ export function cachedFetch<T>(
 
 /** Drop every cached entry whose URL starts with `prefix`. */
 export function invalidate(prefix: string): void {
+  generation++;
   for (const key of cache.keys()) {
     if (key.startsWith(prefix)) cache.delete(key);
   }
@@ -132,6 +178,7 @@ export function invalidate(prefix: string): void {
 
 /** Drop every cached entry whose URL matches `predicate`. */
 export function invalidatePredicate(predicate: (url: string) => boolean): void {
+  generation++;
   for (const key of cache.keys()) {
     if (predicate(key)) cache.delete(key);
   }
@@ -139,6 +186,7 @@ export function invalidatePredicate(predicate: (url: string) => boolean): void {
 
 /** Drop the entire cache. Used by mutations with broad blast radius and tests. */
 export function invalidateAll(): void {
+  generation++;
   cache.clear();
 }
 

--- a/packages/frontend/src/services/api/core.ts
+++ b/packages/frontend/src/services/api/core.ts
@@ -1,10 +1,23 @@
 import { toast } from '../toast-store.js';
+import { cachedFetch, isCacheable, invalidateAll } from './cache.js';
 
 export const BASE_URL = '/api/v1';
+
+/** Options for {@link fetchJson}. */
+export interface FetchJsonOptions {
+  /**
+   * Per-call opt-out of the SWR cache. Defaults to `true` (cache on) for any
+   * cacheable GET. Pass `false` to force a live network read — e.g. for a
+   * surface that must never serve a stale payload but isn't on the global
+   * deny-list. Deny-listed URLs are never cached regardless of this flag.
+   */
+  cache?: boolean;
+}
 
 export async function fetchJson<T>(
   path: string,
   params?: Record<string, string | undefined>,
+  options?: FetchJsonOptions,
 ): Promise<T> {
   const url = new URL(`${BASE_URL}${path}`, window.location.origin);
   if (params) {
@@ -12,11 +25,23 @@ export async function fetchJson<T>(
       if (value) url.searchParams.set(key, value);
     }
   }
+  const key = url.toString();
 
+  // Default-on SWR caching for GETs, unless the caller opted out or the URL is on
+  // the always-fresh deny-list (sessions, key reveal/rotate, SSE, health).
+  const useCache = options?.cache !== false && isCacheable(key);
+  if (useCache) {
+    return cachedFetch<T>(key, () => doFetchJson<T>(key));
+  }
+  return doFetchJson<T>(key);
+}
+
+/** Performs the raw GET + error handling. Kept separate so the cache wraps only the network. */
+async function doFetchJson<T>(url: string): Promise<T> {
   // 'default' lets the browser revalidate via ETag / Cache-Control. Backend
   // analytics endpoints set short max-age=10 which keeps stale UI bounded;
   // SSE-driven refetches still bypass cache because they pass a unique signal.
-  const res = await fetch(url.toString(), { credentials: 'include', cache: 'default' });
+  const res = await fetch(url, { credentials: 'include', cache: 'default' });
   if (res.status === 401) {
     // Only redirect to /login when the 401 looks like a real session
     // expiry. Per-endpoint 401s (e.g. an endpoint that requires a
@@ -58,6 +83,12 @@ export async function fetchMutate<T = void>(path: string, options: RequestInit):
     toast.error(message);
     throw new Error(message);
   }
+  // A mutation (POST/PUT/PATCH/DELETE) can change data behind any number of GET
+  // keys (e.g. renaming an agent touches the agent list, every per-agent view,
+  // and the message log). The blast radius isn't statically knowable from the
+  // path alone, so drop the whole GET cache — the next navigation refetches
+  // fresh. Mutations are rare relative to reads, so this is cheap and correct.
+  invalidateAll();
   const text = await res.text();
   if (!text) return undefined as T;
   return JSON.parse(text) as T;

--- a/packages/frontend/src/services/api/model-params.ts
+++ b/packages/frontend/src/services/api/model-params.ts
@@ -29,11 +29,14 @@ export function getModelParamSpecs(
   authType: AuthType,
   model: string,
 ) {
-  return fetchJson<ProviderParamSpec[]>(routingPath(agentName, 'model-param-specs/by-model'), {
-    provider,
-    authType,
-    model,
-  });
+  // Opt out of the shared SWR cache: this is fetched on-demand when the user opens
+  // a model's param dialog and the client contract is explicitly "don't cache
+  // model specs in the frontend" — a stale spec would mis-render the dialog.
+  return fetchJson<ProviderParamSpec[]>(
+    routingPath(agentName, 'model-param-specs/by-model'),
+    { provider, authType, model },
+    { cache: false },
+  );
 }
 
 /** Route identity of a model that has configurable params (no param metadata). */

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -428,12 +428,17 @@ export function invalidateCustomProvidersCache(agentName?: string): void {
 export function getCustomProviders(agentName: string): Promise<CustomProviderData[]> {
   const cached = customProvidersCache.get(agentName);
   if (cached) return cached;
-  const promise = fetchJson<CustomProviderData[]>(routingPath(agentName, 'custom-providers')).catch(
-    (err) => {
-      customProvidersCache.delete(agentName);
-      throw err;
-    },
-  );
+  // Opt out of the shared SWR cache (core.ts): this endpoint already has its own
+  // module-scoped cache + invalidation (above), and double-caching would let a
+  // stale SWR entry mask the invalidations this function manages.
+  const promise = fetchJson<CustomProviderData[]>(
+    routingPath(agentName, 'custom-providers'),
+    undefined,
+    { cache: false },
+  ).catch((err) => {
+    customProvidersCache.delete(agentName);
+    throw err;
+  });
   customProvidersCache.set(agentName, promise);
   return promise;
 }

--- a/packages/frontend/src/services/sse.ts
+++ b/packages/frontend/src/services/sse.ts
@@ -1,5 +1,6 @@
 import { createSignal } from 'solid-js';
 import { invalidateCustomProvidersCache } from './api/routing.js';
+import { invalidateGroup } from './api/cache.js';
 
 // pingCount counts ANY event from the bus (legacy back-compat for callers that
 // don't care which kind fired). New code should depend on the targeted
@@ -25,6 +26,11 @@ export function connectSse(): () => void {
     if (messageBumpTimer) return;
     messageBumpTimer = setTimeout(() => {
       messageBumpTimer = null;
+      // Invalidate the SWR cache BEFORE bumping the ping. The ping drives the
+      // resource refetch; if the stale message/overview/usage entries were still
+      // cached, that refetch would read them and the dashboard wouldn't update
+      // live. Dropping them first guarantees the refetch hits the network.
+      invalidateGroup('message');
       setMessagePing((n) => n + 1);
     }, 500);
   };
@@ -43,13 +49,18 @@ export function connectSse(): () => void {
     bumpPing();
   });
   es.addEventListener('agent', () => {
+    // Drop agent-list/per-agent GET cache before the agentPing refetch reads it.
+    invalidateGroup('agent');
     setAgentPing((n) => n + 1);
     bumpPing();
   });
   es.addEventListener('routing', () => {
     // Custom providers are user-global; a routing change (incl. a custom-provider
     // create/update/delete on any agent) can change every agent's list, so drop
-    // the cached lists before the routingPing-driven refetch reads them.
+    // the cached lists before the routingPing-driven refetch reads them. Order
+    // matters: invalidate the SWR cache (and the custom-providers cache) BEFORE
+    // bumping routingPing so the refetch reads fresh routing/provider data.
+    invalidateGroup('routing');
     invalidateCustomProvidersCache();
     setRoutingPing((n) => n + 1);
     bumpPing();

--- a/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
@@ -22,6 +22,13 @@ const apiMocks = vi.hoisted(() => ({
   getGlobalPerProviderCostTimeseries: vi.fn(),
 }));
 
+const sseMocks = vi.hoisted(() => ({
+  bumpAgent: undefined as undefined | (() => void),
+  bumpMessage: undefined as undefined | (() => void),
+  bumpRouting: undefined as undefined | (() => void),
+  reset: undefined as undefined | (() => void),
+}));
+
 let filterSelectProps: {
   onUnselectAll: () => void;
   onSelectAll: () => void;
@@ -145,11 +152,21 @@ vi.mock('../../src/components/GlobalOverviewSkeleton.jsx', () => ({
   default: () => <div data-testid="global-overview-skeleton" />,
 }));
 
-vi.mock('../../src/services/sse.js', () => ({
-  agentPing: () => 0,
-  messagePing: () => 0,
-  routingPing: () => 0,
-}));
+vi.mock('../../src/services/sse.js', async () => {
+  const { createSignal } = await vi.importActual<typeof import('solid-js')>('solid-js');
+  const [agentPing, setAgentPing] = createSignal(0);
+  const [messagePing, setMessagePing] = createSignal(0);
+  const [routingPing, setRoutingPing] = createSignal(0);
+  sseMocks.bumpAgent = () => setAgentPing((n) => n + 1);
+  sseMocks.bumpMessage = () => setMessagePing((n) => n + 1);
+  sseMocks.bumpRouting = () => setRoutingPing((n) => n + 1);
+  sseMocks.reset = () => {
+    setAgentPing(0);
+    setMessagePing(0);
+    setRoutingPing(0);
+  };
+  return { agentPing, messagePing, routingPing };
+});
 
 vi.mock('../../src/services/scroll-fade.js', () => ({
   toggleScrollFade: vi.fn(),
@@ -239,6 +256,7 @@ beforeEach(() => {
   sessionStorage.clear();
   mockIsSelfHosted = false;
   filterSelectProps = null;
+  sseMocks.reset?.();
 
   apiMocks.getAgents.mockResolvedValue(agentsResponse);
   apiMocks.getGlobalProviders.mockResolvedValue(providersResponse);
@@ -275,9 +293,7 @@ describe('GlobalOverview filter onUnselectAll', () => {
     // Fire the unselect-all handler (GlobalOverview's inline callback).
     fireEvent.click(getByTestId('filter-unselect-all'));
 
-    await waitFor(() =>
-      expect(sessionStorage.getItem('global-agent-filter:provider')).toBe('[]'),
-    );
+    await waitFor(() => expect(sessionStorage.getItem('global-agent-filter:provider')).toBe('[]'));
   });
 
   it('swallows a sessionStorage write failure during "unselect all"', async () => {
@@ -302,5 +318,27 @@ describe('GlobalOverview filter onUnselectAll', () => {
     render(() => <GlobalOverview />);
     await waitFor(() => expect(filterSelectProps).not.toBeNull());
     expect(typeof filterSelectProps!.onUnselectAll).toBe('function');
+  });
+
+  it('refetches global usage data when a message SSE ping lands', async () => {
+    render(() => <GlobalOverview />);
+
+    await waitFor(() => expect(apiMocks.getOverview).toHaveBeenCalledTimes(1));
+    expect(apiMocks.getAgents).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getGlobalProviders).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getGlobalProviderUsage).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getGlobalPerProviderTimeseries).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getGlobalPerProviderMessageTimeseries).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getGlobalPerProviderCostTimeseries).toHaveBeenCalledTimes(1);
+
+    sseMocks.bumpMessage?.();
+
+    await waitFor(() => expect(apiMocks.getOverview).toHaveBeenCalledTimes(2));
+    expect(apiMocks.getAgents).toHaveBeenCalledTimes(2);
+    expect(apiMocks.getGlobalProviders).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getGlobalProviderUsage).toHaveBeenCalledTimes(2);
+    expect(apiMocks.getGlobalPerProviderTimeseries).toHaveBeenCalledTimes(2);
+    expect(apiMocks.getGlobalPerProviderMessageTimeseries).toHaveBeenCalledTimes(2);
+    expect(apiMocks.getGlobalPerProviderCostTimeseries).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/frontend/tests/services/api/cache.test.ts
+++ b/packages/frontend/tests/services/api/cache.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  cachedFetch,
+  isCacheable,
+  invalidate,
+  invalidatePredicate,
+  invalidateAll,
+  invalidateGroup,
+  INVALIDATION_GROUPS,
+  DEFAULT_TTL_MS,
+} from '../../../src/services/api/cache';
+
+describe('api SWR cache', () => {
+  beforeEach(() => {
+    invalidateAll();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    invalidateAll();
+  });
+
+  describe('cachedFetch', () => {
+    it('fetches and stores on a cache miss', async () => {
+      const fetcher = vi.fn().mockResolvedValue({ n: 1 });
+      const out = await cachedFetch('/api/v1/overview', fetcher);
+      expect(out).toEqual({ n: 1 });
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves a fresh cached entry without hitting the network', async () => {
+      const fetcher = vi.fn().mockResolvedValue({ n: 1 });
+      await cachedFetch('/api/v1/overview', fetcher);
+      const second = await cachedFetch('/api/v1/overview', fetcher);
+      expect(second).toEqual({ n: 1 });
+      // Second read is a fresh hit — no additional fetch.
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('de-dupes concurrent identical GETs via a shared in-flight promise', async () => {
+      let resolve!: (v: { n: number }) => void;
+      const fetcher = vi.fn().mockReturnValue(
+        new Promise<{ n: number }>((r) => {
+          resolve = r;
+        }),
+      );
+      const p1 = cachedFetch('/api/v1/messages', fetcher);
+      const p2 = cachedFetch('/api/v1/messages', fetcher);
+      // Both calls share one underlying fetch.
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      resolve({ n: 7 });
+      expect(await p1).toEqual({ n: 7 });
+      expect(await p2).toEqual({ n: 7 });
+    });
+
+    it('revalidates in the background after the TTL expires (stale-while-revalidate)', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce({ n: 1 })
+        .mockResolvedValueOnce({ n: 2 });
+
+      const first = await cachedFetch('/api/v1/costs', fetcher);
+      expect(first).toEqual({ n: 1 });
+
+      // Advance past the TTL so the entry is stale.
+      vi.setSystemTime(DEFAULT_TTL_MS + 1);
+      const stale = await cachedFetch('/api/v1/costs', fetcher);
+      // SWR returns the stale value immediately...
+      expect(stale).toEqual({ n: 1 });
+      // ...while a background revalidation runs.
+      expect(fetcher).toHaveBeenCalledTimes(2);
+
+      // Let the background promise settle, then the next read sees fresh data.
+      await vi.runAllTimersAsync();
+      const fresh = await cachedFetch('/api/v1/costs', fetcher);
+      expect(fresh).toEqual({ n: 2 });
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not double-fetch while a background revalidation is already in flight', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      let resolveSecond!: (v: { n: number }) => void;
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce({ n: 1 })
+        .mockReturnValueOnce(
+          new Promise<{ n: number }>((r) => {
+            resolveSecond = r;
+          }),
+        );
+
+      await cachedFetch('/api/v1/tokens', fetcher);
+      vi.setSystemTime(DEFAULT_TTL_MS + 1);
+      // First stale read kicks off revalidation #2 (still pending).
+      const a = await cachedFetch('/api/v1/tokens', fetcher);
+      // Second stale read returns stale data, sharing the in-flight revalidation.
+      const b = await cachedFetch('/api/v1/tokens', fetcher);
+      expect(a).toEqual({ n: 1 });
+      expect(b).toEqual({ n: 1 });
+      expect(fetcher).toHaveBeenCalledTimes(2);
+      resolveSecond({ n: 9 });
+      await vi.runAllTimersAsync();
+    });
+
+    it('awaits the in-flight promise on a miss when no prior data exists', async () => {
+      let resolve!: (v: { n: number }) => void;
+      const fetcher = vi.fn().mockReturnValue(
+        new Promise<{ n: number }>((r) => {
+          resolve = r;
+        }),
+      );
+      const p1 = cachedFetch('/api/v1/usage', fetcher);
+      // Second concurrent miss returns the same in-flight promise (no data yet).
+      const p2 = cachedFetch('/api/v1/usage', fetcher);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      resolve({ n: 3 });
+      expect(await p1).toEqual({ n: 3 });
+      expect(await p2).toEqual({ n: 3 });
+    });
+
+    it('does not cache a failed fetch and retries on the next call', async () => {
+      const fetcher = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ n: 5 });
+      await expect(cachedFetch('/api/v1/overview', fetcher)).rejects.toThrow('boom');
+      // The failed key is empty, so the next call refetches and succeeds.
+      const out = await cachedFetch('/api/v1/overview', fetcher);
+      expect(out).toEqual({ n: 5 });
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps stale data when a background revalidation fails', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce({ n: 1 })
+        .mockRejectedValueOnce(new Error('revalidate failed'))
+        .mockResolvedValueOnce({ n: 2 });
+
+      await cachedFetch('/api/v1/overview', fetcher);
+      vi.setSystemTime(DEFAULT_TTL_MS + 1);
+      // Stale read returns old data immediately; background revalidation rejects.
+      const stale = await cachedFetch('/api/v1/overview', fetcher);
+      expect(stale).toEqual({ n: 1 });
+      await vi.runAllTimersAsync();
+
+      // The failed revalidation did NOT evict the good value — but it cleared the
+      // in-flight slot, so the entry is still stale and the next call refetches.
+      const retried = await cachedFetch('/api/v1/overview', fetcher);
+      expect(retried).toEqual({ n: 1 });
+      await vi.runAllTimersAsync();
+      const fresh = await cachedFetch('/api/v1/overview', fetcher);
+      expect(fresh).toEqual({ n: 2 });
+    });
+  });
+
+  describe('isCacheable', () => {
+    it('returns true for ordinary GET URLs', () => {
+      expect(isCacheable('/api/v1/overview?range=7d')).toBe(true);
+      expect(isCacheable('/api/v1/messages')).toBe(true);
+    });
+
+    it('denies always-fresh/sensitive endpoints', () => {
+      expect(isCacheable('/api/auth/get-session')).toBe(false);
+      expect(isCacheable('/api/v1/agents/demo/key')).toBe(false);
+      expect(isCacheable('/api/v1/agents/demo/rotate-key')).toBe(false);
+      expect(isCacheable('/api/v1/events')).toBe(false);
+      expect(isCacheable('/api/v1/health')).toBe(false);
+    });
+  });
+
+  describe('invalidate / invalidatePredicate / invalidateAll', () => {
+    it('drops only keys matching the prefix', async () => {
+      const f = (val: number) => () => Promise.resolve(val);
+      await cachedFetch('/api/v1/overview', f(1));
+      await cachedFetch('/api/v1/messages', f(2));
+      invalidate('/api/v1/overview');
+      const overviewFetcher = vi.fn().mockResolvedValue(10);
+      const messagesFetcher = vi.fn().mockResolvedValue(20);
+      // Overview was invalidated → refetches; messages is still cached → no fetch.
+      await cachedFetch('/api/v1/overview', overviewFetcher);
+      await cachedFetch('/api/v1/messages', messagesFetcher);
+      expect(overviewFetcher).toHaveBeenCalledTimes(1);
+      expect(messagesFetcher).not.toHaveBeenCalled();
+    });
+
+    it('drops keys matching a predicate', async () => {
+      await cachedFetch('/api/v1/overview', () => Promise.resolve(1));
+      invalidatePredicate((url) => url.includes('overview'));
+      const fetcher = vi.fn().mockResolvedValue(2);
+      await cachedFetch('/api/v1/overview', fetcher);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears everything', async () => {
+      await cachedFetch('/api/v1/overview', () => Promise.resolve(1));
+      await cachedFetch('/api/v1/messages', () => Promise.resolve(2));
+      invalidateAll();
+      const a = vi.fn().mockResolvedValue(10);
+      const b = vi.fn().mockResolvedValue(20);
+      await cachedFetch('/api/v1/overview', a);
+      await cachedFetch('/api/v1/messages', b);
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('invalidateGroup', () => {
+    it('invalidates every fragment in a group', async () => {
+      // Seed one key per fragment of the message group, plus an unrelated key.
+      for (const fragment of INVALIDATION_GROUPS.message) {
+        await cachedFetch(`/api/v1${fragment}`, () => Promise.resolve(1));
+      }
+      await cachedFetch('/api/v1/agents', () => Promise.resolve(99));
+
+      invalidateGroup('message');
+
+      // Every message-group key refetches.
+      for (const fragment of INVALIDATION_GROUPS.message) {
+        const fetcher = vi.fn().mockResolvedValue(2);
+        await cachedFetch(`/api/v1${fragment}`, fetcher);
+        expect(fetcher).toHaveBeenCalledTimes(1);
+      }
+      // The unrelated /agents key survived.
+      const agentsFetcher = vi.fn().mockResolvedValue(100);
+      await cachedFetch('/api/v1/agents', agentsFetcher);
+      expect(agentsFetcher).not.toHaveBeenCalled();
+    });
+
+    it('routing group invalidates routing/provider keys', async () => {
+      await cachedFetch('/api/v1/routing/demo', () => Promise.resolve(1));
+      invalidateGroup('routing');
+      const fetcher = vi.fn().mockResolvedValue(2);
+      await cachedFetch('/api/v1/routing/demo', fetcher);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('agent group invalidates agent-list and per-agent keys', async () => {
+      await cachedFetch('/api/v1/agents', () => Promise.resolve(1));
+      await cachedFetch('/api/v1/agent/demo/usage', () => Promise.resolve(2));
+      invalidateGroup('agent');
+      const a = vi.fn().mockResolvedValue(10);
+      const b = vi.fn().mockResolvedValue(20);
+      await cachedFetch('/api/v1/agents', a);
+      await cachedFetch('/api/v1/agent/demo/usage', b);
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/frontend/tests/services/api/cache.test.ts
+++ b/packages/frontend/tests/services/api/cache.test.ts
@@ -132,6 +132,102 @@ describe('api SWR cache', () => {
       expect(fetcher).toHaveBeenCalledTimes(2);
     });
 
+    it('does not resurrect a key invalidated while its fetch was in flight', async () => {
+      let resolve!: (v: { n: number }) => void;
+      const fetcher = vi.fn().mockReturnValue(
+        new Promise<{ n: number }>((r) => {
+          resolve = r;
+        }),
+      );
+      // Cold miss: the entry has no prior data, so the call awaits the in-flight.
+      const pending = cachedFetch('/api/v1/overview', fetcher);
+      // An SSE invalidation drops the key WHILE the fetch is still in flight.
+      invalidate('/api/v1/overview');
+      // The original fetch now resolves — its (stale) payload must NOT repopulate
+      // the cache, otherwise the post-invalidation refetch would read it.
+      resolve({ n: 1 });
+      expect(await pending).toEqual({ n: 1 });
+
+      // The next read sees an empty key and refetches fresh data.
+      const fresh = vi.fn().mockResolvedValue({ n: 2 });
+      const out = await cachedFetch('/api/v1/overview', fresh);
+      expect(out).toEqual({ n: 2 });
+      expect(fresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses an in-flight write when an unrelated invalidation bumps the generation', async () => {
+      let resolve!: (v: { n: number }) => void;
+      const fetcher = vi.fn().mockReturnValue(
+        new Promise<{ n: number }>((r) => {
+          resolve = r;
+        }),
+      );
+      // Cold miss: registers an in-flight slot for this key (entry survives —
+      // the invalidation below targets a *different* prefix, so the key is kept
+      // but the generation still advances).
+      const pending = cachedFetch('/api/v1/overview', fetcher);
+      invalidate('/api/v1/something-else');
+      resolve({ n: 1 });
+      expect(await pending).toEqual({ n: 1 });
+
+      // Even though the key was never deleted, its in-flight write was suppressed
+      // because the generation moved — so it holds no data and refetches.
+      const fresh = vi.fn().mockResolvedValue({ n: 2 });
+      const out = await cachedFetch('/api/v1/overview', fresh);
+      expect(out).toEqual({ n: 2 });
+      expect(fresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not resurrect prior data when a stale revalidation outlives an invalidation', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      let resolveReval!: (v: { n: number }) => void;
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce({ n: 1 })
+        .mockReturnValueOnce(
+          new Promise<{ n: number }>((r) => {
+            resolveReval = r;
+          }),
+        );
+
+      await cachedFetch('/api/v1/overview', fetcher);
+      vi.setSystemTime(DEFAULT_TTL_MS + 1);
+      // Stale read returns old data immediately and kicks off a background reval.
+      const stale = await cachedFetch('/api/v1/overview', fetcher);
+      expect(stale).toEqual({ n: 1 });
+      // Invalidate the key while that reval is still pending.
+      invalidate('/api/v1/overview');
+      // The reval resolves late — it must not write back into the dropped key.
+      resolveReval({ n: 9 });
+      await vi.runAllTimersAsync();
+
+      // The key is empty, so the next read refetches rather than serving n:9.
+      const next = vi.fn().mockResolvedValue({ n: 3 });
+      const out = await cachedFetch('/api/v1/overview', next);
+      expect(out).toEqual({ n: 3 });
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('prunes expired idle entries on a successful write', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      // Seed a cacheable entry, then let it expire fully (no refetch touches it).
+      await cachedFetch('/api/v1/messages', () => Promise.resolve({ n: 1 }));
+      vi.setSystemTime(DEFAULT_TTL_MS + 1);
+      // A successful write to a *different* key triggers a prune sweep that drops
+      // the now-expired, idle /messages entry.
+      await cachedFetch('/api/v1/overview', () => Promise.resolve({ n: 2 }));
+
+      // /messages was swept (not just expired): the next read is a cold miss that
+      // awaits and returns the fresh value. Had the stale entry survived, SWR
+      // would have returned the old {n:1} immediately instead.
+      const refetch = vi.fn().mockResolvedValue({ n: 5 });
+      const out = await cachedFetch('/api/v1/messages', refetch);
+      expect(out).toEqual({ n: 5 });
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+
     it('keeps stale data when a background revalidation fails', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(0);

--- a/packages/frontend/tests/services/api/cache.test.ts
+++ b/packages/frontend/tests/services/api/cache.test.ts
@@ -55,10 +55,7 @@ describe('api SWR cache', () => {
     it('revalidates in the background after the TTL expires (stale-while-revalidate)', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(0);
-      const fetcher = vi
-        .fn()
-        .mockResolvedValueOnce({ n: 1 })
-        .mockResolvedValueOnce({ n: 2 });
+      const fetcher = vi.fn().mockResolvedValueOnce({ n: 1 }).mockResolvedValueOnce({ n: 2 });
 
       const first = await cachedFetch('/api/v1/costs', fetcher);
       expect(first).toEqual({ n: 1 });
@@ -311,7 +308,7 @@ describe('api SWR cache', () => {
       for (const fragment of INVALIDATION_GROUPS.message) {
         await cachedFetch(`/api/v1${fragment}`, () => Promise.resolve(1));
       }
-      await cachedFetch('/api/v1/agents', () => Promise.resolve(99));
+      await cachedFetch('/api/v1/model-prices', () => Promise.resolve(99));
 
       invalidateGroup('message');
 
@@ -321,10 +318,10 @@ describe('api SWR cache', () => {
         await cachedFetch(`/api/v1${fragment}`, fetcher);
         expect(fetcher).toHaveBeenCalledTimes(1);
       }
-      // The unrelated /agents key survived.
-      const agentsFetcher = vi.fn().mockResolvedValue(100);
-      await cachedFetch('/api/v1/agents', agentsFetcher);
-      expect(agentsFetcher).not.toHaveBeenCalled();
+      // The unrelated /model-prices key survived.
+      const modelPricesFetcher = vi.fn().mockResolvedValue(100);
+      await cachedFetch('/api/v1/model-prices', modelPricesFetcher);
+      expect(modelPricesFetcher).not.toHaveBeenCalled();
     });
 
     it('routing group invalidates routing/provider keys', async () => {

--- a/packages/frontend/tests/services/api/core.test.ts
+++ b/packages/frontend/tests/services/api/core.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fetchJson, fetchMutate, parseErrorMessage, routingPath } from '../../../src/services/api/core';
+import { invalidateAll } from '../../../src/services/api/cache';
 
 const mockToastError = vi.fn();
 vi.mock('../../../src/services/toast-store.js', () => ({
@@ -33,6 +34,9 @@ describe('core api helpers', () => {
     location = { origin: 'http://localhost', pathname: '/dashboard', href: '' };
     vi.stubGlobal('window', { location });
     mockToastError.mockReset();
+    // Start each test with an empty SWR cache so cached payloads from a prior
+    // test don't satisfy a later GET before its fetch mock is asserted.
+    invalidateAll();
   });
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -152,6 +156,56 @@ describe('core api helpers', () => {
 
       await expect(fetchJson('/anything')).rejects.toThrow('The operation was aborted');
     });
+
+    it('serves a cacheable GET from the SWR cache on the second call', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeResponse({ body: { v: 1 } }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const first = await fetchJson<{ v: number }>('/overview', { range: '7d' });
+      const second = await fetchJson<{ v: number }>('/overview', { range: '7d' });
+      expect(first).toEqual({ v: 1 });
+      expect(second).toEqual({ v: 1 });
+      // Second identical GET is a cache hit — only one network call.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('keys the cache by full URL incl. query params', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeResponse({ body: { v: 1 } }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await fetchJson('/overview', { range: '7d' });
+      await fetchJson('/overview', { range: '30d' });
+      // Different params → different keys → two network calls.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('bypasses the cache when called with { cache: false }', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeResponse({ body: { v: 1 } }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await fetchJson('/overview', undefined, { cache: false });
+      await fetchJson('/overview', undefined, { cache: false });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('never caches a deny-listed sensitive URL', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeResponse({ body: { key: 'secret' } }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await fetchJson('/agents/demo/key');
+      await fetchJson('/agents/demo/key');
+      // Deny-listed → every call hits the network, never a stale secret.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('still passes cache: default to the underlying fetch', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeResponse({ body: {} }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await fetchJson('/overview');
+      const init = fetchMock.mock.calls[0][1] as RequestInit & { cache?: string };
+      expect(init.cache).toBe('default');
+    });
   });
 
   describe('parseErrorMessage', () => {
@@ -196,6 +250,44 @@ describe('core api helpers', () => {
 
       const out = await fetchMutate('/something', { method: 'DELETE' });
       expect(out).toBeUndefined();
+    });
+
+    it('invalidates the GET cache on a successful mutation', async () => {
+      // Prime the cache with a GET, then mutate, then GET again.
+      const getRes = vi.fn().mockResolvedValue(makeResponse({ body: { v: 1 } }));
+      vi.stubGlobal('fetch', getRes);
+      await fetchJson('/overview');
+      expect(getRes).toHaveBeenCalledTimes(1);
+
+      const mutateRes = vi.fn().mockResolvedValue(makeResponse({ body: undefined, text: '' }));
+      vi.stubGlobal('fetch', mutateRes);
+      await fetchMutate('/agents/demo', { method: 'PATCH' });
+
+      // After the mutation, the previously-cached GET must refetch.
+      const getRes2 = vi.fn().mockResolvedValue(makeResponse({ body: { v: 2 } }));
+      vi.stubGlobal('fetch', getRes2);
+      const out = await fetchJson<{ v: number }>('/overview');
+      expect(out).toEqual({ v: 2 });
+      expect(getRes2).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT invalidate the cache on a failed mutation', async () => {
+      const getRes = vi.fn().mockResolvedValue(makeResponse({ body: { v: 1 } }));
+      vi.stubGlobal('fetch', getRes);
+      await fetchJson('/overview');
+
+      const failRes = vi
+        .fn()
+        .mockResolvedValue(makeResponse({ ok: false, status: 400, body: { message: 'bad' } }));
+      vi.stubGlobal('fetch', failRes);
+      await expect(fetchMutate('/agents/demo', { method: 'PATCH' })).rejects.toThrow('bad');
+
+      // The cached GET survives a failed mutation — still served from cache.
+      const getRes2 = vi.fn().mockResolvedValue(makeResponse({ body: { v: 2 } }));
+      vi.stubGlobal('fetch', getRes2);
+      const out = await fetchJson<{ v: number }>('/overview');
+      expect(out).toEqual({ v: 1 });
+      expect(getRes2).not.toHaveBeenCalled();
     });
 
     it('throws and toasts the parsed message on failure', async () => {

--- a/packages/frontend/tests/services/sse.test.ts
+++ b/packages/frontend/tests/services/sse.test.ts
@@ -136,3 +136,108 @@ describe("sse", () => {
     expect(pingCount()).toBe(beforePing + 1);
   });
 });
+
+// SSE-driven SWR cache invalidation. These tests mock the cache + routing modules
+// so they can assert (a) the right key group is invalidated for each event and
+// (b) the invalidation runs BEFORE the corresponding ping signal is bumped — the
+// ordering that keeps live dashboard updates working with caching in place.
+describe("sse cache invalidation", () => {
+  let mockEventSource: any;
+  const invalidateGroup = vi.fn();
+  const invalidateCustomProvidersCache = vi.fn();
+  // Records the order of invalidateGroup vs ping-bump observations.
+  let order: string[] = [];
+
+  function getHandler(type: string) {
+    return mockEventSource.addEventListener.mock.calls.find(
+      (c: any[]) => c[0] === type,
+    )?.[1];
+  }
+
+  beforeEach(() => {
+    order = [];
+    mockEventSource = { addEventListener: vi.fn(), close: vi.fn() };
+    vi.stubGlobal("EventSource", vi.fn(() => mockEventSource));
+    vi.resetModules();
+    invalidateGroup.mockReset();
+    invalidateCustomProvidersCache.mockReset();
+    invalidateGroup.mockImplementation((g: string) => order.push(`invalidate:${g}`));
+    vi.doMock("../../src/services/api/cache.js", () => ({ invalidateGroup }));
+    vi.doMock("../../src/services/api/routing.js", () => ({
+      invalidateCustomProvidersCache,
+    }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("../../src/services/api/cache.js");
+    vi.doUnmock("../../src/services/api/routing.js");
+  });
+
+  it("invalidates the 'message' group BEFORE bumping messagePing", async () => {
+    vi.useFakeTimers();
+    const { connectSse, messagePing } = await import("../../src/services/sse");
+    connectSse();
+    const handler = getHandler("message");
+    const before = messagePing();
+    handler();
+    // The coalesced bump (and its invalidation) fire after 500ms.
+    vi.advanceTimersByTime(500);
+    expect(messagePing()).toBe(before + 1);
+    // Invalidation happened, targeting the message group.
+    expect(invalidateGroup).toHaveBeenCalledWith("message");
+    // And it happened inside the same tick, before the signal observers run.
+    expect(order[0]).toBe("invalidate:message");
+  });
+
+  it("invalidates the 'agent' group BEFORE bumping agentPing", async () => {
+    const { connectSse, agentPing } = await import("../../src/services/sse");
+    connectSse();
+    const handler = getHandler("agent");
+    const before = agentPing();
+    // The invalidate spy records its call; capture the ping value at call time.
+    invalidateGroup.mockImplementation((g: string) => {
+      order.push(`invalidate:${g}@ping=${agentPing()}`);
+    });
+    handler();
+    expect(agentPing()).toBe(before + 1);
+    // Invalidation observed the pre-bump ping value → it ran first.
+    expect(order[0]).toBe(`invalidate:agent@ping=${before}`);
+  });
+
+  it("invalidates routing group AND custom-providers cache BEFORE bumping routingPing", async () => {
+    const { connectSse, routingPing } = await import("../../src/services/sse");
+    connectSse();
+    const handler = getHandler("routing");
+    const before = routingPing();
+    invalidateGroup.mockImplementation((g: string) => {
+      order.push(`invalidate:${g}@ping=${routingPing()}`);
+    });
+    invalidateCustomProvidersCache.mockImplementation(() => {
+      order.push(`custom@ping=${routingPing()}`);
+    });
+    handler();
+    expect(routingPing()).toBe(before + 1);
+    // Both invalidations ran before the ping bump.
+    expect(invalidateGroup).toHaveBeenCalledWith("routing");
+    expect(invalidateCustomProvidersCache).toHaveBeenCalled();
+    expect(order).toEqual([
+      `invalidate:routing@ping=${before}`,
+      `custom@ping=${before}`,
+    ]);
+  });
+
+  it("clears the pending message-bump timer on cleanup without invalidating", async () => {
+    vi.useFakeTimers();
+    const { connectSse, messagePing } = await import("../../src/services/sse");
+    const cleanup = connectSse();
+    const handler = getHandler("message");
+    const before = messagePing();
+    handler();
+    cleanup();
+    vi.advanceTimersByTime(1000);
+    // Neither the bump nor its invalidation fire after cleanup.
+    expect(messagePing()).toBe(before);
+    expect(invalidateGroup).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/tests/setup.ts
+++ b/packages/frontend/tests/setup.ts
@@ -1,0 +1,10 @@
+import { beforeEach } from 'vitest';
+import { invalidateAll } from '../src/services/api/cache';
+
+// The SWR GET cache (src/services/api/cache.ts) is a module-level singleton that
+// persists across tests in the same file. Reset it before every test so a cached
+// payload from one test never satisfies a GET in another (test isolation), the
+// same way fetch mocks are reset between tests.
+beforeEach(() => {
+  invalidateAll();
+});

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -86,6 +86,7 @@ export default defineConfig(({ command }) => ({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./tests/setup.ts'],
     transformMode: { web: [/\.[jt]sx?$/] },
     deps: {
       optimizer: { web: { include: ['solid-js'] } },


### PR DESCRIPTION
Related to #2274 (the "every tab switch refetches everything" follow-up noted there).

## Problem
Every dashboard page fetches with raw `createResource`, and the router unmounts/remounts pages on navigation, so switching Overview → Messages → Subscriptions → back refetches **everything** every time. No cross-navigation cache.

## Change
A transparent stale-while-revalidate cache behind the shared `fetchJson` GET helper — pages need no edits.
- 30s TTL, stale-while-revalidate, in-flight dedupe; only resolved 2xx GETs cached.
- Deny-list for always-fresh/sensitive routes (`/auth`, `/key`, `/rotate-key`, `/events`, `/health`) + per-call `{ cache: false }` opt-out; mutations invalidate on success.
- **SSE-driven freshness**: each `message`/`agent`/`routing` event invalidates its key group **before** bumping the ping signal, so the ping-triggered refetch reads fresh data. Live updates are preserved — navigation is instant *and* never stale past the next SSE tick.

Compatible with #2274's `/api/v1/providers/usage` split: the `message` group (`/usage`) and `routing` group (`/providers`) substring-match that endpoint, so new-message live refresh of the usage widget keeps working once both land.

## Tests
Frontend 3896 passed, 100% line coverage on new/changed files (cache hit/miss/SWR/dedupe/TTL/deny-list/opt-out/mutation + per-ping invalidation ordering). Build + lint green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a transparent SWR cache behind `fetchJson` GETs so dashboard tab switches stop refetching everything. Live data stays fresh via SSE-driven invalidation; addresses the follow-up in #2274.

- **New Features**
  - 30s TTL SWR cache for cacheable GETs with in-flight dedupe; caches only 2xx and keys by full URL.
  - Safety: deny-list (`/auth`, `/key`, `/rotate-key`, `/events`, `/health`); per-call `{ cache: false }`; `getModelParamSpecs` and `getCustomProviders` bypass shared SWR; mutations drop all GETs on success.
  - SSE invalidates URL groups (`message`, `agent`, `routing`) before ping bumps so refetches read fresh data; routing also clears the custom-providers cache.

- **Bug Fixes**
  - Prevent cache resurrection by suppressing writes from requests that started before an invalidation (generation guard), and scope error cleanup to the correct in-flight slot.
  - Prune fully expired, idle entries on successful writes to bound growth; ensure GlobalOverview usage/overview charts refetch on message pings by keying resources on `messagePing()`.

<sup>Written for commit 1f3b7901f28575f797899b5e29c91d038fbc5b9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

