### PR TITLE
perf: defer agent overview hidden charts

### DIFF
--- a/.changeset/lazy-agent-overview-charts.md
+++ b/.changeset/lazy-agent-overview-charts.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Lazy-load hidden token and cost chart series on agent overview.

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -87,6 +87,9 @@ type PivotedTimeseries = {
   timeseries: Array<Record<string, number | string>>;
 };
 
+type ProviderView = 'cost' | 'tokens' | 'messages';
+type TimeseriesKey = { range: string; agent: string; _ping: number };
+
 const Overview: Component = () => {
   const params = useParams<{ agentName: string }>();
   const location = useLocation<{ newApiKey?: string }>();
@@ -101,7 +104,14 @@ const Overview: Component = () => {
   const { range, setRange, handleRangeChange } = useOverviewRange({
     markUserSelected: () => setUserSelectedRange(true),
   });
-  const [activeView, setActiveView] = createSignal<'cost' | 'tokens' | 'messages'>('messages');
+  const [activeView, setActiveViewRaw] = createSignal<ProviderView>('messages');
+  const [tokenChartRequested, setTokenChartRequested] = createSignal(false);
+  const [costChartRequested, setCostChartRequested] = createSignal(false);
+  const setActiveView = (view: ProviderView) => {
+    if (view === 'tokens') setTokenChartRequested(true);
+    if (view === 'cost') setCostChartRequested(true);
+    setActiveViewRaw(view);
+  };
   // Open gate keys off a persistent "setup pending" flag (localStorage) so the
   // modal reliably reopens after a page refresh until the user dismisses or
   // completes it; `isRecentlyCreated` is an in-session OR that need not survive
@@ -232,9 +242,13 @@ const Overview: Component = () => {
   };
   const [selectedProviders, setSelectedProviders] = createSignal<Set<string>>(loadSavedProviders());
 
-  const tsKey = () => ({ range: range(), agent: params.agentName, _ping: messagePing() });
+  const tsKey = (): TimeseriesKey => ({
+    range: range(),
+    agent: params.agentName,
+    _ping: messagePing(),
+  });
   const [providerTokenTs] = createResource(
-    tsKey,
+    () => (tokenChartRequested() ? tsKey() : false),
     (p) => getPerProviderTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
   const [providerMessageTs] = createResource(
@@ -242,7 +256,7 @@ const Overview: Component = () => {
     (p) => getPerProviderMessageTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
   const [providerCostTs] = createResource(
-    tsKey,
+    () => (costChartRequested() ? tsKey() : false),
     (p) => getPerProviderCostTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
 

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -61,14 +61,17 @@ vi.mock('../../src/services/setup-status.js', () => ({
   checkIsSelfHosted: () => mockCheckIsSelfHosted(),
 }));
 
-// The per-agent Overview renders ProviderChartCard → MultiAgentTokenChart and
-// fetches three per-provider timeseries. Stub the chart to a marker exposing
-// its series, and the API to a controllable resolver.
+// The per-agent Overview renders ProviderChartCard → MultiAgentTokenChart.
+// Stub the chart to a marker exposing its series, and the per-view provider
+// timeseries endpoints to a controllable resolver.
 const mockPerProvider = vi.fn(() => Promise.resolve({ agents: [], timeseries: [] }));
+const mockPerProviderTokens = vi.fn((...a: unknown[]) => mockPerProvider(...a));
+const mockPerProviderMessages = vi.fn((...a: unknown[]) => mockPerProvider(...a));
+const mockPerProviderCosts = vi.fn((...a: unknown[]) => mockPerProvider(...a));
 vi.mock('../../src/services/api/analytics.js', () => ({
-  getPerProviderTimeseries: (...a: unknown[]) => mockPerProvider(...a),
-  getPerProviderMessageTimeseries: (...a: unknown[]) => mockPerProvider(...a),
-  getPerProviderCostTimeseries: (...a: unknown[]) => mockPerProvider(...a),
+  getPerProviderTimeseries: (...a: unknown[]) => mockPerProviderTokens(...a),
+  getPerProviderMessageTimeseries: (...a: unknown[]) => mockPerProviderMessages(...a),
+  getPerProviderCostTimeseries: (...a: unknown[]) => mockPerProviderCosts(...a),
 }));
 
 vi.mock('../../src/components/MultiAgentTokenChart.jsx', () => ({
@@ -391,6 +394,44 @@ describe('Overview', () => {
     render(() => <Overview />);
     await vi.waitFor(() => {
       expect(mockGetOverview).toHaveBeenCalled();
+    });
+  });
+
+  it('only fetches the visible provider chart series on mount', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['openai'],
+      timeseries: [{ hour: '1', openai: 5 }],
+    });
+    render(() => <Overview />);
+
+    await vi.waitFor(() => {
+      expect(mockPerProviderMessages).toHaveBeenCalledWith('test-agent', '30d');
+    });
+    expect(mockPerProviderMessages).toHaveBeenCalledTimes(1);
+    expect(mockPerProviderTokens).not.toHaveBeenCalled();
+    expect(mockPerProviderCosts).not.toHaveBeenCalled();
+  });
+
+  it('fetches token and cost provider series when those chart views are opened', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['openai'],
+      timeseries: [{ hour: '1', openai: 5 }],
+    });
+    const { container } = render(() => <Overview />);
+
+    await vi.waitFor(() => {
+      expect(mockPerProviderMessages).toHaveBeenCalledTimes(1);
+    });
+    const stats = container.querySelectorAll('.chart-card__stat--clickable');
+    fireEvent.click(stats[2]); // tokens
+    await vi.waitFor(() => {
+      expect(mockPerProviderTokens).toHaveBeenCalledWith('test-agent', '30d');
+    });
+    fireEvent.click(stats[0]); // cost
+    await vi.waitFor(() => {
+      expect(mockPerProviderCosts).toHaveBeenCalledWith('test-agent', '30d');
     });
   });
 


### PR DESCRIPTION
### ✨ What changed
- Agent overview fetches only the visible provider chart on mount.
- Token and cost provider series load when their chart is opened.
- Added tests for lazy chart requests.
- Added a patch changeset.

### 💭 Why
Agent overview was doing hidden chart work during initial load. Totals still load from the summary request.

### 👤 For users
Agent overview opens with less up-front chart work. The visible UI does not change.

### 📝 Notes
- Local: frontend typecheck passed.
- Local: frontend coverage passed.
- Local: frontend Vite build passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer loading of hidden charts on Agent Overview to reduce initial API calls and speed up first render. Only the visible provider messages chart loads on mount; token and cost charts load when opened.

- **Performance**
  - Fetch provider messages series on mount; request tokens and cost when their chart is opened.
  - Totals still come from the overview summary request.
  - Added tests for lazy chart requests and a patch changeset.

<sup>Written for commit 46c88c2e1e9aabb157df3c9198bd15a50181b328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

