### PR TITLE
fix: improve routing empty state in dark mode

### DIFF
--- a/.changeset/routing-empty-state-dark-mode.md
+++ b/.changeset/routing-empty-state-dark-mode.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Improve the agent routing empty state contrast in dark mode.

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -1891,7 +1891,8 @@
   padding: 48px 24px;
   gap: 24px;
   width: 100%;
-  background: hsl(var(--muted) / 0.45);
+  background: hsl(var(--muted) / 0.34);
+  border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
 }
 
@@ -1913,6 +1914,7 @@
   font-size: var(--font-size-sm);
   color: hsl(var(--muted-foreground));
   line-height: 1.5;
+  max-width: 360px;
 }
 
 .no-connections-prompt__cards {
@@ -1921,7 +1923,7 @@
   justify-content: center;
   gap: 12px;
   width: 100%;
-  max-width: 1400px;
+  max-width: 1040px;
 }
 
 .no-connections-prompt__cards > * {
@@ -1935,7 +1937,7 @@
   text-align: left;
   gap: 4px;
   padding: 16px 20px;
-  background: #ffffff73;
+  background: hsl(var(--card));
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   transition:
@@ -1946,9 +1948,21 @@
 }
 
 .no-connections-prompt__card:hover {
-  background: #ffffffa6;
+  background: hsl(var(--accent));
   border-color: hsl(var(--foreground) / 0.2);
   box-shadow: 0 2px 8px hsl(var(--foreground) / 0.06);
+}
+
+.dark .no-connections-prompt {
+  background: hsl(var(--muted) / 0.24);
+}
+
+.dark .no-connections-prompt__card {
+  background: hsl(var(--card));
+}
+
+.dark .no-connections-prompt__card:hover {
+  background: hsl(var(--muted) / 0.55);
 }
 
 .no-connections-prompt__card-icon {


### PR DESCRIPTION
### ✨ What changed

- Restyled the no-provider prompt with theme tokens.
- Added a patch changeset for the Manifest UI fix.

### 💭 Why

The previous prompt used hardcoded translucent white cards, which looked off in dark mode.

### 👤 For users

Agent Routing shows a cleaner no-provider state in dark mode.

### 📝 Notes

Validation: focused frontend tests, Prettier check, frontend build, and dark-mode browser smoke.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the Agent Routing “no provider” empty state for dark mode using theme tokens and better contrast. The prompt is now consistent with the theme and easier to read.

- **Bug Fixes**
  - Replaced hardcoded translucent white with theme tokens and dark-mode overrides; added border and hover styles for clarity.
  - Tweaked layout widths (text and cards) for better fit; added a patch changeset for `manifest` to release the fix.

<sup>Written for commit 0501bb05a8bdba0cd2e3fcdaa9faae3dd0219259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

