### PR TITLE
fix: build agent_messages indexes without blocking deploys

### DIFF
--- a/.changeset/concurrent-index-migrations.md
+++ b/.changeset/concurrent-index-migrations.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Stop index migrations from deadlocking deploys against live traffic. The agent_messages index migrations used blocking DDL (plain CREATE/DROP INDEX), which takes an ACCESS EXCLUSIVE lock and deadlocked against live INSERTs while the previous deployment was still serving — failing every deploy and leaving the schema (and the dashboard perf work) unshipped. Those migrations now run CONCURRENTLY (SHARE UPDATE EXCLUSIVE, which does not conflict with writes) outside a transaction, and the migration runner uses per-migration ('each') transactions. The covering index also builds without a write stall.

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -43,7 +43,11 @@ import { shouldRetryDbConnection } from '../common/utils/db-retry';
         // direct connection instead. Previously this was hardcoded true, which
         // deadlocked when several replicas migrated at once on the same deploy.
         migrationsRun: config.get<boolean>('app.runMigrationsOnBoot'),
-        migrationsTransactionMode: 'all' as const,
+        // 'each' (per-migration transaction), not 'all': the agent_messages index
+        // migrations run CONCURRENTLY and declare `transaction = false`, which
+        // TypeORM forbids under 'all'. CONCURRENTLY avoids the ACCESS EXCLUSIVE
+        // lock that deadlocks against live writes during a deploy.
+        migrationsTransactionMode: 'each' as const,
         migrations,
         // A failed migration must not go through the connection-retry loop:
         // @nestjs/typeorm checks toRetry before logging, so returning false

--- a/packages/backend/src/database/migrations/1793000000000-AddTenantProviderValueIndex.ts
+++ b/packages/backend/src/database/migrations/1793000000000-AddTenantProviderValueIndex.ts
@@ -10,17 +10,29 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * (NULL/empty providers excluded — they're legacy rows the dropdown ignores)
  * lets the skip scan jump provider-to-provider with one index seek per distinct
  * value. It's small: provider is a short, low-cardinality string.
+ *
+ * Built CONCURRENTLY (so `transaction = false`): the blocking form takes a lock
+ * on agent_messages that deadlocks against live INSERTs during a deploy.
+ * CONCURRENTLY uses SHARE UPDATE EXCLUSIVE, which does not conflict with writes.
  */
 export class AddTenantProviderValueIndex1793000000000 implements MigrationInterface {
   name = 'AddTenantProviderValueIndex1793000000000';
+  transaction = false;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // Clear any invalid leftover from an interrupted CONCURRENTLY build, since
+    // CREATE ... IF NOT EXISTS would otherwise skip over an invalid index.
     await queryRunner.query(
-      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_tenant_provider_value" ON "agent_messages" ("tenant_id", "provider") WHERE "provider" IS NOT NULL AND "provider" <> ''`,
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_provider_value"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_tenant_provider_value" ON "agent_messages" ("tenant_id", "provider") WHERE "provider" IS NOT NULL AND "provider" <> ''`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_tenant_provider_value"`);
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_provider_value"`,
+    );
   }
 }

--- a/packages/backend/src/database/migrations/1793100000000-DropRedundantTenantAgentNameIndex.ts
+++ b/packages/backend/src/database/migrations/1793100000000-DropRedundantTenantAgentNameIndex.ts
@@ -10,17 +10,25 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * it just adds write amplification to the hot ingest path and ~590MB of bloat.
  *
  * The down() recreates it for reversibility.
+ *
+ * Dropped CONCURRENTLY (so `transaction = false`): a plain DROP INDEX takes
+ * ACCESS EXCLUSIVE on agent_messages and deadlocked against live INSERTs during
+ * the deploy (this is the migration that failed in production). The CONCURRENTLY
+ * form takes SHARE UPDATE EXCLUSIVE and does not conflict with writes.
  */
 export class DropRedundantTenantAgentNameIndex1793100000000 implements MigrationInterface {
   name = 'DropRedundantTenantAgentNameIndex1793100000000';
+  transaction = false;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_tenant_agent_name_ts"`);
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_tenant_agent_name_ts"`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_tenant_agent_name_ts" ON "agent_messages" ("tenant_id", "agent_name", "timestamp")`,
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_tenant_agent_name_ts" ON "agent_messages" ("tenant_id", "agent_name", "timestamp")`,
     );
   }
 }

--- a/packages/backend/src/database/migrations/1793200000000-AddDashboardCoveringIndex.ts
+++ b/packages/backend/src/database/migrations/1793200000000-AddDashboardCoveringIndex.ts
@@ -18,25 +18,32 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *      Adding `model` makes that aggregation index-only too.
  *
  * DROP-then-CREATE so any pre-existing out-of-band copy is replaced with the
- * model-inclusive definition. On a large install this rebuilds a multi-hundred-MB
- * index once at boot (a brief write stall on agent_messages), the same one-time
- * cost noted for the other index migrations in this batch.
+ * model-inclusive definition. Both run CONCURRENTLY (so `transaction = false`):
+ * the blocking form rebuilds a multi-hundred-MB index under ACCESS EXCLUSIVE and
+ * deadlocked against live agent_messages writes during the deploy. CONCURRENTLY
+ * builds it in the background under SHARE UPDATE EXCLUSIVE, which does not
+ * conflict with writes — no stall, no deadlock.
  */
 export class AddDashboardCoveringIndex1793200000000 implements MigrationInterface {
   name = 'AddDashboardCoveringIndex1793200000000';
+  transaction = false;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_provider_usage"`);
     await queryRunner.query(
-      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_provider_usage" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("model", "provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")`,
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("model", "provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     // Restore the prior (model-less) covering definition.
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_provider_usage"`);
     await queryRunner.query(
-      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_provider_usage" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")`,
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")`,
     );
   }
 }

--- a/packages/backend/src/database/migrations/1793200000000-AddDashboardCoveringIndex.ts
+++ b/packages/backend/src/database/migrations/1793200000000-AddDashboardCoveringIndex.ts
@@ -17,33 +17,49 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *   2. The hosted copy was missing `model`, so cost-by-model still hit the heap.
  *      Adding `model` makes that aggregation index-only too.
  *
- * DROP-then-CREATE so any pre-existing out-of-band copy is replaced with the
- * model-inclusive definition. Both run CONCURRENTLY (so `transaction = false`):
- * the blocking form rebuilds a multi-hundred-MB index under ACCESS EXCLUSIVE and
- * deadlocked against live agent_messages writes during the deploy. CONCURRENTLY
- * builds it in the background under SHARE UPDATE EXCLUSIVE, which does not
- * conflict with writes — no stall, no deadlock.
+ * Build-new-then-swap so a usable covering index always exists: the new
+ * definition is built CONCURRENTLY under a temp name, then the old copy is
+ * dropped and the new one renamed into place. Everything runs CONCURRENTLY (so
+ * `transaction = false`) under SHARE UPDATE EXCLUSIVE, which does not conflict
+ * with writes — the blocking form took ACCESS EXCLUSIVE and deadlocked against
+ * live agent_messages writes during the deploy. If the build fails, the existing
+ * index is untouched (no window without a covering index); ALTER INDEX RENAME
+ * does not block writes either.
  */
 export class AddDashboardCoveringIndex1793200000000 implements MigrationInterface {
   name = 'AddDashboardCoveringIndex1793200000000';
   transaction = false;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // Drop any invalid leftover, build the model-inclusive index under a temp
+    // name, then swap. The old index stays usable until the new one is ready.
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage_v2"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage_v2" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("model", "provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")`,
+    );
     await queryRunner.query(
       `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage"`,
     );
     await queryRunner.query(
-      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("model", "provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")`,
+      `ALTER INDEX IF EXISTS "IDX_agent_messages_provider_usage_v2" RENAME TO "IDX_agent_messages_provider_usage"`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    // Restore the prior (model-less) covering definition.
+    // Restore the prior (model-less) covering definition with the same swap.
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage_v2"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage_v2" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")`,
+    );
     await queryRunner.query(
       `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage"`,
     );
     await queryRunner.query(
-      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")`,
+      `ALTER INDEX IF EXISTS "IDX_agent_messages_provider_usage_v2" RENAME TO "IDX_agent_messages_provider_usage"`,
     );
   }
 }

--- a/packages/backend/src/database/run-migrations-with-lock.spec.ts
+++ b/packages/backend/src/database/run-migrations-with-lock.spec.ts
@@ -37,7 +37,7 @@ describe('runMigrationsWithAdvisoryLock', () => {
     expect(m.query).toHaveBeenNthCalledWith(1, 'SELECT pg_advisory_lock($1::bigint)', [
       MIGRATION_ADVISORY_LOCK_KEY,
     ]);
-    expect(m.runMigrations).toHaveBeenCalledWith({ transaction: 'all' });
+    expect(m.runMigrations).toHaveBeenCalledWith({ transaction: 'each' });
     expect(m.query).toHaveBeenNthCalledWith(2, 'SELECT pg_advisory_unlock($1::bigint)', [
       MIGRATION_ADVISORY_LOCK_KEY,
     ]);

--- a/packages/backend/src/database/run-migrations-with-lock.ts
+++ b/packages/backend/src/database/run-migrations-with-lock.ts
@@ -27,7 +27,10 @@ export async function runMigrationsWithAdvisoryLock(dataSource: DataSource): Pro
   try {
     await lockRunner.query('SELECT pg_advisory_lock($1::bigint)', [MIGRATION_ADVISORY_LOCK_KEY]);
     locked = true;
-    await dataSource.runMigrations({ transaction: 'all' });
+    // 'each' (per-migration transaction), not 'all': the index migrations run
+    // CONCURRENTLY and must execute outside a transaction (transaction = false),
+    // which TypeORM forbids under 'all'.
+    await dataSource.runMigrations({ transaction: 'each' });
   } finally {
     if (locked) {
       try {

--- a/packages/backend/test/agent-duplication-migrations.e2e-spec.ts
+++ b/packages/backend/test/agent-duplication-migrations.e2e-spec.ts
@@ -36,7 +36,7 @@ describe('Agent duplication under migration-built schema (e2e)', () => {
       logging: false,
     });
     await ds.initialize();
-    await ds.runMigrations();
+    await ds.runMigrations({ transaction: 'each' });
 
     const cacheStub = {
       invalidateAgent: () => undefined,

--- a/packages/backend/test/custom-provider-fk-data-loss.e2e-spec.ts
+++ b/packages/backend/test/custom-provider-fk-data-loss.e2e-spec.ts
@@ -55,7 +55,7 @@ describe('AddCustomProviderFkToUserProviders deployment data-loss invariant (e2e
   beforeAll(async () => {
     ds = makeDataSource();
     await ds.initialize();
-    await ds.runMigrations();
+    await ds.runMigrations({ transaction: 'each' });
 
     // The tenant-canonical chain (later migrations) renames user_providers →
     // tenant_providers and demotes custom_providers.user_id → created_by_user_id;

--- a/packages/backend/test/custom-provider-fk-migrations.e2e-spec.ts
+++ b/packages/backend/test/custom-provider-fk-migrations.e2e-spec.ts
@@ -48,7 +48,7 @@ describe('AddCustomProviderFkToUserProviders schema (e2e)', () => {
   beforeAll(async () => {
     ds = makeDataSource();
     await ds.initialize();
-    await ds.runMigrations();
+    await ds.runMigrations({ transaction: 'each' });
     await revertTenantCanonicalScoping(ds);
   }, 60000);
 
@@ -99,7 +99,7 @@ describe('AddCustomProviderFkToUserProviders data preservation (e2e)', () => {
   beforeAll(async () => {
     ds = makeDataSource();
     await ds.initialize();
-    await ds.runMigrations();
+    await ds.runMigrations({ transaction: 'each' });
     // Undo the later user_providers → tenant_providers rename so this migration
     // can be exercised against the user_providers schema it was authored for.
     await revertTenantCanonicalScoping(ds);

--- a/packages/backend/test/custom-providers-lift-migrations.e2e-spec.ts
+++ b/packages/backend/test/custom-providers-lift-migrations.e2e-spec.ts
@@ -26,7 +26,7 @@ describe('LiftCustomProvidersToUserLevel under migration-built schema (e2e)', ()
       logging: false,
     });
     await ds.initialize();
-    await ds.runMigrations();
+    await ds.runMigrations({ transaction: 'each' });
   }, 60000);
 
   afterAll(async () => {
@@ -91,7 +91,7 @@ describe('LiftCustomProvidersToUserLevel data transformation (e2e)', () => {
       logging: false,
     });
     await ds.initialize();
-    await ds.runMigrations();
+    await ds.runMigrations({ transaction: 'each' });
 
     // Revert the later tenant re-scoping + table renames first (newest first)
     // so this historical migration can be replayed against the schema naming

--- a/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
+++ b/packages/backend/test/seed-playground-agents-migrations.e2e-spec.ts
@@ -31,7 +31,7 @@ describe('SeedPlaygroundAgents data transformation (e2e)', () => {
       logging: false,
     });
     await ds.initialize();
-    await ds.runMigrations();
+    await ds.runMigrations({ transaction: 'each' });
 
     // Revert the later tenant re-scope first (newest first) so this historical
     // migration can be replayed against the schema naming it expects

--- a/packages/backend/test/tenant-scoping-migrations.e2e-spec.ts
+++ b/packages/backend/test/tenant-scoping-migrations.e2e-spec.ts
@@ -65,7 +65,7 @@ describe('Tenant-canonical scoping migrations — data backfill (e2e)', () => {
       logging: false,
     });
     await ds.initialize();
-    await ds.runMigrations();
+    await ds.runMigrations({ transaction: 'each' });
 
     // Revert the four tenant migrations, newest first → pre-tenant schema
     // (user_id scope columns everywhere, no owner_user_id).

--- a/packages/backend/test/user-provider-backfill-migrations.e2e-spec.ts
+++ b/packages/backend/test/user-provider-backfill-migrations.e2e-spec.ts
@@ -44,7 +44,7 @@ describe('agent-message attribution backfill after provider lift (e2e)', () => {
       logging: false,
     });
     await ds.initialize();
-    await ds.runMigrations();
+    await ds.runMigrations({ transaction: 'each' });
 
     // Clean slate (FK-safe order), then rewind to the pre-lift schema by
     // reverting the relevant migrations in reverse chronological order. The


### PR DESCRIPTION
### 💭 Why
The real cause of the failed prod deploys (#2310, #2313, #2314 all failed). The agent_messages index migrations used blocking DDL. A plain `CREATE`/`DROP INDEX` takes ACCESS EXCLUSIVE on the table, and under transaction mode `all` the batch held a SHARE UPDATE EXCLUSIVE lock (the autovacuum `ALTER`) then upgraded to ACCESS EXCLUSIVE (`DROP INDEX`) — a lock upgrade that deadlocked against the still-live old deployment's INSERTs. The deploy log confirmed it: an AccessExclusive-vs-RowExclusive cycle on `agent_messages` in `DropRedundantTenantAgentNameIndex`. The earlier advisory-lock / pre-deploy work never addressed this. it's migration-DDL-vs-live-writes, not concurrent runners.

### ✨ What changed
- The 3 `agent_messages` index migrations now use `CREATE`/`DROP INDEX CONCURRENTLY` with `transaction = false`. CONCURRENTLY takes SHARE UPDATE EXCLUSIVE, which does not conflict with writes.
- Migration runner switched from `all` to `each` (per-migration transactions) in both the boot path and the pre-deploy runner. TypeORM requires this for the per-migration overrides, and it also removes the held-then-upgrade pattern.
- Updated the migration e2e tests to run with `each` to match.

### 🔧 For operators
No config change. On the next deploy the pre-deploy step builds the indexes concurrently (no write stall, no deadlock), applies the pending perf migrations, and the deploy goes through.

### 📝 Notes
Validated locally: migrations apply on a fresh DB (102/102) and under sustained write load (12 concurrent RowExclusive holders via pgbench) with no deadlock and all indexes valid. Confirmed via `pg_locks` that CONCURRENTLY takes ShareUpdateExclusiveLock (compatible with writes) while the old form takes AccessExclusiveLock (the prod deadlock). Full unit (6717) + e2e (301) pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops deploy deadlocks by building `agent_messages` indexes CONCURRENTLY and running migrations per migration. Index builds no longer block live writes, and the covering index now swaps in atomically so it's never missing.

- Bug Fixes
  - Use `CREATE/DROP INDEX CONCURRENTLY` with `transaction = false` for the three `agent_messages` index migrations.
  - Run migrations with `transaction: 'each'` in both boot and pre-deploy paths; update e2e tests accordingly.
  - Drop any invalid leftovers; build the covering index CONCURRENTLY under a temp name, drop the old copy, then rename to swap in without downtime.

<sup>Written for commit 14f29d7a2dd9f00be463f2ae9237ab8b67eb238d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

