### PR TITLE
ci: stop schema-diff failing on migration PRs

### DIFF
--- a/.github/workflows/db-diagram.yml
+++ b/.github/workflows/db-diagram.yml
@@ -80,15 +80,21 @@ jobs:
             -- packages/backend/src/database/migrations/ > /tmp/changed-migrations.txt
           cat /tmp/changed-migrations.txt
 
-      - name: Swap migrations dir to base ref
-        run: |
-          rm -rf packages/backend/src/database/migrations
-          git checkout "$BASE_SHA" -- packages/backend/src/database/migrations/
-
-      - name: Run BASE migrations
+      - name: Run BASE migrations (clean base checkout)
         env:
           DATABASE_URL: ${{ env.BASE_DB_URL }}
-        run: npm run migration:run --workspace=packages/backend
+        run: |
+          # Build the base schema from a clean checkout of the base commit so the
+          # whole database definition (data-source-definitions.ts + entities +
+          # migrations) stays internally consistent. Swapping only the migrations
+          # directory breaks once migrations are imported explicitly
+          # (data-source-definitions.ts) or when a PR adds/removes entities.
+          # Reuse the already-installed HEAD node_modules: dependency versions do
+          # not change across the few commits in a PR range.
+          git worktree add --detach /tmp/base-tree "$BASE_SHA"
+          ln -s "$GITHUB_WORKSPACE/node_modules" /tmp/base-tree/node_modules
+          cd /tmp/base-tree
+          npm run migration:run --workspace=packages/backend
 
       - name: Extract BASE schema
         env:


### PR DESCRIPTION
### 💭 Why
The DB-diagram schema-diff check fails on every migration PR. It builds the base schema by swapping just the migrations folder to the base ref but keeps HEAD's `data-source-definitions.ts`, which now imports each migration explicitly. The base run then can't find the new migration file, and it breaks further on PRs that add or remove entities.

### ✨ What changed
- Run the base migrations from a clean `git worktree` at the base commit, so `data-source-definitions.ts`, entities, and migrations all sit at the base ref and stay consistent.
- Drop the partial "swap migrations dir to base ref" step.

### 📝 Notes
This workflow only runs on PRs that touch `migrations/`, so this PR can't exercise it directly. Validated locally: base migrations from a base worktree apply cleanly with zero module-not-found errors (28 tables). It goes green on the next migration PR (for example #2317's schema-diff once this lands).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI schema-diff failures on migration PRs by building the base schema from a clean checkout at the base commit. Keeps `data-source-definitions.ts`, entities, and migrations aligned to avoid module-not-found errors.

- **Bug Fixes**
  - Run base migrations from a `git worktree` at `$BASE_SHA` instead of swapping only the migrations directory.
  - Reuse HEAD `node_modules` via symlink and run `npm run migration:run --workspace=packages/backend` in the base worktree for a consistent base schema even when entities change or migrations are imported explicitly.

<sup>Written for commit 6d0443cbe162c92b86f1ca6f6050c3f60e4781d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

