### PR TITLE
feat: sync manifest subscription model lists (2026-06-21)

### DIFF
--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -2402,11 +2402,17 @@ describe('ModelDiscoveryService', () => {
 
       const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'openai');
 
-      expect(result.length).toBe(4);
-      expect(result.map((m) => m.id)).toContain('gpt-5.5');
-      expect(result.map((m) => m.id)).toContain('gpt-5.4');
-      expect(result.map((m) => m.id)).toContain('gpt-5.4-mini');
-      expect(result.map((m) => m.id)).toContain('gpt-5.3-codex-spark');
+      expect(result.map((m) => m.id)).toEqual([
+        'gpt-5.5',
+        'gpt-5.4',
+        'gpt-5.4-image-2',
+        'gpt-5.4-mini',
+        'gpt-5.4-nano',
+        'gpt-5.3-codex-spark',
+        'gpt-5.2-chat',
+        'gpt-5.2-pro',
+        'gpt-5.1-codex-mini',
+      ]);
       expect(result.map((m) => m.id)).not.toContain('gpt-5.3-codex');
       expect(result.map((m) => m.id)).not.toContain('gpt-5.2-codex');
       expect(result.map((m) => m.id)).not.toContain('gpt-5.1-codex-max');
@@ -2605,13 +2611,21 @@ describe('ModelDiscoveryService', () => {
 
       const result = supplementWithKnownModels(raw, 'openai');
 
-      // 1 discovered + 4 ChatGPT-account supported knownModels
-      expect(result.length).toBe(5);
+      // 1 discovered + 9 ChatGPT-account supported knownModels
+      expect(result.length).toBe(10);
       expect(result[0].id).toBe('gpt-oss-120b');
-      expect(result.map((m) => m.id)).toContain('gpt-5.5');
-      expect(result.map((m) => m.id)).toContain('gpt-5.4');
-      expect(result.map((m) => m.id)).toContain('gpt-5.4-mini');
-      expect(result.map((m) => m.id)).toContain('gpt-5.3-codex-spark');
+      expect(result.map((m) => m.id)).toEqual([
+        'gpt-oss-120b',
+        'gpt-5.5',
+        'gpt-5.4',
+        'gpt-5.4-image-2',
+        'gpt-5.4-mini',
+        'gpt-5.4-nano',
+        'gpt-5.3-codex-spark',
+        'gpt-5.2-chat',
+        'gpt-5.2-pro',
+        'gpt-5.1-codex-mini',
+      ]);
       expect(result.map((m) => m.id)).not.toContain('gpt-5.2-codex');
     });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -2404,14 +2404,14 @@ describe('ModelDiscoveryService', () => {
 
       expect(result.map((m) => m.id)).toEqual([
         'gpt-5.5',
-        'gpt-5.4',
         'gpt-5.4-image-2',
-        'gpt-5.4-mini',
         'gpt-5.4-nano',
-        'gpt-5.3-codex-spark',
+        'gpt-5.4',
+        'gpt-5.4-mini',
         'gpt-5.2-chat',
         'gpt-5.2-pro',
         'gpt-5.1-codex-mini',
+        'gpt-5.3-codex-spark',
       ]);
       expect(result.map((m) => m.id)).not.toContain('gpt-5.3-codex');
       expect(result.map((m) => m.id)).not.toContain('gpt-5.2-codex');
@@ -2617,14 +2617,14 @@ describe('ModelDiscoveryService', () => {
       expect(result.map((m) => m.id)).toEqual([
         'gpt-oss-120b',
         'gpt-5.5',
-        'gpt-5.4',
         'gpt-5.4-image-2',
-        'gpt-5.4-mini',
         'gpt-5.4-nano',
-        'gpt-5.3-codex-spark',
+        'gpt-5.4',
+        'gpt-5.4-mini',
         'gpt-5.2-chat',
         'gpt-5.2-pro',
         'gpt-5.1-codex-mini',
+        'gpt-5.3-codex-spark',
       ]);
       expect(result.map((m) => m.id)).not.toContain('gpt-5.2-codex');
     });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -53,7 +53,17 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     supportsSubscription: true as const,
     subscriptionLabel: 'ChatGPT Plus/Pro/Team',
     subscriptionAuthMode: 'popup_oauth' as const,
-    knownModels: Object.freeze(['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex-spark']),
+    knownModels: Object.freeze([
+      'gpt-5.5',
+      'gpt-5.4-image-2',
+      'gpt-5.4-nano',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.2-chat',
+      'gpt-5.2-pro',
+      'gpt-5.1-codex-mini',
+      'gpt-5.3-codex-spark',
+    ]),
     knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
@@ -167,6 +177,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionAuthMode: 'token' as const,
     subscriptionKeyPlaceholder: 'Paste your Z.ai API key',
     knownModels: Object.freeze([
+      'glm-5.2',
       'glm-5.1',
       'glm-5-turbo',
       'glm-5',


### PR DESCRIPTION
### ✨ What changed
- Adds `gpt-5.5`, `gpt-5.4-image-2`, `gpt-5.4-nano`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.2-chat`, `gpt-5.2-pro`, `gpt-5.1-codex-mini`, `gpt-5.3-codex-spark`, `glm-5.2` to subscription `knownModels` in configs.ts.

### 💭 Why
Discovery found these subscription models served by the provider but missing from the curated `knownModels` list.

### 📝 Notes
- Smoke skipped (openai): no endpoint config for "openai" — add it to ENDPOINTS (mirror provider-endpoints.ts).
- Smoke ✅ (zai): `glm-5.2` answered on the plan endpoint (served as `glm-5.2`).
- Not added: `grok-4.20-0309-non-reasoning`, `grok-4.3`, `grok-4.20-0309-reasoning`, `grok-build-0.1` (already curated, dynamically fetched, or a routing artifact).
- 136 new api_key models auto-discover at runtime, not listed here.
- Pricing (models.dev) and params (modelparams.dev) out of scope.
- Draft PR, auto-generated by the modelparams agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs subscription knownModels for OpenAI and Z.ai, and updates tests to assert exact ordered fallback and supplement lists to satisfy CI. Adds OpenAI models gpt-5.5, gpt-5.4-image-2, gpt-5.4-nano, gpt-5.4, gpt-5.4-mini, gpt-5.2-chat, gpt-5.2-pro, gpt-5.1-codex-mini, gpt-5.3-codex-spark, and Z.ai glm-5.2.

<sup>Written for commit efe5e12e003f2e7f361bccbfa6b4731dc1f13cdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

