### PR TITLE
perf: speed up overview and messages

### DIFF
--- a/.changeset/fast-overview-messages.md
+++ b/.changeset/fast-overview-messages.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Speed up global overview and Messages by collapsing overview usage timeseries queries and letting Messages load rows before exact totals/filter metadata.

--- a/packages/backend/src/analytics/controllers/messages.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.spec.ts
@@ -9,6 +9,7 @@ import { SpecificityFeedbackService } from '../services/specificity-feedback.ser
 describe('MessagesController', () => {
   let controller: MessagesController;
   let mockGetMessages: jest.Mock;
+  let mockGetMessageFilterOptions: jest.Mock;
   let mockGetDetails: jest.Mock;
   let mockSetFeedback: jest.Mock;
   let mockClearFeedback: jest.Mock;
@@ -23,6 +24,7 @@ describe('MessagesController', () => {
       total_count: 0,
       providers: [],
     });
+    mockGetMessageFilterOptions = jest.fn().mockResolvedValue({ providers: [] });
 
     mockGetDetails = jest.fn().mockResolvedValue({
       message: { id: 'msg-1', status: 'ok' },
@@ -42,7 +44,10 @@ describe('MessagesController', () => {
       providers: [
         {
           provide: MessagesQueryService,
-          useValue: { getMessages: mockGetMessages },
+          useValue: {
+            getMessages: mockGetMessages,
+            getMessageFilterOptions: mockGetMessageFilterOptions,
+          },
         },
         {
           provide: MessageDetailsService,
@@ -89,6 +94,8 @@ describe('MessagesController', () => {
       routing_tier: undefined,
       specificity_category: undefined,
       header_tier_id: undefined,
+      include_total: undefined,
+      include_filter_options: undefined,
     });
   });
 
@@ -110,6 +117,8 @@ describe('MessagesController', () => {
       routing_tier: 'simple',
       specificity_category: 'coding',
       header_tier_id: 'ht-premium',
+      include_total: false,
+      include_filter_options: false,
     };
     await controller.getMessages(query as never, ctx as never);
 
@@ -128,6 +137,21 @@ describe('MessagesController', () => {
       routing_tier: 'simple',
       specificity_category: 'coding',
       header_tier_id: 'ht-premium',
+      include_total: false,
+      include_filter_options: false,
+    });
+  });
+
+  it('delegates message filter options lookup', async () => {
+    await controller.getMessageFilterOptions(
+      { range: '30d', agent_name: 'bot-1' } as never,
+      ctx as never,
+    );
+
+    expect(mockGetMessageFilterOptions).toHaveBeenCalledWith({
+      range: '30d',
+      tenantId: 'tenant-1',
+      agent_name: 'bot-1',
     });
   });
 

--- a/packages/backend/src/analytics/controllers/messages.controller.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.ts
@@ -45,6 +45,17 @@ export class MessagesController {
       routing_tier: query.routing_tier,
       specificity_category: query.specificity_category,
       header_tier_id: query.header_tier_id,
+      include_total: query.include_total,
+      include_filter_options: query.include_filter_options,
+    });
+  }
+
+  @Get('messages/filter-options')
+  async getMessageFilterOptions(@Query() query: MessagesQueryDto, @TenantCtx() ctx: TenantContext) {
+    return this.messagesQuery.getMessageFilterOptions({
+      range: query.range,
+      tenantId: ctx.tenantId,
+      agent_name: query.agent_name,
     });
   }
 

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -36,9 +36,19 @@ function mockTimeseries(): Record<string, jest.Mock> {
     getPerAgentTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
     getPerAgentMessageTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
     getPerAgentCostTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getAgentUsageTimeseries: jest.fn().mockResolvedValue({
+      tokenUsage: { agents: [], timeseries: [] },
+      messageUsage: { agents: [], timeseries: [] },
+      costUsage: { agents: [], timeseries: [] },
+    }),
     getPerProviderTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
     getPerProviderMessageTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
     getPerProviderCostTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getProviderUsageTimeseries: jest.fn().mockResolvedValue({
+      tokenUsage: { agents: [], timeseries: [] },
+      messageUsage: { agents: [], timeseries: [] },
+      costUsage: { agents: [], timeseries: [] },
+    }),
     getPerModelTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
     getPerModelMessageTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
     getPerModelCostTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
@@ -109,6 +119,16 @@ describe('OverviewController', () => {
       undefined,
       true,
     );
+  });
+
+  it('returns combined agent usage timeseries', async () => {
+    await controller.getOverviewAgentsUsage({ range: '24h' }, ctx as never);
+    expect(ts.getAgentUsageTimeseries).toHaveBeenCalledWith('24h', 'tenant-123', true);
+  });
+
+  it('returns combined provider usage timeseries with agent scope', async () => {
+    await controller.getOverviewProvidersUsage({ range: '7d', agent_name: 'bot-1' }, ctx as never);
+    expect(ts.getProviderUsageTimeseries).toHaveBeenCalledWith('7d', 'tenant-123', false, 'bot-1');
   });
 
   it('defaults range to 24h when not specified', async () => {

--- a/packages/backend/src/analytics/controllers/overview.controller.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.ts
@@ -98,6 +98,12 @@ export class OverviewController {
     return this.timeseries.getPerAgentCostTimeseries(range, ctx.tenantId, hourly);
   }
 
+  @Get('overview/agents/usage')
+  async getOverviewAgentsUsage(@Query() query: RangeQueryDto, @TenantCtx() ctx: TenantContext) {
+    const { range, hourly } = this.deriveTimeseriesArgs(query);
+    return this.timeseries.getAgentUsageTimeseries(range, ctx.tenantId, hourly);
+  }
+
   @Get('overview/per-provider-timeseries')
   async getPerProviderTimeseries(@Query() query: RangeQueryDto, @TenantCtx() ctx: TenantContext) {
     const { range, hourly, agentName } = this.deriveTimeseriesArgs(query);
@@ -120,6 +126,12 @@ export class OverviewController {
   ) {
     const { range, hourly, agentName } = this.deriveTimeseriesArgs(query);
     return this.timeseries.getPerProviderCostTimeseries(range, ctx.tenantId, hourly, agentName);
+  }
+
+  @Get('overview/providers/usage')
+  async getOverviewProvidersUsage(@Query() query: RangeQueryDto, @TenantCtx() ctx: TenantContext) {
+    const { range, hourly, agentName } = this.deriveTimeseriesArgs(query);
+    return this.timeseries.getProviderUsageTimeseries(range, ctx.tenantId, hourly, agentName);
   }
 
   @Get('overview/per-model-cost-timeseries')

--- a/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
@@ -88,6 +88,17 @@ describe('MessagesQueryDto', () => {
     expect(dto.recorded).toBe(false);
   });
 
+  it('coerces include_total and include_filter_options flags', async () => {
+    const dto = plainToInstance(MessagesQueryDto, {
+      include_total: 'false',
+      include_filter_options: '1',
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+    expect(dto.include_total).toBe(false);
+    expect(dto.include_filter_options).toBe(true);
+  });
+
   it('accepts each known routing_tier value including playground', async () => {
     for (const tier of ['simple', 'standard', 'complex', 'reasoning', 'playground']) {
       const dto = plainToInstance(MessagesQueryDto, { routing_tier: tier });

--- a/packages/backend/src/analytics/dto/messages-query.dto.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.ts
@@ -83,4 +83,14 @@ export class MessagesQueryDto {
   @IsOptional()
   @IsString()
   header_tier_id?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === true || value === 'true' || value === '1')
+  include_total?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === true || value === 'true' || value === '1')
+  include_filter_options?: boolean;
 }

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -4,6 +4,7 @@ import { Brackets, In } from 'typeorm';
 import { MessagesQueryService } from './messages-query.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { CustomProvider } from '../../entities/custom-provider.entity';
+import type { MessageStatusFilter } from '../dto/messages-query.dto';
 
 describe('MessagesQueryService', () => {
   let service: MessagesQueryService;
@@ -669,6 +670,40 @@ describe('MessagesQueryService', () => {
     );
     expect(tierCall).toBeDefined();
     expect(tierCall?.[1]).toEqual({ tierFilter: 'playground' });
+  });
+
+  it.each<[MessageStatusFilter, string, Record<string, unknown>]>([
+    [
+      'errors',
+      'at.status IN (:...errorStatuses)',
+      { errorStatuses: ['error', 'fallback_error', 'rate_limited'] },
+    ],
+    ['ok', 'at.status = :statusFilter', { statusFilter: 'ok' }],
+  ])('passes %s status filter through to the query builder', async (status, clause, bindings) => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 1 });
+    mockGetRawMany
+      .mockResolvedValueOnce([
+        { id: 'msg-1', timestamp: '2026-04-24 10:00:00', model: 'gpt-4o-mini', cost: 0 },
+      ])
+      .mockResolvedValueOnce([{ model: 'gpt-4o-mini' }]);
+
+    const mockQb = (
+      service as unknown as { turnRepo: { createQueryBuilder: jest.Mock } }
+    ).turnRepo.createQueryBuilder();
+    const andWhereSpy = mockQb.andWhere as jest.Mock;
+    andWhereSpy.mockClear();
+
+    const result = await service.getMessages({
+      range: '24h',
+      tenantId: 'test-user',
+      limit: 20,
+      status,
+    });
+
+    expect(result.total_count).toBe(1);
+    const statusCall = andWhereSpy.mock.calls.find(([candidate]) => candidate === clause);
+    expect(statusCall).toBeDefined();
+    expect(statusCall?.[1]).toEqual(bindings);
   });
 
   it('passes specificity_category filter through to the query builder', async () => {

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -198,6 +198,25 @@ describe('MessagesQueryService', () => {
     expect(result.provider_labels).toEqual({});
   });
 
+  it('uses the row count as the lower-bound total when skipped totals have no next page', async () => {
+    mockGetRawMany.mockResolvedValueOnce([
+      { id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' },
+    ]);
+
+    const result = await service.getMessages({
+      range: '24h',
+      tenantId: 'test-user',
+      limit: 2,
+      include_total: false,
+      include_filter_options: false,
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.next_cursor).toBeNull();
+    expect(result.total_count).toBe(1);
+    expect(result.total_count_exact).toBe(false);
+  });
+
   it('returns next_cursor when more items exist', async () => {
     const rows = Array.from({ length: 6 }, (_, i) => ({
       id: `msg-${i}`,

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -121,6 +121,22 @@ describe('MessagesQueryService', () => {
     expect(result.provider_labels).toEqual({ 'custom:u-1': 'MyLLM' });
   });
 
+  it('returns message filter metadata independently from row pagination', async () => {
+    mockGetRawMany.mockResolvedValueOnce([
+      { model: 'custom:u-1/m', provider: 'custom:u-1' },
+      { model: 'gpt-4o', provider: 'openai' },
+    ]);
+    mockCustomProviderFind.mockResolvedValueOnce([{ id: 'u-1', name: 'MyLLM' }]);
+
+    const result = await service.getMessageFilterOptions({
+      range: '24h',
+      tenantId: 'labels-user',
+    });
+
+    expect(result.providers).toEqual(['custom', 'custom:u-1', 'openai']);
+    expect(result.provider_labels).toEqual({ 'custom:u-1': 'MyLLM' });
+  });
+
   it('returns empty provider_labels without querying when no custom providers appear', async () => {
     mockGetRawOne.mockResolvedValueOnce({ total: 0 });
     mockGetRawMany.mockResolvedValueOnce([]);
@@ -154,6 +170,31 @@ describe('MessagesQueryService', () => {
     expect(result.items).toHaveLength(2);
     expect(result.next_cursor).toBeNull();
     expect(result.providers).toEqual(['anthropic', 'openai']);
+  });
+
+  it('can skip exact totals and filter metadata for fast row-only pagination', async () => {
+    mockGetRawMany.mockResolvedValueOnce([
+      { id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' },
+      { id: 'msg-2', timestamp: '2026-02-16 09:00:00', model: 'gpt-4o' },
+      { id: 'extra', timestamp: '2026-02-16 08:00:00', model: 'gpt-4o' },
+    ]);
+
+    const result = await service.getMessages({
+      range: '24h',
+      tenantId: 'test-user',
+      limit: 2,
+      include_total: false,
+      include_filter_options: false,
+    });
+
+    expect(mockGetRawOne).not.toHaveBeenCalled();
+    expect(mockGetRawMany).toHaveBeenCalledTimes(1);
+    expect(result.items).toHaveLength(2);
+    expect(result.next_cursor).toContain('|msg-2');
+    expect(result.total_count).toBe(3);
+    expect(result.total_count_exact).toBe(false);
+    expect(result.providers).toEqual([]);
+    expect(result.provider_labels).toEqual({});
   });
 
   it('returns next_cursor when more items exist', async () => {

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -17,6 +17,28 @@ const DISTINCT_MODELS_DEFAULT_INTERVAL = '90 days';
 const COUNT_CACHE_TTL_MS = 30_000;
 const MAX_CACHE_ENTRIES = 5_000;
 
+interface MessageFilterParams {
+  range?: string;
+  tenantId: string | null;
+  agent_name?: string;
+}
+
+interface MessageQueryParams extends MessageFilterParams {
+  provider?: string;
+  service_type?: string;
+  cost_min?: number;
+  cost_max?: number;
+  limit: number;
+  cursor?: string;
+  status?: MessageStatusFilter;
+  recorded?: boolean;
+  routing_tier?: string;
+  specificity_category?: string;
+  header_tier_id?: string;
+  include_total?: boolean;
+  include_filter_options?: boolean;
+}
+
 @Injectable()
 export class MessagesQueryService {
   private readonly modelsCache = new TtlCache<string, { models: string[]; providers: string[] }>({
@@ -35,24 +57,11 @@ export class MessagesQueryService {
     private readonly customProviderRepo: Repository<CustomProvider>,
   ) {}
 
-  async getMessages(params: {
-    range?: string;
-    tenantId: string | null;
-    provider?: string;
-    service_type?: string;
-    cost_min?: number;
-    cost_max?: number;
-    limit: number;
-    cursor?: string;
-    agent_name?: string;
-    status?: MessageStatusFilter;
-    recorded?: boolean;
-    routing_tier?: string;
-    specificity_category?: string;
-    header_tier_id?: string;
-  }) {
+  async getMessages(params: MessageQueryParams) {
     const baseQb = await this.buildBaseMessageQuery(params);
 
+    const includeTotal = params.include_total !== false;
+    const includeFilterOptions = params.include_filter_options !== false;
     const countCacheKey = this.buildCountCacheKey(params);
     const countQb = baseQb.clone().select('COUNT(*)', 'total');
 
@@ -67,39 +76,53 @@ export class MessagesQueryService {
 
     this.applyCursor(dataQb, params.cursor);
 
-    // Run count, data, and models+providers queries in parallel. The models
-    // query row shape includes both model and provider so we can derive the
-    // full provider set in a single round trip.
-    const cachedCount = params.cursor ? this.countCache.get(countCacheKey) : undefined;
+    const cachedCount =
+      includeTotal && params.cursor ? this.countCache.get(countCacheKey) : undefined;
     const countHit = cachedCount !== undefined;
-    const [countResult, rows, distinctRows] = await Promise.all([
-      countHit ? null : countQb.getRawOne(),
+    const [countResult, rows, filterOptions] = await Promise.all([
+      includeTotal ? (countHit ? null : countQb.getRawOne()) : null,
       dataQb
         .orderBy('at.timestamp', 'DESC')
         .addOrderBy('at.id', 'DESC')
         .limit(params.limit + 1)
         .getRawMany(),
-      this.getDistinctModels(params.tenantId, params.range, params.agent_name),
+      includeFilterOptions
+        ? this.getMessageFilterOptions(params)
+        : Promise.resolve({ providers: [] as string[], provider_labels: {} }),
     ]);
-
-    const totalCount = countHit
-      ? cachedCount
-      : this.cacheAndReturnCount(countCacheKey, Number(countResult?.total ?? 0));
 
     const hasMore = rows.length > params.limit;
     const items = rows.slice(0, params.limit);
+    const totalCount = includeTotal
+      ? countHit
+        ? (cachedCount ?? 0)
+        : this.cacheAndReturnCount(countCacheKey, Number(countResult?.total ?? 0))
+      : items.length + (hasMore ? 1 : 0);
     const lastItem = items[items.length - 1] as Record<string, unknown> | undefined;
     const nextCursor = hasMore && lastItem ? this.encodeCursor(lastItem) : null;
-    const providers = this.deriveProviders(distinctRows.models, distinctRows.providers);
-    const providerLabels = await this.resolveCustomProviderLabels(providers, params.tenantId);
 
     return {
       items,
       next_cursor: nextCursor,
       total_count: totalCount,
-      providers,
-      provider_labels: providerLabels,
+      total_count_exact: includeTotal,
+      providers: filterOptions.providers,
+      provider_labels: filterOptions.provider_labels,
     };
+  }
+
+  async getMessageFilterOptions(params: MessageFilterParams): Promise<{
+    providers: string[];
+    provider_labels: Record<string, string>;
+  }> {
+    const distinctRows = await this.getDistinctModels(
+      params.tenantId,
+      params.range,
+      params.agent_name,
+    );
+    const providers = this.deriveProviders(distinctRows.models, distinctRows.providers);
+    const providerLabels = await this.resolveCustomProviderLabels(providers, params.tenantId);
+    return { providers, provider_labels: providerLabels };
   }
 
   /**

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -93,11 +93,15 @@ export class MessagesQueryService {
 
     const hasMore = rows.length > params.limit;
     const items = rows.slice(0, params.limit);
-    const totalCount = includeTotal
-      ? countHit
-        ? (cachedCount ?? 0)
-        : this.cacheAndReturnCount(countCacheKey, Number(countResult?.total ?? 0))
-      : items.length + (hasMore ? 1 : 0);
+    let totalCount: number;
+    if (!includeTotal) {
+      totalCount = items.length;
+      if (hasMore) totalCount += 1;
+    } else if (cachedCount !== undefined) {
+      totalCount = cachedCount;
+    } else {
+      totalCount = this.cacheAndReturnCount(countCacheKey, Number(countResult?.total ?? 0));
+    }
     const lastItem = items[items.length - 1] as Record<string, unknown> | undefined;
     const nextCursor = hasMore && lastItem ? this.encodeCursor(lastItem) : null;
 

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -613,6 +613,16 @@ describe('TimeseriesQueriesService', () => {
       expect(out.timeseries).toEqual([{ date: '2026-01-01', alpha: 2.5 }]);
     });
 
+    it('getAgentUsageTimeseries pivots tokens, messages, and cost from one query', async () => {
+      mockGetRawMany.mockResolvedValue(rows);
+      const out = await service.getAgentUsageTimeseries('24h', 'u1', true);
+
+      expect(out.tokenUsage.timeseries[0]).toEqual({ hour: '01', alpha: 10, bravo: 5 });
+      expect(out.messageUsage.timeseries[0]).toEqual({ hour: '01', alpha: 1, bravo: 2 });
+      expect(out.costUsage.timeseries[0]).toEqual({ hour: '01', alpha: 1, bravo: 0.5 });
+      expect(mockGetRawMany).toHaveBeenCalledTimes(1);
+    });
+
     const labelClause = "LOWER(COALESCE(at.provider_key_label, 'Default')) = LOWER(:keyLabel)";
 
     it('scopes each per-agent timeseries to a connection label when provided', async () => {
@@ -758,6 +768,19 @@ describe('TimeseriesQueriesService', () => {
       mockGetRawMany.mockResolvedValue([{ hour: '01', provider: 'openai', cost: 1.25 }]);
       const out = await service.getPerProviderCostTimeseries('24h', 'u1', true);
       expect(out.timeseries).toEqual([{ hour: '01', openai: 1.25 }]);
+    });
+
+    it('getProviderUsageTimeseries pivots tokens, messages, and cost from one query', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { hour: '01', provider: 'openai', tokens: 10, messages: 2, cost: 1.5 },
+        { hour: '01', provider: 'anthropic', tokens: 5, messages: 1, cost: 0.5 },
+      ]);
+      const out = await service.getProviderUsageTimeseries('24h', 'u1', true);
+
+      expect(out.tokenUsage.timeseries[0]).toEqual({ hour: '01', anthropic: 5, openai: 10 });
+      expect(out.messageUsage.timeseries[0]).toEqual({ hour: '01', anthropic: 1, openai: 2 });
+      expect(out.costUsage.timeseries[0]).toEqual({ hour: '01', anthropic: 0.5, openai: 1.5 });
+      expect(mockGetRawMany).toHaveBeenCalledTimes(1);
     });
 
     it('getPerModelTimeseries pivots tokens', async () => {

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -623,6 +623,26 @@ describe('TimeseriesQueriesService', () => {
       expect(mockGetRawMany).toHaveBeenCalledTimes(1);
     });
 
+    it('getAgentUsageTimeseries supports date buckets and provider filters', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { date: '2026-01-01', agent_name: 'alpha', tokens: 10, messages: 2, cost: 1.25 },
+      ]);
+      const out = await service.getAgentUsageTimeseries(
+        '7d',
+        'u1',
+        false,
+        'subscription',
+        'openai',
+      );
+
+      expect(out.tokenUsage.timeseries[0]).toEqual({ date: '2026-01-01', alpha: 10 });
+      expect(out.messageUsage.timeseries[0]).toEqual({ date: '2026-01-01', alpha: 2 });
+      expect(out.costUsage.timeseries[0]).toEqual({ date: '2026-01-01', alpha: 1.25 });
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0]);
+      expect(clauses).toContain('at.auth_type = :authType');
+      expect(clauses).toContain('at.provider = :provider');
+    });
+
     const labelClause = "LOWER(COALESCE(at.provider_key_label, 'Default')) = LOWER(:keyLabel)";
 
     it('scopes each per-agent timeseries to a connection label when provided', async () => {
@@ -781,6 +801,17 @@ describe('TimeseriesQueriesService', () => {
       expect(out.messageUsage.timeseries[0]).toEqual({ hour: '01', anthropic: 1, openai: 2 });
       expect(out.costUsage.timeseries[0]).toEqual({ hour: '01', anthropic: 0.5, openai: 1.5 });
       expect(mockGetRawMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('getProviderUsageTimeseries supports date buckets', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { date: '2026-01-01', provider: 'openai', tokens: 10, messages: 2, cost: 1.5 },
+      ]);
+      const out = await service.getProviderUsageTimeseries('7d', 'u1', false, 'agent-x');
+
+      expect(out.tokenUsage.timeseries[0]).toEqual({ date: '2026-01-01', openai: 10 });
+      expect(out.messageUsage.timeseries[0]).toEqual({ date: '2026-01-01', openai: 2 });
+      expect(out.costUsage.timeseries[0]).toEqual({ date: '2026-01-01', openai: 1.5 });
     });
 
     it('getPerModelTimeseries pivots tokens', async () => {

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -30,6 +30,17 @@ interface TimeseriesBucketRow {
   count: number;
 }
 
+export interface PivotedTimeseries {
+  agents: string[];
+  timeseries: Array<Record<string, number | string>>;
+}
+
+export interface UsageTimeseries {
+  tokenUsage: PivotedTimeseries;
+  messageUsage: PivotedTimeseries;
+  costUsage: PivotedTimeseries;
+}
+
 @Injectable()
 export class TimeseriesQueriesService {
   constructor(
@@ -421,6 +432,45 @@ export class TimeseriesQueriesService {
     return pivotByKey(rows, bucketAlias, 'agent_name', 'cost');
   }
 
+  async getAgentUsageTimeseries(
+    range: string,
+    tenantId: string | null,
+    hourly: boolean,
+    authType?: string,
+    provider?: string,
+    label?: string,
+    tenantProviderId?: string,
+  ): Promise<UsageTimeseries> {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+    const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
+
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.agent_name', 'agent_name')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
+      .addSelect('COUNT(*)', 'messages')
+      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.agent_name IS NOT NULL');
+    excludePlaygroundAgents(qb);
+    addTenantFilter(qb, tenantId);
+    if (authType) qb.andWhere('at.auth_type = :authType', { authType });
+    if (provider) qb.andWhere('at.provider = :provider', { provider });
+    scopeToConnection(qb, tenantProviderId, label);
+
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.agent_name')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+
+    return pivotUsageRows(rows, bucketAlias, 'agent_name');
+  }
+
   async getPerProviderTimeseries(
     range: string,
     tenantId: string | null,
@@ -589,6 +639,37 @@ export class TimeseriesQueriesService {
     return pivotByKey(rows, bucketAlias, 'provider', 'cost');
   }
 
+  async getProviderUsageTimeseries(
+    range: string,
+    tenantId: string | null,
+    hourly: boolean,
+    agentName?: string,
+  ): Promise<UsageTimeseries> {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+    const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .leftJoin(CustomProvider, 'cp', CUSTOM_PROVIDER_JOIN_CONDITION)
+      .select(bucketExpr, bucketAlias)
+      .addSelect(PROVIDER_SERIES_KEY_EXPR, 'provider')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
+      .addSelect('COUNT(*)', 'messages')
+      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.provider IS NOT NULL');
+    excludePlaygroundAgents(qb);
+    addTenantFilter(qb, tenantId, agentName);
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy(PROVIDER_SERIES_KEY_EXPR)
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+    return pivotUsageRows(rows, bucketAlias, 'provider');
+  }
+
   async getPerModelCostTimeseries(
     range: string,
     tenantId: string | null,
@@ -680,4 +761,16 @@ function pivotByKey(
   });
 
   return { agents: keys, timeseries };
+}
+
+function pivotUsageRows(
+  rows: Array<Record<string, unknown>>,
+  bucketAlias: string,
+  keyField: string,
+): UsageTimeseries {
+  return {
+    tokenUsage: pivotByKey(rows, bucketAlias, keyField, 'tokens'),
+    messageUsage: pivotByKey(rows, bucketAlias, keyField, 'messages'),
+    costUsage: pivotByKey(rows, bucketAlias, keyField, 'cost'),
+  };
 }

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -24,12 +24,8 @@ import { customProviderLogo } from '../components/ProviderIcon.jsx';
 import { stripCustomPrefix } from '../services/routing-utils.js';
 import {
   getOverview,
-  getGlobalPerAgentTimeseries,
-  getGlobalPerAgentMessageTimeseries,
-  getGlobalPerProviderTimeseries,
-  getGlobalPerProviderMessageTimeseries,
-  getGlobalPerAgentCostTimeseries,
-  getGlobalPerProviderCostTimeseries,
+  getOverviewAgentUsage,
+  getOverviewProviderUsage,
 } from '../services/api/analytics.js';
 import { formatNumber, formatCost, formatTimeAgo } from '../services/formatters.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
@@ -188,8 +184,8 @@ const GlobalOverview: Component = () => {
     () => ({ _agentPing: agentPing(), _messagePing: messagePing() }),
     async () => {
       try {
-        const data = await getAgents();
-        return ((data as any)?.agents ?? data ?? []) as AgentRow[];
+        const data = (await getAgents()) as { agents?: AgentRow[] } | AgentRow[] | null;
+        return Array.isArray(data) ? data : (data?.agents ?? []);
       } catch {
         return [] as AgentRow[];
       }
@@ -240,34 +236,15 @@ const GlobalOverview: Component = () => {
   };
 
   type TSResult = { agents: string[]; timeseries: Array<Record<string, number | string>> };
-  const tokenFetcher = (range: string, group: string): Promise<TSResult> => {
-    if (group === 'provider') return getGlobalPerProviderTimeseries(range) as Promise<TSResult>;
-    return getGlobalPerAgentTimeseries(range) as Promise<TSResult>;
-  };
-  const msgFetcher = (range: string, group: string): Promise<TSResult> => {
-    if (group === 'provider')
-      return getGlobalPerProviderMessageTimeseries(range) as Promise<TSResult>;
-    return getGlobalPerAgentMessageTimeseries(range) as Promise<TSResult>;
+  type UsageTSResult = { tokenUsage: TSResult; messageUsage: TSResult; costUsage: TSResult };
+  const usageFetcher = (range: string, group: string): Promise<UsageTSResult> => {
+    if (group === 'provider') return getOverviewProviderUsage(range) as Promise<UsageTSResult>;
+    return getOverviewAgentUsage(range) as Promise<UsageTSResult>;
   };
 
-  const [agentTimeseries] = createResource(
+  const [usageTimeseries] = createResource(
     () => ({ range: chartRange(), group: groupBy(), _ping: messagePing() }),
-    (p) => tokenFetcher(p.range, p.group),
-  );
-
-  const [agentMessageTimeseries] = createResource(
-    () => ({ range: chartRange(), group: groupBy(), _ping: messagePing() }),
-    (p) => msgFetcher(p.range, p.group),
-  );
-
-  const costFetcher = (range: string, group: string): Promise<TSResult> => {
-    if (group === 'provider') return getGlobalPerProviderCostTimeseries(range) as Promise<TSResult>;
-    return getGlobalPerAgentCostTimeseries(range) as Promise<TSResult>;
-  };
-
-  const [agentCostTimeseries] = createResource(
-    () => ({ range: chartRange(), group: groupBy(), _ping: messagePing() }),
-    (p) => costFetcher(p.range, p.group),
+    (p) => usageFetcher(p.range, p.group),
   );
 
   // Provider-grouped series key custom providers as 'custom:<uuid>'. Remap
@@ -291,9 +268,9 @@ const GlobalOverview: Component = () => {
       ),
     };
   };
-  const tokenSeries = createMemo(() => remapCustomSeries(agentTimeseries()));
-  const messageSeries = createMemo(() => remapCustomSeries(agentMessageTimeseries()));
-  const costSeries = createMemo(() => remapCustomSeries(agentCostTimeseries()));
+  const tokenSeries = createMemo(() => remapCustomSeries(usageTimeseries()?.tokenUsage));
+  const messageSeries = createMemo(() => remapCustomSeries(usageTimeseries()?.messageUsage));
+  const costSeries = createMemo(() => remapCustomSeries(usageTimeseries()?.costUsage));
 
   // ── Harness filter state (sessionStorage) ────────────────────────────
   // Scope the persisted selection by groupBy(): the provider grouping and the
@@ -326,7 +303,8 @@ const GlobalOverview: Component = () => {
   const allAgents = createMemo(() => {
     const tokenAgents = tokenSeries()?.agents ?? [];
     const msgAgents = messageSeries()?.agents ?? [];
-    const set = new Set([...tokenAgents, ...msgAgents]);
+    const costAgents = costSeries()?.agents ?? [];
+    const set = new Set([...tokenAgents, ...msgAgents, ...costAgents]);
     return [...set].sort();
   });
 

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -26,6 +26,7 @@ import {
   getAgents,
   getSpecificityAssignments,
   getMessages,
+  getMessageFilterOptions,
   getRoutingStatus,
   listHeaderTiers,
   setMessageFeedback,
@@ -52,6 +53,12 @@ interface MessagesData {
   items: MessageRow[];
   next_cursor: string | null;
   total_count: number;
+  total_count_exact?: boolean;
+  providers: string[];
+  provider_labels?: Record<string, string>;
+}
+
+interface MessageFilterOptionsData {
   providers: string[];
   provider_labels?: Record<string, string>;
 }
@@ -264,7 +271,18 @@ const MessageLog: Component = () => {
       if (p.agentName) q.agent_name = p.agentName;
       if (p.cursor) q.cursor = p.cursor;
       q.limit = String(p.limit);
+      q.include_total = 'false';
+      q.include_filter_options = 'false';
       return getMessages(q) as Promise<MessagesData>;
+    },
+  );
+
+  const [messageFilterOptions] = createResource(
+    () => ({ agentName: agentFilter() || params.agentName, _ping: messagePing() }),
+    (p) => {
+      const q: Record<string, string> = {};
+      if (p.agentName) q.agent_name = p.agentName;
+      return getMessageFilterOptions(q) as Promise<MessageFilterOptionsData>;
     },
   );
 
@@ -296,6 +314,13 @@ const MessageLog: Component = () => {
   const hasNoData = () => {
     const d = data();
     return d && d.total_count === 0;
+  };
+
+  const totalForPager = () => {
+    const d = data();
+    if (!d) return 0;
+    if (d.total_count_exact !== false) return d.total_count;
+    return (pager.currentPage() - 1) * pager.pageSize + d.total_count;
   };
 
   const showEmptyState = () => hasNoData() && !hasActiveFilters() && !hasProviders();
@@ -341,12 +366,12 @@ const MessageLog: Component = () => {
     if (prov) return prov.name;
     // Custom providers arrive as `custom:<uuid>` — the backend ships a label
     // map alongside the provider list so the dropdown can show their names.
-    return data()?.provider_labels?.[id] ?? id;
+    return messageFilterOptions()?.provider_labels?.[id] ?? id;
   };
 
   const providerOptions = createMemo(() => [
     { label: 'All providers', value: '' },
-    ...(data()?.providers ?? []).map((id) => ({
+    ...(messageFilterOptions()?.providers ?? []).map((id) => ({
       label: providerDisplayName(id),
       icon: providerIcon(id, 14) ?? undefined,
       value: id,
@@ -600,7 +625,7 @@ const MessageLog: Component = () => {
                   Messages
                 </div>
                 <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                  {data()?.total_count ?? 0} total
+                  {totalForPager()} total
                 </span>
               </div>
               <div class="data-table-scroll">
@@ -622,7 +647,7 @@ const MessageLog: Component = () => {
               </div>
               <Pagination
                 currentPage={pager.currentPage}
-                totalItems={() => data()?.total_count ?? 0}
+                totalItems={totalForPager}
                 pageSize={pager.pageSize}
                 hasNextPage={pager.hasNextPage}
                 isLoading={() => data.loading}

--- a/packages/frontend/src/services/api/analytics.ts
+++ b/packages/frontend/src/services/api/analytics.ts
@@ -5,6 +5,12 @@ export type PivotedTimeseries = Promise<{
   timeseries: Array<Record<string, number | string>>;
 }>;
 
+export type UsageTimeseries = Promise<{
+  tokenUsage: Awaited<PivotedTimeseries>;
+  messageUsage: Awaited<PivotedTimeseries>;
+  costUsage: Awaited<PivotedTimeseries>;
+}>;
+
 export function getProviderAnalytics(
   authType: string,
   range = '24h',
@@ -95,6 +101,10 @@ export function getGlobalPerAgentCostTimeseries(range = '24h'): PivotedTimeserie
   return fetchJson('/overview/per-agent-cost-timeseries', { range }) as PivotedTimeseries;
 }
 
+export function getOverviewAgentUsage(range = '24h'): UsageTimeseries {
+  return fetchJson('/overview/agents/usage', { range }) as UsageTimeseries;
+}
+
 export function getGlobalPerProviderTimeseries(range = '24h'): PivotedTimeseries {
   return fetchJson('/overview/per-provider-timeseries', { range }) as PivotedTimeseries;
 }
@@ -105,6 +115,10 @@ export function getGlobalPerProviderMessageTimeseries(range = '24h'): PivotedTim
 
 export function getGlobalPerProviderCostTimeseries(range = '24h'): PivotedTimeseries {
   return fetchJson('/overview/per-provider-cost-timeseries', { range }) as PivotedTimeseries;
+}
+
+export function getOverviewProviderUsage(range = '24h'): UsageTimeseries {
+  return fetchJson('/overview/providers/usage', { range }) as UsageTimeseries;
 }
 
 export function getGlobalPerModelTimeseries(range = '24h'): PivotedTimeseries {

--- a/packages/frontend/src/services/api/messages.ts
+++ b/packages/frontend/src/services/api/messages.ts
@@ -114,9 +114,20 @@ export function getMessages(
     routing_tier?: string;
     specificity_category?: string;
     header_tier_id?: string;
+    include_total?: string;
+    include_filter_options?: string;
   } = {},
 ) {
   return fetchJson('/messages', params);
+}
+
+export function getMessageFilterOptions(
+  params: {
+    range?: string;
+    agent_name?: string;
+  } = {},
+) {
+  return fetchJson('/messages/filter-options', params);
 }
 
 export function getMessageDetails(id: string) {

--- a/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
@@ -14,12 +14,8 @@ const apiMocks = vi.hoisted(() => ({
   getGlobalProviders: vi.fn(),
   getGlobalProviderUsage: vi.fn(),
   getOverview: vi.fn(),
-  getGlobalPerAgentTimeseries: vi.fn(),
-  getGlobalPerAgentMessageTimeseries: vi.fn(),
-  getGlobalPerProviderTimeseries: vi.fn(),
-  getGlobalPerProviderMessageTimeseries: vi.fn(),
-  getGlobalPerAgentCostTimeseries: vi.fn(),
-  getGlobalPerProviderCostTimeseries: vi.fn(),
+  getOverviewAgentUsage: vi.fn(),
+  getOverviewProviderUsage: vi.fn(),
 }));
 
 const sseMocks = vi.hoisted(() => ({
@@ -62,18 +58,8 @@ vi.mock('../../src/services/api.js', async () => {
 
 vi.mock('../../src/services/api/analytics.js', () => ({
   getOverview: (...args: unknown[]) => apiMocks.getOverview(...args),
-  getGlobalPerAgentTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerAgentTimeseries(...args),
-  getGlobalPerAgentMessageTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerAgentMessageTimeseries(...args),
-  getGlobalPerProviderTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerProviderTimeseries(...args),
-  getGlobalPerProviderMessageTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerProviderMessageTimeseries(...args),
-  getGlobalPerAgentCostTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerAgentCostTimeseries(...args),
-  getGlobalPerProviderCostTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerProviderCostTimeseries(...args),
+  getOverviewAgentUsage: (...args: unknown[]) => apiMocks.getOverviewAgentUsage(...args),
+  getOverviewProviderUsage: (...args: unknown[]) => apiMocks.getOverviewProviderUsage(...args),
 }));
 
 vi.mock('../../src/services/providers.js', () => ({
@@ -249,6 +235,11 @@ const providerTimeseries = {
   agents: ['openai', 'anthropic'],
   timeseries: [{ hour: '2026-06-04 10:00:00', openai: 1200, anthropic: 900 }],
 };
+const providerUsageTimeseries = {
+  tokenUsage: providerTimeseries,
+  messageUsage: providerTimeseries,
+  costUsage: providerTimeseries,
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -262,12 +253,8 @@ beforeEach(() => {
   apiMocks.getGlobalProviders.mockResolvedValue(providersResponse);
   apiMocks.getGlobalProviderUsage.mockResolvedValue({ providers: [] });
   apiMocks.getOverview.mockResolvedValue(overviewResponse);
-  apiMocks.getGlobalPerAgentTimeseries.mockResolvedValue(providerTimeseries);
-  apiMocks.getGlobalPerAgentMessageTimeseries.mockResolvedValue(providerTimeseries);
-  apiMocks.getGlobalPerProviderTimeseries.mockResolvedValue(providerTimeseries);
-  apiMocks.getGlobalPerProviderMessageTimeseries.mockResolvedValue(providerTimeseries);
-  apiMocks.getGlobalPerAgentCostTimeseries.mockResolvedValue(providerTimeseries);
-  apiMocks.getGlobalPerProviderCostTimeseries.mockResolvedValue(providerTimeseries);
+  apiMocks.getOverviewAgentUsage.mockResolvedValue(providerUsageTimeseries);
+  apiMocks.getOverviewProviderUsage.mockResolvedValue(providerUsageTimeseries);
 });
 
 afterEach(() => {
@@ -327,9 +314,7 @@ describe('GlobalOverview filter onUnselectAll', () => {
     expect(apiMocks.getAgents).toHaveBeenCalledTimes(1);
     expect(apiMocks.getGlobalProviders).toHaveBeenCalledTimes(1);
     expect(apiMocks.getGlobalProviderUsage).toHaveBeenCalledTimes(1);
-    expect(apiMocks.getGlobalPerProviderTimeseries).toHaveBeenCalledTimes(1);
-    expect(apiMocks.getGlobalPerProviderMessageTimeseries).toHaveBeenCalledTimes(1);
-    expect(apiMocks.getGlobalPerProviderCostTimeseries).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getOverviewProviderUsage).toHaveBeenCalledTimes(1);
 
     sseMocks.bumpMessage?.();
 
@@ -337,8 +322,6 @@ describe('GlobalOverview filter onUnselectAll', () => {
     expect(apiMocks.getAgents).toHaveBeenCalledTimes(2);
     expect(apiMocks.getGlobalProviders).toHaveBeenCalledTimes(1);
     expect(apiMocks.getGlobalProviderUsage).toHaveBeenCalledTimes(2);
-    expect(apiMocks.getGlobalPerProviderTimeseries).toHaveBeenCalledTimes(2);
-    expect(apiMocks.getGlobalPerProviderMessageTimeseries).toHaveBeenCalledTimes(2);
-    expect(apiMocks.getGlobalPerProviderCostTimeseries).toHaveBeenCalledTimes(2);
+    expect(apiMocks.getOverviewProviderUsage).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
-import { createSignal } from "solid-js";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
 
-let mockAgentName = "test-agent";
+let mockAgentName = 'test-agent';
 let mockSearchParams: Record<string, string | undefined> = {};
 let mockSearchAgentAccessor: (() => string | undefined) | null = null;
 const mockNavigate = vi.fn();
-vi.mock("@solidjs/router", () => ({
+vi.mock('@solidjs/router', () => ({
   useParams: () => ({ agentName: mockAgentName }),
   useSearchParams: () => [
     {
@@ -17,15 +17,20 @@ vi.mock("@solidjs/router", () => ({
     vi.fn(),
   ],
   useNavigate: () => mockNavigate,
-  A: (props: any) => <a href={props.href} style={props.style} class={props.class}>{props.children}</a>,
+  A: (props: any) => (
+    <a href={props.href} style={props.style} class={props.class}>
+      {props.children}
+    </a>
+  ),
 }));
 
-vi.mock("@solidjs/meta", () => ({
+vi.mock('@solidjs/meta', () => ({
   Title: (props: any) => <title>{props.children}</title>,
-  Meta: (props: any) => <meta name={props.name ?? ""} content={props.content ?? ""} />,
+  Meta: (props: any) => <meta name={props.name ?? ''} content={props.content ?? ''} />,
 }));
 
 const mockGetMessages = vi.fn();
+const mockGetMessageFilterOptions = vi.fn();
 const mockGetAgents = vi.fn();
 const mockGetCustomProviders = vi.fn();
 const mockGetSpecificityAssignments = vi.fn();
@@ -35,8 +40,9 @@ const mockListHeaderTiers = vi.fn();
 const mockSetMessageFeedback = vi.fn();
 const mockClearMessageFeedback = vi.fn();
 const mockDeleteMessageRecording = vi.fn();
-vi.mock("../../src/services/api.js", () => ({
+vi.mock('../../src/services/api.js', () => ({
   getMessages: (...args: unknown[]) => mockGetMessages(...args),
+  getMessageFilterOptions: (...args: unknown[]) => mockGetMessageFilterOptions(...args),
   getAgents: (...args: unknown[]) => mockGetAgents(...args),
   getCustomProviders: (...args: unknown[]) => mockGetCustomProviders(...args),
   getSpecificityAssignments: (...args: unknown[]) => mockGetSpecificityAssignments(...args),
@@ -48,24 +54,24 @@ vi.mock("../../src/services/api.js", () => ({
   deleteMessageRecording: (...args: unknown[]) => mockDeleteMessageRecording(...args),
 }));
 
-vi.mock("../../src/services/sse.js", () => ({
+vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
   messagePing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
 }));
 
-vi.mock("../../src/services/model-display.js", () => ({
-  getModelDisplayName: (slug: string) => slug.replace(/^custom:[^/]+\//, ""),
+vi.mock('../../src/services/model-display.js', () => ({
+  getModelDisplayName: (slug: string) => slug.replace(/^custom:[^/]+\//, ''),
   preloadModelDisplayNames: () => {},
 }));
 
-vi.mock("../../src/services/formatters.js", () => ({
+vi.mock('../../src/services/formatters.js', () => ({
   formatCost: (v: number) => `$${v.toFixed(2)}`,
   formatNumber: (v: number) => String(v),
   formatStatus: (s: string) => s,
   formatTime: (t: string) => t,
-  formatDuration: (ms: number) => ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`,
+  formatDuration: (ms: number) => (ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`),
   formatErrorMessage: (s: string) => s,
   customProviderColor: vi.fn(() => '#6366f1'),
   sortedHeaderEntries: (h: Record<string, string> | null | undefined) =>
@@ -73,153 +79,211 @@ vi.mock("../../src/services/formatters.js", () => ({
 }));
 
 const mockCheckIsSelfHosted = vi.fn(() => Promise.resolve(false));
-vi.mock("../../src/services/setup-status.js", () => ({
+vi.mock('../../src/services/setup-status.js', () => ({
   checkIsSelfHosted: () => mockCheckIsSelfHosted(),
 }));
 
-vi.mock("../../src/components/SetupModal.jsx", () => ({
+vi.mock('../../src/components/SetupModal.jsx', () => ({
   default: (props: any) => (
     <div
       data-testid="setup-modal"
-      data-open={props.open ? "true" : "false"}
-      data-agent={props.agentName ?? ""}
-      data-platform={props.agentPlatform ?? ""}
-      data-category={props.agentCategory ?? ""}
+      data-open={props.open ? 'true' : 'false'}
+      data-agent={props.agentName ?? ''}
+      data-platform={props.agentPlatform ?? ''}
+      data-category={props.agentCategory ?? ''}
     >
-      <button data-testid="setup-close" onClick={() => props.onClose?.()}>Close</button>
+      <button data-testid="setup-close" onClick={() => props.onClose?.()}>
+        Close
+      </button>
     </div>
   ),
 }));
 
-vi.mock("../../src/components/FeedbackModal.jsx", () => ({
+vi.mock('../../src/components/FeedbackModal.jsx', () => ({
   default: (props: any) => (
-    <div data-testid="feedback-modal" data-open={props.open ? "true" : "false"}>
-      <button data-testid="feedback-submit" onClick={() => props.onSubmit?.(['Too slow'], 'test')}>Submit</button>
-      <button data-testid="feedback-close" onClick={() => props.onClose?.()}>Close</button>
+    <div data-testid="feedback-modal" data-open={props.open ? 'true' : 'false'}>
+      <button data-testid="feedback-submit" onClick={() => props.onSubmit?.(['Too slow'], 'test')}>
+        Submit
+      </button>
+      <button data-testid="feedback-close" onClick={() => props.onClose?.()}>
+        Close
+      </button>
     </div>
   ),
 }));
 
-vi.mock("../../src/components/InfoTooltip.jsx", () => ({
+vi.mock('../../src/components/InfoTooltip.jsx', () => ({
   default: () => <span data-testid="info-tooltip" />,
 }));
 
-vi.mock("../../src/components/Select.jsx", () => ({
+vi.mock('../../src/components/Select.jsx', () => ({
   default: (props: any) => (
-    <select data-testid="select" value={props.value} onChange={(e: any) => props.onChange(e.target.value)}>
-      {props.options?.map((o: any) => <option value={o.value}>{o.label}</option>)}
+    <select
+      data-testid="select"
+      value={props.value}
+      onChange={(e: any) => props.onChange(e.target.value)}
+    >
+      {props.options?.map((o: any) => (
+        <option value={o.value}>{o.label}</option>
+      ))}
     </select>
   ),
 }));
 
-vi.mock("../../src/components/ErrorState.jsx", () => ({
+vi.mock('../../src/components/ErrorState.jsx', () => ({
   default: (props: any) => <div data-testid="error-state">{props.title}</div>,
 }));
 
-vi.mock("../../src/components/Pagination.jsx", () => ({
+vi.mock('../../src/components/Pagination.jsx', () => ({
   default: (props: any) => {
     const total = props.totalItems();
     return total > props.pageSize ? (
       <div data-testid="pagination">
-        <button data-testid="pagination-prev" onClick={props.onPrevious} disabled={props.currentPage() <= 1}>Previous</button>
-        <button data-testid="pagination-next" onClick={props.onNext} disabled={!props.hasNextPage()}>Next</button>
+        <button
+          data-testid="pagination-prev"
+          onClick={props.onPrevious}
+          disabled={props.currentPage() <= 1}
+        >
+          Previous
+        </button>
+        <button
+          data-testid="pagination-next"
+          onClick={props.onNext}
+          disabled={!props.hasNextPage()}
+        >
+          Next
+        </button>
       </div>
     ) : null;
   },
 }));
 
-import MessageLog from "../../src/pages/MessageLog";
+import MessageLog from '../../src/pages/MessageLog';
 
 const messagesData = {
   items: [
-    { id: "msg-12345678", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "gpt-4o", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok", cache_read_tokens: 500, cache_creation_tokens: 100, duration_ms: 1200 },
-    { id: "msg-87654321", timestamp: "2026-02-18T09:00:00Z", agent_name: "test-agent", model: "claude-3.5-sonnet", input_tokens: 200, output_tokens: 100, total_tokens: 300, cost: 0.02, status: "error", cache_read_tokens: null, cache_creation_tokens: null, duration_ms: null },
+    {
+      id: 'msg-12345678',
+      timestamp: '2026-02-18T10:00:00Z',
+      agent_name: 'test-agent',
+      model: 'gpt-4o',
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      cost: 0.01,
+      status: 'ok',
+      cache_read_tokens: 500,
+      cache_creation_tokens: 100,
+      duration_ms: 1200,
+    },
+    {
+      id: 'msg-87654321',
+      timestamp: '2026-02-18T09:00:00Z',
+      agent_name: 'test-agent',
+      model: 'claude-3.5-sonnet',
+      input_tokens: 200,
+      output_tokens: 100,
+      total_tokens: 300,
+      cost: 0.02,
+      status: 'error',
+      cache_read_tokens: null,
+      cache_creation_tokens: null,
+      duration_ms: null,
+    },
   ],
   next_cursor: null,
   total_count: 2,
-  providers: ["anthropic", "openai"],
+  providers: ['anthropic', 'openai'],
 };
 
-describe("MessageLog", () => {
+describe('MessageLog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
-    mockAgentName = "test-agent";
+    mockAgentName = 'test-agent';
     mockSearchParams = {};
     mockSearchAgentAccessor = null;
-    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "agent-alpha" }, { agent_name: "agent-beta" }] });
+    mockGetAgents.mockResolvedValue({
+      agents: [{ agent_name: 'agent-alpha' }, { agent_name: 'agent-beta' }],
+    });
+    mockGetMessageFilterOptions.mockResolvedValue({ providers: ['anthropic', 'openai'] });
     mockGetCustomProviders.mockResolvedValue([]);
     mockGetSpecificityAssignments.mockResolvedValue([]);
     mockGetRoutingStatus.mockResolvedValue({ enabled: false });
     mockListHeaderTiers.mockResolvedValue([]);
   });
 
-  it("renders Messages heading", () => {
+  it('renders Messages heading', () => {
     mockGetMessages.mockResolvedValue(messagesData);
     render(() => <MessageLog />);
-    expect(screen.getByText("Messages")).toBeDefined();
+    expect(screen.getByText('Messages')).toBeDefined();
   });
 
-  it("renders breadcrumb subtitle", () => {
+  it('renders breadcrumb subtitle', () => {
     mockGetMessages.mockResolvedValue(messagesData);
     render(() => <MessageLog />);
     expect(screen.getByText(/Full log of every LLM call/)).toBeDefined();
   });
 
-  it("shows loading skeleton while fetching", () => {
+  it('shows loading skeleton while fetching', () => {
     mockGetMessages.mockReturnValue(new Promise(() => {}));
     const { container } = render(() => <MessageLog />);
-    const skeletons = container.querySelectorAll(".skeleton");
+    const skeletons = container.querySelectorAll('.skeleton');
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it("shows message items after data loads", async () => {
+  it('shows message items after data loads', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("msg-1234");
-      expect(container.textContent).toContain("msg-8765");
-      expect(container.textContent).toContain("gpt-4o");
-      expect(container.textContent).toContain("claude-3.5-sonnet");
+      expect(container.textContent).toContain('msg-1234');
+      expect(container.textContent).toContain('msg-8765');
+      expect(container.textContent).toContain('gpt-4o');
+      expect(container.textContent).toContain('claude-3.5-sonnet');
     });
   });
 
-  it("shows total count", async () => {
+  it('shows total count', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("2 total");
+      expect(container.textContent).toContain('2 total');
     });
   });
 
-  it("shows table headers", async () => {
+  it('shows table headers', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Date");
-      expect(container.textContent).toContain("Cost");
-      expect(container.textContent).toContain("Total Tokens");
-      expect(container.textContent).toContain("Model");
-      expect(container.textContent).toContain("Cache");
-      expect(container.textContent).toContain("Latency");
-      expect(container.textContent).toContain("Status");
+      expect(container.textContent).toContain('Date');
+      expect(container.textContent).toContain('Cost');
+      expect(container.textContent).toContain('Total Tokens');
+      expect(container.textContent).toContain('Model');
+      expect(container.textContent).toContain('Cache');
+      expect(container.textContent).toContain('Latency');
+      expect(container.textContent).toContain('Status');
     });
   });
 
-  it("shows formatted costs", async () => {
+  it('shows formatted costs', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("$0.01");
-      expect(container.textContent).toContain("$0.02");
+      expect(container.textContent).toContain('$0.01');
+      expect(container.textContent).toContain('$0.02');
     });
   });
 
-  it("shows empty state for new agent", async () => {
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+  it('shows empty state for new agent', async () => {
+    mockGetMessages.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      total_count: 0,
+      providers: [],
+    });
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("No messages yet");
+      expect(container.textContent).toContain('No messages yet');
     });
   });
 
@@ -231,14 +295,19 @@ describe("MessageLog", () => {
       expect(selects.length).toBeGreaterThanOrEqual(1);
     });
     const selects = container.querySelectorAll('[data-testid="select"]');
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
-    await fireEvent.change(selects[0], { target: { value: "openai" } });
+    mockGetMessages.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      total_count: 0,
+      providers: ['openai'],
+    });
+    await fireEvent.change(selects[0], { target: { value: 'openai' } });
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("No messages match your filters");
+      expect(container.textContent).toContain('No messages match your filters');
     });
   });
 
-  it("does not show waiting banner when filters return 0 results", async () => {
+  it('does not show waiting banner when filters return 0 results', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
@@ -246,58 +315,62 @@ describe("MessageLog", () => {
       expect(selects.length).toBeGreaterThanOrEqual(1);
     });
     const selects = container.querySelectorAll('[data-testid="select"]');
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
-    await fireEvent.change(selects[0], { target: { value: "openai" } });
+    mockGetMessages.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      total_count: 0,
+      providers: ['openai'],
+    });
+    await fireEvent.change(selects[0], { target: { value: 'openai' } });
     await vi.waitFor(() => {
-      expect(container.textContent).not.toContain("Waiting for data");
-      expect(container.textContent).not.toContain("No messages yet");
+      expect(container.textContent).not.toContain('Waiting for data');
+      expect(container.textContent).not.toContain('No messages yet');
     });
   });
 
-  it("shows filter controls when data exists", async () => {
+  it('shows filter controls when data exists', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       const selects = container.querySelectorAll('[data-testid="select"]');
       expect(selects.length).toBeGreaterThanOrEqual(1);
     });
-    expect(container.textContent).not.toContain("Recorded only");
-    expect(container.querySelector(".msg-recorded-filter")).toBeNull();
+    expect(container.textContent).not.toContain('Recorded only');
+    expect(container.querySelector('.msg-recorded-filter')).toBeNull();
   });
 
-  it("renders provider display names in the filter dropdown", async () => {
-    const dataWithUnknown = {
-      ...messagesData,
-      providers: ["anthropic", "openai", "unknown-provider"],
-    };
-    mockGetMessages.mockResolvedValue(dataWithUnknown);
+  it('renders provider display names in the filter dropdown', async () => {
+    mockGetMessages.mockResolvedValue(messagesData);
+    mockGetMessageFilterOptions.mockResolvedValue({
+      providers: ['anthropic', 'openai', 'unknown-provider'],
+    });
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       const select = container.querySelector('[data-testid="select"]');
       expect(select).not.toBeNull();
       // Known providers resolve to display names
-      expect(select!.textContent).toContain("Anthropic");
-      expect(select!.textContent).toContain("OpenAI");
+      expect(select!.textContent).toContain('Anthropic');
+      expect(select!.textContent).toContain('OpenAI');
       // Unknown providers fall back to the raw ID
-      expect(select!.textContent).toContain("unknown-provider");
-      expect(select!.textContent).toContain("All providers");
+      expect(select!.textContent).toContain('unknown-provider');
+      expect(select!.textContent).toContain('All providers');
     });
   });
 
-  it("debounces cost filter inputs", async () => {
+  it('debounces cost filter inputs', async () => {
     vi.useFakeTimers();
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.advanceTimersByTimeAsync(100);
 
-    const inputs = container.querySelectorAll(".cost-range-filter__input");
+    const inputs = container.querySelectorAll('.cost-range-filter__input');
     expect(inputs.length).toBe(2);
 
     mockGetMessages.mockClear();
 
     // Rapid typing should not fire immediately
-    fireEvent.input(inputs[0], { target: { value: "1" } });
-    fireEvent.input(inputs[0], { target: { value: "1.5" } });
+    fireEvent.input(inputs[0], { target: { value: '1' } });
+    fireEvent.input(inputs[0], { target: { value: '1.5' } });
     expect(mockGetMessages).not.toHaveBeenCalled();
 
     // After debounce window, the API call fires
@@ -307,16 +380,16 @@ describe("MessageLog", () => {
     vi.useRealTimers();
   });
 
-  it("debounces cost max filter inputs", async () => {
+  it('debounces cost max filter inputs', async () => {
     vi.useFakeTimers();
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.advanceTimersByTimeAsync(100);
 
-    const inputs = container.querySelectorAll(".cost-range-filter__input");
+    const inputs = container.querySelectorAll('.cost-range-filter__input');
     mockGetMessages.mockClear();
 
-    fireEvent.input(inputs[1], { target: { value: "10" } });
+    fireEvent.input(inputs[1], { target: { value: '10' } });
     expect(mockGetMessages).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(500);
@@ -325,74 +398,72 @@ describe("MessageLog", () => {
     vi.useRealTimers();
   });
 
-  it("keeps showing stale data during refetch instead of skeletons", async () => {
+  it('keeps showing stale data during refetch instead of skeletons', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("msg-1234");
+      expect(container.textContent).toContain('msg-1234');
     });
 
     // Trigger a refetch that never resolves
     mockGetMessages.mockReturnValue(new Promise(() => {}));
     const selects = container.querySelectorAll('[data-testid="select"]');
-    await fireEvent.change(selects[0], { target: { value: "openai" } });
+    await fireEvent.change(selects[0], { target: { value: 'openai' } });
 
     // Should still show old data, not skeletons
-    expect(container.textContent).toContain("msg-1234");
-    expect(container.querySelectorAll(".skeleton").length).toBe(0);
+    expect(container.textContent).toContain('msg-1234');
+    expect(container.querySelectorAll('.skeleton').length).toBe(0);
   });
 
-  it("shows cost range filter inputs", async () => {
+  it('shows cost range filter inputs', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const inputs = container.querySelectorAll(".cost-range-filter__input");
+      const inputs = container.querySelectorAll('.cost-range-filter__input');
       expect(inputs.length).toBe(2);
     });
   });
 
-  it("shows cache tokens when present", async () => {
+  it('shows cache tokens when present', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Read: 500 / Write: 100");
+      expect(container.textContent).toContain('Read: 500 / Write: 100');
     });
   });
 
-  it("shows dash for null cache tokens", async () => {
+  it('shows dash for null cache tokens', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const rows = container.querySelectorAll("tbody tr");
+      const rows = container.querySelectorAll('tbody tr');
       expect(rows.length).toBe(2);
     });
   });
 
-  it("shows dash for zero cache tokens", async () => {
+  it('shows dash for zero cache tokens', async () => {
     const dataWithZeroCache = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], cache_read_tokens: 0, cache_creation_tokens: 0 },
-      ],
+      items: [{ ...messagesData.items[0], cache_read_tokens: 0, cache_creation_tokens: 0 }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithZeroCache);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       // Zero cache tokens should show dash, not "Read: 0 / Write: 0"
-      expect(container.textContent).not.toContain("Read: 0 / Write: 0");
+      expect(container.textContent).not.toContain('Read: 0 / Write: 0');
     });
   });
 
-  it("shows formatted duration", async () => {
+  it('shows formatted duration', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("1.2s");
+      expect(container.textContent).toContain('1.2s');
     });
   });
 
-  it("shows dash for null duration", async () => {
+  it('shows dash for null duration', async () => {
     const dataWithNullDuration = {
       ...messagesData,
       items: [messagesData.items[1]], // second item has duration_ms: null
@@ -401,26 +472,24 @@ describe("MessageLog", () => {
     mockGetMessages.mockResolvedValue(dataWithNullDuration);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("claude-3.5-sonnet");
+      expect(container.textContent).toContain('claude-3.5-sonnet');
     });
   });
 
-  it("shows sub-second duration in ms format", async () => {
+  it('shows sub-second duration in ms format', async () => {
     const dataWithMsDuration = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], duration_ms: 423 },
-      ],
+      items: [{ ...messagesData.items[0], duration_ms: 423 }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithMsDuration);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("423ms");
+      expect(container.textContent).toContain('423ms');
     });
   });
 
-  it("calls getMessages on mount", async () => {
+  it('calls getMessages on mount', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     render(() => <MessageLog />);
     await vi.waitFor(() => {
@@ -428,54 +497,76 @@ describe("MessageLog", () => {
     });
   });
 
-  describe("error tooltip", () => {
-    it("shows tooltip when error_message is present on a failed row", async () => {
+  describe('error tooltip', () => {
+    it('shows tooltip when error_message is present on a failed row', async () => {
       const dataWithError = {
         ...messagesData,
         items: [
-          { id: "msg-err12345", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "gpt-4o", input_tokens: 0, output_tokens: 0, total_tokens: 0, cost: 0, status: "error", error_message: "401 Unauthorized: invalid API key" },
+          {
+            id: 'msg-err12345',
+            timestamp: '2026-02-18T10:00:00Z',
+            agent_name: 'test-agent',
+            model: 'gpt-4o',
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            cost: 0,
+            status: 'error',
+            error_message: '401 Unauthorized: invalid API key',
+          },
         ],
       };
       mockGetMessages.mockResolvedValue(dataWithError);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        const tooltip = container.querySelector(".status-badge-tooltip");
+        const tooltip = container.querySelector('.status-badge-tooltip');
         expect(tooltip).not.toBeNull();
-        const bubble = container.querySelector(".status-badge-tooltip__bubble");
+        const bubble = container.querySelector('.status-badge-tooltip__bubble');
         expect(bubble).not.toBeNull();
-        expect(bubble!.textContent).toBe("401 Unauthorized: invalid API key");
+        expect(bubble!.textContent).toBe('401 Unauthorized: invalid API key');
       });
     });
 
-    it("does not show tooltip when error_message is absent", async () => {
+    it('does not show tooltip when error_message is absent', async () => {
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("msg-1234");
-        const tooltip = container.querySelector(".status-badge-tooltip");
+        expect(container.textContent).toContain('msg-1234');
+        const tooltip = container.querySelector('.status-badge-tooltip');
         expect(tooltip).toBeNull();
       });
     });
 
-    it("sets aria-label on the tooltip wrapper", async () => {
+    it('sets aria-label on the tooltip wrapper', async () => {
       const dataWithError = {
         ...messagesData,
         items: [
-          { id: "msg-err99999", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "gpt-4o", input_tokens: 0, output_tokens: 0, total_tokens: 0, cost: 0, status: "error", error_message: "timeout" },
+          {
+            id: 'msg-err99999',
+            timestamp: '2026-02-18T10:00:00Z',
+            agent_name: 'test-agent',
+            model: 'gpt-4o',
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            cost: 0,
+            status: 'error',
+            error_message: 'timeout',
+          },
         ],
       };
       mockGetMessages.mockResolvedValue(dataWithError);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        const tooltip = container.querySelector(".status-badge-tooltip");
-        expect(tooltip?.getAttribute("aria-label")).toBe("timeout");
+        const tooltip = container.querySelector('.status-badge-tooltip');
+        expect(tooltip?.getAttribute('aria-label')).toBe('timeout');
       });
     });
   });
 
-  describe("pagination", () => {
-    it("shows pagination when total_count exceeds page size", async () => {
-      const bigData = { ...messagesData, total_count: 120, next_cursor: "cursor-2" };
+  describe('pagination', () => {
+    it('shows pagination when total_count exceeds page size', async () => {
+      const bigData = { ...messagesData, total_count: 120, next_cursor: 'cursor-2' };
       mockGetMessages.mockResolvedValue(bigData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -483,17 +574,17 @@ describe("MessageLog", () => {
       });
     });
 
-    it("hides pagination when total_count is within page size", async () => {
+    it('hides pagination when total_count is within page size', async () => {
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("2 total");
+        expect(container.textContent).toContain('2 total');
         expect(container.querySelector('[data-testid="pagination"]')).toBeNull();
       });
     });
 
-    it("Next calls getMessages with cursor after navigating", async () => {
-      const bigData = { ...messagesData, total_count: 120, next_cursor: "cursor-for-page-2" };
+    it('Next calls getMessages with cursor after navigating', async () => {
+      const bigData = { ...messagesData, total_count: 120, next_cursor: 'cursor-for-page-2' };
       mockGetMessages.mockResolvedValue(bigData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -501,17 +592,19 @@ describe("MessageLog", () => {
       });
       mockGetMessages.mockClear();
       mockGetMessages.mockResolvedValue({ ...messagesData, total_count: 120, next_cursor: null });
-      const nextBtn = container.querySelector('[data-testid="pagination-next"]') as HTMLButtonElement;
+      const nextBtn = container.querySelector(
+        '[data-testid="pagination-next"]',
+      ) as HTMLButtonElement;
       nextBtn.click();
       await vi.waitFor(() => {
         expect(mockGetMessages).toHaveBeenCalledWith(
-          expect.objectContaining({ cursor: "cursor-for-page-2" }),
+          expect.objectContaining({ cursor: 'cursor-for-page-2' }),
         );
       });
     });
   });
 
-  it("clears all filters when Clear filters button is clicked", async () => {
+  it('clears all filters when Clear filters button is clicked', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
@@ -520,13 +613,18 @@ describe("MessageLog", () => {
     });
     // Set a filter to trigger filtered empty state
     const selects = container.querySelectorAll('[data-testid="select"]');
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
-    await fireEvent.change(selects[0], { target: { value: "openai" } });
+    mockGetMessages.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      total_count: 0,
+      providers: ['openai'],
+    });
+    await fireEvent.change(selects[0], { target: { value: 'openai' } });
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("No messages match your filters");
+      expect(container.textContent).toContain('No messages match your filters');
     });
     // Click Clear filters
-    const clearBtn = container.querySelector(".btn--outline")!;
+    const clearBtn = container.querySelector('.btn--outline')!;
     fireEvent.click(clearBtn);
     // Filters should be cleared (API re-called)
     await vi.waitFor(() => {
@@ -534,27 +632,30 @@ describe("MessageLog", () => {
     });
   });
 
-  it("shows routing tier badge when present", async () => {
+  it('shows routing tier badge when present', async () => {
     const dataWithTier = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], routing_tier: "simple" },
-      ],
+      items: [{ ...messagesData.items[0], routing_tier: 'simple' }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithTier);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".tier-badge");
+      const badge = container.querySelector('.tier-badge');
       expect(badge).not.toBeNull();
-      expect(badge?.textContent).toBe("simple");
+      expect(badge?.textContent).toBe('simple');
     });
   });
 
-  it("closes setup modal via onClose callback", async () => {
+  it('closes setup modal via onClose callback', async () => {
     // To trigger setup modal, we need a new agent without setup completed
-    localStorage.removeItem("setup_completed_test-agent");
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+    localStorage.removeItem('setup_completed_test-agent');
+    mockGetMessages.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      total_count: 0,
+      providers: [],
+    });
     const { container } = render(() => <MessageLog />);
     // The setup-close button in our mock will call onClose
     const closeBtn = container.querySelector('[data-testid="setup-close"]');
@@ -565,70 +666,104 @@ describe("MessageLog", () => {
     expect(container.querySelector('[data-testid="setup-modal"]')).not.toBeNull();
   });
 
-  it("shows Connect provider button when setupCompleted but no providers", async () => {
-    localStorage.setItem("setup_completed_test-agent", "1");
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+  it('shows Connect provider button when setupCompleted but no providers', async () => {
+    localStorage.setItem('setup_completed_test-agent', '1');
+    mockGetMessages.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      total_count: 0,
+      providers: [],
+    });
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Connect provider");
-      expect(container.textContent).toContain("Connect a provider to start routing LLM calls");
-      expect(container.textContent).not.toContain("Enable routing");
+      expect(container.textContent).toContain('Connect provider');
+      expect(container.textContent).toContain('Connect a provider to start routing LLM calls');
+      expect(container.textContent).not.toContain('Enable routing');
       const btn = container.querySelector('.empty-state button.btn--primary');
       expect(btn).not.toBeNull();
     });
   });
 
-  it("navigates to routing with openProviders state when Connect provider clicked", async () => {
-    localStorage.setItem("setup_completed_test-agent", "1");
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+  it('navigates to routing with openProviders state when Connect provider clicked', async () => {
+    localStorage.setItem('setup_completed_test-agent', '1');
+    mockGetMessages.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      total_count: 0,
+      providers: [],
+    });
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Connect provider");
+      expect(container.textContent).toContain('Connect provider');
     });
     const btn = container.querySelector('.empty-state button.btn--primary') as HTMLButtonElement;
     fireEvent.click(btn);
-    expect(mockNavigate).toHaveBeenCalledWith(
-      "/harnesses/test-agent/routing",
-      { state: { openProviders: true } },
-    );
+    expect(mockNavigate).toHaveBeenCalledWith('/harnesses/test-agent/routing', {
+      state: { openProviders: true },
+    });
   });
 
-  it("shows message table when providers are enabled but no data", async () => {
+  it('shows message table when providers are enabled but no data', async () => {
     mockGetRoutingStatus.mockResolvedValue({ enabled: true });
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+    mockGetMessages.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      total_count: 0,
+      providers: [],
+    });
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       expect(container.querySelector('.waiting-banner')).not.toBeNull();
       expect(container.querySelector('.empty-state')).toBeNull();
-      expect(container.textContent).toContain("0 total");
+      expect(container.textContent).toContain('0 total');
     });
   });
 
-  it("shows Set up harness when no setupCompleted and no providers", async () => {
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+  it('shows Set up harness when no setupCompleted and no providers', async () => {
+    mockGetMessages.mockResolvedValue({
+      items: [],
+      next_cursor: null,
+      total_count: 0,
+      providers: [],
+    });
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Set up harness");
-      expect(container.textContent).not.toContain("Enable routing");
-      expect(container.textContent).not.toContain("Connect provider");
+      expect(container.textContent).toContain('Set up harness');
+      expect(container.textContent).not.toContain('Enable routing');
+      expect(container.textContent).not.toContain('Connect provider');
     });
   });
 
-  describe("custom provider models", () => {
+  describe('custom provider models', () => {
     // The backend resolves the custom provider's name into each row
     // (`custom_provider_name`) and ships a `provider_labels` map for the
     // filter dropdown; the page no longer fetches the list itself.
     const customMessagesData = {
       items: [
-        { id: "msg-cp1", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "custom:abc-123/my-llama", provider: "custom:abc-123", custom_provider_name: "Cerebras", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok", cache_read_tokens: null, cache_creation_tokens: null, duration_ms: 800 },
+        {
+          id: 'msg-cp1',
+          timestamp: '2026-02-18T10:00:00Z',
+          agent_name: 'test-agent',
+          model: 'custom:abc-123/my-llama',
+          provider: 'custom:abc-123',
+          custom_provider_name: 'Cerebras',
+          input_tokens: 100,
+          output_tokens: 50,
+          total_tokens: 150,
+          cost: 0.01,
+          status: 'ok',
+          cache_read_tokens: null,
+          cache_creation_tokens: null,
+          duration_ms: 800,
+        },
       ],
       next_cursor: null,
       total_count: 1,
-      providers: ["custom:abc-123"],
-      provider_labels: { "custom:abc-123": "Cerebras" },
+      providers: ['custom:abc-123'],
+      provider_labels: { 'custom:abc-123': 'Cerebras' },
     };
 
-    it("renders custom provider icon in message rows", async () => {
+    it('renders custom provider icon in message rows', async () => {
       mockGetMessages.mockResolvedValue(customMessagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -637,24 +772,28 @@ describe("MessageLog", () => {
       });
     });
 
-    it("strips custom prefix from model name display", async () => {
+    it('strips custom prefix from model name display', async () => {
       mockGetMessages.mockResolvedValue(customMessagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("my-llama");
-        expect(container.textContent).not.toContain("custom:abc-123/");
+        expect(container.textContent).toContain('my-llama');
+        expect(container.textContent).not.toContain('custom:abc-123/');
       });
     });
 
-    it("labels the provider filter option with the custom provider name", async () => {
+    it('labels the provider filter option with the custom provider name', async () => {
       mockGetMessages.mockResolvedValue(customMessagesData);
+      mockGetMessageFilterOptions.mockResolvedValue({
+        providers: ['custom:abc-123'],
+        provider_labels: { 'custom:abc-123': 'Cerebras' },
+      });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("Cerebras");
+        expect(container.textContent).toContain('Cerebras');
       });
     });
 
-    it("falls back to model prefix when custom provider was deleted", async () => {
+    it('falls back to model prefix when custom provider was deleted', async () => {
       const deletedProvider = {
         ...customMessagesData,
         items: [{ ...customMessagesData.items[0], custom_provider_name: null }],
@@ -663,29 +802,29 @@ describe("MessageLog", () => {
       mockGetMessages.mockResolvedValue(deletedProvider);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("my-llama");
-        expect(container.textContent).not.toContain("custom:abc-123/");
+        expect(container.textContent).toContain('my-llama');
+        expect(container.textContent).not.toContain('custom:abc-123/');
       });
     });
 
-    it("resolves custom provider name + icon in global mode from the response", async () => {
+    it('resolves custom provider name + icon in global mode from the response', async () => {
       // Global ("All harnesses") log has no route agent. The backend resolves
       // the custom provider's name into each row (`custom_provider_name`), so
       // custom:<uuid> models still render with the real name and provider icon
       // — the page no longer fetches the provider list itself.
       mockAgentName = undefined;
-      mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "agent-alpha" }] });
+      mockGetAgents.mockResolvedValue({ agents: [{ agent_name: 'agent-alpha' }] });
       mockGetMessages.mockResolvedValue(customMessagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         expect(container.querySelector('img[alt="Cerebras"]')).not.toBeNull();
-        expect(container.textContent).not.toContain("custom:abc-123/");
+        expect(container.textContent).not.toContain('custom:abc-123/');
       });
     });
   });
 
-  describe("clear filters", () => {
-    it("clears all filters when clear button is clicked", async () => {
+  describe('clear filters', () => {
+    it('clears all filters when clear button is clicked', async () => {
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -695,81 +834,76 @@ describe("MessageLog", () => {
 
       // Set a filter
       const selects = container.querySelectorAll('[data-testid="select"]');
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
-      await fireEvent.change(selects[0], { target: { value: "openai" } });
+      mockGetMessages.mockResolvedValue({
+        items: [],
+        next_cursor: null,
+        total_count: 0,
+        providers: ['openai'],
+      });
+      await fireEvent.change(selects[0], { target: { value: 'openai' } });
 
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("No messages match your filters");
+        expect(container.textContent).toContain('No messages match your filters');
       });
 
       // Click clear filters
-      const clearBtn = container.querySelector(".message-log__clear-btn");
+      const clearBtn = container.querySelector('.message-log__clear-btn');
       if (clearBtn) {
         mockGetMessages.mockResolvedValue(messagesData);
         fireEvent.click(clearBtn);
         await vi.waitFor(() => {
-          expect(container.textContent).toContain("msg-1234");
+          expect(container.textContent).toContain('msg-1234');
         });
       }
     });
   });
 
-  it("shows $0.00 cost for flat-fee subscription messages (cost null)", async () => {
+  it('shows $0.00 cost for flat-fee subscription messages (cost null)', async () => {
     const dataWithSub = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], auth_type: "subscription", cost: null },
-      ],
+      items: [{ ...messagesData.items[0], auth_type: 'subscription', cost: null }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithSub);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("$0.00");
+      expect(container.textContent).toContain('$0.00');
       expect(container.querySelector('[title="Included in subscription"]')).not.toBeNull();
     });
   });
 
-  it("shows the recorded per-request cost for OpenCode Go subscription messages", async () => {
+  it('shows the recorded per-request cost for OpenCode Go subscription messages', async () => {
     const dataWithPerRequestSub = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], auth_type: "subscription", cost: 0.013636 },
-      ],
+      items: [{ ...messagesData.items[0], auth_type: 'subscription', cost: 0.013636 }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithPerRequestSub);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       // Per-request subscriptions (OpenCode Go) record real costs — don't hide them.
-      expect(container.textContent).toContain("$0.01");
-      expect(
-        container.querySelector('[title^="Per-request subscription cost:"]'),
-      ).not.toBeNull();
+      expect(container.textContent).toContain('$0.01');
+      expect(container.querySelector('[title^="Per-request subscription cost:"]')).not.toBeNull();
     });
   });
 
-  it("shows formatCost fallback for non-subscription messages with cost", async () => {
+  it('shows formatCost fallback for non-subscription messages with cost', async () => {
     const dataWithCost = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], auth_type: null, cost: 0.05 },
-      ],
+      items: [{ ...messagesData.items[0], auth_type: null, cost: 0.05 }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithCost);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("$0.05");
+      expect(container.textContent).toContain('$0.05');
     });
   });
 
-  it("renders provider icon SVG for known provider model", async () => {
+  it('renders provider icon SVG for known provider model', async () => {
     const dataWithProvider = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], model: "gpt-4o", auth_type: null },
-      ],
+      items: [{ ...messagesData.items[0], model: 'gpt-4o', auth_type: null }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithProvider);
@@ -778,70 +912,64 @@ describe("MessageLog", () => {
       // providerIcon returns an inline SVG for known providers
       const providerSpan = container.querySelector('[role="img"]');
       expect(providerSpan).not.toBeNull();
-      const svg = providerSpan!.querySelector("svg");
+      const svg = providerSpan!.querySelector('svg');
       expect(svg).not.toBeNull();
     });
   });
 
-  it("renders subscription auth badge on provider icon", async () => {
+  it('renders subscription auth badge on provider icon', async () => {
     const dataWithSub = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], model: "claude-sonnet-4", auth_type: "subscription" },
-      ],
+      items: [{ ...messagesData.items[0], model: 'claude-sonnet-4', auth_type: 'subscription' }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithSub);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".provider-auth-badge--sub");
+      const badge = container.querySelector('.provider-auth-badge--sub');
       expect(badge).not.toBeNull();
     });
   });
 
-  it("renders api_key auth badge when auth_type is api_key", async () => {
+  it('renders api_key auth badge when auth_type is api_key', async () => {
     const dataWithApiKey = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], model: "claude-sonnet-4", auth_type: "api_key" },
-      ],
+      items: [{ ...messagesData.items[0], model: 'claude-sonnet-4', auth_type: 'api_key' }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithApiKey);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".provider-auth-badge--key");
+      const badge = container.querySelector('.provider-auth-badge--key');
       expect(badge).not.toBeNull();
-      const subBadge = container.querySelector(".provider-auth-badge--sub");
+      const subBadge = container.querySelector('.provider-auth-badge--sub');
       expect(subBadge).toBeNull();
     });
   });
 
-  it("renders meta description tag", () => {
+  it('renders meta description tag', () => {
     mockGetMessages.mockResolvedValue(messagesData);
     render(() => <MessageLog />);
     // Meta is mocked as null, just ensure it renders without error
-    expect(screen.getByText("Messages")).toBeDefined();
+    expect(screen.getByText('Messages')).toBeDefined();
   });
 
-  it("renders routing tier badge when present", async () => {
+  it('renders routing tier badge when present', async () => {
     const dataWithTier = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], routing_tier: "simple" },
-      ],
+      items: [{ ...messagesData.items[0], routing_tier: 'simple' }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithTier);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".tier-badge");
+      const badge = container.querySelector('.tier-badge');
       expect(badge).not.toBeNull();
-      expect(badge!.textContent).toBe("simple");
+      expect(badge!.textContent).toBe('simple');
     });
   });
 
-  it("renders setup modal", async () => {
+  it('renders setup modal', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
@@ -849,43 +977,41 @@ describe("MessageLog", () => {
     });
   });
 
-  it("renders fallback badge when fallback_from_model is present", async () => {
+  it('renders fallback badge when fallback_from_model is present', async () => {
     const dataWithFallback = {
       ...messagesData,
-      items: [
-        { ...messagesData.items[0], fallback_from_model: "gpt-4o", fallback_index: 0 },
-      ],
+      items: [{ ...messagesData.items[0], fallback_from_model: 'gpt-4o', fallback_index: 0 }],
       total_count: 1,
     };
     mockGetMessages.mockResolvedValue(dataWithFallback);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".tier-badge--fallback");
+      const badge = container.querySelector('.tier-badge--fallback');
       expect(badge).not.toBeNull();
-      expect(badge!.textContent).toBe("fallback");
-      expect(badge!.getAttribute("title")).toContain("gpt-4o");
+      expect(badge!.textContent).toBe('fallback');
+      expect(badge!.getAttribute('title')).toContain('gpt-4o');
     });
   });
 
-  it("does not render fallback badge when fallback_from_model is absent", async () => {
+  it('does not render fallback badge when fallback_from_model is absent', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("gpt-4o");
-      const badge = container.querySelector(".tier-badge--fallback");
+      expect(container.textContent).toContain('gpt-4o');
+      const badge = container.querySelector('.tier-badge--fallback');
       expect(badge).toBeNull();
     });
   });
 
-  it("renders fallback_error status with orange Handled badge", async () => {
+  it('renders fallback_error status with orange Handled badge', async () => {
     const dataWithHandled = {
       ...messagesData,
       items: [
         {
           ...messagesData.items[0],
-          status: "fallback_error",
-          model: "gemini-flash",
-          error_message: "Provider returned HTTP 429, routed to fallback",
+          status: 'fallback_error',
+          model: 'gemini-flash',
+          error_message: 'Provider returned HTTP 429, routed to fallback',
         },
       ],
       total_count: 1,
@@ -893,211 +1019,215 @@ describe("MessageLog", () => {
     mockGetMessages.mockResolvedValue(dataWithHandled);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".status-badge--fallback_error");
+      const badge = container.querySelector('.status-badge--fallback_error');
       expect(badge).not.toBeNull();
-      expect(badge!.textContent).toBe("fallback_error");
+      expect(badge!.textContent).toBe('fallback_error');
     });
   });
 
-  it("assigns row IDs for scroll targeting", async () => {
+  it('assigns row IDs for scroll targeting', async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const row = container.querySelector("#msg-msg-12345678");
+      const row = container.querySelector('#msg-msg-12345678');
       expect(row).not.toBeNull();
     });
   });
 
-  it("scrolls to fallback success when clicking Handled badge", async () => {
+  it('scrolls to fallback success when clicking Handled badge', async () => {
     const dataWithChain = {
       ...messagesData,
       items: [
         {
-          id: "success-1",
-          timestamp: "2026-02-18T10:00:00.200Z",
-          agent_name: "test-agent",
-          model: "deepseek-chat",
+          id: 'success-1',
+          timestamp: '2026-02-18T10:00:00.200Z',
+          agent_name: 'test-agent',
+          model: 'deepseek-chat',
           input_tokens: 500,
           output_tokens: 100,
           total_tokens: 600,
           cost: 0.01,
-          status: "ok",
+          status: 'ok',
           cache_read_tokens: 0,
           cache_creation_tokens: 0,
           duration_ms: 800,
-          fallback_from_model: "gemini-flash",
+          fallback_from_model: 'gemini-flash',
           fallback_index: 0,
         },
         {
-          id: "primary-fail-1",
-          timestamp: "2026-02-18T10:00:00.000Z",
-          agent_name: "test-agent",
-          model: "gemini-flash",
+          id: 'primary-fail-1',
+          timestamp: '2026-02-18T10:00:00.000Z',
+          agent_name: 'test-agent',
+          model: 'gemini-flash',
           input_tokens: 0,
           output_tokens: 0,
           total_tokens: 0,
           cost: null,
-          status: "fallback_error",
+          status: 'fallback_error',
           cache_read_tokens: 0,
           cache_creation_tokens: 0,
           duration_ms: null,
-          error_message: "Provider returned HTTP 429, routed to fallback",
+          error_message: 'Provider returned HTTP 429, routed to fallback',
         },
       ],
       total_count: 2,
-      providers: ["deepseek", "gemini"],
+      providers: ['deepseek', 'gemini'],
     };
     mockGetMessages.mockResolvedValue(dataWithChain);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".status-badge--fallback_error");
+      const badge = container.querySelector('.status-badge--fallback_error');
       expect(badge).not.toBeNull();
     });
-    const successRow = container.querySelector("#msg-success-1");
+    const successRow = container.querySelector('#msg-success-1');
     const scrollSpy = vi.fn();
     if (successRow) {
       successRow.scrollIntoView = scrollSpy;
     }
-    const badge = container.querySelector(".status-badge--fallback_error")!;
+    const badge = container.querySelector('.status-badge--fallback_error')!;
     fireEvent.click(badge);
     expect(scrollSpy).toHaveBeenCalled();
   });
 
-  describe("feedback", () => {
-    it("calls setMessageFeedback with like when thumb up is clicked", async () => {
+  describe('feedback', () => {
+    it('calls setMessageFeedback with like when thumb up is clicked', async () => {
       mockSetMessageFeedback.mockResolvedValue(undefined);
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const likeBtn = container.querySelector(".feedback-btn") as HTMLElement;
+      const likeBtn = container.querySelector('.feedback-btn') as HTMLElement;
       fireEvent.click(likeBtn);
-      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "like" });
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith('msg-12345678', { rating: 'like' });
     });
 
-    it("calls setMessageFeedback with dislike and opens modal when thumb down is clicked", async () => {
+    it('calls setMessageFeedback with dislike and opens modal when thumb down is clicked', async () => {
       mockSetMessageFeedback.mockResolvedValue(undefined);
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      const dislikeBtn = container.querySelectorAll('.feedback-btn')[1] as HTMLElement;
       fireEvent.click(dislikeBtn);
-      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike" });
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith('msg-12345678', { rating: 'dislike' });
       const modal = container.querySelector('[data-testid="feedback-modal"]');
-      expect(modal?.getAttribute("data-open")).toBe("true");
+      expect(modal?.getAttribute('data-open')).toBe('true');
     });
 
-    it("calls clearMessageFeedback when active like is clicked", async () => {
+    it('calls clearMessageFeedback when active like is clicked', async () => {
       mockClearMessageFeedback.mockResolvedValue(undefined);
       const dataWithFeedback = {
         ...messagesData,
-        items: [{ ...messagesData.items[0], feedback_rating: "like" }, messagesData.items[1]],
+        items: [{ ...messagesData.items[0], feedback_rating: 'like' }, messagesData.items[1]],
       };
       mockGetMessages.mockResolvedValue(dataWithFeedback);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn--active-like')).not.toBeNull();
       });
-      const likeBtn = container.querySelector(".feedback-btn--active-like") as HTMLElement;
+      const likeBtn = container.querySelector('.feedback-btn--active-like') as HTMLElement;
       fireEvent.click(likeBtn);
-      expect(mockClearMessageFeedback).toHaveBeenCalledWith("msg-12345678");
+      expect(mockClearMessageFeedback).toHaveBeenCalledWith('msg-12345678');
     });
 
-    it("submits feedback details from modal", async () => {
+    it('submits feedback details from modal', async () => {
       mockSetMessageFeedback.mockResolvedValue(undefined);
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
       // Click dislike to open modal
-      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      const dislikeBtn = container.querySelectorAll('.feedback-btn')[1] as HTMLElement;
       fireEvent.click(dislikeBtn);
       // Submit via modal
       const submitBtn = container.querySelector('[data-testid="feedback-submit"]') as HTMLElement;
       fireEvent.click(submitBtn);
-      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike", tags: ["Too slow"], details: "test" });
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith('msg-12345678', {
+        rating: 'dislike',
+        tags: ['Too slow'],
+        details: 'test',
+      });
     });
 
-    it("closes feedback modal without submitting", async () => {
+    it('closes feedback modal without submitting', async () => {
       mockSetMessageFeedback.mockResolvedValue(undefined);
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      const dislikeBtn = container.querySelectorAll('.feedback-btn')[1] as HTMLElement;
       fireEvent.click(dislikeBtn);
       const closeBtn = container.querySelector('[data-testid="feedback-close"]') as HTMLElement;
       fireEvent.click(closeBtn);
       const modal = container.querySelector('[data-testid="feedback-modal"]');
-      expect(modal?.getAttribute("data-open")).toBe("false");
+      expect(modal?.getAttribute('data-open')).toBe('false');
     });
 
-    it("hides feedback column and modal in the self-hosted version", async () => {
+    it('hides feedback column and modal in the self-hosted version', async () => {
       mockCheckIsSelfHosted.mockResolvedValue(true);
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".data-table")).not.toBeNull();
+        expect(container.querySelector('.data-table')).not.toBeNull();
       });
-      expect(container.querySelector(".feedback-btn")).toBeNull();
+      expect(container.querySelector('.feedback-btn')).toBeNull();
       expect(container.querySelector('[data-testid="feedback-modal"]')).toBeNull();
       mockCheckIsSelfHosted.mockResolvedValue(false);
     });
 
-    it("reverts optimistic like on API error", async () => {
-      mockSetMessageFeedback.mockRejectedValue(new Error("fail"));
+    it('reverts optimistic like on API error', async () => {
+      mockSetMessageFeedback.mockRejectedValue(new Error('fail'));
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const likeBtn = container.querySelector(".feedback-btn") as HTMLElement;
+      const likeBtn = container.querySelector('.feedback-btn') as HTMLElement;
       fireEvent.click(likeBtn);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-like")).toBeNull();
+        expect(container.querySelector('.feedback-btn--active-like')).toBeNull();
       });
     });
 
-    it("reverts optimistic dislike on API error", async () => {
-      mockSetMessageFeedback.mockRejectedValue(new Error("fail"));
+    it('reverts optimistic dislike on API error', async () => {
+      mockSetMessageFeedback.mockRejectedValue(new Error('fail'));
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn')).not.toBeNull();
       });
-      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      const dislikeBtn = container.querySelectorAll('.feedback-btn')[1] as HTMLElement;
       fireEvent.click(dislikeBtn);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-dislike")).toBeNull();
+        expect(container.querySelector('.feedback-btn--active-dislike')).toBeNull();
       });
     });
 
-    it("reverts optimistic clear on API error", async () => {
-      mockClearMessageFeedback.mockRejectedValue(new Error("fail"));
+    it('reverts optimistic clear on API error', async () => {
+      mockClearMessageFeedback.mockRejectedValue(new Error('fail'));
       const dataWithFeedback = {
         ...messagesData,
-        items: [{ ...messagesData.items[0], feedback_rating: "like" }, messagesData.items[1]],
+        items: [{ ...messagesData.items[0], feedback_rating: 'like' }, messagesData.items[1]],
       };
       mockGetMessages.mockResolvedValue(dataWithFeedback);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn--active-like')).not.toBeNull();
       });
-      const likeBtn = container.querySelector(".feedback-btn--active-like") as HTMLElement;
+      const likeBtn = container.querySelector('.feedback-btn--active-like') as HTMLElement;
       fireEvent.click(likeBtn);
       await vi.waitFor(() => {
-        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+        expect(container.querySelector('.feedback-btn--active-like')).not.toBeNull();
       });
     });
   });
 
-  describe("Recording modal", () => {
-    it("opens the recorded-message modal when the row is clicked", async () => {
+  describe('Recording modal', () => {
+    it('opens the recorded-message modal when the row is clicked', async () => {
       const withRecording = {
         ...messagesData,
         items: [{ ...messagesData.items[0], recorded: true }, messagesData.items[1]],
@@ -1107,7 +1237,7 @@ describe("MessageLog", () => {
         message: {
           id: withRecording.items[0].id,
           timestamp: withRecording.items[0].timestamp,
-          model: "gpt-4o",
+          model: 'gpt-4o',
           request_headers: {},
           recorded: true,
         },
@@ -1116,7 +1246,7 @@ describe("MessageLog", () => {
           response_body: null,
           response_headers: {},
           size_bytes: 0,
-          created_at: "",
+          created_at: '',
         },
         llm_calls: [],
         tool_executions: [],
@@ -1124,15 +1254,15 @@ describe("MessageLog", () => {
       });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".msg-row--clickable")).not.toBeNull();
+        expect(container.querySelector('.msg-row--clickable')).not.toBeNull();
       });
-      fireEvent.click(container.querySelector(".msg-row--clickable") as HTMLElement);
+      fireEvent.click(container.querySelector('.msg-row--clickable') as HTMLElement);
       await vi.waitFor(() => {
-        expect(document.body.textContent).toContain("Message log");
+        expect(document.body.textContent).toContain('Message log');
       });
     });
 
-    it("refetches the messages list after deleting a recording from the modal", async () => {
+    it('refetches the messages list after deleting a recording from the modal', async () => {
       const withRecording = {
         ...messagesData,
         items: [{ ...messagesData.items[0], recorded: true }, messagesData.items[1]],
@@ -1142,7 +1272,7 @@ describe("MessageLog", () => {
         message: {
           id: withRecording.items[0].id,
           timestamp: withRecording.items[0].timestamp,
-          model: "gpt-4o",
+          model: 'gpt-4o',
           request_headers: {},
           recorded: true,
         },
@@ -1151,7 +1281,7 @@ describe("MessageLog", () => {
           response_body: null,
           response_headers: {},
           size_bytes: 0,
-          created_at: "",
+          created_at: '',
         },
         llm_calls: [],
         tool_executions: [],
@@ -1160,12 +1290,12 @@ describe("MessageLog", () => {
       mockDeleteMessageRecording.mockResolvedValue(undefined);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".msg-row--clickable")).not.toBeNull();
+        expect(container.querySelector('.msg-row--clickable')).not.toBeNull();
       });
       // Open the recording modal by clicking the row
-      fireEvent.click(container.querySelector(".msg-row--clickable") as HTMLElement);
+      fireEvent.click(container.querySelector('.msg-row--clickable') as HTMLElement);
       await vi.waitFor(() => {
-        expect(document.body.textContent).toContain("Message log");
+        expect(document.body.textContent).toContain('Message log');
       });
       // Open the overflow menu so the delete affordance is in the DOM.
       // The overflow menu is now inside the DrawerHeader (the "More actions" button).
@@ -1174,43 +1304,47 @@ describe("MessageLog", () => {
         expect(moreBtn.length).toBeGreaterThan(0);
       });
       fireEvent.click(
-        Array.from(document.querySelectorAll('button[aria-label="More actions"]'))[0] as HTMLElement,
+        Array.from(
+          document.querySelectorAll('button[aria-label="More actions"]'),
+        )[0] as HTMLElement,
       );
       await vi.waitFor(() => {
-        const btn = Array.from(document.querySelectorAll("button")).find(
-          (b) => b.textContent?.trim() === "Delete recording",
+        const btn = Array.from(document.querySelectorAll('button')).find(
+          (b) => b.textContent?.trim() === 'Delete recording',
         );
         expect(btn).not.toBeUndefined();
       });
       // Snapshot getMessages call count before delete
       const callsBeforeDelete = mockGetMessages.mock.calls.length;
-      const deleteBtn = Array.from(document.querySelectorAll("button")).find(
-        (b) => b.textContent?.trim() === "Delete recording",
+      const deleteBtn = Array.from(document.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Delete recording',
       ) as HTMLButtonElement;
       expect(deleteBtn).not.toBeUndefined();
       fireEvent.click(deleteBtn);
       // Confirm the delete — now it's a modal with "Delete recording" confirm button
       await vi.waitFor(() => {
-        const confirmBtn = Array.from(document.querySelectorAll("button")).find(
-          (b) => b.textContent?.trim() === "Delete recording" && b.classList.contains("btn--danger"),
+        const confirmBtn = Array.from(document.querySelectorAll('button')).find(
+          (b) =>
+            b.textContent?.trim() === 'Delete recording' && b.classList.contains('btn--danger'),
         );
         expect(confirmBtn).not.toBeUndefined();
       });
       fireEvent.click(
-        Array.from(document.querySelectorAll("button")).find(
-          (b) => b.textContent?.trim() === "Delete recording" && b.classList.contains("btn--danger"),
+        Array.from(document.querySelectorAll('button')).find(
+          (b) =>
+            b.textContent?.trim() === 'Delete recording' && b.classList.contains('btn--danger'),
         ) as HTMLButtonElement,
       );
       // deleteMessageRecording should have been called and MessageLog should refetch
       await vi.waitFor(() => {
-        expect(mockDeleteMessageRecording).toHaveBeenCalledWith("msg-12345678");
+        expect(mockDeleteMessageRecording).toHaveBeenCalledWith('msg-12345678');
         expect(mockGetMessages.mock.calls.length).toBeGreaterThan(callsBeforeDelete);
       });
     });
   });
 
-  describe("Tier filter", () => {
-    it("renders a Tier select with Playground among the options", async () => {
+  describe('Tier filter', () => {
+    it('renders a Tier select with Playground among the options', async () => {
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -1220,20 +1354,20 @@ describe("MessageLog", () => {
       const selects = container.querySelectorAll('[data-testid="select"]');
       // Second Select is the tier filter (first is providers).
       const tierSelect = selects[1] as HTMLSelectElement;
-      expect(tierSelect.textContent).toContain("All tiers");
-      expect(tierSelect.textContent).toContain("Playground");
-      expect(tierSelect.textContent).toContain("Simple");
+      expect(tierSelect.textContent).toContain('All tiers');
+      expect(tierSelect.textContent).toContain('Playground');
+      expect(tierSelect.textContent).toContain('Simple');
     });
 
-    it("adds active task-specific categories and defined custom tiers to the tier options", async () => {
+    it('adds active task-specific categories and defined custom tiers to the tier options', async () => {
       mockGetMessages.mockResolvedValue(messagesData);
       mockGetSpecificityAssignments.mockResolvedValue([
-        { category: "coding", is_active: true },
-        { category: "trading", is_active: false },
+        { category: 'coding', is_active: true },
+        { category: 'trading', is_active: false },
       ]);
       mockListHeaderTiers.mockResolvedValue([
-        { id: "ht-premium", name: "Premium", enabled: true, sort_order: 0 },
-        { id: "ht-legacy", name: "Legacy", enabled: false, sort_order: 1 },
+        { id: 'ht-premium', name: 'Premium', enabled: true, sort_order: 0 },
+        { id: 'ht-legacy', name: 'Legacy', enabled: false, sort_order: 1 },
       ]);
 
       const { container } = render(() => <MessageLog />);
@@ -1241,20 +1375,20 @@ describe("MessageLog", () => {
         const tierSelect = container.querySelectorAll(
           '[data-testid="select"]',
         )[1] as HTMLSelectElement;
-        expect(tierSelect.textContent).toContain("Coding");
-        expect(tierSelect.textContent).toContain("Premium");
+        expect(tierSelect.textContent).toContain('Coding');
+        expect(tierSelect.textContent).toContain('Premium');
       });
 
       const tierSelect = container.querySelectorAll(
         '[data-testid="select"]',
       )[1] as HTMLSelectElement;
-      expect(tierSelect.textContent).not.toContain("Trading");
-      expect(tierSelect.textContent).toContain("Legacy");
-      expect(tierSelect.textContent).not.toContain("Task:");
-      expect(tierSelect.textContent).not.toContain("Custom:");
+      expect(tierSelect.textContent).not.toContain('Trading');
+      expect(tierSelect.textContent).toContain('Legacy');
+      expect(tierSelect.textContent).not.toContain('Task:');
+      expect(tierSelect.textContent).not.toContain('Custom:');
     });
 
-    it("sends routing_tier in the query when a tier is selected", async () => {
+    it('sends routing_tier in the query when a tier is selected', async () => {
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -1266,17 +1400,17 @@ describe("MessageLog", () => {
         '[data-testid="select"]',
       )[1] as HTMLSelectElement;
       mockGetMessages.mockClear();
-      fireEvent.change(tierSelect, { target: { value: "playground" } });
+      fireEvent.change(tierSelect, { target: { value: 'playground' } });
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
-        expect(lastQ.routing_tier).toBe("playground");
+        expect(lastQ.routing_tier).toBe('playground');
       });
     });
 
-    it("sends specificity_category in the query when a task category is selected", async () => {
+    it('sends specificity_category in the query when a task category is selected', async () => {
       mockGetMessages.mockResolvedValue(messagesData);
-      mockGetSpecificityAssignments.mockResolvedValue([{ category: "coding", is_active: true }]);
+      mockGetSpecificityAssignments.mockResolvedValue([{ category: 'coding', is_active: true }]);
 
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -1289,19 +1423,19 @@ describe("MessageLog", () => {
         '[data-testid="select"]',
       )[1] as HTMLSelectElement;
       mockGetMessages.mockClear();
-      fireEvent.change(tierSelect, { target: { value: "specificity:coding" } });
+      fireEvent.change(tierSelect, { target: { value: 'specificity:coding' } });
 
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
-        expect(lastQ.specificity_category).toBe("coding");
+        expect(lastQ.specificity_category).toBe('coding');
         expect(lastQ.routing_tier).toBeUndefined();
       });
     });
 
-    it("sends header_tier_id in the query when a custom tier is selected", async () => {
+    it('sends header_tier_id in the query when a custom tier is selected', async () => {
       mockGetMessages.mockResolvedValue(messagesData);
-      mockListHeaderTiers.mockResolvedValue([{ id: "ht-premium", name: "Premium" }]);
+      mockListHeaderTiers.mockResolvedValue([{ id: 'ht-premium', name: 'Premium' }]);
 
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -1314,43 +1448,43 @@ describe("MessageLog", () => {
         '[data-testid="select"]',
       )[1] as HTMLSelectElement;
       mockGetMessages.mockClear();
-      fireEvent.change(tierSelect, { target: { value: "header:ht-premium" } });
+      fireEvent.change(tierSelect, { target: { value: 'header:ht-premium' } });
 
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
-        expect(lastQ.header_tier_id).toBe("ht-premium");
+        expect(lastQ.header_tier_id).toBe('ht-premium');
         expect(lastQ.routing_tier).toBeUndefined();
       });
     });
   });
 
-  describe("Agent filter (global mode)", () => {
-    it("renders agent filter dropdown in global mode (no agentName)", async () => {
-      mockAgentName = "";
+  describe('Agent filter (global mode)', () => {
+    it('renders agent filter dropdown in global mode (no agentName)', async () => {
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         const selects = container.querySelectorAll('[data-testid="select"]');
         // agent filter is the first select in global mode
         expect(selects.length).toBeGreaterThanOrEqual(1);
-        expect(selects[0].textContent).toContain("All harnesses");
+        expect(selects[0].textContent).toContain('All harnesses');
       });
     });
 
-    it("populates agent filter with sorted agent names from getAgents()", async () => {
-      mockAgentName = "";
+    it('populates agent filter with sorted agent names from getAgents()', async () => {
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         const selects = container.querySelectorAll('[data-testid="select"]');
-        expect(selects[0].textContent).toContain("agent-alpha");
-        expect(selects[0].textContent).toContain("agent-beta");
+        expect(selects[0].textContent).toContain('agent-alpha');
+        expect(selects[0].textContent).toContain('agent-beta');
       });
     });
 
-    it("requests system agents so the reserved Playground agent appears in the filter", async () => {
-      mockAgentName = "";
+    it('requests system agents so the reserved Playground agent appears in the filter', async () => {
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -1358,114 +1492,126 @@ describe("MessageLog", () => {
       });
     });
 
-    it("seeds the agent filter from the ?agent= search param (View more redirect)", async () => {
-      mockAgentName = "";
-      mockSearchParams = { agent: "agent-beta" };
+    it('seeds the agent filter from the ?agent= search param (View more redirect)', async () => {
+      mockAgentName = '';
+      mockSearchParams = { agent: 'agent-beta' };
       mockGetMessages.mockResolvedValue(messagesData);
       render(() => <MessageLog />);
       await vi.waitFor(() => {
         const lastCall = mockGetMessages.mock.calls.at(-1)![0] as Record<string, string>;
-        expect(lastCall.agent_name).toBe("agent-beta");
+        expect(lastCall.agent_name).toBe('agent-beta');
       });
     });
 
-    it("ignores the ?agent= search param in agent-scoped mode (route param wins)", async () => {
+    it('ignores the ?agent= search param in agent-scoped mode (route param wins)', async () => {
       // mockAgentName is "test-agent" from beforeEach
-      mockSearchParams = { agent: "agent-beta" };
+      mockSearchParams = { agent: 'agent-beta' };
       mockGetMessages.mockResolvedValue(messagesData);
       render(() => <MessageLog />);
       await vi.waitFor(() => {
         const lastCall = mockGetMessages.mock.calls.at(-1)![0] as Record<string, string>;
-        expect(lastCall.agent_name).toBe("test-agent");
+        expect(lastCall.agent_name).toBe('test-agent');
       });
     });
 
-    it("does NOT render agent filter dropdown in agent-scoped mode", async () => {
+    it('does NOT render agent filter dropdown in agent-scoped mode', async () => {
       // mockAgentName is "test-agent" from beforeEach
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         const selects = container.querySelectorAll('[data-testid="select"]');
         // In agent mode, first select is provider filter (no "All harnesses" option)
-        expect(selects[0].textContent).not.toContain("All harnesses");
-        expect(selects[0].textContent).toContain("All providers");
+        expect(selects[0].textContent).not.toContain('All harnesses');
+        expect(selects[0].textContent).toContain('All providers');
       });
     });
 
-    it("passes agent_name query param when an agent is selected", async () => {
-      mockAgentName = "";
+    it('passes agent_name query param when an agent is selected', async () => {
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       // Wait for agentList to resolve so the options are populated
       await vi.waitFor(() => {
-        const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-        expect(agentSelect.textContent).toContain("agent-alpha");
+        const agentSelect = container.querySelectorAll(
+          '[data-testid="select"]',
+        )[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain('agent-alpha');
       });
       mockGetMessages.mockClear();
-      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      const agentSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: 'agent-alpha' } });
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
-        expect(lastQ.agent_name).toBe("agent-alpha");
+        expect(lastQ.agent_name).toBe('agent-alpha');
       });
     });
 
-    it("pre-seeds the agent filter from the ?agent= query param (View more deep-link)", async () => {
-      mockAgentName = "";
-      mockSearchParams = { agent: "agent-beta" };
+    it('pre-seeds the agent filter from the ?agent= query param (View more deep-link)', async () => {
+      mockAgentName = '';
+      mockSearchParams = { agent: 'agent-beta' };
       mockGetMessages.mockResolvedValue(messagesData);
       render(() => <MessageLog />);
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
-        expect(lastQ.agent_name).toBe("agent-beta");
+        expect(lastQ.agent_name).toBe('agent-beta');
       });
     });
 
-    it("updates the agent filter when the ?agent= query param changes", async () => {
-      mockAgentName = "";
+    it('updates the agent filter when the ?agent= query param changes', async () => {
+      mockAgentName = '';
       const [searchAgent, setSearchAgent] = createSignal<string | undefined>();
       mockSearchAgentAccessor = searchAgent;
       mockGetMessages.mockResolvedValue(messagesData);
 
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-        expect(agentSelect.textContent).toContain("agent-beta");
+        const agentSelect = container.querySelectorAll(
+          '[data-testid="select"]',
+        )[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain('agent-beta');
       });
 
       mockGetMessages.mockClear();
-      setSearchAgent("agent-beta");
+      setSearchAgent('agent-beta');
 
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
-        expect(lastQ.agent_name).toBe("agent-beta");
+        expect(lastQ.agent_name).toBe('agent-beta');
       });
-      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-      expect(agentSelect.value).toBe("agent-beta");
+      const agentSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[0] as HTMLSelectElement;
+      expect(agentSelect.value).toBe('agent-beta');
     });
 
     it("omits agent_name query param when 'All harnesses' is selected", async () => {
-      mockAgentName = "";
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       // Wait for agentList to resolve so the options are populated
       await vi.waitFor(() => {
-        const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-        expect(agentSelect.textContent).toContain("agent-alpha");
+        const agentSelect = container.querySelectorAll(
+          '[data-testid="select"]',
+        )[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain('agent-alpha');
       });
       // Select an agent first
-      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      const agentSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: 'agent-alpha' } });
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
-        expect(calls.some((c: any[]) => c[0]?.agent_name === "agent-alpha")).toBe(true);
+        expect(calls.some((c: any[]) => c[0]?.agent_name === 'agent-alpha')).toBe(true);
       });
       mockGetMessages.mockClear();
       // Then go back to "All harnesses"
-      fireEvent.change(agentSelect, { target: { value: "" } });
+      fireEvent.change(agentSelect, { target: { value: '' } });
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
@@ -1473,41 +1619,59 @@ describe("MessageLog", () => {
       });
     });
 
-    it("includes agentFilter in hasActiveFilters so filtered-empty state appears", async () => {
-      mockAgentName = "";
+    it('includes agentFilter in hasActiveFilters so filtered-empty state appears', async () => {
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       // Wait for agentList to resolve before interacting with the filter
       await vi.waitFor(() => {
-        const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-        expect(agentSelect.textContent).toContain("agent-alpha");
+        const agentSelect = container.querySelectorAll(
+          '[data-testid="select"]',
+        )[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain('agent-alpha');
       });
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
-      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      mockGetMessages.mockResolvedValue({
+        items: [],
+        next_cursor: null,
+        total_count: 0,
+        providers: ['openai'],
+      });
+      const agentSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: 'agent-alpha' } });
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("No messages match your filters");
+        expect(container.textContent).toContain('No messages match your filters');
       });
     });
 
-    it("clears agentFilter when Clear filters is clicked", async () => {
-      mockAgentName = "";
+    it('clears agentFilter when Clear filters is clicked', async () => {
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       // Wait for agentList to resolve before interacting with the filter
       await vi.waitFor(() => {
-        const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-        expect(agentSelect.textContent).toContain("agent-alpha");
+        const agentSelect = container.querySelectorAll(
+          '[data-testid="select"]',
+        )[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain('agent-alpha');
       });
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
-      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      mockGetMessages.mockResolvedValue({
+        items: [],
+        next_cursor: null,
+        total_count: 0,
+        providers: ['openai'],
+      });
+      const agentSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: 'agent-alpha' } });
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("No messages match your filters");
+        expect(container.textContent).toContain('No messages match your filters');
       });
       // Clear filters — restores data
       mockGetMessages.mockResolvedValue(messagesData);
-      const clearBtn = container.querySelector(".btn--outline") as HTMLButtonElement;
+      const clearBtn = container.querySelector('.btn--outline') as HTMLButtonElement;
       fireEvent.click(clearBtn);
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
@@ -1515,15 +1679,15 @@ describe("MessageLog", () => {
       });
     });
 
-    it("surfaces getAgents() errors to the resource error state (not silently empty)", async () => {
-      mockAgentName = "";
+    it('surfaces getAgents() errors to the resource error state (not silently empty)', async () => {
+      mockAgentName = '';
       // The loader no longer swallows errors: when getAgents() rejects the
       // rejection propagates out of the loader so SolidJS resource transitions
       // into error state instead of silently returning [].
       // We verify: (1) getAgents was actually called; (2) the UI still renders
       // the agent filter gracefully via `agentList() ?? []`.
       mockGetAgents.mockImplementation(async () => {
-        throw new Error("network error");
+        throw new Error('network error');
       });
       mockGetMessages.mockResolvedValue(messagesData);
       const { container, unmount } = render(() => <MessageLog />);
@@ -1531,34 +1695,40 @@ describe("MessageLog", () => {
         expect(mockGetAgents).toHaveBeenCalled();
         const selects = container.querySelectorAll('[data-testid="select"]');
         // Agent filter still renders gracefully (agentList() ?? [] = [])
-        expect(selects[0].textContent).toContain("All harnesses");
-        expect(selects[0].textContent).not.toContain("agent-alpha");
+        expect(selects[0].textContent).toContain('All harnesses');
+        expect(selects[0].textContent).not.toContain('agent-alpha');
       });
       // Unmount and reset before the rejection can leak into the next test.
       unmount();
       mockGetAgents.mockResolvedValue({ agents: [] });
     });
 
-    it("resets page when agentFilter changes", async () => {
-      mockAgentName = "";
-      const bigData = { ...messagesData, total_count: 120, next_cursor: "cursor-2" };
+    it('resets page when agentFilter changes', async () => {
+      mockAgentName = '';
+      const bigData = { ...messagesData, total_count: 120, next_cursor: 'cursor-2' };
       mockGetMessages.mockResolvedValue(bigData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         expect(container.querySelector('[data-testid="pagination-next"]')).not.toBeNull();
       });
       // Navigate to next page
-      const nextBtn = container.querySelector('[data-testid="pagination-next"]') as HTMLButtonElement;
+      const nextBtn = container.querySelector(
+        '[data-testid="pagination-next"]',
+      ) as HTMLButtonElement;
       mockGetMessages.mockResolvedValue({ ...bigData, next_cursor: null });
       nextBtn.click();
       await vi.waitFor(() => {
-        expect(mockGetMessages).toHaveBeenCalledWith(expect.objectContaining({ cursor: "cursor-2" }));
+        expect(mockGetMessages).toHaveBeenCalledWith(
+          expect.objectContaining({ cursor: 'cursor-2' }),
+        );
       });
       // Changing agent filter should reset page (no cursor)
       mockGetMessages.mockClear();
       mockGetMessages.mockResolvedValue(messagesData);
-      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
-      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      const agentSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: 'agent-alpha' } });
       await vi.waitFor(() => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
@@ -1570,15 +1740,15 @@ describe("MessageLog", () => {
       // Fix: columns() now inserts 'agent' before 'model' when !params.agentName.
       // This test asserts the Harness column header actually appears in the DOM,
       // not just that the component receives the columns array.
-      mockAgentName = "";
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("gpt-4o");
+        expect(container.textContent).toContain('gpt-4o');
       });
-      const headers = Array.from(container.querySelectorAll("thead th"));
+      const headers = Array.from(container.querySelectorAll('thead th'));
       const headerTexts = headers.map((th) => th.textContent?.trim());
-      expect(headerTexts).toContain("Harness");
+      expect(headerTexts).toContain('Harness');
     });
 
     it("does NOT render 'Harness' column header in agent-scoped mode", async () => {
@@ -1587,84 +1757,89 @@ describe("MessageLog", () => {
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("gpt-4o");
+        expect(container.textContent).toContain('gpt-4o');
       });
-      const headers = Array.from(container.querySelectorAll("thead th"));
+      const headers = Array.from(container.querySelectorAll('thead th'));
       const headerTexts = headers.map((th) => th.textContent?.trim());
-      expect(headerTexts).not.toContain("Harness");
+      expect(headerTexts).not.toContain('Harness');
     });
 
-    it("renders agent_name values in the Agent column cells in global mode", async () => {
+    it('renders agent_name values in the Agent column cells in global mode', async () => {
       // Each message row must show its agent_name in the Agent cell when
       // the 'agent' column is included (global mode).
-      mockAgentName = "";
+      mockAgentName = '';
       const globalMessagesData = {
         ...messagesData,
         items: [
-          { ...messagesData.items[0], agent_name: "alpha-bot" },
-          { ...messagesData.items[1], agent_name: "beta-bot" },
+          { ...messagesData.items[0], agent_name: 'alpha-bot' },
+          { ...messagesData.items[1], agent_name: 'beta-bot' },
         ],
       };
       mockGetMessages.mockResolvedValue(globalMessagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("alpha-bot");
-        expect(container.textContent).toContain("beta-bot");
+        expect(container.textContent).toContain('alpha-bot');
+        expect(container.textContent).toContain('beta-bot');
       });
     });
 
-    it("renders harness platform icons in global Harness column cells", async () => {
-      mockAgentName = "";
+    it('renders harness platform icons in global Harness column cells', async () => {
+      mockAgentName = '';
       mockGetAgents.mockResolvedValue({
         agents: [
           {
-            agent_name: "alpha-bot",
-            agent_platform: "openclaw",
-            agent_category: "personal",
+            agent_name: 'alpha-bot',
+            agent_platform: 'openclaw',
+            agent_category: 'personal',
           },
         ],
       });
       mockGetMessages.mockResolvedValue({
         ...messagesData,
-        items: [{ ...messagesData.items[0], agent_name: "alpha-bot" }],
+        items: [{ ...messagesData.items[0], agent_name: 'alpha-bot' }],
       });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("alpha-bot");
+        expect(container.textContent).toContain('alpha-bot');
         expect(container.querySelector('td img[src="/icons/openclaw.svg"]')).not.toBeNull();
       });
     });
   });
 
-  describe("global mode title and CTA (Bug 2 + Bug 3)", () => {
+  describe('global mode title and CTA (Bug 2 + Bug 3)', () => {
     it("renders 'Messages - Manifest' title without agent prefix in global mode", () => {
-      mockAgentName = "";
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
-      const title = container.querySelector("title");
-      expect(title?.textContent).toBe("Messages - Manifest");
+      const title = container.querySelector('title');
+      expect(title?.textContent).toBe('Messages - Manifest');
     });
 
-    it("renders agent-scoped title in agent mode", () => {
+    it('renders agent-scoped title in agent mode', () => {
       // mockAgentName is "test-agent" from beforeEach
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
-      const title = container.querySelector("title");
-      expect(title?.textContent).toContain("test-agent");
-      expect(title?.textContent).toContain("Messages - Manifest");
+      const title = container.querySelector('title');
+      expect(title?.textContent).toContain('test-agent');
+      expect(title?.textContent).toContain('Messages - Manifest');
     });
 
     it("does not render 'undefined' in the title in global mode", () => {
-      mockAgentName = "";
+      mockAgentName = '';
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
-      const title = container.querySelector("title");
-      expect(title?.textContent).not.toContain("undefined");
+      const title = container.querySelector('title');
+      expect(title?.textContent).not.toContain('undefined');
     });
 
-    it("does not render SetupModal in global mode (no agentName)", async () => {
-      mockAgentName = "";
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+    it('does not render SetupModal in global mode (no agentName)', async () => {
+      mockAgentName = '';
+      mockGetMessages.mockResolvedValue({
+        items: [],
+        next_cursor: null,
+        total_count: 0,
+        providers: [],
+      });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         // Setup modal must not be rendered when there is no agentName
@@ -1673,31 +1848,41 @@ describe("MessageLog", () => {
     });
 
     it("shows 'Go to Harnesses' link (not SetupModal CTA) in the empty state in global mode", async () => {
-      mockAgentName = "";
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+      mockAgentName = '';
+      mockGetMessages.mockResolvedValue({
+        items: [],
+        next_cursor: null,
+        total_count: 0,
+        providers: [],
+      });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("No messages yet");
+        expect(container.textContent).toContain('No messages yet');
         // Global empty state guides to /harnesses, not set-up-agent modal
         const link = container.querySelector('a[href="/harnesses"]') as HTMLAnchorElement;
         expect(link).not.toBeNull();
-        expect(link.textContent).toContain("Go to Harnesses");
+        expect(link.textContent).toContain('Go to Harnesses');
         // No "Set up harness" button in global mode
-        expect(container.textContent).not.toContain("Set up harness");
+        expect(container.textContent).not.toContain('Set up harness');
       });
     });
 
-    it("does not navigate to /harnesses/undefined/routing in global mode", async () => {
-      mockAgentName = "";
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+    it('does not navigate to /harnesses/undefined/routing in global mode', async () => {
+      mockAgentName = '';
+      mockGetMessages.mockResolvedValue({
+        items: [],
+        next_cursor: null,
+        total_count: 0,
+        providers: [],
+      });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("No messages yet");
+        expect(container.textContent).toContain('No messages yet');
       });
       // Clicking the "Go to Harnesses" link should use the href attribute, not navigate()
       // Verify no button triggers mockNavigate with "/harnesses/undefined/routing"
       expect(mockNavigate).not.toHaveBeenCalledWith(
-        expect.stringContaining("undefined"),
+        expect.stringContaining('undefined'),
         expect.anything(),
       );
     });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -602,6 +602,35 @@ describe('MessageLog', () => {
         );
       });
     });
+
+    it('uses lower-bound totals after skipping exact counts on later pages', async () => {
+      const firstPage = {
+        ...messagesData,
+        total_count: 51,
+        total_count_exact: false,
+        next_cursor: 'cursor-for-page-2',
+      };
+      mockGetMessages.mockResolvedValue(firstPage);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain('51 total');
+      });
+
+      mockGetMessages.mockResolvedValue({
+        ...messagesData,
+        total_count: 2,
+        total_count_exact: false,
+        next_cursor: null,
+      });
+      const nextBtn = container.querySelector(
+        '[data-testid="pagination-next"]',
+      ) as HTMLButtonElement;
+      nextBtn.click();
+
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain('52 total');
+      });
+    });
   });
 
   it('clears all filters when Clear filters button is clicked', async () => {

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -18,12 +18,8 @@ const apiMocks = vi.hoisted(() => ({
   refreshModels: vi.fn(),
   fetchMutate: vi.fn(),
   getOverview: vi.fn(),
-  getGlobalPerAgentTimeseries: vi.fn(),
-  getGlobalPerAgentMessageTimeseries: vi.fn(),
-  getGlobalPerProviderTimeseries: vi.fn(),
-  getGlobalPerProviderMessageTimeseries: vi.fn(),
-  getGlobalPerAgentCostTimeseries: vi.fn(),
-  getGlobalPerProviderCostTimeseries: vi.fn(),
+  getOverviewAgentUsage: vi.fn(),
+  getOverviewProviderUsage: vi.fn(),
   getConnectionDetail: vi.fn(),
   getProviderAnalytics: vi.fn(),
   getPerAgentTimeseries: vi.fn(),
@@ -74,18 +70,8 @@ vi.mock('../../src/services/api/routing.js', () => ({
 
 vi.mock('../../src/services/api/analytics.js', () => ({
   getOverview: (...args: unknown[]) => apiMocks.getOverview(...args),
-  getGlobalPerAgentTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerAgentTimeseries(...args),
-  getGlobalPerAgentMessageTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerAgentMessageTimeseries(...args),
-  getGlobalPerProviderTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerProviderTimeseries(...args),
-  getGlobalPerProviderMessageTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerProviderMessageTimeseries(...args),
-  getGlobalPerAgentCostTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerAgentCostTimeseries(...args),
-  getGlobalPerProviderCostTimeseries: (...args: unknown[]) =>
-    apiMocks.getGlobalPerProviderCostTimeseries(...args),
+  getOverviewAgentUsage: (...args: unknown[]) => apiMocks.getOverviewAgentUsage(...args),
+  getOverviewProviderUsage: (...args: unknown[]) => apiMocks.getOverviewProviderUsage(...args),
   getConnectionDetail: (...args: unknown[]) => apiMocks.getConnectionDetail(...args),
   getProviderAnalytics: (...args: unknown[]) => apiMocks.getProviderAnalytics(...args),
   getPerAgentTimeseries: (...args: unknown[]) => apiMocks.getPerAgentTimeseries(...args),
@@ -503,6 +489,18 @@ const providerTimeseries = {
   timeseries: [{ hour: '2026-06-04 10:00:00', openai: 1200, anthropic: 900 }],
 };
 
+const agentUsageTimeseries = {
+  tokenUsage: agentTimeseries,
+  messageUsage: agentTimeseries,
+  costUsage: agentTimeseries,
+};
+
+const providerUsageTimeseries = {
+  tokenUsage: providerTimeseries,
+  messageUsage: providerTimeseries,
+  costUsage: providerTimeseries,
+};
+
 const connectionDetail = {
   connection: {
     id: 'conn-openai',
@@ -569,12 +567,8 @@ beforeEach(() => {
   apiMocks.refreshModels.mockResolvedValue(undefined);
   apiMocks.fetchMutate.mockResolvedValue({});
   apiMocks.getOverview.mockResolvedValue(overviewResponse);
-  apiMocks.getGlobalPerAgentTimeseries.mockResolvedValue(agentTimeseries);
-  apiMocks.getGlobalPerAgentMessageTimeseries.mockResolvedValue(agentTimeseries);
-  apiMocks.getGlobalPerProviderTimeseries.mockResolvedValue(providerTimeseries);
-  apiMocks.getGlobalPerProviderMessageTimeseries.mockResolvedValue(providerTimeseries);
-  apiMocks.getGlobalPerAgentCostTimeseries.mockResolvedValue(agentTimeseries);
-  apiMocks.getGlobalPerProviderCostTimeseries.mockResolvedValue(providerTimeseries);
+  apiMocks.getOverviewAgentUsage.mockResolvedValue(agentUsageTimeseries);
+  apiMocks.getOverviewProviderUsage.mockResolvedValue(providerUsageTimeseries);
   apiMocks.getConnectionDetail.mockResolvedValue(connectionDetail);
   apiMocks.getProviderAnalytics.mockResolvedValue(connectionAnalytics);
   apiMocks.getPerAgentTimeseries.mockResolvedValue(agentTimeseries);
@@ -759,9 +753,11 @@ describe('GlobalOverview (analytics)', () => {
       agents: ['openai', 'custom:cp-1'],
       timeseries: [{ hour: '2026-06-04 10:00:00', openai: 1200, 'custom:cp-1': 300 }],
     };
-    apiMocks.getGlobalPerProviderTimeseries.mockResolvedValue(customSeries);
-    apiMocks.getGlobalPerProviderMessageTimeseries.mockResolvedValue(customSeries);
-    apiMocks.getGlobalPerProviderCostTimeseries.mockResolvedValue(customSeries);
+    apiMocks.getOverviewProviderUsage.mockResolvedValue({
+      tokenUsage: customSeries,
+      messageUsage: customSeries,
+      costUsage: customSeries,
+    });
     // A custom model with no display_name must render its stripped name, not
     // the raw custom:<uuid>/ slug.
     apiMocks.getOverview.mockResolvedValue({
@@ -1072,9 +1068,7 @@ describe('ConnectionDetail (analytics)', () => {
     apiMocks.getConnectionDetail.mockRejectedValueOnce(new Error('network down'));
 
     const { container } = render(() => <ConnectionDetail />);
-    await waitFor(() =>
-      expect(screen.getByText("Couldn't load this connection")).toBeDefined(),
-    );
+    await waitFor(() => expect(screen.getByText("Couldn't load this connection")).toBeDefined());
     expect(container.querySelector('[style*="skeleton-pulse"]')).toBeNull();
 
     // Retry re-fetches; on success the connection renders.
@@ -1468,9 +1462,7 @@ describe('ConnectionDetail (analytics)', () => {
 
     fireEvent.click(screen.getByText('Manage'));
     // Active subscription → "Connected via subscription" (line 963 truthy branch).
-    await waitFor(() =>
-      expect(screen.getByText(/Connected via\s+subscription/)).toBeDefined(),
-    );
+    await waitFor(() => expect(screen.getByText(/Connected via\s+subscription/)).toBeDefined());
   });
 
   it('renders a dash for a recent message with no model', async () => {

--- a/packages/frontend/tests/services/api/analytics.test.ts
+++ b/packages/frontend/tests/services/api/analytics.test.ts
@@ -112,12 +112,13 @@ describe('analytics API client', () => {
   });
 
   it('per-agent timeseries endpoints forward connection_id when provided', async () => {
-    const fns: Array<[(a: string, p: string, r?: string, l?: string, c?: string) => unknown, string]> =
-      [
-        [analytics.getPerAgentTimeseries, 'per-agent-timeseries'],
-        [analytics.getPerAgentMessageTimeseries, 'per-agent-message-timeseries'],
-        [analytics.getPerAgentCostTimeseries, 'per-agent-cost-timeseries'],
-      ];
+    const fns: Array<
+      [(a: string, p: string, r?: string, l?: string, c?: string) => unknown, string]
+    > = [
+      [analytics.getPerAgentTimeseries, 'per-agent-timeseries'],
+      [analytics.getPerAgentMessageTimeseries, 'per-agent-message-timeseries'],
+      [analytics.getPerAgentCostTimeseries, 'per-agent-cost-timeseries'],
+    ];
     for (const [fn, path] of fns) {
       const fetchMock = setupFetch({ agents: [], timeseries: [] });
       await fn('subscription', 'openai', '30d', 'Work', 'conn-7');
@@ -140,9 +141,11 @@ describe('analytics API client', () => {
       [analytics.getGlobalPerAgentTimeseries, 'per-agent-timeseries'],
       [analytics.getGlobalPerAgentMessageTimeseries, 'per-agent-message-timeseries'],
       [analytics.getGlobalPerAgentCostTimeseries, 'per-agent-cost-timeseries'],
+      [analytics.getOverviewAgentUsage, 'agents/usage'],
       [analytics.getGlobalPerProviderTimeseries, 'per-provider-timeseries'],
       [analytics.getGlobalPerProviderMessageTimeseries, 'per-provider-message-timeseries'],
       [analytics.getGlobalPerProviderCostTimeseries, 'per-provider-cost-timeseries'],
+      [analytics.getOverviewProviderUsage, 'providers/usage'],
       [analytics.getGlobalPerModelTimeseries, 'per-model-timeseries'],
       [analytics.getGlobalPerModelMessageTimeseries, 'per-model-message-timeseries'],
       [analytics.getGlobalPerModelCostTimeseries, 'per-model-cost-timeseries'],

--- a/packages/frontend/tests/services/api/messages.test.ts
+++ b/packages/frontend/tests/services/api/messages.test.ts
@@ -43,6 +43,8 @@ describe('messages API client', () => {
       agent_name: 'demo',
       cost_min: '0.01',
       cost_max: '1.00',
+      include_total: 'false',
+      include_filter_options: 'false',
     });
     const url = fetchMock.mock.calls[0][0] as string;
     expect(url).toContain('range=7d');
@@ -53,10 +55,26 @@ describe('messages API client', () => {
     expect(url).toContain('agent_name=demo');
     expect(url).toContain('cost_min=0.01');
     expect(url).toContain('cost_max=1.00');
+    expect(url).toContain('include_total=false');
+    expect(url).toContain('include_filter_options=false');
+  });
+
+  it('getMessageFilterOptions GETs filter metadata with agent scope', async () => {
+    const fetchMock = setupFetch({ providers: [] });
+    await messages.getMessageFilterOptions({ range: '30d', agent_name: 'demo' });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/messages/filter-options');
+    expect(url).toContain('range=30d');
+    expect(url).toContain('agent_name=demo');
   });
 
   it('getMessageDetails GETs the details endpoint with encoded id', async () => {
-    const fetchMock = setupFetch({ message: {}, llm_calls: [], tool_executions: [], agent_logs: [] });
+    const fetchMock = setupFetch({
+      message: {},
+      llm_calls: [],
+      tool_executions: [],
+      agent_logs: [],
+    });
     await messages.getMessageDetails('msg/1');
     const url = fetchMock.mock.calls[0][0] as string;
     expect(url).toContain('/api/v1/messages/msg%2F1/details');


### PR DESCRIPTION
### ✨ What changed
- Added `/overview/agents/usage` and `/overview/providers/usage` for chart data.
- Collapsed token, message, and cost overview series into one query per grouping.
- Messages can load rows without exact totals or filter options.
- Added `/messages/filter-options` for provider dropdown metadata.

### 💭 Why
Global overview and Messages still did expensive `agent_messages` work on initial load after the provider split.
The page should show useful data before counts and filter metadata finish.

### 👤 For users
Global overview charts and the Messages table should start rendering faster on large workspaces.

### 🔧 For operators
No migration, env var, or deploy-order requirement.

### 📝 Notes
Validation: focused backend analytics tests, focused frontend tests, backend build, frontend build, lint, Prettier, diff check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up Global Overview and Messages by merging token/message/cost timeseries into single endpoints and letting Messages render rows before exact totals or filter metadata. Charts and tables start showing data faster on large workspaces.

- **New Features**
  - Added `GET /overview/agents/usage` and `GET /overview/providers/usage` returning tokens, messages, and cost in one response.
  - `GET /messages` accepts `include_total` and `include_filter_options`; responds with `total_count_exact` when totals are approximate.
  - Added `GET /messages/filter-options` to fetch provider list and labels (supports agent scope).

- **Refactors**
  - Collapsed per-agent and per-provider usage into a single pivoted query on the backend.
  - GlobalOverview now calls `getOverviewAgentUsage`/`getOverviewProviderUsage`.
  - MessageLog loads rows first with totals/options disabled, then fetches filter options separately and paginates with a running total.

<sup>Written for commit 30f67fa36645111f7683fd67a665530d9825b6c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

