### PR TITLE
perf: speed up dashboard load and model picker

### DIFF
--- a/.changeset/frontend-load-perf.md
+++ b/.changeset/frontend-load-perf.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Speed up dashboard load and the model picker. Tree-shaking the shared package trims ~7KB off the critical-path bundle, and the model picker no longer re-groups every model on each keystroke.

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Show, type Component } from 'solid-js';
+import { createSignal, createMemo, For, Show, type Component } from 'solid-js';
 import {
   refreshProviderModels,
   type AuthType,
@@ -145,23 +145,28 @@ const ModelPickerModal: Component<Props> = (props) => {
     }
   };
 
-  const providerLabelMap = (): Map<string, string> => {
+  // PROVIDERS is a module constant, so these maps never change once built —
+  // memoize them so they're computed once instead of being rebuilt on every
+  // groupedModels() recompute (e.g. on every search keystroke).
+  const providerLabelMap = createMemo((): Map<string, string> => {
     const map = new Map<string, string>();
     for (const prov of PROVIDERS) {
       for (const m of prov.models) map.set(m.value, m.label);
     }
     return map;
-  };
+  });
 
-  const providerIdSet = (): Set<string> => new Set(PROVIDERS.map((p) => p.id.toLowerCase()));
+  const providerIdSet = createMemo(
+    (): Set<string> => new Set(PROVIDERS.map((p) => p.id.toLowerCase())),
+  );
 
-  const customProviderNameMap = (): Map<string, string> => {
+  const customProviderNameMap = createMemo((): Map<string, string> => {
     const map = new Map<string, string>();
     for (const cp of props.customProviders ?? []) {
       map.set(`custom:${cp.id}`, cp.name);
     }
     return map;
-  };
+  });
 
   /** Provider IDs that have an active connection of the given auth type. */
   const providerIdsForTab = (authType: AuthType): Set<string> => {
@@ -176,7 +181,12 @@ const ModelPickerModal: Component<Props> = (props) => {
     return ids;
   };
 
-  const groupedModels = () => {
+  // Grouping/filtering/sorting every model is read from three separate JSX
+  // sites (the list, the empty-state, and the count). As a plain function each
+  // read re-ran the full pass; memoizing collapses them into one computation
+  // that only re-derives when an actual dependency (search, tab, models, …)
+  // changes.
+  const groupedModels = createMemo(() => {
     const q = search().toLowerCase().trim();
     const labels = providerLabelMap();
     const providerIds = providerIdSet();
@@ -266,7 +276,7 @@ const ModelPickerModal: Component<Props> = (props) => {
     }
     groups.sort((a, b) => a.name.localeCompare(b.name));
     return groups;
-  };
+  });
 
   /** Returns the role of a model in the current tier: "Primary", "Fallback 1", etc. or null */
   const modelRole = (

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -576,9 +576,13 @@ const GlobalOverview: Component = () => {
 
         {/* ── 3. Summary Stat Cards (4 columns) ────────────────────── */}
         {(() => {
-          const subs = () => providerList().filter((g) => g.auth_type === 'subscription');
-          const byok = () => providerList().filter((g) => g.auth_type === 'api_key');
-          const local = () => providerList().filter((g) => g.auth_type === 'local');
+          // Each list is read twice below (count + preview row); memoize so the
+          // provider list is filtered once per change instead of on every read.
+          const subs = createMemo(() =>
+            providerList().filter((g) => g.auth_type === 'subscription'),
+          );
+          const byok = createMemo(() => providerList().filter((g) => g.auth_type === 'api_key'));
+          const local = createMemo(() => providerList().filter((g) => g.auth_type === 'local'));
           const totalConns = (list: ProviderGroup[]) =>
             list.reduce((s, g) => s + g.connections.length, 0);
           const connList = (groups: ProviderGroup[]) => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,7 @@
   "name": "manifest-shared",
   "version": "0.1.0",
   "private": true,
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",


### PR DESCRIPTION
### 💭 Why
Every page pays for the entry bundle, and the model picker re-did its full grouping pass on each keystroke. Both were avoidable.

### ✨ What changed
- `manifest-shared`: add `"sideEffects": false` so Rollup drops unused barrel modules from the critical path.
- ModelPickerModal: memoize `groupedModels` + the provider/label maps (read from 3 JSX sites, rebuilt every keystroke).
- GlobalOverview: memoize the subscription/api_key/local provider filters (each ran twice per render).

### 👤 For users
Dashboard loads a bit quicker (entry chunk 115.6 → 108.4 kB raw, 38.0 → 36.5 kB gzip) and typing in the model picker no longer re-groups every model per keystroke. No behavior change.

### 📝 Notes
Frontend-only. No backend code touched; the shared change is bundler metadata. Verified: 3932 frontend tests, 296 shared tests, tsc/eslint/prettier clean, patch coverage 100%.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up dashboard load and make the model picker responsive by removing redundant work. Entry chunk shrinks from 115.6→108.4 kB (raw) and 38.0→36.5 kB (gzip); no behavior change.

- **Refactors**
  - `manifest-shared`: set `"sideEffects": false` to enable tree-shaking of unused barrel modules.
  - ModelPickerModal: memoize provider maps and `groupedModels` to avoid recomputing on each keystroke and at multiple read sites.
  - GlobalOverview: memoize subscription/api_key/local provider filters to prevent duplicate filtering per render.

<sup>Written for commit 2901260006ee4de0b633fe7a733b8786023cc6d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

