### PR TITLE
fix: support large proxy image payloads

### DIFF
--- a/.changeset/proxy-inline-image-body-limit.md
+++ b/.changeset/proxy-inline-image-body-limit.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Support large OpenAI-compatible inline image requests on `/v1/*` with route-scoped body parsing, clear body-size errors, and redacted inline image data for routing and message recordings.

--- a/packages/backend/src/common/middleware/body-parser-limits.spec.ts
+++ b/packages/backend/src/common/middleware/body-parser-limits.spec.ts
@@ -96,6 +96,24 @@ describe('body parser limits', () => {
     expect(thirdNext).toHaveBeenCalledTimes(1);
   });
 
+  it('skips body budgets for requests without proxy bodies', () => {
+    const middleware = createProxyBodyBudgetMiddleware();
+    const next = jest.fn();
+
+    middleware({ method: 'GET', headers: {} } as express.Request, createMockResponse(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows proxy request bodies without Content-Length when they are not chunked', () => {
+    const middleware = createProxyBodyBudgetMiddleware();
+    const next = jest.fn();
+
+    middleware({ method: 'POST', headers: {} } as express.Request, createMockResponse(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects chunked proxy request bodies without a Content-Length budget', () => {
     const middleware = createProxyBodyBudgetMiddleware();
     const res = createMockResponse();
@@ -117,5 +135,75 @@ describe('body parser limits', () => {
       error: 'Length Required',
       statusCode: 411,
     });
+  });
+
+  it('rejects invalid proxy Content-Length headers', () => {
+    const middleware = createProxyBodyBudgetMiddleware();
+    const res = createMockResponse();
+    const next = jest.fn();
+
+    middleware(
+      {
+        method: 'POST',
+        headers: { 'content-length': '-1' },
+      } as express.Request,
+      res,
+      next,
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Invalid Content-Length header',
+      error: 'Bad Request',
+      statusCode: 400,
+    });
+  });
+
+  it('rejects proxy request bodies above the proxy limit before parsing', () => {
+    const middleware = createProxyBodyBudgetMiddleware();
+    const res = createMockResponse();
+    const next = jest.fn();
+
+    middleware(
+      {
+        method: 'POST',
+        headers: { 'content-length': String(PROXY_BODY_LIMIT_BYTES + 1) },
+      } as express.Request,
+      res,
+      next,
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(413);
+    expect(res.json).toHaveBeenCalledWith({
+      message: `Request body exceeds ${PROXY_BODY_LIMIT}`,
+      error: 'Payload Too Large',
+      statusCode: 413,
+    });
+  });
+
+  it('passes through non-body-parser errors', () => {
+    const res = createMockResponse();
+    const next = jest.fn();
+    const err = new Error('boom');
+
+    bodyParserErrorHandler(err, {} as express.Request, res, next);
+
+    expect(next).toHaveBeenCalledWith(err);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('passes through unsupported body-parser errors', () => {
+    const res = createMockResponse();
+    const next = jest.fn();
+    const err = Object.assign(new Error('unsupported parser error'), {
+      type: 'entity.verify.failed',
+    });
+
+    bodyParserErrorHandler(err, {} as express.Request, res, next);
+
+    expect(next).toHaveBeenCalledWith(err);
+    expect(res.status).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/common/middleware/body-parser-limits.spec.ts
+++ b/packages/backend/src/common/middleware/body-parser-limits.spec.ts
@@ -1,0 +1,121 @@
+import express, { Request, Response } from 'express';
+import { EventEmitter } from 'events';
+import request from 'supertest';
+import {
+  API_BODY_LIMIT,
+  PROXY_BODY_LIMIT,
+  PROXY_BODY_LIMIT_BYTES,
+  bodyParserErrorHandler,
+  createProxyBodyBudgetMiddleware,
+} from './body-parser-limits';
+
+function createParserTestApp() {
+  const app = express();
+  app.use('/v1', createProxyBodyBudgetMiddleware());
+  app.use('/v1', express.json({ limit: PROXY_BODY_LIMIT }));
+  app.use(express.json({ limit: API_BODY_LIMIT }));
+  app.use(bodyParserErrorHandler);
+  app.post('/v1/chat/completions', (req: Request, res: Response) => {
+    res.json({ contentLength: String(req.body.messages[0].content).length });
+  });
+  app.post('/api/v1/test', (req: Request, res: Response) => {
+    res.json({ contentLength: String(req.body.messages[0].content).length });
+  });
+  return app;
+}
+
+function createMockResponse() {
+  const res = new EventEmitter() as express.Response & EventEmitter;
+  res.status = jest.fn(() => res) as unknown as express.Response['status'];
+  res.json = jest.fn(() => res) as unknown as express.Response['json'];
+  return res;
+}
+
+describe('body parser limits', () => {
+  it('allows OpenAI-compatible proxy bodies above the regular Manifest API limit', async () => {
+    const content = 'x'.repeat(1024 * 1024 + 1);
+    const payload = { messages: [{ role: 'user', content }] };
+
+    await request(createParserTestApp()).post('/v1/chat/completions').send(payload).expect(200);
+    const apiRes = await request(createParserTestApp())
+      .post('/api/v1/test')
+      .send(payload)
+      .expect(413);
+
+    expect(apiRes.body).toEqual({
+      message: 'Request body is too large',
+      error: 'Payload Too Large',
+      statusCode: 413,
+    });
+  });
+
+  it('returns JSON 400s for malformed proxy JSON', async () => {
+    const res = await request(createParserTestApp())
+      .post('/v1/chat/completions')
+      .set('Content-Type', 'application/json')
+      .send('{"messages":')
+      .expect(400);
+
+    expect(res.body).toEqual({
+      message: 'Invalid JSON request body',
+      error: 'Bad Request',
+      statusCode: 400,
+    });
+  });
+
+  it('limits the total Content-Length of proxy request bodies in flight', () => {
+    const middleware = createProxyBodyBudgetMiddleware();
+    const firstReq = {
+      method: 'POST',
+      headers: { 'content-length': String(PROXY_BODY_LIMIT_BYTES) },
+    } as express.Request;
+    const secondReq = {
+      method: 'POST',
+      headers: { 'content-length': '1' },
+    } as express.Request;
+    const firstRes = createMockResponse();
+    const secondRes = createMockResponse();
+    const firstNext = jest.fn();
+    const secondNext = jest.fn();
+
+    middleware(firstReq, firstRes, firstNext);
+    middleware(secondReq, secondRes, secondNext);
+
+    expect(firstNext).toHaveBeenCalledTimes(1);
+    expect(secondNext).not.toHaveBeenCalled();
+    expect(secondRes.status).toHaveBeenCalledWith(429);
+    expect(secondRes.json).toHaveBeenCalledWith({
+      message: 'Too many large proxy requests in flight',
+      error: 'Too Many Requests',
+      statusCode: 429,
+    });
+
+    firstRes.emit('finish');
+    const thirdNext = jest.fn();
+    middleware(secondReq, createMockResponse(), thirdNext);
+    expect(thirdNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects chunked proxy request bodies without a Content-Length budget', () => {
+    const middleware = createProxyBodyBudgetMiddleware();
+    const res = createMockResponse();
+    const next = jest.fn();
+
+    middleware(
+      {
+        method: 'POST',
+        headers: { 'transfer-encoding': 'chunked' },
+      } as express.Request,
+      res,
+      next,
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(411);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Content-Length is required for proxy request bodies',
+      error: 'Length Required',
+      statusCode: 411,
+    });
+  });
+});

--- a/packages/backend/src/common/middleware/body-parser-limits.ts
+++ b/packages/backend/src/common/middleware/body-parser-limits.ts
@@ -1,0 +1,119 @@
+import * as express from 'express';
+
+export const API_BODY_LIMIT = '1mb';
+export const PROXY_BODY_LIMIT = '512mb';
+export const PROXY_BODY_LIMIT_BYTES = 512 * 1024 * 1024;
+
+interface BodyParserError extends Error {
+  status?: number;
+  statusCode?: number;
+  type?: string;
+}
+
+function isBodyParserError(err: unknown): err is BodyParserError {
+  if (!(err instanceof Error)) return false;
+  const maybe = err as BodyParserError;
+  return typeof maybe.type === 'string' || maybe.status === 413 || maybe.statusCode === 413;
+}
+
+export function createProxyBodyBudgetMiddleware(): express.RequestHandler {
+  let activeBytes = 0;
+
+  return (req, res, next) => {
+    if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') {
+      next();
+      return;
+    }
+
+    const rawLength = req.headers['content-length'];
+    const contentLength = Array.isArray(rawLength) ? rawLength[0] : rawLength;
+    if (!contentLength) {
+      const rawTransferEncoding = req.headers['transfer-encoding'];
+      const transferEncoding = Array.isArray(rawTransferEncoding)
+        ? rawTransferEncoding.join(',')
+        : rawTransferEncoding;
+      if (transferEncoding?.toLowerCase().includes('chunked')) {
+        res.status(411).json({
+          message: 'Content-Length is required for proxy request bodies',
+          error: 'Length Required',
+          statusCode: 411,
+        });
+        return;
+      }
+      next();
+      return;
+    }
+
+    const bodyBytes = Number.parseInt(contentLength, 10);
+    if (!Number.isFinite(bodyBytes) || bodyBytes < 0) {
+      res.status(400).json({
+        message: 'Invalid Content-Length header',
+        error: 'Bad Request',
+        statusCode: 400,
+      });
+      return;
+    }
+
+    if (bodyBytes > PROXY_BODY_LIMIT_BYTES) {
+      res.status(413).json({
+        message: `Request body exceeds ${PROXY_BODY_LIMIT}`,
+        error: 'Payload Too Large',
+        statusCode: 413,
+      });
+      return;
+    }
+
+    if (activeBytes + bodyBytes > PROXY_BODY_LIMIT_BYTES) {
+      res.status(429).json({
+        message: 'Too many large proxy requests in flight',
+        error: 'Too Many Requests',
+        statusCode: 429,
+      });
+      return;
+    }
+
+    activeBytes += bodyBytes;
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      activeBytes = Math.max(0, activeBytes - bodyBytes);
+    };
+
+    res.once('finish', release);
+    res.once('close', release);
+    next();
+  };
+}
+
+export function bodyParserErrorHandler(
+  err: unknown,
+  _req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): void {
+  if (!isBodyParserError(err)) {
+    next(err);
+    return;
+  }
+
+  if (err.type === 'entity.too.large' || err.status === 413 || err.statusCode === 413) {
+    res.status(413).json({
+      message: 'Request body is too large',
+      error: 'Payload Too Large',
+      statusCode: 413,
+    });
+    return;
+  }
+
+  if (err.type === 'entity.parse.failed' || err instanceof SyntaxError) {
+    res.status(400).json({
+      message: 'Invalid JSON request body',
+      error: 'Bad Request',
+      statusCode: 400,
+    });
+    return;
+  }
+
+  next(err);
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -8,6 +8,12 @@ import { auth } from './auth/auth.instance';
 import { SpaFallbackFilter } from './common/filters/spa-fallback.filter';
 import { httpErrorLogger } from './common/middleware/http-error-logger.middleware';
 import {
+  API_BODY_LIMIT,
+  PROXY_BODY_LIMIT,
+  bodyParserErrorHandler,
+  createProxyBodyBudgetMiddleware,
+} from './common/middleware/body-parser-limits';
+import {
   applyPrivateNetworkAllow,
   buildDevAllowedOrigins,
   buildFrameSrc,
@@ -186,9 +192,15 @@ export async function bootstrap() {
   const { toNodeHandler } = await import('better-auth/node');
   expressApp.all('/api/auth/*splat', toNodeHandler(auth));
 
-  // Re-add body parsing for NestJS routes
-  expressApp.use(express.json({ limit: '1mb' }));
-  expressApp.use(express.urlencoded({ extended: true, limit: '1mb' }));
+  // Re-add body parsing for NestJS routes. The OpenAI-compatible proxy has a
+  // separate parser because clients may legitimately send large inline image
+  // payloads. Regular Manifest API/auth routes stay small.
+  expressApp.use('/v1', createProxyBodyBudgetMiddleware());
+  expressApp.use('/v1', express.json({ limit: PROXY_BODY_LIMIT }));
+  expressApp.use('/v1', express.urlencoded({ extended: true, limit: PROXY_BODY_LIMIT }));
+  expressApp.use(express.json({ limit: API_BODY_LIMIT }));
+  expressApp.use(express.urlencoded({ extended: true, limit: API_BODY_LIMIT }));
+  expressApp.use(bodyParserErrorHandler);
 
   const port = Number(process.env['PORT'] ?? 3001);
   const host = process.env['BIND_ADDRESS'] ?? '127.0.0.1';

--- a/packages/backend/src/routing/proxy/__tests__/inline-image-redaction.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/inline-image-redaction.spec.ts
@@ -1,0 +1,105 @@
+import { redactInlineImageDataUrls } from '../inline-image-redaction';
+
+function imageUrlAt(
+  body: { messages: Array<{ content: Array<{ image_url?: { url: string } }> }> },
+  index: number,
+): string {
+  const part = body.messages[0]?.content[index];
+  if (!part?.image_url) throw new Error(`Missing image_url at index ${index}`);
+  return part.image_url.url;
+}
+
+describe('redactInlineImageDataUrls', () => {
+  it('redacts base64 image data URLs while preserving non-inline image URLs', () => {
+    const body = {
+      model: 'auto',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What do you see?' },
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,aGVsbG8=' },
+            },
+            {
+              type: 'image_url',
+              image_url: { url: 'https://example.test/image.png' },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = redactInlineImageDataUrls(body);
+
+    expect(result).toEqual({
+      model: 'auto',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What do you see?' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: '[inline image: image/png, 5 bytes, 8 base64 chars]',
+              },
+            },
+            {
+              type: 'image_url',
+              image_url: { url: 'https://example.test/image.png' },
+            },
+          ],
+        },
+      ],
+    });
+    expect(imageUrlAt(body, 1)).toBe('data:image/png;base64,aGVsbG8=');
+  });
+
+  it('handles nested image data URLs outside chat-completions content', () => {
+    const result = redactInlineImageDataUrls({
+      input: [
+        {
+          content: [
+            {
+              type: 'input_image',
+              image_url: 'data:image/jpeg;base64,AA==',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      input: [
+        {
+          content: [
+            {
+              type: 'input_image',
+              image_url: '[inline image: image/jpeg, 1 bytes, 4 base64 chars]',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('redacts image data URLs with media-type parameters', () => {
+    const result = redactInlineImageDataUrls({
+      image_url: 'data:image/png;name=example.png;charset=utf-8;base64,aGVsbG8=',
+    });
+
+    expect(result).toEqual({
+      image_url: '[inline image: image/png, 5 bytes, 8 base64 chars]',
+    });
+  });
+
+  it('reuses the original object when no inline image data is present', () => {
+    const body = {
+      messages: [{ role: 'user', content: 'plain text only' }],
+    };
+
+    expect(redactInlineImageDataUrls(body)).toBe(body);
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/inline-image-redaction.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/inline-image-redaction.spec.ts
@@ -95,6 +95,21 @@ describe('redactInlineImageDataUrls', () => {
     });
   });
 
+  it('redacts image data URLs without base64 padding', () => {
+    const result = redactInlineImageDataUrls({
+      image_url: 'data:image/webp;base64,QUJD',
+    });
+
+    expect(result).toEqual({
+      image_url: '[inline image: image/webp, 3 bytes, 4 base64 chars]',
+    });
+  });
+
+  it('returns primitive values unchanged', () => {
+    expect(redactInlineImageDataUrls(null)).toBeNull();
+    expect(redactInlineImageDataUrls(42)).toBe(42);
+  });
+
   it('reuses the original object when no inline image data is present', () => {
     const body = {
       messages: [{ role: 'user', content: 'plain text only' }],

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -226,6 +226,31 @@ describe('ProxyService — orchestration', () => {
       expect(resolveService.resolve).toHaveBeenCalled();
       expect(result.forward.response.status).toBeGreaterThanOrEqual(200);
     });
+
+    it('replaces null content on the forwarded body when routing uses a redacted copy', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(200),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      const body = { messages: [{ role: 'user', content: null }] };
+      const routingBody = { messages: [{ role: 'user', content: null }] };
+
+      await svc.proxyRequest(baseOpts({ body, routingBody } as never));
+
+      expect(body.messages[0].content).toBe('');
+      expect(routingBody.messages[0].content).toBe('');
+      expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body).toBe(body);
+    });
   });
 
   describe('limit enforcement', () => {
@@ -302,6 +327,59 @@ describe('ProxyService — orchestration', () => {
   });
 
   describe('happy path forward', () => {
+    it('uses the redacted routing body for scoring while forwarding the original body', async () => {
+      const body = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Describe this image' },
+              {
+                type: 'image_url',
+                image_url: { url: 'data:image/png;base64,aGVsbG8=' },
+              },
+            ],
+          },
+        ],
+        stream: false,
+      };
+      const routingBody = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Describe this image' },
+              {
+                type: 'image_url',
+                image_url: { url: '[inline image: image/png, 5 bytes, 8 base64 chars]' },
+              },
+            ],
+          },
+        ],
+        stream: false,
+      };
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(200),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await svc.proxyRequest(baseOpts({ body, routingBody }));
+
+      const [, , scoringMessages] = resolveService.resolve.mock.calls[0];
+      expect(scoringMessages).toEqual(routingBody.messages);
+      expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body).toBe(body);
+    });
+
     it('returns the forward result and records tier momentum on a 200 non-stream response', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -380,6 +380,38 @@ describe('ProxyService — orchestration', () => {
       expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body).toBe(body);
     });
 
+    it('reuses converted Responses bodies for routing when no separate routing body is provided', async () => {
+      const body = {
+        input: 'Describe this image',
+        stream: false,
+      };
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(200),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      const validateSpy = jest.spyOn(
+        svc as unknown as { validatePayload: (body: Record<string, unknown>) => void },
+        'validatePayload',
+      );
+
+      await svc.proxyRequest(baseOpts({ body, apiMode: 'responses' } as never));
+
+      const forwardedBody = fallbackService.tryForwardToProvider.mock.calls[0][0].chatBody;
+      expect(validateSpy).toHaveBeenCalledTimes(1);
+      expect(forwardedBody).toBeDefined();
+      expect(forwardedBody?.messages).toEqual([{ role: 'user', content: 'Describe this image' }]);
+    });
+
     it('returns the forward result and records tier momentum on a 200 non-stream response', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',

--- a/packages/backend/src/routing/proxy/inline-image-redaction.ts
+++ b/packages/backend/src/routing/proxy/inline-image-redaction.ts
@@ -1,0 +1,59 @@
+const INLINE_IMAGE_DATA_URL_RE = /^data:(image\/[a-z0-9.+-]+)(?:;[^,]*)?;base64,/i;
+
+export function redactInlineImageDataUrls<T>(value: T): T {
+  return redactValue(value).value as T;
+}
+
+interface RedactResult {
+  value: unknown;
+  changed: boolean;
+}
+
+function redactValue(value: unknown): RedactResult {
+  if (typeof value === 'string') return redactString(value);
+  if (Array.isArray(value)) return redactArray(value);
+  if (!isPlainRecord(value)) return { value, changed: false };
+
+  const out: Record<string, unknown> = {};
+  let changed = false;
+  for (const [key, nested] of Object.entries(value)) {
+    const result = redactValue(nested);
+    out[key] = result.value;
+    changed ||= result.changed;
+  }
+  return changed ? { value: out, changed } : { value, changed: false };
+}
+
+function redactArray(values: unknown[]): RedactResult {
+  let changed = false;
+  const out = values.map((item) => {
+    const result = redactValue(item);
+    changed ||= result.changed;
+    return result.value;
+  });
+  return changed ? { value: out, changed } : { value: values, changed: false };
+}
+
+function redactString(value: string): RedactResult {
+  const match = INLINE_IMAGE_DATA_URL_RE.exec(value);
+  if (!match) return { value, changed: false };
+
+  const mimeType = match[1].toLowerCase();
+  const base64Chars = value.length - match[0].length;
+  const decodedBytes = estimateDecodedBase64Bytes(value.slice(match[0].length));
+  return {
+    value: `[inline image: ${mimeType}, ${decodedBytes} bytes, ${base64Chars} base64 chars]`,
+    changed: true,
+  };
+}
+
+function estimateDecodedBase64Bytes(data: string): number {
+  const padding = data.endsWith('==') ? 2 : data.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((data.length * 3) / 4) - padding);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' && value !== null && Object.getPrototypeOf(value) === Object.prototype
+  );
+}

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -77,6 +77,8 @@ export interface ProxyRequestOptions {
    */
   userId: string | null;
   body: Record<string, unknown>;
+  /** Body used for Manifest-owned routing/scoring/recording; large inline media may be redacted. */
+  routingBody?: Record<string, unknown>;
   apiMode?: ProxyApiMode;
   sessionKey: string;
   agentName?: string;

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -39,6 +39,7 @@ import { formatManifestError } from '../../common/errors/error-codes';
 import type { ProxyApiMode } from './proxy-types';
 import { ResponsesSseError } from './chatgpt-adapter';
 import { sanitizeProviderError } from './proxy-error-sanitizer';
+import { redactInlineImageDataUrls } from './inline-image-redaction';
 
 const MAX_SEEN_TENANTS = 10_000;
 const SEEN_TENANT_TTL_MS = 24 * 60 * 60 * 1000;
@@ -117,6 +118,7 @@ export class ProxyController {
     const callerAttribution = classifyCaller(req.headers);
     const requestHeaders = sanitizeRequestHeaders(req.headers);
     const isStream = body.stream === true;
+    let routingBody = body;
     let headersSent = false;
     let slotAcquired = false;
 
@@ -132,6 +134,7 @@ export class ProxyController {
       this.rateLimiter.checkIpLimit(req.ip ?? '');
       this.rateLimiter.acquireSlot(tenantId);
       slotAcquired = true;
+      routingBody = redactInlineImageDataUrls(body);
       const specificityOverride = req.headers['x-manifest-specificity'] as string | undefined;
       const { forward, meta, failedFallbacks } = await this.proxyService.proxyRequest({
         agentId: req.ingestionContext.agentId,
@@ -139,6 +142,7 @@ export class ProxyController {
         // Attribution only — the recorder writes it to agent_messages.user_id.
         userId: req.ingestionContext.userId,
         body,
+        routingBody,
         sessionKey,
         agentName: req.ingestionContext.agentName,
         signal: clientAbort.signal,
@@ -225,7 +229,7 @@ export class ProxyController {
         startTime,
         callerAttribution,
         requestHeaders,
-        capture ? { capture, requestBody: body } : undefined,
+        capture ? { capture, requestBody: routingBody } : undefined,
       );
     } catch (err: unknown) {
       this.handleProxyError(

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -172,13 +172,16 @@ export class ProxyService {
           ? messagesToChatCompletionsRequest(body)
           : undefined;
     const forwardingBody = chatBody ?? body;
-    const routingChatBody =
-      apiMode === 'responses'
-        ? toChatCompletionsRequest(routingSource)
-        : apiMode === 'messages'
-          ? messagesToChatCompletionsRequest(routingSource)
-          : undefined;
-    const routingBody = routingChatBody ?? routingSource;
+    let routingBody = forwardingBody;
+    if (routingSource !== body) {
+      const routingChatBody =
+        apiMode === 'responses'
+          ? toChatCompletionsRequest(routingSource)
+          : apiMode === 'messages'
+            ? messagesToChatCompletionsRequest(routingSource)
+            : undefined;
+      routingBody = routingChatBody ?? routingSource;
+    }
     this.validatePayload(forwardingBody);
     if (routingBody !== forwardingBody) this.validatePayload(routingBody);
 

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -164,14 +164,23 @@ export class ProxyService {
     const { agentId, tenantId, body, sessionKey, agentName, signal, specificityOverride, headers } =
       opts;
     const apiMode = opts.apiMode ?? 'chat_completions';
+    const routingSource = opts.routingBody ?? body;
     const chatBody =
       apiMode === 'responses'
         ? toChatCompletionsRequest(body)
         : apiMode === 'messages'
           ? messagesToChatCompletionsRequest(body)
           : undefined;
-    const routingBody = chatBody ?? body;
-    this.validatePayload(routingBody);
+    const forwardingBody = chatBody ?? body;
+    const routingChatBody =
+      apiMode === 'responses'
+        ? toChatCompletionsRequest(routingSource)
+        : apiMode === 'messages'
+          ? messagesToChatCompletionsRequest(routingSource)
+          : undefined;
+    const routingBody = routingChatBody ?? routingSource;
+    this.validatePayload(forwardingBody);
+    if (routingBody !== forwardingBody) this.validatePayload(routingBody);
 
     const limitMessage = await this.enforceLimits(tenantId, agentName);
     if (limitMessage) {


### PR DESCRIPTION
### ✨ What changed
- `/v1/*` uses a larger parser and active byte budget.
- Parser errors return JSON 400/413 instead of SPA 404 fallback.
- Inline image data is redacted for routing and recordings.

### 💭 Why
The global 1 MB parser rejects OpenAI-compatible base64 image requests before the proxy route.

### 👤 For users
OpenWebUI and curl vision requests above 1 MB can reach `/v1/chat/completions`.

### 📝 Notes
Fixes #2126.
Validation: `npm test --workspace=packages/backend -- body-parser-limits inline-image-redaction proxy.service`
Validation: `npm run build --workspace=packages/backend`
Validation: touched-file Prettier, `changeset status --since=upstream/main`, `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports large OpenAI-compatible inline image payloads on the `/v1` proxy with a route-scoped 512 MB body parser and an active byte budget. Returns JSON 400/413 errors on parse/size failures and redacts inline image data for routing/recordings while forwarding the original body.

- **New Features**
  - Route-scoped body parsing for `/v1` with `512mb` limit; other API routes stay at `1mb`.
  - Active byte budget for `/v1` POSTs: requires `Content-Length` (411 if chunked), 429 when in-flight total exceeds budget, 413 when a single body exceeds limit.
  - JSON error handler: 400 for malformed JSON and 413 for oversized bodies (replaces SPA 404 fallback).
  - Redacts `data:image/*;base64,...` URLs for routing/scoring/recording while forwarding the original body; adds optional `routingBody` to proxy options.

<sup>Written for commit 5877aa0c85fec4f57b652bae69ab519ac12e3147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

