### PR TITLE
fix: stop deploys deadlocking when replicas migrate at once

### DIFF
--- a/.changeset/serialize-migrations-advisory-lock.md
+++ b/.changeset/serialize-migrations-advisory-lock.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Run database migrations under a Postgres advisory lock so concurrent runners serialize instead of deadlocking. When more than one process ran migrations at once (overlapping deployments, or replicas across regions), they could deadlock acquiring DDL locks on the high-churn agent_messages table and fail the deploy. The deploy migration step now takes a single advisory lock over the direct migration connection: the first runner applies every pending migration, the rest wait and then find nothing pending. Single-instance and self-hosted deploys are unaffected.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json --runInBand",
     "lint": "eslint src/",
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/database/datasource.ts",
-    "migration:run": "typeorm-ts-node-commonjs migration:run -d src/database/datasource.ts",
+    "migration:run": "ts-node -T src/database/migrate.ts",
     "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/database/datasource.ts",
     "migration:show": "typeorm-ts-node-commonjs migration:show -d src/database/datasource.ts",
     "migration:create": "typeorm-ts-node-commonjs migration:create",
@@ -85,6 +85,7 @@
       "!main.ts",
       "!**/database/migrations/**",
       "!**/database/datasource.ts",
+      "!**/database/migrate.ts",
       "!**/*.module.ts",
       "!**/otlp/interfaces/index.ts",
       "!**/otlp/proto/**"

--- a/packages/backend/src/database/migrate.ts
+++ b/packages/backend/src/database/migrate.ts
@@ -1,0 +1,26 @@
+import dataSource from './datasource';
+import { runMigrationsWithAdvisoryLock } from './run-migrations-with-lock';
+
+/**
+ * Migration entry point used by the deploy step (`npm run migration:run`).
+ * Wraps TypeORM's migration run in an advisory lock so concurrent deploys /
+ * replicas don't deadlock on agent_messages locks. The DataSource reads
+ * MIGRATION_DATABASE_URL (a direct, non-pooled connection) so the session-level
+ * advisory lock holds.
+ */
+async function main(): Promise<void> {
+  await dataSource.initialize();
+  try {
+    await runMigrationsWithAdvisoryLock(dataSource);
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+void main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  },
+);

--- a/packages/backend/src/database/run-migrations-with-lock.spec.ts
+++ b/packages/backend/src/database/run-migrations-with-lock.spec.ts
@@ -1,0 +1,89 @@
+import { DataSource } from 'typeorm';
+import {
+  MIGRATION_ADVISORY_LOCK_KEY,
+  runMigrationsWithAdvisoryLock,
+} from './run-migrations-with-lock';
+
+interface Mocks {
+  dataSource: DataSource;
+  query: jest.Mock;
+  release: jest.Mock;
+  connect: jest.Mock;
+  runMigrations: jest.Mock;
+}
+
+function build(): Mocks {
+  const query = jest.fn().mockResolvedValue(undefined);
+  const release = jest.fn().mockResolvedValue(undefined);
+  const connect = jest.fn().mockResolvedValue(undefined);
+  const runMigrations = jest.fn().mockResolvedValue([]);
+  const queryRunner = { connect, query, release };
+  const dataSource = {
+    createQueryRunner: jest.fn(() => queryRunner),
+    runMigrations,
+  } as unknown as DataSource;
+  return { dataSource, query, release, connect, runMigrations };
+}
+
+describe('runMigrationsWithAdvisoryLock', () => {
+  beforeEach(() => jest.spyOn(console, 'error').mockImplementation(() => undefined));
+  afterEach(() => jest.restoreAllMocks());
+
+  it('acquires the advisory lock, runs migrations, then unlocks and releases', async () => {
+    const m = build();
+    await runMigrationsWithAdvisoryLock(m.dataSource);
+
+    expect(m.connect).toHaveBeenCalledTimes(1);
+    expect(m.query).toHaveBeenNthCalledWith(1, 'SELECT pg_advisory_lock($1::bigint)', [
+      MIGRATION_ADVISORY_LOCK_KEY,
+    ]);
+    expect(m.runMigrations).toHaveBeenCalledWith({ transaction: 'all' });
+    expect(m.query).toHaveBeenNthCalledWith(2, 'SELECT pg_advisory_unlock($1::bigint)', [
+      MIGRATION_ADVISORY_LOCK_KEY,
+    ]);
+    expect(m.release).toHaveBeenCalledTimes(1);
+
+    // lock acquired before migrations; migrations before unlock.
+    const lockOrder = m.query.mock.invocationCallOrder[0];
+    const runOrder = m.runMigrations.mock.invocationCallOrder[0];
+    const unlockOrder = m.query.mock.invocationCallOrder[1];
+    expect(lockOrder).toBeLessThan(runOrder);
+    expect(runOrder).toBeLessThan(unlockOrder);
+  });
+
+  it('still unlocks and releases when runMigrations throws, and rethrows', async () => {
+    const m = build();
+    m.runMigrations.mockRejectedValueOnce(new Error('migration boom'));
+
+    await expect(runMigrationsWithAdvisoryLock(m.dataSource)).rejects.toThrow('migration boom');
+    // lock (1) + unlock (2) both ran; runner released.
+    expect(m.query).toHaveBeenCalledTimes(2);
+    expect(m.query).toHaveBeenNthCalledWith(2, 'SELECT pg_advisory_unlock($1::bigint)', [
+      MIGRATION_ADVISORY_LOCK_KEY,
+    ]);
+    expect(m.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows an unlock failure but still releases the runner', async () => {
+    const m = build();
+    m.query.mockImplementation((sql: string) =>
+      sql.includes('pg_advisory_unlock')
+        ? Promise.reject(new Error('unlock failed'))
+        : Promise.resolve(undefined),
+    );
+
+    await expect(runMigrationsWithAdvisoryLock(m.dataSource)).resolves.toBeUndefined();
+    expect(m.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt unlock if the lock was never acquired, but still releases', async () => {
+    const m = build();
+    m.query.mockRejectedValueOnce(new Error('lock failed')); // the pg_advisory_lock call
+
+    await expect(runMigrationsWithAdvisoryLock(m.dataSource)).rejects.toThrow('lock failed');
+    expect(m.runMigrations).not.toHaveBeenCalled();
+    // Only the lock attempt ran — no unlock query.
+    expect(m.query).toHaveBeenCalledTimes(1);
+    expect(m.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/database/run-migrations-with-lock.ts
+++ b/packages/backend/src/database/run-migrations-with-lock.ts
@@ -1,0 +1,43 @@
+import { DataSource } from 'typeorm';
+
+/**
+ * Fixed key for the migration advisory lock. Every Manifest process that runs
+ * migrations (the pre-deploy step, Railway replicas across regions, overlapping
+ * deployments) contends on this one key, so migrations run strictly one at a
+ * time instead of deadlocking while acquiring DDL locks on the high-churn
+ * agent_messages table (the multi-replica deploy deadlock this guards against).
+ */
+export const MIGRATION_ADVISORY_LOCK_KEY = 4011985;
+
+/**
+ * Run pending migrations while holding a PostgreSQL session advisory lock, so
+ * concurrent runners serialize: the first holder applies every pending
+ * migration; the others block on the lock, then find nothing pending and no-op.
+ *
+ * The lock is session-scoped, so this MUST run over a direct connection (the
+ * migration DataSource uses MIGRATION_DATABASE_URL, not the PgBouncer pool —
+ * transaction pooling would not preserve a session lock).
+ */
+export async function runMigrationsWithAdvisoryLock(dataSource: DataSource): Promise<void> {
+  // Dedicated connection holds the lock for the whole run; runMigrations() uses
+  // its own connection from the pool, which the advisory lock does not block.
+  const lockRunner = dataSource.createQueryRunner();
+  await lockRunner.connect();
+  let locked = false;
+  try {
+    await lockRunner.query('SELECT pg_advisory_lock($1::bigint)', [MIGRATION_ADVISORY_LOCK_KEY]);
+    locked = true;
+    await dataSource.runMigrations({ transaction: 'all' });
+  } finally {
+    if (locked) {
+      try {
+        await lockRunner.query('SELECT pg_advisory_unlock($1::bigint)', [
+          MIGRATION_ADVISORY_LOCK_KEY,
+        ]);
+      } catch {
+        // Best effort — the lock is also released when this connection closes.
+      }
+    }
+    await lockRunner.release();
+  }
+}


### PR DESCRIPTION
### 💭 Why
The #2310 production deploy failed: with replicas across regions, more than one process ran DB migrations at the same time and deadlocked acquiring DDL locks on the high-churn `agent_messages` table. Railway rolled back, so the perf work never went live. This will hit any deploy with pending `agent_messages` migrations and >1 concurrent runner.

### ✨ What changed
- Migrations now run under a Postgres session advisory lock. The first runner applies every pending migration; the rest block, then find nothing pending and no-op.
- New `runMigrationsWithAdvisoryLock` helper + a `migrate.ts` entry point; the `migration:run` script (used by the pre-deploy step) points at it.
- The lock uses the direct migration connection (`MIGRATION_DATABASE_URL`), so the session lock holds (PgBouncer transaction pooling would not).
- App-boot (`migrationsRun`) and single-instance / self-hosted behavior are unchanged.

### 🔧 For operators
No config change. After this merges, redeploy `main` — the pending perf migrations from #2310 will apply cleanly under the lock (they didn't apply on the failed deploy, so prod is still on the pre-#2310 schema).

### 📝 Notes
Proven with two concurrent migration runs against a fresh DB: the old path fails (`duplicate key … tool_executions already exists`), the locked path applies all migrations exactly once. Unit-tested at 100% (lock acquire/run/unlock + failure paths).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize database migrations with a Postgres advisory lock to stop deploy deadlocks when multiple runners migrate at once. Updates the deploy migration script to use a locked entry point; app-boot and single-node behavior are unchanged.

- **Bug Fixes**
  - Run migrations under a session advisory lock so concurrent runners serialize instead of deadlocking on `agent_messages`.
  - Add `runMigrationsWithAdvisoryLock` and `migrate.ts`; point `migration:run` to it via `ts-node`.
  - Use the direct `MIGRATION_DATABASE_URL` connection to hold the session lock.

- **Migration**
  - No config change. Redeploy `main` to apply pending migrations safely.

<sup>Written for commit 100a3b420dd04aa6eac461d4a9a81838d61d3b1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

