### PR TITLE
fix(routing): use stored API key when probing models in edit mode

### DIFF
--- a/packages/backend/src/routing/custom-provider.controller.spec.ts
+++ b/packages/backend/src/routing/custom-provider.controller.spec.ts
@@ -32,6 +32,7 @@ describe('CustomProviderController', () => {
       }),
       remove: jest.fn().mockResolvedValue(undefined),
       probeModels: jest.fn().mockResolvedValue([{ model_name: 'm1' }, { model_name: 'm2' }]),
+      loadStoredApiKey: jest.fn().mockResolvedValue(undefined),
     };
     mockProviderService = {
       getProviders: jest.fn().mockResolvedValue([]),
@@ -282,6 +283,8 @@ describe('CustomProviderController', () => {
         undefined,
       );
       expect(result).toEqual({ models: [{ model_name: 'm1' }, { model_name: 'm2' }] });
+      // A user-typed key short-circuits the stored-key lookup entirely.
+      expect(mockCustomProviderService.loadStoredApiKey).not.toHaveBeenCalled();
     });
 
     it('forwards api_kind to the service when provided in the body', async () => {
@@ -312,6 +315,58 @@ describe('CustomProviderController', () => {
       );
     });
 
+    it('decrypts the stored key under the resolved tenant when provider_id is sent without apiKey', async () => {
+      // Edit-mode: the form has no plaintext key, so it forwards provider_id
+      // and the controller looks up the stored key scoped to the resolved
+      // tenant_id — a forged provider_id can't reach another tenant's row.
+      mockCustomProviderService.loadStoredApiKey.mockResolvedValue('sk-stored');
+      await controller.probe(mockCtx, 'test-agent', {
+        base_url: 'http://host.docker.internal:8000/v1',
+        provider_id: 'cp-edit-id',
+      } as never);
+      expect(mockCustomProviderService.loadStoredApiKey).toHaveBeenCalledWith(
+        'tenant-1',
+        'cp-edit-id',
+      );
+      expect(mockCustomProviderService.probeModels).toHaveBeenCalledWith(
+        'http://host.docker.internal:8000/v1',
+        'sk-stored',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('still probes (unauth) when provider_id is sent but no stored key exists', async () => {
+      // Local servers (Ollama, LM Studio) often have no key — the fallback
+      // must not force auth when there's nothing to decrypt.
+      mockCustomProviderService.loadStoredApiKey.mockResolvedValue(undefined);
+      await controller.probe(mockCtx, 'test-agent', {
+        base_url: 'http://localhost:1234/v1',
+        provider_id: 'cp-local',
+      } as never);
+      expect(mockCustomProviderService.probeModels).toHaveBeenCalledWith(
+        'http://localhost:1234/v1',
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('skips loadStoredApiKey entirely when neither apiKey nor provider_id is sent', async () => {
+      // Create-flow with a typo-and-clear: no key, no provider_id. The
+      // controller must not call loadStoredApiKey for this path.
+      await controller.probe(mockCtx, 'test-agent', {
+        base_url: 'http://localhost:1234/v1',
+      } as never);
+      expect(mockCustomProviderService.loadStoredApiKey).not.toHaveBeenCalled();
+      expect(mockCustomProviderService.probeModels).toHaveBeenCalledWith(
+        'http://localhost:1234/v1',
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
     it('propagates NotFoundException from resolveAgent (unauthorized agent)', async () => {
       mockResolveAgent.resolve.mockRejectedValue(new NotFoundException('Agent not found'));
       await expect(
@@ -320,6 +375,7 @@ describe('CustomProviderController', () => {
         } as never),
       ).rejects.toThrow(NotFoundException);
       expect(mockCustomProviderService.probeModels).not.toHaveBeenCalled();
+      expect(mockCustomProviderService.loadStoredApiKey).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
@@ -56,10 +56,20 @@ export class CustomProviderController {
   ) {
     // Resolve for authz — the tenant must own the agent before the server
     // probes anything on its behalf.
-    await this.resolveAgentService.resolve(ctx.tenantId, agentName);
+    const agent = await this.resolveAgentService.resolve(ctx.tenantId, agentName);
+    // Edit-mode fallback: the form has no plaintext key when re-opened
+    // (list() only exposes has_api_key:bool), so it forwards provider_id
+    // and we decrypt the stored key here. Tenant-scoped, so a forged id
+    // from another tenant simply misses and degrades to an unauth probe.
+    // A user-typed apiKey always wins so new keys can be verified pre-save.
+    const apiKey =
+      body.apiKey ??
+      (body.provider_id
+        ? await this.customProviderService.loadStoredApiKey(agent.tenant_id, body.provider_id)
+        : undefined);
     const models = await this.customProviderService.probeModels(
       body.base_url,
-      body.apiKey,
+      apiKey,
       body.api_kind,
       body.provider_name,
     );

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -53,11 +53,13 @@ function makeDeps(overrides: {
   const removeProvider = jest.fn().mockResolvedValue(undefined);
   const retagAuthType = jest.fn().mockResolvedValue(undefined);
   const recalculateTiersForTenant = jest.fn().mockResolvedValue(undefined);
+  const getProviders = jest.fn().mockResolvedValue([]);
   const providerService = {
     upsertProvider,
     removeProvider,
     retagAuthType,
     recalculateTiersForTenant,
+    getProviders,
   } as unknown as ProviderService;
 
   const getCustomProviders = jest.fn().mockReturnValue(overrides.cached ?? null);
@@ -96,6 +98,7 @@ function makeDeps(overrides: {
     removeProvider,
     retagAuthType,
     recalculateTiersForTenant,
+    getProviders,
     getCustomProviders,
     setCustomProviders,
     invalidateTenant,
@@ -1154,6 +1157,72 @@ describe('CustomProviderService', () => {
       } finally {
         global.setTimeout = realSetTimeout;
       }
+    });
+
+    // Edit-page bug repro: opening an existing API-key custom provider and
+    // clicking "Fetch models" without re-typing the key sent an unauth'd
+    // probe (the form never has the plaintext key — list() only returns
+    // has_api_key:bool). Server then 401'd from the upstream. Fix: the
+    // controller now decrypts the stored key via loadStoredApiKey() when
+    // the caller forwards a provider_id, before calling probeModels().
+    describe('loadStoredApiKey', () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { encrypt, getEncryptionSecret } = require('../../common/utils/crypto.util');
+
+      const ORIGINAL_ENV = process.env['MANIFEST_ENCRYPTION_KEY'];
+      beforeAll(() => {
+        process.env['MANIFEST_ENCRYPTION_KEY'] = 'test-encryption-secret-min-32-chars-long-padding';
+      });
+      afterAll(() => {
+        if (ORIGINAL_ENV === undefined) {
+          delete process.env['MANIFEST_ENCRYPTION_KEY'];
+        } else {
+          process.env['MANIFEST_ENCRYPTION_KEY'] = ORIGINAL_ENV;
+        }
+      });
+
+      it('decrypts the stored key for the matching tenant + provider', async () => {
+        const stored = 'sk-stored-secret-value';
+        const enc = encrypt(stored, getEncryptionSecret());
+        const { svc, getProviders } = makeDeps({});
+        getProviders.mockResolvedValueOnce([
+          { provider: 'custom:cp-edit-id', api_key_encrypted: enc },
+        ]);
+
+        await expect(svc.loadStoredApiKey('tenant-1', 'cp-edit-id')).resolves.toBe(stored);
+        expect(getProviders).toHaveBeenCalledWith('tenant-1');
+      });
+
+      it('returns undefined when the provider row has no ciphertext (unauth local server)', async () => {
+        const { svc, getProviders } = makeDeps({});
+        getProviders.mockResolvedValueOnce([
+          { provider: 'custom:cp-local', api_key_encrypted: null },
+        ]);
+        await expect(svc.loadStoredApiKey('tenant-1', 'cp-local')).resolves.toBeUndefined();
+      });
+
+      it('returns undefined when no row exists for the given provider_id', async () => {
+        const { svc, getProviders } = makeDeps({});
+        getProviders.mockResolvedValueOnce([]);
+        await expect(svc.loadStoredApiKey('tenant-1', 'missing')).resolves.toBeUndefined();
+      });
+
+      it('cross-tenant safety: a provider_id from another tenant resolves to undefined', async () => {
+        // The lookup only sees rows for the resolved tenantId, so a forged
+        // provider_id can never surface another tenant's encrypted key.
+        const { svc, getProviders } = makeDeps({});
+        getProviders.mockResolvedValueOnce([]); // tenant-attacker owns nothing
+        await expect(svc.loadStoredApiKey('tenant-attacker', 'cp-victim')).resolves.toBeUndefined();
+        expect(getProviders).toHaveBeenCalledWith('tenant-attacker');
+      });
+
+      it('swallows decrypt errors (corrupt ciphertext) and returns undefined', async () => {
+        const { svc, getProviders } = makeDeps({});
+        getProviders.mockResolvedValueOnce([
+          { provider: 'custom:cp-broken', api_key_encrypted: 'not-a-valid-ciphertext' },
+        ]);
+        await expect(svc.loadStoredApiKey('tenant-1', 'cp-broken')).resolves.toBeUndefined();
+      });
     });
   });
 });

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -25,6 +25,7 @@ import { RoutingCacheService } from '../routing-core/routing-cache.service';
 import { CreateCustomProviderDto, UpdateCustomProviderDto } from '../dto/custom-provider.dto';
 import { validatePublicUrl } from '../../common/utils/url-validation';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
+import { decrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
 import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
@@ -482,6 +483,30 @@ export class CustomProviderService {
       throw new BadRequestException(classifyProbeError({ url, error: err as Error }).message);
     } finally {
       clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * Look up the encrypted API key for an existing custom provider row and
+   * decrypt it for server-side use. Returns undefined on any miss (no row,
+   * null ciphertext, or corrupt blob) so callers fall back to an
+   * unauthenticated request — the upstream response then drives error
+   * classification. Tenant-scoped to prevent cross-tenant key exfiltration
+   * via a forged providerId.
+   *
+   * Used by the probe controller: the edit form never has the plaintext key
+   * (list() only exposes `has_api_key:bool`), so when the user hasn't
+   * re-typed one we decrypt the stored key for a single in-flight probe.
+   */
+  async loadStoredApiKey(tenantId: string, providerId: string): Promise<string | undefined> {
+    const provKey = CustomProviderService.providerKey(providerId);
+    const tenantProviders = await this.providerService.getProviders(tenantId);
+    const row = tenantProviders.find((p) => p.provider === provKey);
+    if (!row?.api_key_encrypted) return undefined;
+    try {
+      return decrypt(row.api_key_encrypted, getEncryptionSecret());
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/backend/src/routing/dto/custom-provider.dto.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.ts
@@ -99,6 +99,16 @@ export class ProbeCustomProviderDto {
   @IsOptional()
   @IsString()
   apiKey?: string;
+
+  // Edit-mode fallback: when the form re-opens an existing provider it has
+  // no plaintext key (list() only returns has_api_key:bool). Sending the
+  // provider id lets the server decrypt and reuse the stored key for the
+  // probe. The controller tenant-scopes the lookup, so a forged id can't
+  // exfiltrate another tenant's key. UUID (36 chars); cap defensively.
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  provider_id?: string;
 }
 
 export class UpdateCustomProviderDto {

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -94,12 +94,18 @@ const CustomProviderForm: Component<Props> = (props) => {
     setProbeBusy(true);
     setProbeError(null);
     try {
+      // Edit mode: forward provider_id so the backend can probe with the
+      // stored key (the form never sees plaintext). A user-typed key still
+      // wins so freshly entered keys can be verified before saving.
+      const typedKey = apiKey().trim() || undefined;
+      const probeId = !typedKey && isEdit() ? props.initialData?.id : undefined;
       const { models } = await probeCustomProvider(
         props.agentName,
         url,
-        apiKey().trim() || undefined,
+        typedKey,
         apiKind(),
         name().trim() || undefined,
+        probeId,
       );
       if (models.length === 0) {
         setProbeError('Server returned no models');

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -489,12 +489,15 @@ export async function probeCustomProvider(
   apiKey?: string,
   api_kind?: CustomProviderApiKind,
   provider_name?: string,
+  // Edit-mode: forwarding the id lets the backend probe with the stored
+  // key (the form never has plaintext). See ProbeCustomProviderDto.
+  provider_id?: string,
 ) {
   const res = await fetch(`${BASE_URL}${routingPath(agentName, 'custom-providers/probe')}`, {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ base_url, apiKey, api_kind, provider_name }),
+    body: JSON.stringify({ base_url, apiKey, api_kind, provider_name, provider_id }),
   });
   if (!res.ok) {
     const message = await parseErrorMessage(res);

--- a/packages/frontend/tests/components/CustomProviderForm.test.tsx
+++ b/packages/frontend/tests/components/CustomProviderForm.test.tsx
@@ -492,6 +492,7 @@ describe("CustomProviderForm — Fetch models probe", () => {
         undefined,
         "openai",
         undefined,
+        undefined,
       );
       const inputs = screen.getAllByPlaceholderText("Model name") as HTMLInputElement[];
       expect(inputs).toHaveLength(2);
@@ -549,6 +550,7 @@ describe("CustomProviderForm — Fetch models probe", () => {
         undefined,
         "openai",
         "Kilo Gateway",
+        undefined,
       );
       expect(
         (screen.getByLabelText("Model 1 input price per million tokens") as HTMLInputElement).value,
@@ -1144,6 +1146,105 @@ describe("CustomProviderForm — edit mode", () => {
     const modelInput = screen.getByLabelText("Model 1 name") as HTMLInputElement;
     expect(modelInput.value).toBe("llama-3.1-70b");
   });
+
+  // ── Edit-mode "Fetch models" hint ──
+  // Bug: in edit mode the form never has the plaintext API key (list() only
+  // exposes has_api_key:bool), so the old probe call sent no key and any
+  // server requiring auth returned 401. The fix is to forward the provider
+  // id so the backend can decrypt the stored key and probe with it. These
+  // three tests pin down the three branches: no editingKey → id hint only,
+  // editingKey with typed key → new key wins, editingKey but field empty →
+  // still send id (the typed-then-cleared edge).
+  it("passes id (not apiKey) to probe when editing without clicking Change", async () => {
+    mockProbeCustomProvider.mockResolvedValue({
+      models: [{ model_name: "llama-3.1-8b" }],
+    });
+
+    render(() => (
+      <CustomProviderForm
+        agentName="test-agent"
+        onCreated={onCreated}
+        onBack={onBack}
+        initialData={initialData}
+      />
+    ));
+
+    fireEvent.click(screen.getByText("Fetch models"));
+
+    await waitFor(() => {
+      expect(mockProbeCustomProvider).toHaveBeenCalledWith(
+        "test-agent",
+        initialData.base_url,
+        undefined, // no plaintext key available — backend falls back to stored
+        "openai",
+        initialData.name, // provider_name still forwarded for enrichment
+        initialData.id, // edit-mode hint
+      );
+    });
+  });
+
+  it("uses the typed apiKey (not id) when the user clicked Change and entered a new key", async () => {
+    mockProbeCustomProvider.mockResolvedValue({
+      models: [{ model_name: "llama-3.1-8b" }],
+    });
+
+    render(() => (
+      <CustomProviderForm
+        agentName="test-agent"
+        onCreated={onCreated}
+        onBack={onBack}
+        initialData={initialData}
+      />
+    ));
+
+    fireEvent.click(screen.getByText("Change"));
+    fireEvent.input(screen.getByPlaceholderText("sk-..."), {
+      target: { value: "sk-new-typed" },
+    });
+    fireEvent.click(screen.getByText("Fetch models"));
+
+    await waitFor(() => {
+      expect(mockProbeCustomProvider).toHaveBeenCalledWith(
+        "test-agent",
+        initialData.base_url,
+        "sk-new-typed", // user-typed key takes precedence
+        "openai",
+        initialData.name,
+        undefined, // no id hint — we have an explicit key
+      );
+    });
+  });
+
+  it("still sends id when editingKey is open but the user left the field empty", async () => {
+    mockProbeCustomProvider.mockResolvedValue({
+      models: [{ model_name: "llama-3.1-8b" }],
+    });
+
+    render(() => (
+      <CustomProviderForm
+        agentName="test-agent"
+        onCreated={onCreated}
+        onBack={onBack}
+        initialData={initialData}
+      />
+    ));
+
+    fireEvent.click(screen.getByText("Change"));
+    // Field opens but stays empty — user changed their mind. The probe
+    // should still hit /models with the stored key, not unauthenticated.
+    fireEvent.click(screen.getByText("Fetch models"));
+
+    await waitFor(() => {
+      expect(mockProbeCustomProvider).toHaveBeenCalledWith(
+        "test-agent",
+        initialData.base_url,
+        undefined,
+        "openai",
+        initialData.name,
+        initialData.id,
+      );
+    });
+  });
 });
 
 describe("CustomProviderForm — probe edge cases and model-row interactions", () => {
@@ -1358,6 +1459,7 @@ describe("CustomProviderForm — API format selector", () => {
         "https://api.anthropic.com",
         undefined,
         "anthropic",
+        undefined,
         undefined,
       );
     });


### PR DESCRIPTION
## Summary

When editing an existing custom provider, clicking **Fetch models** without
re-typing the API key always sent an unauthenticated probe. Any upstream
that required a key (most paid providers) returned 401, and the form
surfaced a misleading "auth failed" error even though the saved key was
fine.

Root cause: the edit form never has the plaintext key — `list()` only
returns `has_api_key: bool` to avoid handing decrypted secrets back to the
browser — so the probe call had nothing to send.

## Fix

- `ProbeCustomProviderDto` gains an optional `provider_id` field.
- When the controller sees `provider_id` and no `apiKey`, it calls a new
  `CustomProviderService.loadStoredApiKey(tenantId, providerId)` helper to
  decrypt the stored ciphertext for a single in-flight probe. The lookup
  is tenant-scoped, so a forged id from another tenant simply misses and
  the probe degrades to unauthenticated.
- A user-typed key always wins, so freshly entered keys can still be
  verified before saving.
- The frontend forwards `provider_id` only in edit mode when the user
  hasn't typed a replacement key.

`probeModels()`'s own signature is unchanged — the controller does the key
selection and hands the resolved key in like before. Corrupt ciphertext
degrades silently to "no key available" rather than 500'ing the form.

## Notes for reviewers

- **Scope of the stored-key fallback.** The stored key is forwarded to
  whichever `base_url` the form sent — including a freshly edited one
  that hasn't been saved yet. That mirrors how the create-flow probe
  already works (a user-typed key goes to a user-typed URL), and since
  custom providers are operator-defined endpoints under the same tenant,
  it stays within the existing trust boundary. If you'd prefer the
  fallback to require `base_url` to match the persisted record, happy to
  add that check in a follow-up.

## Test plan

- [x] Backend unit tests for `loadStoredApiKey`: matching tenant + provider,
      no row, null ciphertext, cross-tenant `provider_id`, corrupt
      ciphertext.
- [x] Backend controller tests: typed key wins, `provider_id` decrypts,
      unauth fallback when stored key is empty, neither field sent.
- [x] Frontend tests: edit mode without re-typing key forwards
      `provider_id`; typed key takes precedence and `provider_id` is
      omitted; opened-then-cleared key field still forwards
      `provider_id`.
- [x] Full `routing/` Jest suite: 3142/3142 passing.
- [x] `custom-provider.controller.ts` reaches 100% line/branch/function
      coverage; `loadStoredApiKey` reaches 100% line coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes edit-mode “Fetch models” to use the stored API key when the user hasn’t re-typed it, preventing false 401s and misleading “auth failed” errors. A user-typed key still wins.

- **Bug Fixes**
  - `ProbeCustomProviderDto` accepts an optional `provider_id`.
  - The controller decrypts the stored key when `provider_id` is present and `apiKey` is empty; lookup is tenant-scoped and falls back to unauth if missing or corrupt.
  - The frontend forwards `provider_id` only in edit mode when the key field is untouched; create flow and typed keys behave as before.

<sup>Written for commit d65507bd63d6ca2ba1e394dbf0abbf4054813eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

