### PR TITLE
perf: index cross-tenant error scans to stop DB saturation

### DIFF
--- a/.changeset/cross-tenant-error-index.md
+++ b/.changeset/cross-tenant-error-index.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add a timestamp-leading partial index for cross-tenant error scans. The Cloud control plane's hourly error-insights rollup scans agent_messages by time window across all tenants, but the only error index was tenant-leading — so each run scanned every error row ever recorded (cost growing with total accumulated errors), which turned into multi-minute scans that saturated the database. A timestamp-leading partial index over error rows turns those into windowed range scans (measured 110ms/29k buffers down to 2ms/274 buffers on ~2M error rows). The index stays partial so write amplification on ingest is negligible.

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -125,6 +125,7 @@ import { TuneAgentMessagesAutovacuum1792900000000 } from './migrations/179290000
 import { AddTenantProviderValueIndex1793000000000 } from './migrations/1793000000000-AddTenantProviderValueIndex';
 import { DropRedundantTenantAgentNameIndex1793100000000 } from './migrations/1793100000000-DropRedundantTenantAgentNameIndex';
 import { AddDashboardCoveringIndex1793200000000 } from './migrations/1793200000000-AddDashboardCoveringIndex';
+import { AddCrossTenantErrorTimestampIndex1795100000000 } from './migrations/1795100000000-AddCrossTenantErrorTimestampIndex';
 import { RemoveMessageRecording1795000000000 } from './migrations/1795000000000-RemoveMessageRecording';
 
 export const entities = [
@@ -254,4 +255,5 @@ export const migrations = [
   DropRedundantTenantAgentNameIndex1793100000000,
   AddDashboardCoveringIndex1793200000000,
   RemoveMessageRecording1795000000000,
+  AddCrossTenantErrorTimestampIndex1795100000000,
 ];

--- a/packages/backend/src/database/migrations/1795100000000-AddCrossTenantErrorTimestampIndex.ts
+++ b/packages/backend/src/database/migrations/1795100000000-AddCrossTenantErrorTimestampIndex.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Timestamp-leading partial index over error rows, for CROSS-TENANT error scans
+ * by time window (the Manifest Cloud control plane's hourly error-insights
+ * rollup: `WHERE timestamp >= $1 AND timestamp < $2 AND status IN (errors)`,
+ * with no tenant filter).
+ *
+ * The existing IDX_agent_messages_errors is `(tenant_id, timestamp) WHERE
+ * status IN (...)` — tenant-leading, so a tenant-less time-window query can't
+ * range-scan it and instead scans EVERY error row ever recorded (cost grows with
+ * total accumulated errors). Measured on ~2M error rows: 110ms / 29k buffers,
+ * and it only gets worse as errors pile up — this was the source of multi-minute
+ * (up to ~5h) scans saturating the prod DB. This timestamp-leading copy turns it
+ * into a windowed range scan (2ms / 274 buffers, constant in total errors).
+ *
+ * Kept partial (errors are a small fraction of rows) so the write-amplification
+ * on the hot ingest path stays negligible. The per-tenant IDX_agent_messages_errors
+ * stays for the dashboard's tenant-scoped error views.
+ *
+ * Built CONCURRENTLY (so `transaction = false`) to avoid the ACCESS EXCLUSIVE
+ * lock that deadlocks against live writes during a deploy.
+ */
+export class AddCrossTenantErrorTimestampIndex1795100000000 implements MigrationInterface {
+  name = 'AddCrossTenantErrorTimestampIndex1795100000000';
+  transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Clear any invalid leftover from an interrupted CONCURRENTLY build, since
+    // CREATE ... IF NOT EXISTS would otherwise skip over an invalid index.
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_errors_timestamp"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_errors_timestamp" ON "agent_messages" ("timestamp") WHERE "status" IN ('error', 'fallback_error', 'rate_limited')`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_errors_timestamp"`,
+    );
+  }
+}


### PR DESCRIPTION
### 💭 Why
The Cloud control plane (Peacock) runs an hourly error-insights rollup that scans `agent_messages` by time window **across all tenants** (no tenant filter). The only error index, `IDX_agent_messages_errors`, is `(tenant_id, timestamp) WHERE status IN (...)` — tenant-leading, so a tenant-less time-window query can't range-scan it and instead scans **every error row ever recorded**. Cost grows with total accumulated errors, so it degraded into multi-minute (up to ~5 h) scans that saturated the prod DB and stalled deploys. This is a dominant, previously-invisible source of the dashboard slowness.

### ✨ What changed
- Add `IDX_agent_messages_errors_timestamp` — `(timestamp) WHERE status IN ('error','fallback_error','rate_limited')`. Timestamp-leading, so cross-tenant time-window error scans become range scans.
- Partial (errors are a small fraction of rows) so ingest write amplification stays negligible. The per-tenant `IDX_agent_messages_errors` stays for the dashboard's tenant-scoped error views.
- Built CONCURRENTLY (`transaction = false`) like the other `agent_messages` index migrations.

### 🔧 For operators
No config change. The migration runs in the pre-deploy step (CONCURRENTLY, non-blocking).

### 📝 Notes
Measured locally on ~2M error rows: the error-window scan drops from 110 ms / 29k buffers to **2 ms / 274 buffers**, and the full rollup from minutes to ~30 ms — and unlike the old index it no longer degrades as errors accumulate. Paired with a `statement_timeout` backstop on Peacock's prod connection (separate PR in mnfst/peacock). Full unit (6679) + e2e (301) pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a timestamp-leading partial index on `agent_messages` error rows to make cross-tenant time-window scans fast range scans. This cuts the hourly error rollup from minutes to milliseconds and prevents DB saturation.

- **Migration**
  - Creates `IDX_agent_messages_errors_timestamp` on `"agent_messages"("timestamp") WHERE status IN ('error','fallback_error','rate_limited')` (partial).
  - Runs CONCURRENTLY with `transaction = false`; drops any invalid leftover before create.
  - Keeps existing per-tenant `IDX_agent_messages_errors`; no config changes required.

<sup>Written for commit 88a85907ce7bd3f9511578b218b8f521e3545cf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

