### PR TITLE
fix: clarify provider disconnect blockers

### DIFF
--- a/.changeset/provider-disconnect-agent-name.md
+++ b/.changeset/provider-disconnect-agent-name.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Name the affected agent when provider disconnect is blocked by routing.

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -22,15 +22,28 @@ const route = (
   model,
 });
 
-const makeQueryBuilder = (agentIds: string[] = ['agent-1']) => ({
+type AgentRow = string | { id: string; name?: string | null; display_name?: string | null };
+
+const makeQueryBuilder = (agents: AgentRow[] = ['agent-1']) => ({
   leftJoin: jest.fn().mockReturnThis(),
   where: jest.fn().mockReturnThis(),
   andWhere: jest.fn().mockReturnThis(),
   select: jest.fn().mockReturnThis(),
-  getRawMany: jest.fn().mockResolvedValue(agentIds.map((id) => ({ id }))),
+  addSelect: jest.fn().mockReturnThis(),
+  getRawMany: jest.fn().mockResolvedValue(
+    agents.map((agent) =>
+      typeof agent === 'string'
+        ? { id: agent, name: agent, display_name: null }
+        : {
+            id: agent.id,
+            name: agent.name ?? agent.id,
+            display_name: agent.display_name ?? null,
+          },
+    ),
+  ),
 });
 
-const makeRepo = (agentIds: string[] = ['agent-1']) => ({
+const makeRepo = (agents: AgentRow[] = ['agent-1']) => ({
   find: jest.fn().mockResolvedValue([]),
   findOne: jest.fn().mockResolvedValue(null),
   insert: jest.fn().mockResolvedValue(undefined),
@@ -39,7 +52,7 @@ const makeRepo = (agentIds: string[] = ['agent-1']) => ({
   remove: jest.fn().mockResolvedValue(undefined),
   update: jest.fn().mockResolvedValue(undefined),
   manager: { transaction: jest.fn() },
-  createQueryBuilder: jest.fn().mockReturnValue(makeQueryBuilder(agentIds)),
+  createQueryBuilder: jest.fn().mockReturnValue(makeQueryBuilder(agents)),
 });
 
 describe('ProviderService — route-only cleanup paths', () => {
@@ -483,6 +496,18 @@ describe('ProviderService — route-only cleanup paths', () => {
     });
 
     it('blocks bulk disable when a route references an active provider', async () => {
+      const agentRepo = makeRepo([
+        { id: 'agent-1', name: 'support-bot', display_name: 'Support Bot' },
+      ]);
+      const localSvc = new ProviderService(
+        providerRepo as unknown as Repository<TenantProvider>,
+        tierRepo as unknown as Repository<TierAssignment>,
+        specRepo as unknown as Repository<SpecificityAssignment>,
+        agentRepo as unknown as Repository<Agent>,
+        headerTierRepo as unknown as Repository<HeaderTier>,
+        pricingCache as unknown as ModelPricingCacheService,
+        routingCache as unknown as RoutingCacheService,
+      );
       providerRepo.find.mockResolvedValueOnce([
         {
           id: 'p1',
@@ -503,8 +528,8 @@ describe('ProviderService — route-only cleanup paths', () => {
       specRepo.find.mockResolvedValue([]);
       headerTierRepo.find.mockResolvedValue([]);
 
-      await expect(svc.deactivateAllProviders('agent-1', 'tenant-1')).rejects.toThrow(
-        /Cannot disconnect provider/,
+      await expect(localSvc.deactivateAllProviders('agent-1', 'tenant-1')).rejects.toThrow(
+        'Update routing first (agent "Support Bot", tier standard, primary: gpt-4o).',
       );
       expect(providerRepo.update).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -40,10 +40,16 @@ const DEFAULT_LABEL = 'Default';
 
 interface ProviderRouteReference {
   agentId: string;
+  agentName: string;
   surface: 'tier' | 'specificity' | 'header';
   name: string;
   model: string;
   position: string;
+}
+
+interface OwnedAgentRouteTarget {
+  id: string;
+  name: string;
 }
 
 @Injectable()
@@ -752,13 +758,24 @@ export class ProviderService {
 
   /** Resolve the ids of every non-deleted agent the tenant owns. */
   async listOwnedAgentIds(tenantId: string): Promise<string[]> {
+    return (await this.listOwnedAgentRouteTargets(tenantId)).map((agent) => agent.id);
+  }
+
+  private async listOwnedAgentRouteTargets(tenantId: string): Promise<OwnedAgentRouteTarget[]> {
     const agents = await this.agentRepo
       .createQueryBuilder('a')
       .where('a.tenant_id = :tenantId', { tenantId })
       .andWhere('a.deleted_at IS NULL')
-      .select('a.id', 'id')
-      .getRawMany<{ id: string }>();
-    return agents.map((a) => a.id);
+      .select(['a.id AS id', 'a.name AS name', 'a.display_name AS display_name'])
+      .getRawMany<{ id: string; name: string | null; display_name: string | null }>();
+    return agents.map((agent) => {
+      const displayName = agent.display_name?.trim();
+      const name = agent.name?.trim();
+      return {
+        id: agent.id,
+        name: displayName || name || agent.id,
+      };
+    });
   }
 
   private async assertProviderRoutesNotUsed(
@@ -768,20 +785,24 @@ export class ProviderService {
     if (providerRows.length === 0) return;
 
     const references: ProviderRouteReference[] = [];
-    for (const agentId of await this.listOwnedAgentIds(tenantId)) {
-      references.push(...(await this.findProviderRouteReferences(agentId, providerRows)));
+    for (const agent of await this.listOwnedAgentRouteTargets(tenantId)) {
+      references.push(
+        ...(await this.findProviderRouteReferences(agent.id, agent.name, providerRows)),
+      );
     }
     if (references.length === 0) return;
 
     const first = references[0];
     throw new ConflictException(
       `Cannot disconnect provider while its models are assigned to routing. ` +
-        `Update routing first (${first.surface} ${first.name}, ${first.position}: ${first.model}).`,
+        `Update routing first (agent "${first.agentName}", ${first.surface} ${first.name}, ` +
+        `${first.position}: ${first.model}).`,
     );
   }
 
   private async findProviderRouteReferences(
     agentId: string,
+    agentName: string,
     providerRows: TenantProvider[],
   ): Promise<ProviderRouteReference[]> {
     const references: ProviderRouteReference[] = [];
@@ -791,6 +812,7 @@ export class ProviderService {
       if (this.routeBelongsToProviderRows(tier.override_route, providerRows)) {
         references.push({
           agentId,
+          agentName,
           surface: 'tier',
           name: tier.tier,
           model: tier.override_route!.model,
@@ -801,6 +823,7 @@ export class ProviderService {
         if (this.routeBelongsToProviderRows(fallback, providerRows)) {
           references.push({
             agentId,
+            agentName,
             surface: 'tier',
             name: tier.tier,
             model: fallback.model,
@@ -815,6 +838,7 @@ export class ProviderService {
       if (this.routeBelongsToProviderRows(row.override_route, providerRows)) {
         references.push({
           agentId,
+          agentName,
           surface: 'specificity',
           name: row.category,
           model: row.override_route!.model,
@@ -825,6 +849,7 @@ export class ProviderService {
         if (this.routeBelongsToProviderRows(fallback, providerRows)) {
           references.push({
             agentId,
+            agentName,
             surface: 'specificity',
             name: row.category,
             model: fallback.model,
@@ -839,6 +864,7 @@ export class ProviderService {
       if (this.routeBelongsToProviderRows(tier.override_route, providerRows)) {
         references.push({
           agentId,
+          agentName,
           surface: 'header',
           name: tier.name,
           model: tier.override_route!.model,
@@ -849,6 +875,7 @@ export class ProviderService {
         if (this.routeBelongsToProviderRows(fallback, providerRows)) {
           references.push({
             agentId,
+            agentName,
             surface: 'header',
             name: tier.name,
             model: fallback.model,


### PR DESCRIPTION
### What changed
- Provider disconnect route checks include the affected agent label.
- Disconnect validation batches owned-agent route reads and stops on the first blocker.
- Checks ignore disabled specificity/header routes and provider rows not enabled for that agent.
- Added focused backend coverage for the conflict message, batching, and misleading blocker cases.

### Why
Global provider disconnect already blocks when routing still uses that provider, but the message did not say which agent to fix. The old guard also scanned route tables once per agent and could report routes that routing would not actually use.

### For users
Disconnect errors now point to the agent whose active routing still references the provider, and the click returns faster on tenants with many agents.

### Notes
Validation: focused backend provider-service suites, backend build, Prettier, changeset status, and `git diff --check`.