### PR TITLE
fix: speed provider disconnect checks

### DIFF
--- a/.changeset/provider-disconnect-speed.md
+++ b/.changeset/provider-disconnect-speed.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Speed up provider disconnect route checks and ignore disabled route rows.

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.coverage.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.coverage.spec.ts
@@ -198,11 +198,32 @@ describe('ProviderService — coverage completion', () => {
     const row = provRow({
       provider: 'openrouter',
       cached_models: [{ id: 'Foo-Model' }] as unknown as TenantProvider['cached_models'],
-      priority: 1,
+      priority: 0,
     });
     expect(
       priv().routeBelongsToProviderRows({ authType: 'api_key', model: 'foo-model' }, [row]),
     ).toBe(true);
+  });
+
+  it('routeBelongsToProviderRows rejects providerless routes for the wrong key', () => {
+    const row = provRow({
+      provider: 'openrouter',
+      auth_type: 'subscription',
+      cached_models: [{ id: 'Foo-Model' }] as unknown as TenantProvider['cached_models'],
+      priority: 0,
+    });
+    expect(
+      priv().routeBelongsToProviderRows({ authType: 'api_key', model: 'foo-model' }, [row]),
+    ).toBe(false);
+
+    const secondary = provRow({
+      provider: 'openrouter',
+      cached_models: [{ id: 'Foo-Model' }] as unknown as TenantProvider['cached_models'],
+      priority: 1,
+    });
+    expect(
+      priv().routeBelongsToProviderRows({ authType: 'api_key', model: 'foo-model' }, [secondary]),
+    ).toBe(false);
   });
 
   it('normalizeLabel rejects empty and local custom labels', () => {

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -108,6 +108,7 @@ describe('ProviderService — route-only cleanup paths', () => {
       ]);
       tierRepo.find.mockResolvedValueOnce([
         {
+          agent_id: 'agent-1',
           tier: 'standard',
           override_route: route('OpenAI', 'gpt-4o'),
           fallback_routes: null,
@@ -136,6 +137,7 @@ describe('ProviderService — route-only cleanup paths', () => {
       ]);
       tierRepo.find.mockResolvedValueOnce([
         {
+          agent_id: 'agent-1',
           tier: 'standard',
           override_route: { provider: '', authType: 'api_key', model: 'custom-x/some' },
           fallback_routes: null,
@@ -165,6 +167,7 @@ describe('ProviderService — route-only cleanup paths', () => {
       pricingCache.getByModel.mockReturnValue({ provider: 'openai' } as never);
       tierRepo.find.mockResolvedValueOnce([
         {
+          agent_id: 'agent-1',
           tier: 'standard',
           override_route: { provider: '', authType: 'api_key', model: 'opaque-id' },
           fallback_routes: null,
@@ -194,9 +197,10 @@ describe('ProviderService — route-only cleanup paths', () => {
       tierRepo.find.mockResolvedValueOnce([]);
       specRepo.find.mockResolvedValueOnce([
         {
+          agent_id: 'agent-1',
           category: 'coding',
           override_route: null,
-          fallback_routes: [route('openai', 'gpt-4o-mini')],
+          fallback_routes: [route('anthropic', 'claude-sonnet'), route('openai', 'gpt-4o-mini')],
         } as unknown as SpecificityAssignment,
       ]);
       headerTierRepo.find.mockResolvedValue([]);
@@ -220,6 +224,7 @@ describe('ProviderService — route-only cleanup paths', () => {
       providerRepo.find.mockResolvedValueOnce([row]);
       tierRepo.find.mockResolvedValueOnce([
         {
+          agent_id: 'agent-1',
           tier: 'standard',
           override_route: { provider: 'other', authType: 'api_key', model: 'custom-x/some' },
           fallback_routes: null,
@@ -239,6 +244,160 @@ describe('ProviderService — route-only cleanup paths', () => {
       expect(routingCache.invalidateTenant).toHaveBeenCalledWith('tenant-1');
     });
 
+    it('skips route checks when the tenant has no owned agents', async () => {
+      const row = {
+        id: 'p1',
+        agent_id: 'agent-1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'Default',
+        priority: 0,
+        is_active: true,
+      } as unknown as TenantProvider;
+      const localSvc = new ProviderService(
+        providerRepo as unknown as Repository<TenantProvider>,
+        tierRepo as unknown as Repository<TierAssignment>,
+        specRepo as unknown as Repository<SpecificityAssignment>,
+        makeRepo([]) as unknown as Repository<Agent>,
+        headerTierRepo as unknown as Repository<HeaderTier>,
+        pricingCache as unknown as ModelPricingCacheService,
+        routingCache as unknown as RoutingCacheService,
+      );
+      providerRepo.find.mockResolvedValueOnce([row]);
+
+      await expect(localSvc.removeProvider(null, 'tenant-1', 'openai')).resolves.toEqual({
+        notifications: [],
+      });
+
+      expect(tierRepo.find).not.toHaveBeenCalled();
+      expect(row.is_active).toBe(false);
+      expect(providerRepo.save).toHaveBeenCalledWith([row]);
+    });
+
+    it('ignores inactive specificity rows and disabled header tiers', async () => {
+      const row = {
+        id: 'p1',
+        agent_id: 'agent-1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'Default',
+        priority: 0,
+        is_active: true,
+      } as unknown as TenantProvider;
+      providerRepo.find.mockResolvedValueOnce([row]);
+      tierRepo.find.mockResolvedValueOnce([]);
+      specRepo.find.mockResolvedValueOnce([
+        {
+          agent_id: 'agent-1',
+          category: 'coding',
+          is_active: false,
+          override_route: route('openai', 'gpt-4o'),
+          fallback_routes: null,
+        } as unknown as SpecificityAssignment,
+      ]);
+      headerTierRepo.find.mockResolvedValueOnce([
+        {
+          agent_id: 'agent-1',
+          name: 'Debug',
+          enabled: false,
+          override_route: route('openai', 'gpt-4o'),
+          fallback_routes: null,
+        } as unknown as HeaderTier,
+      ]);
+
+      await expect(svc.removeProvider('agent-1', 'tenant-1', 'openai')).resolves.toEqual({
+        notifications: [],
+      });
+
+      expect(providerRepo.save).toHaveBeenCalledWith([row]);
+    });
+
+    it('ignores routes on agents where the target provider is not enabled', async () => {
+      const row = {
+        id: 'p1',
+        agent_id: 'agent-1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'Default',
+        priority: 0,
+        is_active: true,
+      } as unknown as TenantProvider;
+      const agentRepo = makeRepo([{ id: 'agent-1', name: 'support-bot' }]);
+      const enabledRepo = makeRepo();
+      enabledRepo.find.mockResolvedValueOnce([]);
+      const localSvc = new ProviderService(
+        providerRepo as unknown as Repository<TenantProvider>,
+        tierRepo as unknown as Repository<TierAssignment>,
+        specRepo as unknown as Repository<SpecificityAssignment>,
+        agentRepo as unknown as Repository<Agent>,
+        headerTierRepo as unknown as Repository<HeaderTier>,
+        pricingCache as unknown as ModelPricingCacheService,
+        routingCache as unknown as RoutingCacheService,
+        enabledRepo as unknown as Repository<AgentEnabledProvider>,
+      );
+      providerRepo.find.mockResolvedValueOnce([row]);
+      tierRepo.find.mockResolvedValueOnce([
+        {
+          agent_id: 'agent-1',
+          tier: 'standard',
+          override_route: route('openai', 'gpt-4o'),
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+      specRepo.find.mockResolvedValueOnce([]);
+      headerTierRepo.find.mockResolvedValueOnce([]);
+
+      await expect(localSvc.removeProvider('agent-1', 'tenant-1', 'openai')).resolves.toEqual({
+        notifications: [],
+      });
+
+      expect(providerRepo.save).toHaveBeenCalledWith([row]);
+      expect(enabledRepo.delete).toHaveBeenCalledWith({ tenant_provider_id: In(['p1']) });
+    });
+
+    it('blocks routes on agents where the target provider is enabled', async () => {
+      const row = {
+        id: 'p1',
+        agent_id: 'agent-1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'Default',
+        priority: 0,
+        is_active: true,
+      } as unknown as TenantProvider;
+      const agentRepo = makeRepo([{ id: 'agent-1', name: 'support-bot' }]);
+      const enabledRepo = makeRepo();
+      enabledRepo.find.mockResolvedValueOnce([
+        { agent_id: 'agent-1', tenant_provider_id: 'p1' } as AgentEnabledProvider,
+      ]);
+      const localSvc = new ProviderService(
+        providerRepo as unknown as Repository<TenantProvider>,
+        tierRepo as unknown as Repository<TierAssignment>,
+        specRepo as unknown as Repository<SpecificityAssignment>,
+        agentRepo as unknown as Repository<Agent>,
+        headerTierRepo as unknown as Repository<HeaderTier>,
+        pricingCache as unknown as ModelPricingCacheService,
+        routingCache as unknown as RoutingCacheService,
+        enabledRepo as unknown as Repository<AgentEnabledProvider>,
+      );
+      providerRepo.find.mockResolvedValueOnce([row]);
+      tierRepo.find.mockResolvedValueOnce([
+        {
+          agent_id: 'agent-1',
+          tier: 'standard',
+          override_route: route('openai', 'gpt-4o'),
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+
+      await expect(localSvc.removeProvider('agent-1', 'tenant-1', 'openai')).rejects.toThrow(
+        'Update routing first (agent "support-bot", tier standard, primary: gpt-4o).',
+      );
+
+      expect(providerRepo.save).not.toHaveBeenCalled();
+      expect(enabledRepo.delete).not.toHaveBeenCalled();
+    });
+
     it('blocks only disconnected auth-type routes when another auth type stays active', async () => {
       providerRepo.find.mockResolvedValueOnce([
         {
@@ -253,6 +412,7 @@ describe('ProviderService — route-only cleanup paths', () => {
       ]);
       tierRepo.find.mockResolvedValueOnce([
         {
+          agent_id: 'agent-1',
           tier: 'standard',
           override_route: route('anthropic', 'claude-sonnet-4-6', 'subscription'),
           fallback_routes: [route('anthropic', 'claude-haiku-4-6', 'api_key')],
@@ -409,6 +569,7 @@ describe('ProviderService — route-only cleanup paths', () => {
       ]);
       tierRepo.find.mockResolvedValue([
         {
+          agent_id: 'agent-1',
           tier: 'standard',
           override_route: route('openai', 'gpt-4o'),
           fallback_routes: null,
@@ -520,6 +681,7 @@ describe('ProviderService — route-only cleanup paths', () => {
       ]);
       tierRepo.find.mockResolvedValueOnce([
         {
+          agent_id: 'agent-1',
           tier: 'standard',
           override_route: route('openai', 'gpt-4o'),
           fallback_routes: null,
@@ -531,6 +693,49 @@ describe('ProviderService — route-only cleanup paths', () => {
       await expect(localSvc.deactivateAllProviders('agent-1', 'tenant-1')).rejects.toThrow(
         'Update routing first (agent "Support Bot", tier standard, primary: gpt-4o).',
       );
+      expect(providerRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('checks owned-agent routes in batches and stops after the first match', async () => {
+      const agentRepo = makeRepo([
+        { id: 'agent-1', name: 'first-bot', display_name: 'First Bot' },
+        { id: 'agent-2', name: 'second-bot', display_name: 'Second Bot' },
+      ]);
+      const localSvc = new ProviderService(
+        providerRepo as unknown as Repository<TenantProvider>,
+        tierRepo as unknown as Repository<TierAssignment>,
+        specRepo as unknown as Repository<SpecificityAssignment>,
+        agentRepo as unknown as Repository<Agent>,
+        headerTierRepo as unknown as Repository<HeaderTier>,
+        pricingCache as unknown as ModelPricingCacheService,
+        routingCache as unknown as RoutingCacheService,
+      );
+      providerRepo.find.mockResolvedValueOnce([
+        {
+          id: 'p1',
+          provider: 'openai',
+          auth_type: 'api_key',
+          label: 'Default',
+          priority: 0,
+          is_active: true,
+        } as unknown as TenantProvider,
+      ]);
+      tierRepo.find.mockResolvedValueOnce([
+        {
+          agent_id: 'agent-2',
+          tier: 'standard',
+          override_route: route('openai', 'gpt-4o'),
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+
+      await expect(localSvc.deactivateAllProviders('agent-1', 'tenant-1')).rejects.toThrow(
+        'Update routing first (agent "Second Bot", tier standard, primary: gpt-4o).',
+      );
+
+      expect(tierRepo.find).toHaveBeenCalledTimes(1);
+      expect(specRepo.find).not.toHaveBeenCalled();
+      expect(headerTierRepo.find).not.toHaveBeenCalled();
       expect(providerRepo.update).not.toHaveBeenCalled();
     });
   });
@@ -567,12 +772,14 @@ describe('ProviderService — route-only cleanup paths', () => {
       headerTierRepo.find.mockResolvedValue([
         {
           id: 'h1',
+          agent_id: 'agent-1',
           override_route: headerPin('Key 2'),
           fallback_routes: [headerPin('Key 2'), headerPin('Default')],
         } as unknown as HeaderTier,
         // Non-matching tier (different pinned label) must be left untouched.
         {
           id: 'h2',
+          agent_id: 'agent-1',
           override_route: headerPin('Default'),
           fallback_routes: null,
         } as unknown as HeaderTier,
@@ -602,6 +809,7 @@ describe('ProviderService — route-only cleanup paths', () => {
       headerTierRepo.find.mockResolvedValue([
         {
           id: 'h1',
+          agent_id: 'agent-1',
           override_route: headerPin('Key 2'),
           fallback_routes: null,
         } as unknown as HeaderTier,
@@ -686,12 +894,14 @@ describe('ProviderService — route-only cleanup paths', () => {
       headerTierRepo.find.mockResolvedValue([
         {
           id: 'h1',
+          agent_id: 'agent-1',
           override_route: route('OpenAI', 'gpt-4o'),
           fallback_routes: [route('openai', 'gpt-4o-mini'), route('anthropic', 'claude')],
         } as unknown as HeaderTier,
         // Belongs to another provider — must survive.
         {
           id: 'h2',
+          agent_id: 'agent-1',
           override_route: route('anthropic', 'claude'),
           fallback_routes: null,
         } as unknown as HeaderTier,

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -784,15 +784,9 @@ export class ProviderService {
   ): Promise<void> {
     if (providerRows.length === 0) return;
 
-    const references: ProviderRouteReference[] = [];
-    for (const agent of await this.listOwnedAgentRouteTargets(tenantId)) {
-      references.push(
-        ...(await this.findProviderRouteReferences(agent.id, agent.name, providerRows)),
-      );
-    }
-    if (references.length === 0) return;
+    const first = await this.findFirstProviderRouteReference(tenantId, providerRows);
+    if (!first) return;
 
-    const first = references[0];
     throw new ConflictException(
       `Cannot disconnect provider while its models are assigned to routing. ` +
         `Update routing first (agent "${first.agentName}", ${first.surface} ${first.name}, ` +
@@ -800,92 +794,122 @@ export class ProviderService {
     );
   }
 
-  private async findProviderRouteReferences(
+  private async findFirstProviderRouteReference(
+    tenantId: string,
+    providerRows: TenantProvider[],
+  ): Promise<ProviderRouteReference | null> {
+    const agents = await this.listOwnedAgentRouteTargets(tenantId);
+    if (agents.length === 0) return null;
+
+    const agentIds = agents.map((agent) => agent.id);
+    const agentNamesById = new Map(agents.map((agent) => [agent.id, agent.name]));
+    const enabledIdsByAgent = await this.listEnabledProviderIdsByAgent(agentIds);
+    const providerRowsForAgent = (agentId: string) => {
+      if (!enabledIdsByAgent) return providerRows;
+      const enabled = enabledIdsByAgent.get(agentId);
+      if (!enabled || enabled.size === 0) return [];
+      return providerRows.filter((row) => enabled.has(row.id));
+    };
+    const agentName = (agentId: string) => agentNamesById.get(agentId) ?? agentId;
+
+    const tiers = await this.tierRepo.find({ where: { agent_id: In(agentIds) } });
+    for (const tier of tiers) {
+      const match = this.findProviderRouteReferenceInRoutes(
+        tier.agent_id,
+        agentName(tier.agent_id),
+        'tier',
+        tier.tier,
+        tier.override_route,
+        tier.fallback_routes,
+        providerRowsForAgent(tier.agent_id),
+      );
+      if (match) return match;
+    }
+
+    const specificityRows = await this.specificityRepo.find({
+      where: { agent_id: In(agentIds), is_active: true },
+    });
+    for (const row of specificityRows) {
+      if (row.is_active === false) continue;
+      const match = this.findProviderRouteReferenceInRoutes(
+        row.agent_id,
+        agentName(row.agent_id),
+        'specificity',
+        row.category,
+        row.override_route,
+        row.fallback_routes,
+        providerRowsForAgent(row.agent_id),
+      );
+      if (match) return match;
+    }
+
+    const headerTiers = await this.headerTierRepo.find({
+      where: { agent_id: In(agentIds), enabled: true },
+    });
+    for (const tier of headerTiers) {
+      if (tier.enabled === false) continue;
+      const match = this.findProviderRouteReferenceInRoutes(
+        tier.agent_id,
+        agentName(tier.agent_id),
+        'header',
+        tier.name,
+        tier.override_route,
+        tier.fallback_routes,
+        providerRowsForAgent(tier.agent_id),
+      );
+      if (match) return match;
+    }
+
+    return null;
+  }
+
+  private async listEnabledProviderIdsByAgent(
+    agentIds: string[],
+  ): Promise<Map<string, Set<string>> | null> {
+    if (!this.enabledProviderRepo) return null;
+    const rows = await this.enabledProviderRepo.find({ where: { agent_id: In(agentIds) } });
+    const byAgent = new Map<string, Set<string>>();
+    for (const row of rows) {
+      const enabled = byAgent.get(row.agent_id) ?? new Set<string>();
+      enabled.add(row.tenant_provider_id);
+      byAgent.set(row.agent_id, enabled);
+    }
+    return byAgent;
+  }
+
+  private findProviderRouteReferenceInRoutes(
     agentId: string,
     agentName: string,
+    surface: ProviderRouteReference['surface'],
+    name: string,
+    overrideRoute: ModelRoute | null,
+    fallbackRoutes: ModelRoute[] | null,
     providerRows: TenantProvider[],
-  ): Promise<ProviderRouteReference[]> {
-    const references: ProviderRouteReference[] = [];
-
-    const tiers = await this.tierRepo.find({ where: { agent_id: agentId } });
-    for (const tier of tiers) {
-      if (this.routeBelongsToProviderRows(tier.override_route, providerRows)) {
-        references.push({
-          agentId,
-          agentName,
-          surface: 'tier',
-          name: tier.tier,
-          model: tier.override_route!.model,
-          position: 'primary',
-        });
-      }
-      for (const [i, fallback] of (tier.fallback_routes ?? []).entries()) {
-        if (this.routeBelongsToProviderRows(fallback, providerRows)) {
-          references.push({
-            agentId,
-            agentName,
-            surface: 'tier',
-            name: tier.tier,
-            model: fallback.model,
-            position: `fallback ${i + 1}`,
-          });
-        }
-      }
+  ): ProviderRouteReference | null {
+    if (providerRows.length === 0) return null;
+    if (this.routeBelongsToProviderRows(overrideRoute, providerRows)) {
+      return {
+        agentId,
+        agentName,
+        surface,
+        name,
+        model: overrideRoute!.model,
+        position: 'primary',
+      };
     }
 
-    const specificityRows = await this.specificityRepo.find({ where: { agent_id: agentId } });
-    for (const row of specificityRows) {
-      if (this.routeBelongsToProviderRows(row.override_route, providerRows)) {
-        references.push({
-          agentId,
-          agentName,
-          surface: 'specificity',
-          name: row.category,
-          model: row.override_route!.model,
-          position: 'primary',
-        });
-      }
-      for (const [i, fallback] of (row.fallback_routes ?? []).entries()) {
-        if (this.routeBelongsToProviderRows(fallback, providerRows)) {
-          references.push({
-            agentId,
-            agentName,
-            surface: 'specificity',
-            name: row.category,
-            model: fallback.model,
-            position: `fallback ${i + 1}`,
-          });
-        }
-      }
+    for (const [i, fallback] of (fallbackRoutes ?? []).entries()) {
+      if (!this.routeBelongsToProviderRows(fallback, providerRows)) continue;
+      return {
+        agentId,
+        agentName,
+        surface,
+        name,
+        model: fallback.model,
+        position: `fallback ${i + 1}`,
+      };
     }
-
-    const headerTiers = await this.headerTierRepo.find({ where: { agent_id: agentId } });
-    for (const tier of headerTiers) {
-      if (this.routeBelongsToProviderRows(tier.override_route, providerRows)) {
-        references.push({
-          agentId,
-          agentName,
-          surface: 'header',
-          name: tier.name,
-          model: tier.override_route!.model,
-          position: 'primary',
-        });
-      }
-      for (const [i, fallback] of (tier.fallback_routes ?? []).entries()) {
-        if (this.routeBelongsToProviderRows(fallback, providerRows)) {
-          references.push({
-            agentId,
-            agentName,
-            surface: 'header',
-            name: tier.name,
-            model: fallback.model,
-            position: `fallback ${i + 1}`,
-          });
-        }
-      }
-    }
-
-    return references;
+    return null;
   }
 
   private routeBelongsToProviderRows(route: ModelRoute | null, rows: TenantProvider[]): boolean {
@@ -906,6 +930,11 @@ export class ProviderService {
       if (routeLabel) return routeLabel === rowLabel;
       return row.priority === 0;
     }
+
+    if (route.authType && route.authType !== row.auth_type) return false;
+    const routeLabel = route.keyLabel?.toLowerCase();
+    if (routeLabel) return routeLabel === rowLabel;
+    if (row.priority !== 0) return false;
 
     const model = route.model.toLowerCase();
     if (model.startsWith(`${providerName}/`)) return true;


### PR DESCRIPTION
### ✨ What changed
- Batch route reads across owned agents during provider disconnect.
- Stop after the first routing blocker instead of collecting every match.
- Ignore disabled specificity/header rows and disabled provider grants.
- Tighten legacy providerless route matching by auth type and default key.

### 💭 Why
Disconnect could wait on per-agent route scans and report stale blockers for agents that cannot use the provider.

### 👤 For users
Disconnect errors still name the blocked agent, but should appear faster and only for active usage.

### 📝 Notes
Validated: focused provider service Jest suite, backend typecheck/build, focused coverage, Prettier, diff check, changeset status.
Changeset: patch for `manifest`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up provider disconnect checks by batching agent route queries and stopping at the first blocker. Errors now show up faster and only when the provider is enabled and actually used.

- **Bug Fixes**
  - Batch route queries across owned agents and stop at the first match.
  - Skip route checks when the tenant has no owned agents.
  - Ignore inactive specificity rows and disabled header tiers.
  - Only consider routes on agents where the provider is enabled; tighten providerless matching by auth type and key label.

- **Dependencies**
  - Changeset: patch for `manifest`.

<sup>Written for commit 8fb56c102e1cd4352529b3264f4d8ca2e2d339c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

