### PR TITLE
feat: unified routing view for clean agents

### DIFF
--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -3,6 +3,7 @@ import {
   createResource,
   createMemo,
   createEffect,
+  For,
   Show,
   type Component,
 } from 'solid-js';
@@ -20,9 +21,18 @@ import { agentPlatform, agentCategory } from '../services/agent-platform-store.j
 import RoutingDefaultTierSection from './RoutingDefaultTierSection.js';
 import RoutingSpecificitySection from './RoutingSpecificitySection.js';
 import RoutingHeaderTiersSection from './RoutingHeaderTiersSection.js';
+import RoutingTierCard from './RoutingTierCard.js';
+import HeaderTierCard from '../components/HeaderTierCard.js';
 import { RoutingLoadingSkeleton, ActiveProviderIcons, RoutingFooter } from './RoutingPanels.js';
 import { createRoutingActions } from './RoutingActions.js';
-import { listHeaderTiers, type HeaderTier } from '../services/api/header-tiers.js';
+import {
+  listHeaderTiers,
+  overrideHeaderTier,
+  deleteHeaderTier,
+  toggleHeaderTier,
+  setHeaderTierResponseMode,
+  type HeaderTier,
+} from '../services/api/header-tiers.js';
 import {
   getTierAssignments,
   setTierResponseMode,
@@ -48,7 +58,7 @@ import {
   type ResponseMode,
 } from '../services/api.js';
 import { parseCustomProviderParams, parseProviderDeepLink } from '../services/routing-params.js';
-import { STAGES } from '../services/providers.js';
+import { DEFAULT_STAGE, STAGES } from '../services/providers.js';
 // Route-scoped: keep the large routing stylesheet (and its sub-imports) out
 // of the global theme bundle so login/overview/etc. don't download it.
 import NoConnectionsPrompt from '../components/NoConnectionsPrompt.jsx';
@@ -135,6 +145,13 @@ const Routing: Component = () => {
   });
   const legacyComplexityVisible = () => legacyComplexityAgent() === agentName();
   const legacySpecificityVisible = () => legacySpecificityAgent() === agentName();
+  const isCleanAgent = () => !legacyComplexityVisible() && !legacySpecificityVisible();
+
+  // For the unified (no-tabs) view: capture openers from HeaderTiersSection
+  // so the header button, dashed add-card, and card edit buttons can trigger modals.
+  let headerTierOpener: (() => void) | undefined;
+  let headerTierCreator: (() => void) | undefined;
+  let headerTierEditor: ((tier: HeaderTier) => void) | undefined;
 
   // Per-route model params, fetched once and threaded down. Scope separates
   // default/complexity tiers, task-specific tiers, and custom header tiers so
@@ -546,102 +563,134 @@ const Routing: Component = () => {
             </div>
           </div>
 
-          <RoutingTabs
-            specificityEnabled={hasAnySpecificityActive}
-            customEnabled={hasCustomTiersEnabled}
-            showSpecificity={legacySpecificityVisible}
-            pipelineHelp={() =>
-              buildPipelineHelp(
-                hasAnySpecificityActive(),
-                hasCustomTiersEnabled(),
-                complexityEnabled(),
-              )
-            }
-          >
-            {{
-              default: (
-                <RoutingDefaultTierSection
-                  agentName={agentName}
-                  tier={() => actions.getTier('default')}
-                  models={() => models() ?? []}
-                  customProviders={() => customProviders() ?? []}
-                  activeProviders={activeProviders}
-                  connectedProviders={enabledConnectedProviders}
-                  tiersLoading={tiers.loading}
-                  changingTier={actions.changingTier}
-                  resettingTier={actions.resettingTier}
-                  resettingAll={actions.resettingAll}
-                  addingFallback={actions.addingFallback}
-                  onDropdownOpen={(tierId) => setDropdownTier(tierId)}
-                  onOverride={handleOverride}
-                  onPinKey={actions.handlePinKey}
-                  onReset={actions.handleReset}
-                  onFallbackUpdate={actions.handleFallbackUpdate}
-                  onAddFallback={(tierId) => setFallbackPickerTier(tierId)}
-                  getFallbacksFor={actions.getFallbacksFor}
-                  getTier={actions.getTier}
-                  complexityEnabled={complexityEnabled}
-                  togglingComplexity={togglingComplexity}
-                  onToggleComplexity={handleToggleComplexity}
-                  showComplexityToggle={legacyComplexityVisible}
-                  responseMode={defaultResponseMode}
-                  changingResponseMode={changingDefaultResponseMode}
-                  onResponseModeChange={handleDefaultResponseModeChange}
-                  embedded
-                  getModelParams={getModelParamsFor}
-                  setModelParams={setModelParamsFor}
-                />
-              ),
-              specificity: (
-                <RoutingSpecificitySection
-                  agentName={agentName}
-                  assignments={specificityAssignments}
-                  models={() => models() ?? []}
-                  customProviders={() => customProviders() ?? []}
-                  activeProviders={activeProviders}
-                  connectedProviders={enabledConnectedProviders}
-                  changingTier={changingSpecificity}
-                  resettingTier={resettingSpecificity}
-                  resettingAll={() => false}
-                  addingFallback={() => null}
-                  onDropdownOpen={(category) => setSpecificityDropdown(category)}
-                  onOverride={handleSpecificityOverride}
-                  onPinKey={handleSpecificityPinKey}
-                  onReset={async (category) => {
-                    setResettingSpecificity(category);
-                    try {
-                      await resetSpecificity(agentName(), category);
-                      await refetchSpecificity();
-                    } catch {
-                      toast.error('Failed to reset');
-                    } finally {
-                      setResettingSpecificity(null);
-                    }
+          <Show
+            when={!isCleanAgent()}
+            fallback={
+              <>
+                {/* ── Unified view for clean agents (no tabs) ──────── */}
+                <div
+                  class="routing-section__header routing-section__header--header-tiers"
+                  style="margin-bottom: 16px; flex-direction: row; align-items: center; justify-content: space-between;"
+                >
+                  <div>
+                    <span class="routing-section__subtitle">
+                      Pick one model and up to 5 fallbacks as your default routing.
+                    </span>
+                  </div>
+                  <Show when={(headerTiers() ?? []).length > 0}>
+                    <button
+                      type="button"
+                      class="btn btn--primary btn--sm routing-section__cta"
+                      onClick={() => headerTierOpener?.()}
+                    >
+                      Manage custom routing
+                    </button>
+                  </Show>
+                  <Show when={(headerTiers() ?? []).length === 0}>
+                    <button
+                      type="button"
+                      class="btn btn--primary btn--sm routing-section__cta"
+                      onClick={() => headerTierCreator?.()}
+                    >
+                      Create custom tier
+                    </button>
+                  </Show>
+                </div>
+                <div
+                  class="routing-cards"
+                  classList={{
+                    'routing-cards--unified-compact': !hasCustomTiersEnabled(),
                   }}
-                  onFallbackUpdate={(category, _updatedFallbacks, updatedRoutes) => {
-                    // Optimistic local state mutation only. Persistence is
-                    // handled by RoutingTierCard via persistFallbacks (with
-                    // routes), so a second network call here would race the
-                    // first and drop route metadata for ambiguous models.
-                    if (updatedRoutes === undefined) return;
-                    mutateSpecificity((prev) =>
-                      prev?.map((a) =>
-                        a.category === category ? { ...a, fallback_routes: updatedRoutes } : a,
-                      ),
-                    );
-                  }}
-                  onAddFallback={(category) => setFallbackPickerTier(category)}
-                  responseMode={specificityResponseMode}
-                  changingResponseMode={changingSpecificityResponseMode}
-                  onResponseModeChange={handleSpecificityResponseModeChange}
-                  refetchAll={refetchAll}
-                  refetchSpecificity={() => refetchSpecificity() as unknown as Promise<void>}
-                  embedded
-                  getModelParams={getModelParamsFor}
-                  setModelParams={setModelParamsFor}
-                />
-              ),
-              custom: (
+                >
+                  <RoutingTierCard
+                    stage={DEFAULT_STAGE}
+                    tier={() => actions.getTier('default')}
+                    models={() => models() ?? []}
+                    customProviders={() => customProviders() ?? []}
+                    activeProviders={activeProviders}
+                    tiersLoading={tiers.loading}
+                    changingTier={actions.changingTier}
+                    resettingTier={actions.resettingTier}
+                    resettingAll={actions.resettingAll}
+                    addingFallback={actions.addingFallback}
+                    agentName={agentName}
+                    onDropdownOpen={(tierId) => setDropdownTier(tierId)}
+                    onOverride={handleOverride}
+                    onPinKey={actions.handlePinKey}
+                    onReset={actions.handleReset}
+                    onFallbackUpdate={actions.handleFallbackUpdate}
+                    onAddFallback={(tierId) => setFallbackPickerTier(tierId)}
+                    getFallbacksFor={actions.getFallbacksFor}
+                    connectedProviders={enabledConnectedProviders}
+                    getModelParams={getModelParamsFor}
+                    setModelParams={setModelParamsFor}
+                  />
+                  <For each={(headerTiers() ?? []).filter((t) => t.enabled)}>
+                    {(tier) => (
+                      <HeaderTierCard
+                        agentName={agentName()}
+                        tier={tier}
+                        models={models() ?? []}
+                        customProviders={customProviders() ?? []}
+                        connectedProviders={enabledConnectedProviders()}
+                        onOverride={async (m, p, a, label) => {
+                          try {
+                            await overrideHeaderTier(agentName(), tier.id, m, p, a, label);
+                            await refetchHeaderTiers();
+                          } catch (err) {
+                            toast.error(
+                              err instanceof Error ? err.message : 'Failed to update tier',
+                            );
+                          }
+                        }}
+                        onFallbacksUpdate={(_fallbacks, updatedRoutes) => {
+                          if (updatedRoutes === undefined) {
+                            void refetchHeaderTiers();
+                            return;
+                          }
+                          mutateHeaderTiers((prev) =>
+                            prev?.map((t) =>
+                              t.id === tier.id ? { ...t, fallback_routes: updatedRoutes } : t,
+                            ),
+                          );
+                        }}
+                        onEdit={() => headerTierEditor?.(tier)}
+                        onDisable={async () => {
+                          try {
+                            await toggleHeaderTier(agentName(), tier.id, false);
+                            await refetchHeaderTiers();
+                          } catch (err) {
+                            toast.error(
+                              err instanceof Error ? err.message : 'Failed to toggle tier',
+                            );
+                          }
+                        }}
+                        getModelParams={getModelParamsFor}
+                        setModelParams={setModelParamsFor}
+                      />
+                    )}
+                  </For>
+                  {/* Dashed add-card */}
+                  <button
+                    type="button"
+                    class="routing-card routing-unified-add-card"
+                    onClick={() => headerTierCreator?.()}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="20"
+                      height="20"
+                      fill="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path d="m21,4h-1v-1c0-.55-.45-1-1-1s-1,.45-1,1v1h-1c-.55,0-1,.45-1,1s.45,1,1,1h1v1c0,.55.45,1,1,1s1-.45,1-1v-1h1c.55,0,1-.45,1-1s-.45-1-1-1Z" />
+                      <path d="m3.24,16.5c0,.76.42,1.45,1.11,1.79l5.87,2.93c.56.28,1.18.42,1.79.42s1.23-.14,1.79-.42l5.87-2.93c.68-.34,1.11-1.03,1.11-1.79s-.42-1.45-1.11-1.79l-.42-.21.42-.21c.68-.34,1.11-1.03,1.11-1.79,0-.76-.42-1.45-1.11-1.79l-5.87-2.93c-1.12-.56-2.46-.56-3.58,0l-5.87,2.93c-.68.34-1.11,1.03-1.11,1.79,0,.76.42,1.45,1.11,1.79l.42.21-.42.21c-.68.34-1.11,1.03-1.11,1.79Zm2-4l5.87-2.93c.28-.14.59-.21.89-.21s.61.07.89.21l5.88,2.93-5.88,2.94c-.56.28-1.23.28-1.79,0l-4.11-2.05-1.76-.88Zm4.97,4.72c1.12.56,2.46.56,3.58,0l3.21-1.61,1.77.88-5.88,2.94c-.56.28-1.23.28-1.79,0l-5.87-2.93,1.76-.88,3.21,1.61Z" />
+                    </svg>
+                    <span>Create custom tier</span>
+                  </button>
+                </div>
+                {/* Headless section for modals only */}
                 <RoutingHeaderTiersSection
                   agentName={agentName}
                   models={() => models() ?? []}
@@ -650,13 +699,130 @@ const Routing: Component = () => {
                   externalTiers={() => headerTiers()}
                   externalRefetch={() => void refetchHeaderTiers()}
                   externalMutate={mutateHeaderTiers}
-                  embedded
+                  headless
+                  onOpenRef={(opener) => {
+                    headerTierOpener = opener;
+                  }}
+                  onCreateRef={(opener) => {
+                    headerTierCreator = opener;
+                  }}
+                  onEditRef={(opener) => {
+                    headerTierEditor = opener;
+                  }}
                   getModelParams={getModelParamsFor}
                   setModelParams={setModelParamsFor}
                 />
-              ),
-            }}
-          </RoutingTabs>
+              </>
+            }
+          >
+            <RoutingTabs
+              specificityEnabled={hasAnySpecificityActive}
+              customEnabled={hasCustomTiersEnabled}
+              showSpecificity={legacySpecificityVisible}
+              pipelineHelp={() =>
+                buildPipelineHelp(
+                  hasAnySpecificityActive(),
+                  hasCustomTiersEnabled(),
+                  complexityEnabled(),
+                )
+              }
+            >
+              {{
+                default: (
+                  <RoutingDefaultTierSection
+                    agentName={agentName}
+                    tier={() => actions.getTier('default')}
+                    models={() => models() ?? []}
+                    customProviders={() => customProviders() ?? []}
+                    activeProviders={activeProviders}
+                    connectedProviders={enabledConnectedProviders}
+                    tiersLoading={tiers.loading}
+                    changingTier={actions.changingTier}
+                    resettingTier={actions.resettingTier}
+                    resettingAll={actions.resettingAll}
+                    addingFallback={actions.addingFallback}
+                    onDropdownOpen={(tierId) => setDropdownTier(tierId)}
+                    onOverride={handleOverride}
+                    onPinKey={actions.handlePinKey}
+                    onReset={actions.handleReset}
+                    onFallbackUpdate={actions.handleFallbackUpdate}
+                    onAddFallback={(tierId) => setFallbackPickerTier(tierId)}
+                    getFallbacksFor={actions.getFallbacksFor}
+                    getTier={actions.getTier}
+                    complexityEnabled={complexityEnabled}
+                    togglingComplexity={togglingComplexity}
+                    onToggleComplexity={handleToggleComplexity}
+                    showComplexityToggle={legacyComplexityVisible}
+                    responseMode={defaultResponseMode}
+                    changingResponseMode={changingDefaultResponseMode}
+                    onResponseModeChange={handleDefaultResponseModeChange}
+                    embedded
+                    getModelParams={getModelParamsFor}
+                    setModelParams={setModelParamsFor}
+                  />
+                ),
+                specificity: (
+                  <RoutingSpecificitySection
+                    agentName={agentName}
+                    assignments={specificityAssignments}
+                    models={() => models() ?? []}
+                    customProviders={() => customProviders() ?? []}
+                    activeProviders={activeProviders}
+                    connectedProviders={enabledConnectedProviders}
+                    changingTier={changingSpecificity}
+                    resettingTier={resettingSpecificity}
+                    resettingAll={() => false}
+                    addingFallback={() => null}
+                    onDropdownOpen={(category) => setSpecificityDropdown(category)}
+                    onOverride={handleSpecificityOverride}
+                    onPinKey={handleSpecificityPinKey}
+                    onReset={async (category) => {
+                      setResettingSpecificity(category);
+                      try {
+                        await resetSpecificity(agentName(), category);
+                        await refetchSpecificity();
+                      } catch {
+                        toast.error('Failed to reset');
+                      } finally {
+                        setResettingSpecificity(null);
+                      }
+                    }}
+                    onFallbackUpdate={(category, _updatedFallbacks, updatedRoutes) => {
+                      if (updatedRoutes === undefined) return;
+                      mutateSpecificity((prev) =>
+                        prev?.map((a) =>
+                          a.category === category ? { ...a, fallback_routes: updatedRoutes } : a,
+                        ),
+                      );
+                    }}
+                    onAddFallback={(category) => setFallbackPickerTier(category)}
+                    responseMode={specificityResponseMode}
+                    changingResponseMode={changingSpecificityResponseMode}
+                    onResponseModeChange={handleSpecificityResponseModeChange}
+                    refetchAll={refetchAll}
+                    refetchSpecificity={() => refetchSpecificity() as unknown as Promise<void>}
+                    embedded
+                    getModelParams={getModelParamsFor}
+                    setModelParams={setModelParamsFor}
+                  />
+                ),
+                custom: (
+                  <RoutingHeaderTiersSection
+                    agentName={agentName}
+                    models={() => models() ?? []}
+                    customProviders={() => customProviders() ?? []}
+                    connectedProviders={enabledConnectedProviders}
+                    externalTiers={() => headerTiers()}
+                    externalRefetch={() => void refetchHeaderTiers()}
+                    externalMutate={mutateHeaderTiers}
+                    embedded
+                    getModelParams={getModelParamsFor}
+                    setModelParams={setModelParamsFor}
+                  />
+                ),
+              }}
+            </RoutingTabs>
+          </Show>
 
           <RoutingFooter
             hasOverrides={hasOverrides}

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -43,6 +43,28 @@ export interface RoutingHeaderTiersSectionProps {
   externalRefetch?: () => void;
   externalMutate?: (mutator: (prev: HeaderTier[] | undefined) => HeaderTier[] | undefined) => void;
   embedded?: boolean;
+  /**
+   * When true, the section renders only its modals (manage, create/edit,
+   * snippet) without the card grid or header. The parent is responsible for
+   * rendering the cards and triggering modal opens via the `onOpenRef`
+   * callback. Used by the unified routing view for clean agents.
+   */
+  headless?: boolean;
+  /**
+   * Called once with an opener function the parent can use to trigger the
+   * manage-or-create modal. Only meaningful when `headless` is true.
+   */
+  onOpenRef?: (opener: () => void) => void;
+  /**
+   * Called once with a function to open the create modal directly.
+   * Only meaningful when `headless` is true.
+   */
+  onCreateRef?: (opener: () => void) => void;
+  /**
+   * Called once with a function to open the edit modal for a specific tier.
+   * Only meaningful when `headless` is true.
+   */
+  onEditRef?: (opener: (tier: HeaderTier) => void) => void;
   getModelParams?: (
     scope: string,
     provider: string,
@@ -171,6 +193,11 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
       setModalTier('new');
     }
   };
+
+  // Expose openers to the parent for headless mode.
+  if (props.onOpenRef) props.onOpenRef(openCreateOrManage);
+  if (props.onCreateRef) props.onCreateRef(() => setModalTier('new'));
+  if (props.onEditRef) props.onEditRef((tier) => setModalTier(tier));
 
   const handleDeleteFromEdit = async (id: string) => {
     await handleDelete(id);
@@ -366,6 +393,149 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
       </Show>
     </>
   );
+
+  if (props.headless) {
+    // Headless mode: render only the modals, no cards or header.
+    // The parent renders cards and triggers openCreateOrManage via onOpenRef.
+    return (
+      <>
+        {/* ── Manage custom routing modal ──────────────────── */}
+        <Show when={manageOpen()}>
+          <div
+            class="modal-overlay"
+            onClick={(e) => {
+              if (e.target === e.currentTarget) setManageOpen(false);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setManageOpen(false);
+            }}
+          >
+            <div
+              class="modal-card header-tier-manage-modal"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="manage-tiers-title"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h2 id="manage-tiers-title" class="specificity-modal__title">
+                Manage custom routing
+              </h2>
+              <p class="specificity-modal__desc">
+                Toggle tiers on or off. Create new tiers or edit them directly on their card.
+              </p>
+              <div class="specificity-modal__list">
+                <For each={tiers()}>
+                  {(tier) => {
+                    const loading = () => toggling() === tier.id;
+                    const toggle = () => {
+                      if (!loading()) handleToggle(tier.id, !tier.enabled);
+                    };
+                    return (
+                      <div
+                        class="specificity-modal__row"
+                        role="button"
+                        tabIndex={0}
+                        aria-pressed={tier.enabled}
+                        style="cursor: pointer;"
+                        onClick={toggle}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            toggle();
+                          }
+                        }}
+                      >
+                        <div class="specificity-modal__info">
+                          <span class="specificity-modal__name">{tier.name}</span>
+                          <span class="specificity-modal__stage-desc">
+                            {tier.header_key}: {tier.header_value}
+                          </span>
+                        </div>
+                        <span
+                          class="specificity-modal__toggle"
+                          classList={{
+                            'specificity-modal__toggle--on': tier.enabled,
+                          }}
+                          aria-hidden="true"
+                        >
+                          <Show
+                            when={loading()}
+                            fallback={<span class="specificity-modal__toggle-thumb" />}
+                          >
+                            <span class="specificity-modal__toggle-thumb">
+                              <span class="spinner" style="width: 10px; height: 10px;" />
+                            </span>
+                          </Show>
+                        </span>
+                      </div>
+                    );
+                  }}
+                </For>
+              </div>
+              <div class="header-tier-manage__footer">
+                <button
+                  type="button"
+                  class="btn btn--outline header-tier-manage__create-btn"
+                  onClick={() => {
+                    setManageOpen(false);
+                    setModalTier('new');
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path d="m21,4h-1v-1c0-.55-.45-1-1-1s-1,.45-1,1v1h-1c-.55,0-1,.45-1,1s.45,1,1,1h1v1c0,.55.45,1,1,1s1-.45,1-1v-1h1c.55,0,1-.45,1-1s-.45-1-1-1Z" />
+                    <path d="m3.24,16.5c0,.76.42,1.45,1.11,1.79l5.87,2.93c.56.28,1.18.42,1.79.42s1.23-.14,1.79-.42l5.87-2.93c.68-.34,1.11-1.03,1.11-1.79s-.42-1.45-1.11-1.79l-.42-.21.42-.21c.68-.34,1.11-1.03,1.11-1.79,0-.76-.42-1.45-1.11-1.79l-5.87-2.93c-1.12-.56-2.46-.56-3.58,0l-5.87,2.93c-.68.34-1.11,1.03-1.11,1.79,0,.76.42,1.45,1.11,1.79l.42.21-.42.21c-.68.34-1.11,1.03-1.11,1.79Zm2-4l5.87-2.93c.28-.14.59-.21.89-.21s.61.07.89.21l5.88,2.93-5.88,2.94c-.56.28-1.23.28-1.79,0l-4.11-2.05-1.76-.88Zm4.97,4.72c1.12.56,2.46.56,3.58,0l3.21-1.61,1.77.88-5.88,2.94c-.56.28-1.23.28-1.79,0l-5.87-2.93,1.76-.88,3.21,1.61Z" />
+                  </svg>
+                  Create new tier
+                </button>
+                <button class="btn btn--primary" onClick={() => setManageOpen(false)}>
+                  Done
+                </button>
+              </div>
+            </div>
+          </div>
+        </Show>
+
+        {/* ── Create / Edit modal ────────────────────────── */}
+        <Show when={modalTier()} keyed>
+          {(state) => (
+            <Suspense fallback={null}>
+              <HeaderTierModal
+                agentName={props.agentName()}
+                existingTiers={tiers()}
+                editing={state === 'new' ? undefined : state}
+                models={props.models()}
+                onClose={() => setModalTier(null)}
+                onSaved={(saved) => {
+                  const wasCreate = state === 'new';
+                  setModalTier(null);
+                  refetch();
+                  if (wasCreate) setSnippetTier(saved);
+                }}
+                onDelete={state !== 'new' ? handleDeleteFromEdit : undefined}
+              />
+            </Suspense>
+          )}
+        </Show>
+
+        <Show when={snippetTier()} keyed>
+          {(t) => (
+            <HeaderTierSnippetModal
+              agentName={props.agentName()}
+              tier={t}
+              onClose={() => setSnippetTier(null)}
+            />
+          )}
+        </Show>
+      </>
+    );
+  }
 
   if (props.embedded) {
     return (

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -192,14 +192,49 @@
   margin: 0 auto;
 }
 
+.routing-cards--unified-compact {
+  grid-template-columns: repeat(2, minmax(280px, 340px));
+  justify-content: center;
+}
+
 .routing-cards-backdrop {
   padding: 16px;
   background: hsl(var(--muted) / 0.45);
   border-radius: var(--radius);
 }
 
+/* ── Dashed add-card for unified routing view ────────── */
+.routing-card.routing-unified-add-card {
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1.5px dashed hsl(var(--border));
+  background: transparent;
+  cursor: pointer;
+  color: hsl(var(--muted-foreground));
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  transition:
+    border-color 0.15s,
+    color 0.15s,
+    background 0.15s;
+}
+
+.dark .routing-card.routing-unified-add-card {
+  background: transparent;
+}
+
+.routing-card.routing-unified-add-card:hover {
+  border-color: hsl(var(--primary));
+  color: hsl(var(--primary));
+  background: hsl(var(--primary) / 0.04);
+}
+
 @media (max-width: 700px) {
-  .routing-cards--centered {
+  .routing-cards--centered,
+  .routing-cards--unified-compact {
+    grid-template-columns: 1fr;
     max-width: 100%;
     min-width: 0;
   }

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -837,7 +837,11 @@ describe('Routing page', () => {
   });
 
   it('updates the default response mode for the default tier', async () => {
+    // Ensure legacy path (tabbed view) by providing a non-default tier override
     mockGetComplexityStatus.mockResolvedValue({ enabled: false });
+    mockGetTierAssignments.mockResolvedValue([
+      { tier: 'simple', override_route: { model: 'm', provider: 'p' } },
+    ]);
     render(() => <Routing />);
     await waitFor(() => {
       expect(screen.getByTestId('default-response-stream')).toBeDefined();
@@ -851,6 +855,9 @@ describe('Routing page', () => {
 
   it('shows buffered copy when default response mode is set back to buffered', async () => {
     mockGetComplexityStatus.mockResolvedValue({ enabled: false });
+    mockGetTierAssignments.mockResolvedValue([
+      { tier: 'simple', override_route: { model: 'm', provider: 'p' } },
+    ]);
     render(() => <Routing />);
     await waitFor(() => {
       expect(screen.getByTestId('default-response-buffered')).toBeDefined();
@@ -864,6 +871,9 @@ describe('Routing page', () => {
 
   it('toasts the API error when default response mode update fails', async () => {
     mockGetComplexityStatus.mockResolvedValue({ enabled: false });
+    mockGetTierAssignments.mockResolvedValue([
+      { tier: 'simple', override_route: { model: 'm', provider: 'p' } },
+    ]);
     mockSetTierResponseMode.mockRejectedValue(new Error('response boom'));
     render(() => <Routing />);
     await waitFor(() => {
@@ -877,6 +887,9 @@ describe('Routing page', () => {
 
   it('inherits streaming mode when complexity routing is enabled from a streamed default tier', async () => {
     mockGetComplexityStatus.mockResolvedValue({ enabled: false });
+    mockGetTierAssignments.mockResolvedValue([
+      { tier: 'simple', override_route: { model: 'm', provider: 'p' } },
+    ]);
     mockToggleComplexity.mockResolvedValue({ enabled: true });
     mockActionGetTier.mockImplementation((tier: string) =>
       tier === 'default' ? { tier: 'default', response_mode: 'stream' } : undefined,


### PR DESCRIPTION
## ✨ What changed
- Clean agents now see a single flat layout instead of separate Default and Custom tabs
- Default tier card and custom header tier cards render in one responsive grid
- A dashed "add" card sits in the grid as a CTA to create new custom tiers
- Header row shows "Create custom tier" or "Manage custom routing" button depending on state
- Legacy agents (with complexity or task-specific config) keep the existing tabbed interface

## 💭 Why
Clean agents only had two tabs (Default and Custom) which added unnecessary navigation for a simple setup. Merging them into one view makes the routing page feel lighter and more direct for new agents.

## 👤 For users
New or unconfigured agents see all their routing tiers on a single page without tab switching. Creating and managing custom tiers works the same way, just without the extra click to switch tabs.

## 🔧 For operators
No operator impact.

## 🧪 How to test
1. Log in as `newuser@manifest.build` / `manifest` (clean cohort)
2. Go to the Routing page: no tabs, default card + dashed "Create custom tier" card side by side
3. Click the dashed card or the header button: create tier modal opens directly
4. Create a custom tier: it appears in the grid, header button switches to "Manage custom routing"
5. Log in as `admin@manifest.build` / `manifest`: existing tabbed view unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the routing page for clean agents by merging the Default and Custom tabs into a single grid view for quicker editing. Legacy agents keep the current tabbed UI.

- **New Features**
  - Single flat layout for clean agents: default tier card plus enabled custom header tier cards in one responsive grid.
  - Dashed “Create custom tier” add-card and a header CTA that switches between “Create custom tier” and “Manage custom routing.”
  - Headless mode for `RoutingHeaderTiersSection` exposes openers so the unified view can trigger manage/create/edit modals from the grid.
  - Integrated header tier actions (override, toggle, delete) with optimistic fallback route updates and refetch on change.

<sup>Written for commit fdab4020a02f410b91e0a415555e05aee02530d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

