### PR TITLE
Fix custom provider modal on Usage-based page

### DIFF
--- a/.changeset/custom-provider-modal.md
+++ b/.changeset/custom-provider-modal.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Restore the "Add custom provider" button on the Usage-based page and use a dedicated modal for creating and editing custom providers

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -43,8 +43,8 @@ const emptyRow = (): ModelRow => ({
   price_estimated: false,
 });
 
-const toModelRows = (models: CustomProviderModel[]): ModelRow[] =>
-  models.map((m) => ({
+const toModelRows = (models: CustomProviderModel[] | undefined): ModelRow[] =>
+  (models ?? []).map((m) => ({
     model_name: m.model_name,
     input_price:
       m.input_price_per_million_tokens != null ? String(m.input_price_per_million_tokens) : '',

--- a/packages/frontend/src/pages/providers/ConnectionDetail.tsx
+++ b/packages/frontend/src/pages/providers/ConnectionDetail.tsx
@@ -43,6 +43,7 @@ import { toast } from '../../services/toast-store.js';
 import '../../styles/charts.css';
 import '../../styles/analytics-overview.css';
 import { getModelDisplayName } from '../../services/model-display.js';
+import CustomProviderForm from '../../components/CustomProviderForm.jsx';
 import '../../styles/routing.css';
 
 const AUTH_TYPE_LABELS: Record<string, string> = {
@@ -862,136 +863,174 @@ const ConnectionDetail: Component = () => {
               </div>
               {/* Manage connection modal */}
               <Show when={showManageModal()}>
-                <div
-                  class="modal-overlay"
-                  onClick={(e) => {
-                    if (e.target === e.currentTarget) setShowManageModal(false);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Escape') setShowManageModal(false);
-                  }}
-                >
-                  <div
-                    class="modal-card"
-                    style="max-width: 420px; padding: 24px;"
-                    role="dialog"
-                    aria-modal="true"
-                  >
-                    {/* Header with provider name and close button */}
-                    <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px;">
-                      <div style="display: flex; align-items: center; gap: 10px;">
-                        <span style="display: flex; align-items: center; width: 28px; height: 28px;">
-                          <Show
-                            when={provDef()}
-                            fallback={
-                              <span style="width: 28px; height: 28px; border-radius: 50%; background: hsl(var(--muted)); display: flex; align-items: center; justify-content: center; font-size: 14px; font-weight: 600; color: hsl(var(--muted-foreground));">
-                                {providerDisplayName().charAt(0)}
-                              </span>
-                            }
-                          >
-                            {providerIcon(provDef()!.id, 28)}
-                          </Show>
-                        </span>
-                        <span style="font-size: var(--font-size-lg); font-weight: 600; color: hsl(var(--foreground));">
-                          {providerDisplayName()}
-                        </span>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => setShowManageModal(false)}
-                        style="background: none; border: none; cursor: pointer; padding: 4px; color: hsl(var(--muted-foreground)); font-size: 18px; line-height: 1;"
-                        aria-label="Close"
+                <Show
+                  when={isCustomProvider() && customProviderData()}
+                  fallback={
+                    <div
+                      class="modal-overlay"
+                      onClick={(e) => {
+                        if (e.target === e.currentTarget) setShowManageModal(false);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Escape') setShowManageModal(false);
+                      }}
+                    >
+                      <div
+                        class="modal-card"
+                        style="max-width: 420px; padding: 24px;"
+                        role="dialog"
+                        aria-modal="true"
                       >
-                        ✕
-                      </button>
-                    </div>
-
-                    {/* Connection name */}
-                    <div style="margin-bottom: 16px;">
-                      <label style="display: block; font-size: var(--font-size-sm); font-weight: 500; color: hsl(var(--foreground)); margin-bottom: 6px;">
-                        Connection name
-                      </label>
-                      <div style="display: flex; align-items: center; gap: 8px;">
-                        <input
-                          type="text"
-                          class={`provider-detail__input${renameError() ? ' provider-detail__input--error' : ''}`}
-                          value={renameValue()}
-                          onInput={(e) => {
-                            setRenameValue(e.currentTarget.value);
-                            setRenameError('');
-                          }}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter') handleRename();
-                          }}
-                          style="flex: 1;"
-                        />
-                        <button
-                          class="btn btn--primary btn--sm"
-                          disabled={renaming() || renameValue().trim() === conn()?.label}
-                          onClick={handleRename}
-                        >
-                          {renaming() ? 'Saving...' : 'Save'}
-                        </button>
-                      </div>
-                      <Show when={renameError()}>
-                        <div style="color: hsl(var(--destructive)); font-size: var(--font-size-sm); margin-top: 4px;">
-                          {renameError()}
+                        {/* Header with provider name and close button */}
+                        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px;">
+                          <div style="display: flex; align-items: center; gap: 10px;">
+                            <span style="display: flex; align-items: center; width: 28px; height: 28px;">
+                              <Show
+                                when={provDef()}
+                                fallback={
+                                  <span style="width: 28px; height: 28px; border-radius: 50%; background: hsl(var(--muted)); display: flex; align-items: center; justify-content: center; font-size: 14px; font-weight: 600; color: hsl(var(--muted-foreground));">
+                                    {providerDisplayName().charAt(0)}
+                                  </span>
+                                }
+                              >
+                                {providerIcon(provDef()!.id, 28)}
+                              </Show>
+                            </span>
+                            <span style="font-size: var(--font-size-lg); font-weight: 600; color: hsl(var(--foreground));">
+                              {providerDisplayName()}
+                            </span>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => setShowManageModal(false)}
+                            style="background: none; border: none; cursor: pointer; padding: 4px; color: hsl(var(--muted-foreground)); font-size: 18px; line-height: 1;"
+                            aria-label="Close"
+                          >
+                            ✕
+                          </button>
                         </div>
-                      </Show>
+
+                        {/* Connection name */}
+                        <div style="margin-bottom: 16px;">
+                          <label style="display: block; font-size: var(--font-size-sm); font-weight: 500; color: hsl(var(--foreground)); margin-bottom: 6px;">
+                            Connection name
+                          </label>
+                          <div style="display: flex; align-items: center; gap: 8px;">
+                            <input
+                              type="text"
+                              class={`provider-detail__input${renameError() ? ' provider-detail__input--error' : ''}`}
+                              value={renameValue()}
+                              onInput={(e) => {
+                                setRenameValue(e.currentTarget.value);
+                                setRenameError('');
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') handleRename();
+                              }}
+                              style="flex: 1;"
+                            />
+                            <button
+                              class="btn btn--primary btn--sm"
+                              disabled={renaming() || renameValue().trim() === conn()?.label}
+                              onClick={handleRename}
+                            >
+                              {renaming() ? 'Saving...' : 'Save'}
+                            </button>
+                          </div>
+                          <Show when={renameError()}>
+                            <div style="color: hsl(var(--destructive)); font-size: var(--font-size-sm); margin-top: 4px;">
+                              {renameError()}
+                            </div>
+                          </Show>
+                        </div>
+
+                        <Show when={c.is_active}>
+                          {/* Models */}
+                          <div style="display: flex; align-items: center; justify-content: space-between; padding: 12px 0; border-top: 1px solid hsl(var(--border));">
+                            <span style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground));">
+                              {c.cached_model_count ?? 0} models
+                            </span>
+                            <button
+                              class="btn btn--outline btn--sm"
+                              disabled={refreshingModels()}
+                              onClick={handleRefreshModels}
+                              style="display: inline-flex; align-items: center; gap: 6px;"
+                            >
+                              {refreshingModels() ? 'Refreshing...' : 'Refresh models'}
+                            </button>
+                          </div>
+
+                          {/* Connection info */}
+                          <div style="padding: 12px 0; border-top: 1px solid hsl(var(--border)); font-size: var(--font-size-sm); color: hsl(var(--muted-foreground));">
+                            Connected via{' '}
+                            {c.auth_type === 'subscription'
+                              ? c.auth_type
+                              : c.auth_type === 'api_key'
+                                ? 'API key'
+                                : 'local server'}
+                          </div>
+
+                          {/* Actions */}
+                          <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 16px; border-top: 1px solid hsl(var(--border));">
+                            <button class="btn btn--destructive btn--sm" onClick={handleDisconnect}>
+                              Disconnect
+                            </button>
+                            <button
+                              class="btn btn--outline btn--sm"
+                              onClick={() => setShowManageModal(false)}
+                            >
+                              Done
+                            </button>
+                          </div>
+                        </Show>
+
+                        <Show when={!c.is_active}>
+                          <div style="display: flex; justify-content: flex-end; padding-top: 12px; border-top: 1px solid hsl(var(--border));">
+                            <button
+                              class="btn btn--outline btn--sm"
+                              onClick={() => setShowManageModal(false)}
+                            >
+                              Close
+                            </button>
+                          </div>
+                        </Show>
+                      </div>
                     </div>
-
-                    <Show when={c.is_active}>
-                      {/* Models */}
-                      <div style="display: flex; align-items: center; justify-content: space-between; padding: 12px 0; border-top: 1px solid hsl(var(--border));">
-                        <span style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground));">
-                          {c.cached_model_count ?? 0} models
-                        </span>
-                        <button
-                          class="btn btn--outline btn--sm"
-                          disabled={refreshingModels()}
-                          onClick={handleRefreshModels}
-                          style="display: inline-flex; align-items: center; gap: 6px;"
-                        >
-                          {refreshingModels() ? 'Refreshing...' : 'Refresh models'}
-                        </button>
-                      </div>
-
-                      {/* Connection info */}
-                      <div style="padding: 12px 0; border-top: 1px solid hsl(var(--border)); font-size: var(--font-size-sm); color: hsl(var(--muted-foreground));">
-                        Connected via{' '}
-                        {c.auth_type === 'subscription'
-                          ? c.auth_type
-                          : c.auth_type === 'api_key'
-                            ? 'API key'
-                            : 'local server'}
-                      </div>
-
-                      {/* Actions */}
-                      <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 16px; border-top: 1px solid hsl(var(--border));">
-                        <button class="btn btn--destructive btn--sm" onClick={handleDisconnect}>
-                          Disconnect
-                        </button>
-                        <button
-                          class="btn btn--outline btn--sm"
-                          onClick={() => setShowManageModal(false)}
-                        >
-                          Done
-                        </button>
-                      </div>
-                    </Show>
-
-                    <Show when={!c.is_active}>
-                      <div style="display: flex; justify-content: flex-end; padding-top: 12px; border-top: 1px solid hsl(var(--border));">
-                        <button
-                          class="btn btn--outline btn--sm"
-                          onClick={() => setShowManageModal(false)}
-                        >
-                          Close
-                        </button>
-                      </div>
-                    </Show>
+                  }
+                >
+                  {/* Custom provider edit modal */}
+                  <div
+                    class="modal-overlay"
+                    onClick={(e) => {
+                      if (e.target === e.currentTarget) setShowManageModal(false);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Escape') setShowManageModal(false);
+                    }}
+                  >
+                    <div
+                      class="modal-card routing-modal"
+                      role="dialog"
+                      aria-modal="true"
+                      aria-label="Edit custom provider"
+                      style="max-width: 600px; max-height: 85vh; overflow-y: auto;"
+                    >
+                      <CustomProviderForm
+                        agentName={firstAgentName()}
+                        initialData={customProviderData()!}
+                        onCreated={() => {
+                          setShowManageModal(false);
+                          refetchDetail();
+                        }}
+                        onBack={() => setShowManageModal(false)}
+                        onDeleted={() => {
+                          setShowManageModal(false);
+                          navigate(backLink());
+                        }}
+                      />
+                    </div>
                   </div>
-                </div>
+                </Show>
               </Show>
             </>
           );

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -32,6 +32,7 @@ import { providerIcon } from '../../components/ProviderIcon.jsx';
 import InfoTooltip from '../../components/InfoTooltip.jsx';
 import { toast } from '../../services/toast-store.js';
 import ProviderSelectModal from '../../components/ProviderSelectModal.jsx';
+import CustomProviderForm from '../../components/CustomProviderForm.jsx';
 import Sparkline from '../../components/Sparkline.jsx';
 import '../../styles/routing.css';
 
@@ -205,6 +206,7 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
   const copy = () => PAGE_COPY[props.kind];
   const navigate = useNavigate();
   const [showModal, setShowModal] = createSignal(false);
+  const [showCustomModal, setShowCustomModal] = createSignal(false);
   const [deepLink, setDeepLink] = createSignal<ProviderDeepLink | null>(null);
   const [customProviderPrefill, setCustomProviderPrefill] =
     createSignal<CustomProviderPrefill | null>(null);
@@ -397,12 +399,14 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
     }
   });
 
-  /* v8 ignore next 6 -- the "Add custom provider" affordance lives in ProviderApiKeyTab; this page never wires a trigger to openCustomProvider, so its body is unreachable from the DOM. */
   const openCustomProvider = () => {
-    setDeepLink(null);
-    setCustomProviderPrefill({ name: '', baseUrl: '' });
-    void refetchModalProviders();
-    setShowModal(true);
+    setShowCustomModal(true);
+  };
+
+  const handleCustomModalClose = () => {
+    setShowCustomModal(false);
+    void refetchGlobalProviders();
+    void refetchCustomProviders();
   };
 
   const handleModalClose = () => {
@@ -428,6 +432,25 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
           <h1 class="page-header__title">{copy().heading}</h1>
           <p class="page-header__subtitle">{copy().subtitle}</p>
         </div>
+        <Show when={copy().customAddLabel}>
+          <button
+            class="btn btn--outline btn--sm"
+            onClick={() => openCustomProvider()}
+            style="display: inline-flex; align-items: center; gap: 6px;"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path d="M7 11h10c.37 0 .72-.21.89-.54s.14-.73-.08-1.04l-5-7c-.38-.53-1.25-.53-1.63 0l-5 7A.997.997 0 0 0 6.99 11Zm5-6.28L15.06 9H8.95l3.06-4.28ZM17.5 13c-2.48 0-4.5 2.02-4.5 4.5s2.02 4.5 4.5 4.5 4.5-2.02 4.5-4.5-2.02-4.5-4.5-4.5m0 7a2.5 2.5 0 0 1 0-5 2.5 2.5 0 0 1 0 5M3 22h7c.55 0 1-.45 1-1v-7c0-.55-.45-1-1-1H3c-.55 0-1 .45-1 1v7c0 .55.45 1 1 1m1-7h5v5H4z" />
+            </svg>
+            {copy().customAddLabel}
+          </button>
+        </Show>
       </div>
 
       <Show when={showMetricCard()}>
@@ -755,6 +778,32 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
           onUpdate={handleModalUpdate}
           onClose={handleModalClose}
         />
+      </Show>
+
+      <Show when={showCustomModal() && firstAgentName()}>
+        <div
+          class="modal-overlay"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) handleCustomModalClose();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') handleCustomModalClose();
+          }}
+        >
+          <div
+            class="modal-card routing-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Add custom provider"
+            style="max-width: 600px; max-height: 85vh; overflow-y: auto;"
+          >
+            <CustomProviderForm
+              agentName={firstAgentName()}
+              onCreated={handleCustomModalClose}
+              onBack={() => handleCustomModalClose()}
+            />
+          </div>
+        </div>
       </Show>
     </div>
   );

--- a/packages/frontend/tests/components/CustomProviderForm.test.tsx
+++ b/packages/frontend/tests/components/CustomProviderForm.test.tsx
@@ -817,6 +817,21 @@ describe("CustomProviderForm — edit mode", () => {
     expect((screen.getByPlaceholderText("https://api.example.com/v1") as HTMLInputElement).value).toBe("https://api.groq.com/openai/v1");
   });
 
+  it("renders with undefined models (toModelRows handles nullish)", () => {
+    const noModels = { ...initialData, models: undefined as any };
+    render(() => (
+      <CustomProviderForm
+        agentName="test-agent"
+        onCreated={onCreated}
+        onBack={onBack}
+        initialData={noModels}
+      />
+    ));
+
+    // The form renders without crashing; no model rows are pre-filled.
+    expect(screen.getByText("Edit custom provider")).toBeDefined();
+  });
+
   it("shows masked API key with Change button", () => {
     render(() => (
       <CustomProviderForm

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -1065,8 +1065,8 @@ describe('ConnectionDetail (analytics)', () => {
     await waitFor(() => expect(screen.getByText('Custom Provider')).toBeDefined());
 
     fireEvent.click(screen.getByText('Manage'));
-    expect(screen.getByText('Connection name')).toBeDefined();
-    fireEvent.click(screen.getByText('Done'));
+    // Custom providers open the CustomProviderForm in edit mode
+    await waitFor(() => expect(screen.getByText('Edit custom provider')).toBeDefined());
   });
 
   it('falls back to empty data when the custom provider lookup rejects', async () => {

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -179,6 +179,27 @@ vi.mock('../../src/components/AddAgentModal.jsx', () => ({
   ),
 }));
 
+const mockCustomProviderForm = vi.fn();
+vi.mock('../../src/components/CustomProviderForm.jsx', () => ({
+  default: (props: Record<string, unknown>) => {
+    mockCustomProviderForm(props);
+    return (
+      <div data-testid="custom-provider-form">
+        Edit custom provider
+        <button onClick={() => (props.onCreated as () => void)()}>form-created</button>
+        <button onClick={() => (props.onBack as () => void)()}>form-back</button>
+        <button
+          onClick={() => {
+            if (props.onDeleted) (props.onDeleted as () => void)();
+          }}
+        >
+          form-deleted
+        </button>
+      </div>
+    );
+  },
+}));
+
 vi.mock('../../src/components/ProviderSelectModal.jsx', () => ({
   default: (props: {
     agentName?: string;
@@ -1067,6 +1088,65 @@ describe('ConnectionDetail (analytics)', () => {
     fireEvent.click(screen.getByText('Manage'));
     // Custom providers open the CustomProviderForm in edit mode
     await waitFor(() => expect(screen.getByText('Edit custom provider')).toBeDefined());
+  });
+
+  const setupCustomConnectionDetail = () => {
+    routerState.params = { connectionId: 'conn-custom' };
+    apiMocks.getConnectionDetail.mockResolvedValue({
+      ...connectionDetail,
+      connection: {
+        ...connectionDetail.connection,
+        id: 'conn-custom',
+        provider: 'custom:cp-1',
+        label: 'Custom key',
+      },
+    });
+  };
+
+  it('closes the custom provider edit modal and refetches on onCreated', async () => {
+    setupCustomConnectionDetail();
+    render(() => <ConnectionDetail />);
+    await waitFor(() => expect(screen.getByText('Custom Provider')).toBeDefined());
+
+    fireEvent.click(screen.getByText('Manage'));
+    await waitFor(() => expect(screen.getByTestId('custom-provider-form')).toBeDefined());
+
+    fireEvent.click(screen.getByText('form-created'));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Edit custom provider' })).toBeNull(),
+    );
+    // Detail is refetched after onCreated.
+    expect(apiMocks.getConnectionDetail.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('closes the custom provider edit modal on onBack', async () => {
+    setupCustomConnectionDetail();
+    render(() => <ConnectionDetail />);
+    await waitFor(() => expect(screen.getByText('Custom Provider')).toBeDefined());
+
+    fireEvent.click(screen.getByText('Manage'));
+    await waitFor(() => expect(screen.getByTestId('custom-provider-form')).toBeDefined());
+
+    fireEvent.click(screen.getByText('form-back'));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Edit custom provider' })).toBeNull(),
+    );
+  });
+
+  it('closes the custom provider edit modal and navigates back on onDeleted', async () => {
+    setupCustomConnectionDetail();
+    render(() => <ConnectionDetail />);
+    await waitFor(() => expect(screen.getByText('Custom Provider')).toBeDefined());
+
+    fireEvent.click(screen.getByText('Manage'));
+    await waitFor(() => expect(screen.getByTestId('custom-provider-form')).toBeDefined());
+
+    fireEvent.click(screen.getByText('form-deleted'));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Edit custom provider' })).toBeNull(),
+    );
+    // onDeleted navigates to backLink() (usage-based for api_key auth type).
+    expect(routerState.navigate).toHaveBeenCalledWith('/providers/usage-based');
   });
 
   it('falls back to empty data when the custom provider lookup rejects', async () => {

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -39,6 +39,20 @@ vi.mock('../../src/components/ProviderSelectModal.jsx', () => ({
   },
 }));
 
+const mockCustomProviderForm = vi.fn();
+vi.mock('../../src/components/CustomProviderForm.jsx', () => ({
+  default: (props: Record<string, unknown>) => {
+    mockCustomProviderForm(props);
+    return (
+      <div data-testid="custom-provider-form">
+        Custom provider form
+        <button onClick={() => (props.onCreated as () => void)()}>created</button>
+        <button onClick={() => (props.onBack as () => void)()}>back</button>
+      </div>
+    );
+  },
+}));
+
 vi.mock('../../src/components/ProviderIcon.jsx', () => ({
   providerIcon: (providerId: string) =>
     providerId === 'openai' ? <span data-testid="provider-icon" /> : null,
@@ -598,6 +612,95 @@ describe('provider pages', () => {
     fireEvent.click(screen.getByLabelText('List view'));
     // Local providers use the "Connected" label rather than an active-count.
     await waitFor(() => expect(screen.getAllByText('Connected').length).toBeGreaterThan(0));
+  });
+
+  it('opens and closes the custom provider modal on the BYOK page', async () => {
+    render(() => <Byok />);
+    await waitFor(() => expect(screen.getByText('Add custom provider')).toBeDefined());
+
+    // Wait for agent to load so the modal can render (guarded by firstAgentName()).
+    await waitFor(() =>
+      expect(
+        (screen.getAllByText('Connect') as HTMLButtonElement[]).some((btn) => !btn.disabled),
+      ).toBe(true),
+    );
+
+    fireEvent.click(screen.getByText('Add custom provider'));
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: 'Add custom provider' })).toBeDefined(),
+    );
+    expect(mockCustomProviderForm).toHaveBeenCalledWith(
+      expect.objectContaining({ agentName: 'demo-agent' }),
+    );
+    // initialData must NOT be passed in create mode.
+    expect(mockCustomProviderForm).toHaveBeenCalledWith(
+      expect.not.objectContaining({ initialData: expect.anything() }),
+    );
+
+    // Close via Escape key.
+    const overlay = document.querySelector('.modal-overlay') as HTMLElement;
+    fireEvent.keyDown(overlay, { key: 'Escape' });
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Add custom provider' })).toBeNull(),
+    );
+    // Closing refetches both global and custom providers.
+    expect(mockGetGlobalProviders.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(mockGetCustomProviders.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('closes the custom modal via overlay click', async () => {
+    render(() => <Byok />);
+    await waitFor(() =>
+      expect(
+        (screen.getAllByText('Connect') as HTMLButtonElement[]).some((btn) => !btn.disabled),
+      ).toBe(true),
+    );
+
+    fireEvent.click(screen.getByText('Add custom provider'));
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: 'Add custom provider' })).toBeDefined(),
+    );
+
+    // Click the overlay itself (target === currentTarget).
+    const overlay = document.querySelector('.modal-overlay') as HTMLElement;
+    fireEvent.click(overlay);
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Add custom provider' })).toBeNull(),
+    );
+  });
+
+  it('closes the custom modal when the form fires onCreated', async () => {
+    render(() => <Byok />);
+    await waitFor(() =>
+      expect(
+        (screen.getAllByText('Connect') as HTMLButtonElement[]).some((btn) => !btn.disabled),
+      ).toBe(true),
+    );
+
+    fireEvent.click(screen.getByText('Add custom provider'));
+    await waitFor(() => expect(screen.getByTestId('custom-provider-form')).toBeDefined());
+
+    fireEvent.click(screen.getByText('created'));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Add custom provider' })).toBeNull(),
+    );
+  });
+
+  it('closes the custom modal when the form fires onBack', async () => {
+    render(() => <Byok />);
+    await waitFor(() =>
+      expect(
+        (screen.getAllByText('Connect') as HTMLButtonElement[]).some((btn) => !btn.disabled),
+      ).toBe(true),
+    );
+
+    fireEvent.click(screen.getByText('Add custom provider'));
+    await waitFor(() => expect(screen.getByTestId('custom-provider-form')).toBeDefined());
+
+    fireEvent.click(screen.getByText('back'));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Add custom provider' })).toBeNull(),
+    );
   });
 
   it('renders a usage sparkline for connected rows that have 7-day data', async () => {

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -12,7 +12,8 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "__tests__"]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -12,8 +12,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0"
+    "moduleResolution": "node"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "__tests__"]


### PR DESCRIPTION
## What changed
- Restored the "Add custom provider" button in the Usage-based page header
- Clicking it opens a dedicated custom provider form modal (name, URL, API key, models) instead of the global provider picker
- The "Manage" button on custom provider connections now opens the same full edit form instead of the generic modal (connection name + refresh models)
- Capped both create and edit modals at 85vh with internal scrolling so long model lists stay within the viewport

## Why
During a prior refactor the "Add custom provider" button was dropped from the Usage-based page. Editing a custom provider also fell back to the generic manage modal, which only showed connection name and refresh: no way to update the base URL, API key, or model list.

## For users
- "Add custom provider" button is back on the Usage-based page (top right)
- Creating and editing custom providers now uses the full form with name, base URL, API format, API key, and models
- Deleting a custom provider from the edit modal navigates back to the Usage-based list
- Modals with many models scroll internally instead of overflowing the screen

## For operators
No operator impact.

## How to test
1. Go to the Usage-based page (`/providers/usage-based`)
2. Verify the "Add custom provider" button is visible in the header
3. Click it: a modal opens with the full custom provider form (not the global provider grid)
4. Create a custom provider with a URL and several models
5. Navigate to that connection's detail page, click "Manage": the full edit form opens with the provider's data pre-filled
6. Add enough models to exceed the viewport height: the modal should scroll internally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the “Add custom provider” button on the Usage-based page and routes create/edit to a dedicated modal with the full custom provider form. Modals support overlay/Escape close, refresh lists after create, and keep long model lists in view.

- **New Features**
  - Add button opens the full custom provider form in a dedicated modal; closes via overlay/Escape and refreshes global/custom provider lists after create.
  - “Manage” on a custom provider opens the same form in edit mode; onCreated refetches connection detail and onDeleted navigates back to the Usage-based list; modals capped at 85vh with internal scrolling.

- **Bug Fixes**
  - Handle undefined model lists in the form mapper to prevent errors.
  - Add tests for custom provider modal flows (open/close, refetch, navigation).
  - Revert TypeScript config `ignoreDeprecations` to restore CI checks on TS 5.x.

<sup>Written for commit 7f0c3ba026f5a72398773baec26e937ca274af7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

