### PR TITLE
feat: auto-heal recoverable provider errors and retry

### DIFF
--- a/.changeset/request-healing.md
+++ b/.changeset/request-healing.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add per-agent request healing. On a request-side 4xx (deprecated model, bad param, tool/message shape), Manifest asks the Healing service for deterministic catalog operations, applies them, and retries the same provider before falling back. Opt-in per agent via a dashboard toggle, and inert until HEALING_API_URL is set. The healer only ever receives a structural request plus the error, never provider keys or prompt content.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MIT",
       "workspaces": [
         "packages/shared",
+        "packages/healing-engine",
         "packages/frontend",
         "packages/backend",
         "packages/manifest"
@@ -490,7 +491,7 @@
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.3",
@@ -502,7 +503,7 @@
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
       "version": "10.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
@@ -1372,7 +1373,7 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1390,7 +1391,7 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "2.1.4",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1412,7 +1413,7 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1438,7 +1439,7 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1459,7 +1460,7 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1482,6 +1483,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1498,6 +1500,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1514,6 +1517,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1530,6 +1534,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1546,6 +1551,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1562,6 +1568,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1578,6 +1585,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1594,6 +1602,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1610,6 +1619,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1626,6 +1636,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1642,6 +1653,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1658,6 +1670,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1674,6 +1687,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1690,6 +1704,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1706,6 +1721,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1722,6 +1738,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1736,6 +1753,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1752,6 +1770,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1768,6 +1787,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1784,6 +1804,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1800,6 +1821,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1816,6 +1838,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1832,6 +1855,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1848,6 +1872,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1864,6 +1889,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1880,6 +1906,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2651,7 +2678,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2677,7 +2704,7 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2691,7 +2718,7 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3951,6 +3978,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3964,6 +3992,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3977,6 +4006,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3990,6 +4020,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4003,6 +4034,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4016,6 +4048,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4029,6 +4062,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4042,6 +4076,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4055,6 +4090,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4068,6 +4104,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4081,6 +4118,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4094,6 +4132,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4107,6 +4146,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4120,6 +4160,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4133,6 +4174,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4146,6 +4188,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4157,6 +4200,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4168,6 +4212,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4181,6 +4226,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4194,6 +4240,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4207,6 +4254,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4220,6 +4268,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4233,6 +4282,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4246,6 +4296,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5303,7 +5354,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -6479,7 +6530,7 @@
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
@@ -6495,7 +6546,7 @@
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
@@ -6526,7 +6577,7 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6952,6 +7003,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6968,6 +7020,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6984,6 +7037,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7000,6 +7054,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7016,6 +7071,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7032,6 +7088,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7048,6 +7105,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7064,6 +7122,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7080,6 +7139,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7096,6 +7156,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7112,6 +7173,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7128,6 +7190,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7144,6 +7207,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7160,6 +7224,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7176,6 +7241,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7192,6 +7258,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7208,6 +7275,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7224,6 +7292,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7240,6 +7309,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7256,6 +7326,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7272,6 +7343,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7288,6 +7360,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7304,6 +7377,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7320,6 +7394,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7336,6 +7411,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8218,6 +8294,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8509,7 +8586,7 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
@@ -8579,7 +8656,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -8591,7 +8668,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -8828,7 +8905,7 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -9916,7 +9993,7 @@
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.2.1",
@@ -10364,6 +10441,10 @@
       "resolved": "packages/frontend",
       "link": true
     },
+    "node_modules/manifest-healing-engine": {
+      "resolved": "packages/healing-engine",
+      "link": true
+    },
     "node_modules/manifest-shared": {
       "resolved": "packages/shared",
       "link": true
@@ -10726,7 +10807,7 @@
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -10958,7 +11039,7 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -10969,7 +11050,7 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11355,7 +11436,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11700,6 +11781,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11728,7 +11810,7 @@
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -11784,7 +11866,7 @@
     },
     "node_modules/saxes": {
       "version": "6.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -12445,7 +12527,7 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -12477,7 +12559,7 @@
     },
     "node_modules/terser": {
       "version": "5.46.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -12587,12 +12669,12 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map": {
       "version": "0.6.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -12600,7 +12682,7 @@
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -12727,7 +12809,7 @@
     },
     "node_modules/tldts": {
       "version": "6.1.86",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
@@ -12738,7 +12820,7 @@
     },
     "node_modules/tldts-core": {
       "version": "6.1.86",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -12794,7 +12876,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
@@ -12805,7 +12887,7 @@
     },
     "node_modules/tr46": {
       "version": "5.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -13310,7 +13392,7 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -13547,6 +13629,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13600,7 +13683,7 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -13639,7 +13722,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -13790,7 +13873,7 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -13801,7 +13884,7 @@
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13812,7 +13895,7 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13820,7 +13903,7 @@
     },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
@@ -13997,7 +14080,7 @@
     },
     "node_modules/ws": {
       "version": "8.20.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -14017,7 +14100,7 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -14025,7 +14108,7 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
@@ -14049,7 +14132,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -14144,6 +14227,7 @@
         "eventsource-parser": "^3.1.0",
         "express-rate-limit": "^8.5.1",
         "helmet": "^8.1.0",
+        "manifest-healing-engine": "*",
         "manifest-shared": "*",
         "pg": "^8.13.0",
         "react": "^19.2.4",
@@ -14423,7 +14507,7 @@
     },
     "packages/frontend/node_modules/@types/node": {
       "version": "22.19.15",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -14910,8 +14994,18 @@
         }
       }
     },
+    "packages/healing-engine": {
+      "name": "manifest-healing-engine",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.6",
+        "typescript": "^5.7.3"
+      }
+    },
     "packages/manifest": {
-      "version": "6.9.2"
+      "version": "6.11.0"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "packageManager": "npm@10.9.2",
   "workspaces": [
     "packages/shared",
+    "packages/healing-engine",
     "packages/frontend",
     "packages/backend",
     "packages/manifest"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "manifest-shared": "*",
+    "manifest-healing-engine": "*",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.0",

--- a/packages/backend/src/config/app.config.ts
+++ b/packages/backend/src/config/app.config.ts
@@ -44,4 +44,9 @@ export const appConfig = registerAs('app', () => ({
   // When true, /api/v1/public/* endpoints expose aggregate stats without auth.
   // Off by default — only Manifest Cloud's marketing homepage should enable it.
   publicStatsEnabled: process.env['MANIFEST_PUBLIC_STATS'] === 'true',
+  // Request-healing service (advisory). When HEALING_API_URL is set, the proxy
+  // asks it for a fix on a request-side 4xx, for agents that have healing enabled.
+  healingApiUrl: process.env['HEALING_API_URL'] ?? '',
+  healingApiToken: process.env['HEALING_API_TOKEN'] ?? '',
+  healingTimeoutMs: Number(process.env['HEALING_TIMEOUT_MS'] ?? 3000),
 }));

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -23,6 +23,7 @@ import { PlaygroundRun } from '../entities/playground-run.entity';
 import { PlaygroundColumn } from '../entities/playground-column.entity';
 import { ReasoningContentCacheEntry } from '../entities/reasoning-content-cache-entry.entity';
 import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
+import { AgentHealingEnabled } from '../entities/agent-healing-enabled.entity';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -126,6 +127,7 @@ import { AddTenantProviderValueIndex1793000000000 } from './migrations/179300000
 import { DropRedundantTenantAgentNameIndex1793100000000 } from './migrations/1793100000000-DropRedundantTenantAgentNameIndex';
 import { AddDashboardCoveringIndex1793200000000 } from './migrations/1793200000000-AddDashboardCoveringIndex';
 import { AddCrossTenantErrorTimestampIndex1795100000000 } from './migrations/1795100000000-AddCrossTenantErrorTimestampIndex';
+import { AddAgentHealingEnabled1796000000000 } from './migrations/1796000000000-AddAgentHealingEnabled';
 import { RemoveMessageRecording1795000000000 } from './migrations/1795000000000-RemoveMessageRecording';
 
 export const entities = [
@@ -148,6 +150,7 @@ export const entities = [
   PlaygroundColumn,
   ReasoningContentCacheEntry,
   AgentEnabledProvider,
+  AgentHealingEnabled,
   BackfillState,
 ];
 
@@ -256,4 +259,5 @@ export const migrations = [
   AddDashboardCoveringIndex1793200000000,
   RemoveMessageRecording1795000000000,
   AddCrossTenantErrorTimestampIndex1795100000000,
+  AddAgentHealingEnabled1796000000000,
 ];

--- a/packages/backend/src/database/migrations/1796000000000-AddAgentHealingEnabled.ts
+++ b/packages/backend/src/database/migrations/1796000000000-AddAgentHealingEnabled.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Per-agent request-healing activation. Presence of a row = healing enabled for
+ * that agent (same model as `agent_enabled_providers`). CASCADE on agent delete.
+ */
+export class AddAgentHealingEnabled1796000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "agent_healing_enabled" (
+        "agent_id" varchar NOT NULL,
+        CONSTRAINT "PK_agent_healing_enabled" PRIMARY KEY ("agent_id"),
+        CONSTRAINT "FK_agent_healing_enabled_agent" FOREIGN KEY ("agent_id")
+          REFERENCES "agents" ("id") ON DELETE CASCADE
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "agent_healing_enabled"`);
+  }
+}

--- a/packages/backend/src/entities/agent-healing-enabled.entity.ts
+++ b/packages/backend/src/entities/agent-healing-enabled.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Agent } from './agent.entity';
+
+/**
+ * Per-agent activation of request healing. Presence of a row means healing is
+ * enabled for that agent; no row means disabled. Mirrors the
+ * `agent_enabled_providers` junction (toggled in the UI), minus the provider
+ * dimension since healing is a single feature.
+ */
+@Entity('agent_healing_enabled')
+export class AgentHealingEnabled {
+  @PrimaryColumn('varchar')
+  agent_id!: string;
+
+  @ManyToOne(() => Agent, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'agent_id' })
+  agent!: Agent;
+}

--- a/packages/backend/src/healing/agent-healing.controller.spec.ts
+++ b/packages/backend/src/healing/agent-healing.controller.spec.ts
@@ -1,0 +1,80 @@
+import { HttpException } from '@nestjs/common';
+import { AgentHealingController } from './agent-healing.controller';
+import type { TenantContext } from '../common/decorators/tenant-context.decorator';
+
+describe('AgentHealingController', () => {
+  let healingRepo: { findOne: jest.Mock; delete: jest.Mock; createQueryBuilder: jest.Mock };
+  let agentRepo: { findOne: jest.Mock };
+  let controller: AgentHealingController;
+  const execute = jest.fn().mockResolvedValue(undefined);
+  const qb = {
+    insert: jest.fn().mockReturnThis(),
+    into: jest.fn().mockReturnThis(),
+    values: jest.fn().mockReturnThis(),
+    orIgnore: jest.fn().mockReturnThis(),
+    execute,
+  };
+  const ctx = (tenantId: string | null = 'tenant-1') => ({ tenantId }) as TenantContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    healingRepo = {
+      findOne: jest.fn(),
+      delete: jest.fn().mockResolvedValue(undefined),
+      createQueryBuilder: jest.fn(() => qb),
+    };
+    agentRepo = { findOne: jest.fn() };
+    controller = new AgentHealingController(healingRepo as never, agentRepo as never);
+  });
+
+  describe('status', () => {
+    it('returns enabled:true when an activation row exists', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1' });
+      healingRepo.findOne.mockResolvedValue({ agent_id: 'agent-1' });
+      expect(await controller.status(ctx(), 'My Agent')).toEqual({ enabled: true });
+    });
+
+    it('returns enabled:false when no row exists', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1' });
+      healingRepo.findOne.mockResolvedValue(null);
+      expect(await controller.status(ctx(), 'My Agent')).toEqual({ enabled: false });
+    });
+
+    it('returns enabled:false without a tenant', async () => {
+      expect(await controller.status(ctx(null), 'a')).toEqual({ enabled: false });
+      expect(agentRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns enabled:false when the agent is unknown', async () => {
+      agentRepo.findOne.mockResolvedValue(null);
+      expect(await controller.status(ctx(), 'a')).toEqual({ enabled: false });
+    });
+  });
+
+  describe('enable', () => {
+    it('inserts an activation row for a known agent', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1' });
+      expect(await controller.enable(ctx(), 'a')).toEqual({ ok: true });
+      expect(qb.values).toHaveBeenCalledWith({ agent_id: 'agent-1' });
+      expect(execute).toHaveBeenCalled();
+    });
+
+    it('404s for an unknown agent', async () => {
+      agentRepo.findOne.mockResolvedValue(null);
+      await expect(controller.enable(ctx(), 'a')).rejects.toThrow(HttpException);
+    });
+  });
+
+  describe('disable', () => {
+    it('deletes the activation row for a known agent', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1' });
+      expect(await controller.disable(ctx(), 'a')).toEqual({ ok: true });
+      expect(healingRepo.delete).toHaveBeenCalledWith({ agent_id: 'agent-1' });
+    });
+
+    it('404s for an unknown agent', async () => {
+      agentRepo.findOne.mockResolvedValue(null);
+      await expect(controller.disable(ctx(), 'a')).rejects.toThrow(HttpException);
+    });
+  });
+});

--- a/packages/backend/src/healing/agent-healing.controller.ts
+++ b/packages/backend/src/healing/agent-healing.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, Delete, Get, HttpException, HttpStatus, Param, Put } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TenantCtx, TenantContext } from '../common/decorators/tenant-context.decorator';
+import { Agent } from '../entities/agent.entity';
+import { AgentHealingEnabled } from '../entities/agent-healing-enabled.entity';
+
+/**
+ * Per-agent healing activation, toggled from the dashboard. Mirrors
+ * `agent-enabled-providers.controller`: presence of a row = enabled.
+ */
+@Controller('api/v1/agents/:agentName/healing')
+export class AgentHealingController {
+  constructor(
+    @InjectRepository(AgentHealingEnabled)
+    private readonly healingRepo: Repository<AgentHealingEnabled>,
+    @InjectRepository(Agent)
+    private readonly agentRepo: Repository<Agent>,
+  ) {}
+
+  private resolveAgent(agentName: string, tenantId: string | null) {
+    if (!tenantId) return null;
+    return this.agentRepo.findOne({
+      where: { name: decodeURIComponent(agentName), tenant_id: tenantId, is_playground: false },
+    });
+  }
+
+  @Get()
+  async status(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
+    const agent = await this.resolveAgent(agentName, ctx.tenantId);
+    if (!agent) return { enabled: false };
+    const row = await this.healingRepo.findOne({ where: { agent_id: agent.id } });
+    return { enabled: Boolean(row) };
+  }
+
+  @Put()
+  async enable(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
+    const agent = await this.resolveAgent(agentName, ctx.tenantId);
+    if (!agent) throw new HttpException('Agent not found', HttpStatus.NOT_FOUND);
+    await this.healingRepo
+      .createQueryBuilder()
+      .insert()
+      .into(AgentHealingEnabled)
+      .values({ agent_id: agent.id })
+      .orIgnore()
+      .execute();
+    return { ok: true };
+  }
+
+  @Delete()
+  async disable(@TenantCtx() ctx: TenantContext, @Param('agentName') agentName: string) {
+    const agent = await this.resolveAgent(agentName, ctx.tenantId);
+    if (!agent) throw new HttpException('Agent not found', HttpStatus.NOT_FOUND);
+    await this.healingRepo.delete({ agent_id: agent.id });
+    return { ok: true };
+  }
+}

--- a/packages/backend/src/healing/healing.module.ts
+++ b/packages/backend/src/healing/healing.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Agent } from '../entities/agent.entity';
+import { AgentHealingEnabled } from '../entities/agent-healing-enabled.entity';
+import { AgentHealingController } from './agent-healing.controller';
+import { HealingService } from './healing.service';
+
+/**
+ * Request healing: the per-agent activation API + the advisory client the proxy
+ * uses on a request-side 4xx. Exports HealingService for ProxyModule to inject.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([AgentHealingEnabled, Agent])],
+  controllers: [AgentHealingController],
+  providers: [HealingService],
+  exports: [HealingService],
+})
+export class HealingModule {}

--- a/packages/backend/src/healing/healing.service.spec.ts
+++ b/packages/backend/src/healing/healing.service.spec.ts
@@ -1,0 +1,239 @@
+import { HealingService, HealAttemptContext } from './healing.service';
+
+type FetchMock = jest.Mock;
+
+const config = (overrides: Record<string, unknown> = {}) => {
+  const values: Record<string, unknown> = {
+    'app.healingApiUrl': 'http://healer.test',
+    'app.healingApiToken': 'tok',
+    'app.healingTimeoutMs': 3000,
+    ...overrides,
+  };
+  return { get: jest.fn((k: string) => values[k]) };
+};
+
+const ctx = (overrides: Partial<HealAttemptContext> = {}): HealAttemptContext => ({
+  requestId: 'req-1',
+  tenantId: 'tenant-1',
+  agentId: 'agent-1',
+  provider: 'openai',
+  model: 'gpt-4-vision-preview',
+  body: {
+    model: 'gpt-4-vision-preview',
+    temperature: 0.5,
+    messages: [{ role: 'user', content: 'hi' }],
+  },
+  errorStatus: 404,
+  errorBodyText: JSON.stringify({
+    error: {
+      message: 'deprecated',
+      type: 'not_found_error',
+      code: 'model_not_found',
+      param: 'model',
+    },
+  }),
+  ...overrides,
+});
+
+const make = (
+  cfg = config(),
+  repo: { count: jest.Mock } = { count: jest.fn().mockResolvedValue(1) },
+) => new HealingService(repo as never, cfg as never);
+
+const fetchOk = (payload: unknown): FetchMock =>
+  jest.fn().mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue(payload) });
+
+describe('HealingService', () => {
+  afterEach(() => {
+    delete (global as { fetch?: unknown }).fetch;
+    jest.restoreAllMocks();
+  });
+
+  it('reports configured only when a URL is set', () => {
+    expect(make().configured).toBe(true);
+    expect(make(config({ 'app.healingApiUrl': '' })).configured).toBe(false);
+  });
+
+  it('treats request-side 4xx (except 429) as candidates', () => {
+    const svc = make();
+    expect(svc.isCandidateStatus(404)).toBe(true);
+    expect(svc.isCandidateStatus(400)).toBe(true);
+    expect(svc.isCandidateStatus(429)).toBe(false);
+    expect(svc.isCandidateStatus(500)).toBe(false);
+    expect(svc.isCandidateStatus(200)).toBe(false);
+  });
+
+  it('reads per-agent activation from the repository', async () => {
+    expect(await make(config(), { count: jest.fn().mockResolvedValue(1) }).isEnabled('a')).toBe(
+      true,
+    );
+    expect(await make(config(), { count: jest.fn().mockResolvedValue(0) }).isEnabled('a')).toBe(
+      false,
+    );
+  });
+
+  describe('tryHeal', () => {
+    it('returns null and does not call out when not configured', async () => {
+      const fetchMock = jest.fn();
+      (global as { fetch?: unknown }).fetch = fetchMock;
+      const result = await make(config({ 'app.healingApiUrl': '' })).tryHeal(ctx());
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('applies returned operations to the body and yields an outcome token', async () => {
+      const fetchMock = fetchOk({
+        outcome: 'patch',
+        patchRef: 'p1',
+        issueRef: 'i1',
+        operations: [{ type: 'remap_model', from: 'gpt-4-vision-preview', to: 'gpt-4o' }],
+      });
+      (global as { fetch?: unknown }).fetch = fetchMock;
+
+      const result = await make().tryHeal(ctx());
+
+      expect(result).not.toBeNull();
+      expect(result!.body.model).toBe('gpt-4o');
+      expect(result!.token).toEqual({
+        requestId: 'req-1',
+        patchRef: 'p1',
+        issueRef: 'i1',
+        tenantId: 'tenant-1',
+        agentId: 'agent-1',
+      });
+      // Structural, content-free payload.
+      const sent = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+      expect(sent.request.params).toEqual({ temperature: 0.5 });
+      expect(sent.request.messages).toEqual([{ role: 'user', bytes: 4 }]);
+      expect(sent.error).toEqual({
+        statusCode: 404,
+        type: 'not_found_error',
+        code: 'model_not_found',
+        param: 'model',
+        message: 'deprecated',
+      });
+      expect(
+        (fetchMock.mock.calls[0][1] as { headers: Record<string, string> }).headers.authorization,
+      ).toBe('Bearer tok');
+    });
+
+    it('returns null for a non-patch outcome', async () => {
+      (global as { fetch?: unknown }).fetch = fetchOk({
+        outcome: 'unpatchable',
+        issueRef: null,
+        reason: 'no_known_fix',
+      });
+      expect(await make().tryHeal(ctx())).toBeNull();
+    });
+
+    it('returns null when an operation is outside the catalog', async () => {
+      (global as { fetch?: unknown }).fetch = fetchOk({
+        outcome: 'patch',
+        patchRef: 'p',
+        issueRef: 'i',
+        operations: [{ type: 'definitely_not_real' }],
+      });
+      expect(await make().tryHeal(ctx())).toBeNull();
+    });
+
+    it('returns null on a non-2xx heal response', async () => {
+      (global as { fetch?: unknown }).fetch = jest
+        .fn()
+        .mockResolvedValue({ ok: false, json: jest.fn() });
+      expect(await make().tryHeal(ctx())).toBeNull();
+    });
+
+    it('returns null when the heal call throws', async () => {
+      (global as { fetch?: unknown }).fetch = jest.fn().mockRejectedValue(new Error('network'));
+      expect(await make().tryHeal(ctx())).toBeNull();
+    });
+
+    it('strips tool descriptions and tolerates a non-JSON error body and odd messages', async () => {
+      const fetchMock = fetchOk({
+        outcome: 'patch',
+        patchRef: 'p',
+        issueRef: 'i',
+        operations: [{ type: 'drop_param', param: 'temperature' }],
+      });
+      (global as { fetch?: unknown }).fetch = fetchMock;
+      await make(config({ 'app.healingApiToken': '' })).tryHeal(
+        ctx({
+          errorBodyText: 'not json at all',
+          body: {
+            model: 'gpt-4o',
+            messages: [
+              { role: 7 as unknown as string, content: 'x' },
+              'weird' as unknown as Record<string, unknown>,
+            ],
+            tools: [
+              {
+                type: 'function',
+                function: {
+                  name: 'f',
+                  description: 'secret',
+                  parameters: { type: 'object', description: 'd' },
+                },
+              },
+            ],
+          },
+        }),
+      );
+      const sent = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+      expect(sent.request.tools[0].function.description).toBeUndefined();
+      expect(sent.request.tools[0].function.parameters.description).toBeUndefined();
+      expect(sent.request.messages[0].role).toBe('unknown');
+      expect(sent.error.message).toBe('not json at all');
+      // No token configured => no Authorization header.
+      expect(
+        (fetchMock.mock.calls[0][1] as { headers: Record<string, string> }).headers.authorization,
+      ).toBeUndefined();
+    });
+
+    it('parses a top-level error object and defaults the timeout', async () => {
+      const fetchMock = fetchOk({
+        outcome: 'patch',
+        patchRef: 'p',
+        issueRef: 'i',
+        operations: [{ type: 'drop_param', param: 'x' }],
+      });
+      (global as { fetch?: unknown }).fetch = fetchMock;
+      await make(config({ 'app.healingTimeoutMs': undefined })).tryHeal(
+        ctx({ errorBodyText: JSON.stringify({ message: 'top level', type: 'e' }) }),
+      );
+      const sent = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+      expect(sent.error.message).toBe('top level');
+      expect(sent.maxWaitMs).toBe(3000);
+    });
+  });
+
+  describe('reportOutcome', () => {
+    const token = { requestId: 'r', patchRef: 'p', issueRef: 'i', tenantId: 't', agentId: 'a' };
+
+    it('posts the outcome when configured', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+      (global as { fetch?: unknown }).fetch = fetchMock;
+      await make().reportOutcome(token, 'healed');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://healer.test/heal/outcome',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body)).toMatchObject({
+        outcome: 'healed',
+        mode: 'post_error',
+        patchRef: 'p',
+      });
+    });
+
+    it('no-ops when not configured', async () => {
+      const fetchMock = jest.fn();
+      (global as { fetch?: unknown }).fetch = fetchMock;
+      await make(config({ 'app.healingApiUrl': '' })).reportOutcome(token, 'failed');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('swallows report errors', async () => {
+      (global as { fetch?: unknown }).fetch = jest.fn().mockRejectedValue(new Error('down'));
+      await expect(make().reportOutcome(token, 'failed')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/backend/src/healing/healing.service.ts
+++ b/packages/backend/src/healing/healing.service.ts
@@ -1,0 +1,237 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  applyOperations,
+  isKnownOperationType,
+  type HealRequest,
+  type HealResponse,
+  type StructuralMessage,
+} from 'manifest-healing-engine';
+import { AgentHealingEnabled } from '../entities/agent-healing-enabled.entity';
+
+/** Context the proxy hands to the healer on a request-side 4xx. */
+export interface HealAttemptContext {
+  requestId: string;
+  tenantId: string;
+  agentId: string;
+  provider: string;
+  model: string;
+  body: Record<string, unknown>;
+  errorStatus: number;
+  errorBodyText: string;
+}
+
+/** Returned on a successful heal: the rewritten body + a token for the outcome report. */
+export interface HealedRequest {
+  body: Record<string, unknown>;
+  token: HealOutcomeToken;
+}
+
+export interface HealOutcomeToken {
+  requestId: string;
+  patchRef: string;
+  issueRef: string;
+  tenantId: string;
+  agentId: string;
+}
+
+const NON_PARAM_KEYS = new Set(['model', 'messages', 'tools', 'stream']);
+
+/**
+ * Advisory healing client. On a request-side 4xx the proxy asks the external
+ * Healing service for catalog operations, applies them locally (via the shared
+ * engine), and the proxy retries the same provider. The brain never receives
+ * provider credentials or prompt content — only a structural request + the error.
+ *
+ * Every failure mode (not configured, timeout, non-2xx, bad payload, unknown op)
+ * returns null/no-ops so healing can NEVER make the original failure worse.
+ */
+@Injectable()
+export class HealingService {
+  private readonly logger = new Logger(HealingService.name);
+
+  constructor(
+    @InjectRepository(AgentHealingEnabled)
+    private readonly enabledRepo: Repository<AgentHealingEnabled>,
+    private readonly config: ConfigService,
+  ) {}
+
+  /** True once a Healing service URL is configured. */
+  get configured(): boolean {
+    return Boolean(this.apiUrl);
+  }
+
+  /** Request-side 4xx the healer can attempt (429 is a rate limit, not request-side). */
+  isCandidateStatus(status: number): boolean {
+    return status >= 400 && status < 500 && status !== 429;
+  }
+
+  /** Per-agent activation: a row exists iff healing is enabled for the agent. */
+  async isEnabled(agentId: string): Promise<boolean> {
+    const count = await this.enabledRepo.count({ where: { agent_id: agentId } });
+    return count > 0;
+  }
+
+  /**
+   * Attempt to heal. Returns the rewritten body + an outcome token, or null if
+   * there is nothing to apply (or anything went wrong). Never throws.
+   */
+  async tryHeal(ctx: HealAttemptContext): Promise<HealedRequest | null> {
+    if (!this.configured) return null;
+    try {
+      const response = await this.callHeal(this.buildRequest(ctx));
+      if (!response || response.outcome !== 'patch') return null;
+      if (!response.operations.every((op) => isKnownOperationType((op as { type: string }).type))) {
+        this.logger.warn('Healing returned an unknown operation type; skipping.');
+        return null;
+      }
+      const { body } = applyOperations(ctx.body, response.operations);
+      return {
+        body,
+        token: {
+          requestId: ctx.requestId,
+          patchRef: response.patchRef,
+          issueRef: response.issueRef,
+          tenantId: ctx.tenantId,
+          agentId: ctx.agentId,
+        },
+      };
+    } catch (err) {
+      this.logger.warn(`Healing attempt failed: ${String(err)}`);
+      return null;
+    }
+  }
+
+  /** Report whether the retry under the patch succeeded (metering + learning). Never throws. */
+  async reportOutcome(token: HealOutcomeToken, outcome: 'healed' | 'failed'): Promise<void> {
+    if (!this.configured) return;
+    try {
+      await fetch(`${this.apiUrl}/heal/outcome`, {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify({
+          requestId: token.requestId,
+          patchRef: token.patchRef,
+          issueRef: token.issueRef,
+          tenantId: token.tenantId,
+          agentId: token.agentId,
+          outcome,
+          mode: 'post_error',
+        }),
+      });
+    } catch (err) {
+      this.logger.warn(`Healing outcome report failed: ${String(err)}`);
+    }
+  }
+
+  private get apiUrl(): string {
+    return this.config.get<string>('app.healingApiUrl') ?? '';
+  }
+
+  private get apiToken(): string {
+    return this.config.get<string>('app.healingApiToken') ?? '';
+  }
+
+  private get timeoutMs(): number {
+    return Number(this.config.get<number>('app.healingTimeoutMs') ?? 3000);
+  }
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (this.apiToken) headers.authorization = `Bearer ${this.apiToken}`;
+    return headers;
+  }
+
+  private async callHeal(request: HealRequest): Promise<HealResponse | null> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(`${this.apiUrl}/heal`, {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify(request),
+        signal: controller.signal,
+      });
+      if (!res.ok) return null;
+      return (await res.json()) as HealResponse;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private buildRequest(ctx: HealAttemptContext): HealRequest {
+    return {
+      requestId: ctx.requestId,
+      tenantId: ctx.tenantId,
+      agentId: ctx.agentId,
+      request: {
+        provider: ctx.provider,
+        model: ctx.model,
+        params: this.extractParams(ctx.body),
+        tools: this.extractTools(ctx.body),
+        messages: this.extractMessages(ctx.body),
+      },
+      error: this.parseError(ctx.errorStatus, ctx.errorBodyText),
+      maxWaitMs: this.timeoutMs,
+    };
+  }
+
+  /** Sampling/limit params only (not prompt content). */
+  private extractParams(body: Record<string, unknown>): Record<string, unknown> {
+    const params: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(body)) {
+      if (!NON_PARAM_KEYS.has(k)) params[k] = v;
+    }
+    return params;
+  }
+
+  /** Tool JSON-schema structure with human-readable `description`s stripped. */
+  private extractTools(body: Record<string, unknown>): Array<Record<string, unknown>> | undefined {
+    if (!Array.isArray(body.tools)) return undefined;
+    return (body.tools as unknown[]).map((t) => stripDescriptions(t) as Record<string, unknown>);
+  }
+
+  /** Messages reduced to role + byte size — never content. */
+  private extractMessages(body: Record<string, unknown>): StructuralMessage[] {
+    if (!Array.isArray(body.messages)) return [];
+    return (body.messages as Array<Record<string, unknown>>).map((m) => ({
+      role: typeof m.role === 'string' ? m.role : 'unknown',
+      bytes: JSON.stringify(m.content ?? '').length,
+    }));
+  }
+
+  private parseError(statusCode: number, text: string): HealRequest['error'] {
+    try {
+      const parsed = JSON.parse(text) as { error?: Record<string, unknown> } & Record<
+        string,
+        unknown
+      >;
+      const e = (parsed.error ?? parsed) as Record<string, unknown>;
+      return {
+        statusCode,
+        type: typeof e.type === 'string' ? e.type : null,
+        code: typeof e.code === 'string' ? e.code : null,
+        param: typeof e.param === 'string' ? e.param : null,
+        message: typeof e.message === 'string' ? e.message : text.slice(0, 500),
+      };
+    } catch {
+      return { statusCode, type: null, code: null, param: null, message: text.slice(0, 500) };
+    }
+  }
+}
+
+/** Recursively remove `description` keys from a tool schema (developer text). */
+function stripDescriptions(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(stripDescriptions);
+  if (node && typeof node === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+      if (k === 'description') continue;
+      out[k] = stripDescriptions(v);
+    }
+    return out;
+  }
+  return node;
+}

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -24,6 +24,7 @@ import type { ThinkingBlockCache } from '../thinking-block-cache';
 import type { ReasoningContentCache } from '../reasoning-content-cache';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
 import type { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
+import type { HealingService } from '../../../healing/healing.service';
 
 /**
  * Stream-warmup helper is mocked because the real implementation depends on
@@ -96,6 +97,13 @@ describe('ProxyService — orchestration', () => {
   let reasoningCache: ReasoningContentCache;
   let modelParamsService: { get: jest.Mock; list: jest.Mock; set: jest.Mock; delete: jest.Mock };
   let providerParamSpecs: { getSpecs: jest.Mock; list: jest.Mock };
+  let healingService: {
+    configured: boolean;
+    isCandidateStatus: jest.Mock;
+    isEnabled: jest.Mock;
+    tryHeal: jest.Mock;
+    reportOutcome: jest.Mock;
+  };
   let svc: ProxyService;
 
   beforeEach(() => {
@@ -158,6 +166,13 @@ describe('ProxyService — orchestration', () => {
       ),
       list: jest.fn().mockResolvedValue(specCatalog),
     };
+    healingService = {
+      configured: false,
+      isCandidateStatus: jest.fn((s: number) => s >= 400 && s < 500 && s !== 429),
+      isEnabled: jest.fn().mockResolvedValue(true),
+      tryHeal: jest.fn().mockResolvedValue(null),
+      reportOutcome: jest.fn().mockResolvedValue(undefined),
+    };
 
     svc = new ProxyService(
       resolveService as unknown as ResolveService,
@@ -178,6 +193,7 @@ describe('ProxyService — orchestration', () => {
       reasoningCache,
       modelParamsService as unknown as AgentModelParamsService,
       providerParamSpecs as unknown as ProviderParamSpecService,
+      healingService as unknown as HealingService,
     );
   });
 
@@ -250,6 +266,106 @@ describe('ProxyService — orchestration', () => {
       expect(body.messages[0].content).toBe('');
       expect(routingBody.messages[0].content).toBe('');
       expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body).toBe(body);
+    });
+  });
+
+  describe('request healing', () => {
+    const setupRoute = () =>
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+    const forwardResult = (status: number) => ({
+      response: okResponse(status),
+      isGoogle: false,
+      isAnthropic: false,
+      isChatGpt: false,
+    });
+    const token = {
+      requestId: 'r',
+      patchRef: 'p',
+      issueRef: 'i',
+      tenantId: 'tenant-1',
+      agentId: 'agent-1',
+    };
+
+    it('heals a request-side 4xx and retries the same provider', async () => {
+      setupRoute();
+      healingService.configured = true;
+      fallbackService.tryForwardToProvider
+        .mockResolvedValueOnce(forwardResult(404))
+        .mockResolvedValueOnce(forwardResult(200));
+      healingService.tryHeal.mockResolvedValue({ body: { model: 'gpt-4o', messages: [] }, token });
+
+      const result = await svc.proxyRequest(baseOpts());
+
+      expect(result.forward.response.status).toBe(200);
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledTimes(2);
+      expect(fallbackService.tryForwardToProvider.mock.calls[1][0].body).toEqual({
+        model: 'gpt-4o',
+        messages: [],
+      });
+      expect(healingService.reportOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({ patchRef: 'p' }),
+        'healed',
+      );
+    });
+
+    it('reports a failed outcome and falls through when the retry still fails', async () => {
+      setupRoute();
+      healingService.configured = true;
+      fallbackService.tryForwardToProvider
+        .mockResolvedValueOnce(forwardResult(404))
+        .mockResolvedValueOnce(forwardResult(400));
+      fallbackService.tryFallbacks.mockResolvedValue({ success: null, failures: [] });
+      healingService.tryHeal.mockResolvedValue({ body: {}, token });
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(healingService.reportOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({ patchRef: 'p' }),
+        'failed',
+      );
+    });
+
+    it('does not heal when the healer returns nothing', async () => {
+      setupRoute();
+      healingService.configured = true;
+      fallbackService.tryForwardToProvider.mockResolvedValue(forwardResult(404));
+      fallbackService.tryFallbacks.mockResolvedValue({ success: null, failures: [] });
+      healingService.tryHeal.mockResolvedValue(null);
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(healingService.tryHeal).toHaveBeenCalled();
+      expect(healingService.reportOutcome).not.toHaveBeenCalled();
+    });
+
+    it('skips healing when not enabled for the agent', async () => {
+      setupRoute();
+      healingService.configured = true;
+      healingService.isEnabled.mockResolvedValue(false);
+      fallbackService.tryForwardToProvider.mockResolvedValue(forwardResult(404));
+      fallbackService.tryFallbacks.mockResolvedValue({ success: null, failures: [] });
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(healingService.tryHeal).not.toHaveBeenCalled();
+    });
+
+    it('skips healing for non-request-side statuses', async () => {
+      setupRoute();
+      healingService.configured = true;
+      fallbackService.tryForwardToProvider.mockResolvedValue(forwardResult(500));
+      fallbackService.tryFallbacks.mockResolvedValue({ success: null, failures: [] });
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(healingService.tryHeal).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -26,6 +26,7 @@ import { ThinkingBlockCache } from './thinking-block-cache';
 import { ReasoningContentCache } from './reasoning-content-cache';
 import { CodexSessionAffinity } from './codex-session-affinity';
 import { ProxyExceptionFilter } from './proxy-exception.filter';
+import { HealingModule } from '../../healing/healing.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { ProxyExceptionFilter } from './proxy-exception.filter';
     ResolveModule,
     CustomProviderModule,
     HeaderTiersModule,
+    HealingModule,
   ],
   controllers: [ProxyController],
   providers: [

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -57,6 +57,8 @@ import { peekStream, STREAM_WARMUP_MS } from './stream-warmup';
 import { toChatCompletionsRequest } from './responses-adapter';
 import { messagesToChatCompletionsRequest } from './anthropic-messages-adapter';
 import { effectiveRoutesForResponseMode } from '../routing-core/response-mode-guard';
+import { randomUUID } from 'crypto';
+import { HealingService } from '../../healing/healing.service';
 
 type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>>;
 
@@ -158,6 +160,7 @@ export class ProxyService {
     private readonly reasoningCache: ReasoningContentCache,
     private readonly modelParamsService: AgentModelParamsService,
     private readonly providerParamSpecs: ProviderParamSpecService,
+    private readonly healing: HealingService,
   ) {}
 
   async proxyRequest(opts: ProxyRequestOptions): Promise<ProxyResult> {
@@ -263,7 +266,7 @@ export class ProxyService {
       specs: primarySpecs,
     });
 
-    const forward = await this.fallbackService.tryForwardToProvider({
+    const forwardOpts = {
       provider: route.provider,
       apiKey: credentials.apiKey,
       model: primaryModel,
@@ -284,7 +287,43 @@ export class ProxyService {
       thinkingLookup,
       reasoningContentLookup,
       paramMergeContext,
-    });
+    };
+    let forward = await this.fallbackService.tryForwardToProvider(forwardOpts);
+
+    // Request healing: on a request-side 4xx (chat_completions only), ask the
+    // Healing service for catalog fixes, apply them locally, and retry the same
+    // provider once before falling back. Fully guarded — it can only upgrade a
+    // failed response to a success, never make the original failure worse.
+    if (
+      apiMode === 'chat_completions' &&
+      !forward.response.ok &&
+      this.healing.configured &&
+      this.healing.isCandidateStatus(forward.response.status) &&
+      (await this.healing.isEnabled(agentId))
+    ) {
+      const healed = await this.healing.tryHeal({
+        requestId: randomUUID(),
+        tenantId,
+        agentId,
+        provider: route.provider,
+        model: primaryModel,
+        body,
+        errorStatus: forward.response.status,
+        errorBodyText: await forward.response.clone().text(),
+      });
+      if (healed) {
+        const healedForward = await this.fallbackService.tryForwardToProvider({
+          ...forwardOpts,
+          body: healed.body,
+        });
+        if (healedForward.response.ok) {
+          void this.healing.reportOutcome(healed.token, 'healed');
+          forward = healedForward;
+        } else {
+          void this.healing.reportOutcome(healed.token, 'failed');
+        }
+      }
+    }
 
     if (!forward.response.ok && shouldTriggerFallback(forward.response.status)) {
       const fallbackResult = await this.tryFallbackChain({

--- a/packages/frontend/src/components/HealingToggle.tsx
+++ b/packages/frontend/src/components/HealingToggle.tsx
@@ -1,0 +1,49 @@
+import { createResource, createSignal, type Component } from 'solid-js';
+import { disableHealing, enableHealing, getHealingStatus } from '../services/api/routing.js';
+import { toast } from '../services/toast-store.js';
+
+/**
+ * Per-agent request-healing activation. On = recoverable provider errors for
+ * this agent are auto-repaired and retried (mirrors provider activation).
+ */
+const HealingToggle: Component<{ agentName: () => string }> = (props) => {
+  const [status, { mutate }] = createResource(props.agentName, getHealingStatus);
+  const [busy, setBusy] = createSignal(false);
+  const enabled = () => status()?.enabled ?? false;
+
+  const toggle = async () => {
+    if (busy()) return;
+    setBusy(true);
+    const next = !enabled();
+    try {
+      if (next) await enableHealing(props.agentName());
+      else await disableHealing(props.agentName());
+      mutate({ enabled: next });
+    } catch {
+      toast.error('Failed to update request healing');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div class="healing-toggle">
+      <div class="healing-toggle__copy">
+        <h3>Request healing</h3>
+        <p>Automatically repair recoverable provider errors and retry the request.</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={enabled()}
+        class="healing-toggle__switch"
+        disabled={busy() || status.loading}
+        onClick={toggle}
+      >
+        {enabled() ? 'Enabled' : 'Disabled'}
+      </button>
+    </div>
+  );
+};
+
+export default HealingToggle;

--- a/packages/frontend/src/pages/AgentProviders.tsx
+++ b/packages/frontend/src/pages/AgentProviders.tsx
@@ -13,6 +13,7 @@ import { toast } from '../services/toast-store.js';
 import { customProviderColor } from '../services/formatters.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
 import NoConnectionsPrompt from '../components/NoConnectionsPrompt.jsx';
+import HealingToggle from '../components/HealingToggle.jsx';
 import '../styles/routing.css';
 
 const AUTH_BADGES: Record<string, string> = {
@@ -147,6 +148,8 @@ const AgentProviders: Component = () => {
         Enable the global provider connections this harness may use. A provider can't be turned off
         while its models are assigned to this harness's routing. Update routing first to remove it.
       </p>
+
+      <HealingToggle agentName={agentName} />
 
       <Show when={connections().length > 0} fallback={<NoConnectionsPrompt />}>
         <div class="panel" style="padding: 0; overflow-x: auto;">

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -369,6 +369,28 @@ export function disableProviderForAgent(agentName: string, userProviderId: strin
   );
 }
 
+/* -- Routing: Request healing (per-agent activation) -- */
+
+export interface HealingStatus {
+  enabled: boolean;
+}
+
+function healingPath(agentName: string): string {
+  return `/agents/${encodeURIComponent(agentName)}/healing`;
+}
+
+export function getHealingStatus(agentName: string) {
+  return fetchJson<HealingStatus>(healingPath(agentName));
+}
+
+export function enableHealing(agentName: string) {
+  return fetchMutate<{ ok: boolean }>(healingPath(agentName), { method: 'PUT' });
+}
+
+export function disableHealing(agentName: string) {
+  return fetchMutate<{ ok: boolean }>(healingPath(agentName), { method: 'DELETE' });
+}
+
 /* -- Routing: Pricing cache health -- */
 
 export interface PricingHealth {

--- a/packages/frontend/tests/components/HealingToggle.test.tsx
+++ b/packages/frontend/tests/components/HealingToggle.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
+
+const mockGet = vi.fn();
+const mockEnable = vi.fn();
+const mockDisable = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock('../../src/services/api/routing.js', () => ({
+  getHealingStatus: (...a: unknown[]) => mockGet(...a),
+  enableHealing: (...a: unknown[]) => mockEnable(...a),
+  disableHealing: (...a: unknown[]) => mockDisable(...a),
+}));
+vi.mock('../../src/services/toast-store.js', () => ({
+  toast: { error: (...a: unknown[]) => mockToastError(...a) },
+}));
+
+import HealingToggle from '../../src/components/HealingToggle';
+
+describe('HealingToggle', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockEnable.mockReset().mockResolvedValue({ ok: true });
+    mockDisable.mockReset().mockResolvedValue({ ok: true });
+    mockToastError.mockReset();
+  });
+
+  it('shows Disabled and enables on click', async () => {
+    mockGet.mockResolvedValue({ enabled: false });
+    render(() => <HealingToggle agentName={() => 'my-agent'} />);
+    const btn = await screen.findByRole('switch');
+    expect(btn.textContent).toContain('Disabled');
+
+    await fireEvent.click(btn);
+
+    await waitFor(() => expect(mockEnable).toHaveBeenCalledWith('my-agent'));
+    await waitFor(() => expect(screen.getByRole('switch').textContent).toContain('Enabled'));
+  });
+
+  it('shows Enabled and disables on click', async () => {
+    mockGet.mockResolvedValue({ enabled: true });
+    render(() => <HealingToggle agentName={() => 'my-agent'} />);
+    const btn = await screen.findByRole('switch');
+    await waitFor(() => expect(btn.getAttribute('aria-checked')).toBe('true'));
+
+    await fireEvent.click(btn);
+
+    await waitFor(() => expect(mockDisable).toHaveBeenCalledWith('my-agent'));
+  });
+
+  it('toasts when the update fails', async () => {
+    mockGet.mockResolvedValue({ enabled: false });
+    mockEnable.mockRejectedValue(new Error('boom'));
+    render(() => <HealingToggle agentName={() => 'my-agent'} />);
+    const btn = await screen.findByRole('switch');
+
+    await fireEvent.click(btn);
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+  });
+});

--- a/packages/frontend/tests/services/routing-healing.test.ts
+++ b/packages/frontend/tests/services/routing-healing.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getHealingStatus, enableHealing, disableHealing } from '../../src/services/api/routing';
+
+describe('healing api client', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const ok = (payload: unknown) =>
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(payload),
+      text: () => Promise.resolve(JSON.stringify(payload)),
+    } as unknown as Response);
+
+  it('getHealingStatus GETs the per-agent healing endpoint', async () => {
+    ok({ enabled: true });
+    const result = await getHealingStatus('my agent');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/agents/my%20agent/healing'),
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    expect(result).toEqual({ enabled: true });
+  });
+
+  it('enableHealing PUTs to the healing endpoint', async () => {
+    ok({ ok: true });
+    await enableHealing('a');
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    expect(call[0]).toContain('/agents/a/healing');
+    expect((call[1] as RequestInit).method).toBe('PUT');
+  });
+
+  it('disableHealing DELETEs the healing endpoint', async () => {
+    ok({ ok: true });
+    await disableHealing('a');
+    expect((vi.mocked(fetch).mock.calls[0]![1] as RequestInit).method).toBe('DELETE');
+  });
+});

--- a/packages/healing-engine/__tests__/applicator.spec.ts
+++ b/packages/healing-engine/__tests__/applicator.spec.ts
@@ -1,0 +1,193 @@
+import { applyOperations, UnknownOperationError } from '../src/applicator';
+import { Operation } from '../src/operation';
+
+const apply = (body: Record<string, unknown>, ops: Operation[]) => applyOperations(body, ops).body;
+
+describe('applyOperations', () => {
+  it('does not mutate the original body', () => {
+    const original = { model: 'gpt-4-vision-preview', messages: [] };
+    applyOperations(original, [{ type: 'remap_model', from: 'gpt-4-vision-preview', to: 'gpt-4o' }]);
+    expect(original.model).toBe('gpt-4-vision-preview');
+  });
+
+  describe('rename_param', () => {
+    it('renames a present param', () => {
+      expect(apply({ max_tokens: 100 }, [{ type: 'rename_param', from: 'max_tokens', to: 'max_completion_tokens' }])).toEqual({ max_completion_tokens: 100 });
+    });
+    it('is a no-op when the param is absent', () => {
+      expect(apply({ model: 'x' }, [{ type: 'rename_param', from: 'max_tokens', to: 'max_completion_tokens' }])).toEqual({ model: 'x' });
+    });
+  });
+
+  it('drop_param removes the key', () => {
+    expect(apply({ model: 'x', store: true }, [{ type: 'drop_param', param: 'store' }])).toEqual({ model: 'x' });
+  });
+
+  describe('clamp_param', () => {
+    it('clamps a value above max', () => {
+      expect(apply({ max_tokens: 999999 }, [{ type: 'clamp_param', param: 'max_tokens', max: 4096 }])).toEqual({ max_tokens: 4096 });
+    });
+    it('leaves a value at or below max', () => {
+      expect(apply({ max_tokens: 100 }, [{ type: 'clamp_param', param: 'max_tokens', max: 4096 }])).toEqual({ max_tokens: 100 });
+    });
+    it('ignores a non-numeric value', () => {
+      expect(apply({ max_tokens: 'lots' }, [{ type: 'clamp_param', param: 'max_tokens', max: 4096 }])).toEqual({ max_tokens: 'lots' });
+    });
+  });
+
+  describe('strip_schema_keys', () => {
+    it('removes keys recursively from tools', () => {
+      const body = { tools: [{ function: { parameters: { type: 'object', $schema: 'http://x', additionalProperties: false } } }] };
+      expect(apply(body, [{ type: 'strip_schema_keys', keys: ['$schema', 'additionalProperties'] }])).toEqual({ tools: [{ function: { parameters: { type: 'object' } } }] });
+    });
+    it('recurses through nested arrays in a tool schema', () => {
+      const body = { tools: [{ function: { parameters: { type: 'object', required: ['a', 'b'], $schema: 'http://x' } } }] };
+      expect(apply(body, [{ type: 'strip_schema_keys', keys: ['$schema'] }])).toEqual({ tools: [{ function: { parameters: { type: 'object', required: ['a', 'b'] } } }] });
+    });
+    it('is a no-op when there are no tools', () => {
+      expect(apply({ model: 'x' }, [{ type: 'strip_schema_keys', keys: ['$schema'] }])).toEqual({ model: 'x' });
+    });
+  });
+
+  describe('remap_model', () => {
+    it('remaps a matching model', () => {
+      expect(apply({ model: 'gpt-4-vision-preview' }, [{ type: 'remap_model', from: 'gpt-4-vision-preview', to: 'gpt-4o' }])).toEqual({ model: 'gpt-4o' });
+    });
+    it('leaves a non-matching model', () => {
+      expect(apply({ model: 'gpt-4o' }, [{ type: 'remap_model', from: 'gpt-4-vision-preview', to: 'gpt-4o' }])).toEqual({ model: 'gpt-4o' });
+    });
+  });
+
+  describe('reorder_messages', () => {
+    it('user_first drops leading non-user turns and pins system', () => {
+      const body = { messages: [{ role: 'system', content: 's' }, { role: 'assistant', content: 'a' }, { role: 'user', content: 'u' }] };
+      expect(apply(body, [{ type: 'reorder_messages', rule: 'user_first' }]).messages).toEqual([{ role: 'system', content: 's' }, { role: 'user', content: 'u' }]);
+    });
+    it('alternate collapses consecutive same-role turns', () => {
+      const body = { messages: [{ role: 'user', content: 'a' }, { role: 'user', content: 'b' }, { role: 'assistant', content: 'c' }] };
+      expect(apply(body, [{ type: 'reorder_messages', rule: 'alternate' }]).messages).toEqual([{ role: 'user', content: 'a' }, { role: 'assistant', content: 'c' }]);
+    });
+    it('defaults missing messages to an empty list', () => {
+      expect(apply({ model: 'x' }, [{ type: 'reorder_messages', rule: 'alternate' }]).messages).toEqual([]);
+    });
+  });
+
+  describe('inject_field', () => {
+    it('creates a nested path', () => {
+      expect(apply({ response_format: { json_schema: { schema: {} } } }, [{ type: 'inject_field', path: 'response_format.json_schema.schema.additionalProperties', value: false }])).toEqual({ response_format: { json_schema: { schema: { additionalProperties: false } } } });
+    });
+    it('creates intermediate objects when the path is absent', () => {
+      expect(apply({}, [{ type: 'inject_field', path: 'a.b', value: 1 }])).toEqual({ a: { b: 1 } });
+    });
+  });
+
+  describe('trim_context', () => {
+    it('summarize replaces older turns with a summary when more than two remain', () => {
+      const body = { messages: [{ role: 'user', content: '1' }, { role: 'assistant', content: '2' }, { role: 'user', content: '3' }, { role: 'assistant', content: '4' }] };
+      const out = apply(body, [{ type: 'trim_context', strategy: 'summarize', targetTokens: 10 }]).messages as Array<{ role: string }>;
+      expect(out[0].role).toBe('system');
+      expect(out.length).toBe(3);
+    });
+    it('summarize with two or fewer turns falls back to the budget path', () => {
+      const body = { messages: [{ role: 'user', content: 'hi' }] };
+      expect(apply(body, [{ type: 'trim_context', strategy: 'summarize', targetTokens: 10 }]).messages).toEqual([{ role: 'user', content: 'hi' }]);
+    });
+    it('drop_oldest keeps the most recent turns within budget', () => {
+      const body = { messages: [{ role: 'user', content: 'aaaaaaaa' }, { role: 'user', content: 'bbbbbbbb' }] };
+      const out = apply(body, [{ type: 'trim_context', strategy: 'drop_oldest', targetTokens: 1 }]).messages as Array<{ content: string }>;
+      expect(out).toEqual([{ role: 'user', content: 'bbbbbbbb' }]);
+    });
+  });
+
+  describe('drop_orphan_tool_messages', () => {
+    it('keeps a tool message preceded by an assistant tool_calls turn', () => {
+      const body = { messages: [{ role: 'assistant', content: null, tool_calls: [{ id: 't1' }] }, { role: 'tool', content: 'r' }] };
+      expect((apply(body, [{ type: 'drop_orphan_tool_messages' }]).messages as unknown[]).length).toBe(2);
+    });
+    it('drops an orphan tool message and one whose assistant lacks tool_calls', () => {
+      const body = { messages: [{ role: 'tool', content: 'orphan' }, { role: 'assistant', content: 'a' }, { role: 'tool', content: 'r' }] };
+      expect(apply(body, [{ type: 'drop_orphan_tool_messages' }]).messages).toEqual([{ role: 'assistant', content: 'a' }]);
+    });
+  });
+
+  it('strip_message_keys deletes stray keys from every message', () => {
+    const body = { messages: [{ role: 'assistant', content: 'a', reasoning_content: 'secret' }] };
+    expect(apply(body, [{ type: 'strip_message_keys', keys: ['reasoning_content'] }]).messages).toEqual([{ role: 'assistant', content: 'a' }]);
+  });
+
+  describe('ensure_array_items', () => {
+    it('adds a default items schema to array sub-schemas, recursing arrays and objects', () => {
+      const body = { tools: [{ function: { parameters: { type: 'object', properties: { tags: { type: 'array' } } } } }], response_format: { type: 'array' } };
+      const out = apply(body, [{ type: 'ensure_array_items' }]);
+      expect((out.tools as any)[0].function.parameters.properties.tags.items).toEqual({ type: 'string' });
+      expect((out.response_format as any).items).toEqual({ type: 'string' });
+    });
+    it('is a no-op when there are no schemas', () => {
+      expect(apply({ model: 'x' }, [{ type: 'ensure_array_items' }])).toEqual({ model: 'x' });
+    });
+  });
+
+  describe('drop_oversized_content', () => {
+    it('drops oversized content parts and keeps small ones', () => {
+      const big = 'x'.repeat(200);
+      const body = { messages: [{ role: 'user', content: [{ type: 'text', text: 'ok' }, { type: 'image', data: big }] }] };
+      const out = apply(body, [{ type: 'drop_oversized_content', maxBytes: 50 }]).messages as Array<{ content: unknown[] }>;
+      expect(out[0].content).toEqual([{ type: 'text', text: 'ok' }]);
+    });
+    it('passes through messages whose content is not an array', () => {
+      const body = { messages: [{ role: 'user', content: 'plain' }] };
+      expect(apply(body, [{ type: 'drop_oversized_content', maxBytes: 50 }]).messages).toEqual([{ role: 'user', content: 'plain' }]);
+    });
+  });
+
+  describe('message-default and nullish branches', () => {
+    it('defaults missing messages to empty for every message op', () => {
+      const ops: Operation[] = [
+        { type: 'trim_context', strategy: 'drop_oldest', targetTokens: 10 },
+        { type: 'drop_orphan_tool_messages' },
+        { type: 'strip_message_keys', keys: ['reasoning_content'] },
+        { type: 'drop_oversized_content', maxBytes: 100 },
+      ];
+      for (const op of ops) {
+        expect(apply({ model: 'x' }, [op]).messages).toEqual([]);
+      }
+    });
+    it('drop_oversized_content keeps a nullish content part (treated as empty)', () => {
+      const body = { messages: [{ role: 'user', content: [null, { data: 'x'.repeat(200) }] }] };
+      expect((apply(body, [{ type: 'drop_oversized_content', maxBytes: 50 }]).messages as Array<{ content: unknown[] }>)[0].content).toEqual([null]);
+    });
+  });
+
+  describe('fail-safe', () => {
+    it('throws UnknownOperationError on an op outside the catalog', () => {
+      expect(() => applyOperations({}, [{ type: 'bogus_op' } as unknown as Operation])).toThrow(UnknownOperationError);
+    });
+    it('exposes the offending op type on the error', () => {
+      try {
+        applyOperations({}, [{ type: 'bogus_op' } as unknown as Operation]);
+      } catch (e) {
+        expect((e as UnknownOperationError).opType).toBe('bogus_op');
+        expect((e as UnknownOperationError).name).toBe('UnknownOperationError');
+      }
+    });
+  });
+
+  describe('diff', () => {
+    it('reports scalar field changes and message counts, never message/tool content', () => {
+      const body = { model: 'gpt-4-vision-preview', store: true, messages: [{ role: 'user', content: 'hi' }] };
+      const { diff } = applyOperations(body, [
+        { type: 'remap_model', from: 'gpt-4-vision-preview', to: 'gpt-4o' },
+        { type: 'drop_param', param: 'store' },
+      ]);
+      expect(diff.operations).toEqual(['remap_model', 'drop_param']);
+      expect((diff.fields as any).model).toEqual({ before: 'gpt-4-vision-preview', after: 'gpt-4o' });
+      expect((diff.fields as any).store).toEqual({ before: true, after: null });
+      expect((diff.fields as any).messages).toBeUndefined();
+      expect((diff.messageCount as any)).toEqual({ before: 1, after: 1 });
+    });
+    it('defaults message counts to zero when there are no messages', () => {
+      const { diff } = applyOperations({ model: 'x' }, [{ type: 'remap_model', from: 'x', to: 'y' }]);
+      expect((diff.messageCount as any)).toEqual({ before: 0, after: 0 });
+    });
+  });
+});

--- a/packages/healing-engine/__tests__/operation.spec.ts
+++ b/packages/healing-engine/__tests__/operation.spec.ts
@@ -1,0 +1,44 @@
+import {
+  KNOWN_OPERATION_TYPES,
+  SEMANTIC_OPS,
+  isKnownOperationType,
+  riskClassFor,
+} from '../src/operation';
+import { CATALOG_VERSION } from '../src/contract';
+
+describe('operation catalog', () => {
+  it('CATALOG_VERSION is 1', () => {
+    expect(CATALOG_VERSION).toBe(1);
+  });
+
+  it('knows all twelve operation types', () => {
+    expect(KNOWN_OPERATION_TYPES.size).toBe(12);
+  });
+
+  describe('riskClassFor', () => {
+    it('is auto_safe for a catalog of safe ops', () => {
+      expect(riskClassFor([{ type: 'remap_model', from: 'a', to: 'b' }, { type: 'drop_param', param: 'x' }])).toBe('auto_safe');
+    });
+    it('is semantic when any op changes request meaning', () => {
+      expect(riskClassFor([{ type: 'trim_context', strategy: 'drop_oldest', targetTokens: 10 }])).toBe('semantic');
+      expect(riskClassFor([{ type: 'drop_oversized_content', maxBytes: 100 }])).toBe('semantic');
+    });
+    it('marks both semantic ops', () => {
+      expect(SEMANTIC_OPS.has('trim_context')).toBe(true);
+      expect(SEMANTIC_OPS.has('drop_oversized_content')).toBe(true);
+    });
+  });
+
+  describe('isKnownOperationType', () => {
+    it('accepts a catalog type', () => {
+      expect(isKnownOperationType('remap_model')).toBe(true);
+    });
+    it('rejects an unknown string', () => {
+      expect(isKnownOperationType('bogus')).toBe(false);
+    });
+    it('rejects a non-string', () => {
+      expect(isKnownOperationType(42)).toBe(false);
+      expect(isKnownOperationType(undefined)).toBe(false);
+    });
+  });
+});

--- a/packages/healing-engine/jest.config.js
+++ b/packages/healing-engine/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/__tests__'],
+  testMatch: ['**/*.spec.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/index.ts'],
+  coverageDirectory: 'coverage',
+};

--- a/packages/healing-engine/package.json
+++ b/packages/healing-engine/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "manifest-healing-engine",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.6",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/healing-engine/src/applicator.ts
+++ b/packages/healing-engine/src/applicator.ts
@@ -1,0 +1,229 @@
+import { Operation } from './operation';
+
+/**
+ * Thrown when an operation type is not in the catalog. The applicator is
+ * fail-safe: it NEVER silently ignores an unknown op (which would mask drift
+ * between the Healing service and this engine). Callers treat this as "do not
+ * apply, surface the original error".
+ */
+export class UnknownOperationError extends Error {
+  constructor(public readonly opType: string) {
+    super(`Unknown healing operation: ${opType}`);
+    this.name = 'UnknownOperationError';
+  }
+}
+
+interface Msg {
+  role: string;
+  content: unknown;
+  name?: string;
+}
+
+export interface ApplyResult {
+  body: Record<string, unknown>;
+  /** Redaction-safe summary of what changed: op types, scalar field diffs, message counts. */
+  diff: Record<string, unknown>;
+}
+
+/** JSON deep clone — request bodies are JSON-serializable, so this is total and dep-free. */
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Apply catalog operations to an (OpenAI-shaped) request body. Pure and total:
+ * no I/O, no mutation of the input. Given the same body + ops it always yields
+ * the same output. Throws UnknownOperationError on an op outside the catalog.
+ */
+export function applyOperations(
+  originalBody: Record<string, unknown>,
+  ops: Operation[],
+): ApplyResult {
+  const body = clone(originalBody);
+  for (const op of ops) applyOne(body, op);
+  return { body, diff: computeDiff(originalBody, body, ops) };
+}
+
+function applyOne(body: Record<string, unknown>, op: Operation): void {
+  switch (op.type) {
+    case 'rename_param':
+      if (op.from in body) {
+        body[op.to] = body[op.from];
+        delete body[op.from];
+      }
+      return;
+    case 'drop_param':
+      delete body[op.param];
+      return;
+    case 'clamp_param':
+      if (typeof body[op.param] === 'number' && (body[op.param] as number) > op.max) {
+        body[op.param] = op.max;
+      }
+      return;
+    case 'strip_schema_keys':
+      stripKeys((body.tools as unknown[]) ?? [], op.keys);
+      return;
+    case 'remap_model':
+      if (body.model === op.from) body.model = op.to;
+      return;
+    case 'reorder_messages':
+      body.messages = reorder((body.messages as Msg[]) ?? [], op.rule);
+      return;
+    case 'inject_field':
+      setPath(body, op.path, op.value);
+      return;
+    case 'trim_context':
+      body.messages = trim((body.messages as Msg[]) ?? [], op.strategy, op.targetTokens);
+      return;
+    case 'drop_orphan_tool_messages':
+      body.messages = dropOrphanTools((body.messages as Msg[]) ?? []);
+      return;
+    case 'strip_message_keys':
+      body.messages = stripMessageKeys((body.messages as Msg[]) ?? [], op.keys);
+      return;
+    case 'ensure_array_items':
+      ensureArrayItems(body.tools);
+      ensureArrayItems(body.response_format);
+      return;
+    case 'drop_oversized_content':
+      body.messages = dropOversized((body.messages as Msg[]) ?? [], op.maxBytes);
+      return;
+    default:
+      // Fail-safe: an unknown op type (catalog drift) is rejected, never ignored.
+      throw new UnknownOperationError((op as { type: string }).type);
+  }
+}
+
+/** Remove tool-role messages not preceded by an assistant `tool_calls` turn. */
+function dropOrphanTools(messages: Msg[]): Msg[] {
+  const out: Msg[] = [];
+  for (const m of messages) {
+    if (m.role === 'tool') {
+      const prev = out[out.length - 1] as (Msg & { tool_calls?: unknown }) | undefined;
+      const ok =
+        prev?.role === 'assistant' && Array.isArray(prev.tool_calls) && prev.tool_calls.length > 0;
+      if (!ok) continue;
+    }
+    out.push(m);
+  }
+  return out;
+}
+
+/** Delete stray keys (e.g. replayed `reasoning_content`) from every message. */
+function stripMessageKeys(messages: Msg[], keys: string[]): Msg[] {
+  return messages.map((m) => {
+    const copy = { ...m } as Record<string, unknown>;
+    for (const k of keys) delete copy[k];
+    return copy as unknown as Msg;
+  });
+}
+
+/** Add a default `items` schema to any array sub-schema missing one. */
+function ensureArrayItems(node: unknown): void {
+  if (Array.isArray(node)) {
+    node.forEach((n) => ensureArrayItems(n));
+    return;
+  }
+  if (node && typeof node === 'object') {
+    const obj = node as Record<string, unknown>;
+    if (obj.type === 'array' && obj.items === undefined) obj.items = { type: 'string' };
+    for (const v of Object.values(obj)) ensureArrayItems(v);
+  }
+}
+
+/** Drop oversized inline content parts (huge base64 data URLs) — semantic. */
+function dropOversized(messages: Msg[], maxBytes: number): Msg[] {
+  return messages.map((m) => {
+    if (!Array.isArray(m.content)) return m;
+    const content = (m.content as unknown[]).filter(
+      (part) => JSON.stringify(part ?? '').length <= maxBytes,
+    );
+    return { ...m, content };
+  });
+}
+
+function stripKeys(tools: unknown[], keys: string[]): void {
+  const recurse = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(recurse);
+      return;
+    }
+    if (node && typeof node === 'object') {
+      const obj = node as Record<string, unknown>;
+      for (const k of keys) delete obj[k];
+      for (const v of Object.values(obj)) recurse(v);
+    }
+  };
+  tools.forEach(recurse);
+}
+
+function reorder(messages: Msg[], rule: 'alternate' | 'user_first'): Msg[] {
+  const system = messages.filter((m) => m.role === 'system');
+  const rest = messages.filter((m) => m.role !== 'system');
+  if (rule === 'user_first') {
+    while (rest.length && rest[0].role !== 'user') rest.shift();
+    return [...system, ...rest];
+  }
+  const alt: Msg[] = [];
+  for (const m of rest) {
+    if (!alt.length || alt[alt.length - 1].role !== m.role) alt.push(m);
+  }
+  return [...system, ...alt];
+}
+
+function trim(messages: Msg[], strategy: 'drop_oldest' | 'summarize', targetTokens: number): Msg[] {
+  const budgetChars = targetTokens * 4;
+  const system = messages.filter((m) => m.role === 'system');
+  const rest = messages.filter((m) => m.role !== 'system');
+  if (strategy === 'summarize' && rest.length > 2) {
+    const dropped = rest.slice(0, rest.length - 2);
+    const summary: Msg = {
+      role: 'system',
+      content: `[summary of ${dropped.length} earlier messages]`,
+    };
+    return [...system, summary, ...rest.slice(-2)];
+  }
+  const kept: Msg[] = [];
+  let size = JSON.stringify(system).length;
+  for (let i = rest.length - 1; i >= 0; i--) {
+    const c = JSON.stringify(rest[i]).length;
+    if (size + c > budgetChars && kept.length) break;
+    kept.unshift(rest[i]);
+    size += c;
+  }
+  return [...system, ...kept];
+}
+
+function setPath(body: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split('.');
+  let cur: Record<string, unknown> = body;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (typeof cur[parts[i]] !== 'object' || cur[parts[i]] === null) cur[parts[i]] = {};
+    cur = cur[parts[i]] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+/** Redaction-safe diff: scalar before/after + message counts, never content. */
+function computeDiff(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+  ops: Operation[],
+): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const k of keys) {
+    if (k === 'messages' || k === 'tools') continue;
+    if (JSON.stringify(before[k]) !== JSON.stringify(after[k])) {
+      fields[k] = { before: before[k] ?? null, after: after[k] ?? null };
+    }
+  }
+  return {
+    operations: ops.map((o) => o.type),
+    fields,
+    messageCount: {
+      before: (before.messages as unknown[])?.length ?? 0,
+      after: (after.messages as unknown[])?.length ?? 0,
+    },
+  };
+}

--- a/packages/healing-engine/src/contract.ts
+++ b/packages/healing-engine/src/contract.ts
@@ -1,0 +1,65 @@
+import type { Operation } from './operation';
+
+/** Bump when the catalog changes. Surfaced on `/heal` responses for telemetry. */
+export const CATALOG_VERSION = 1;
+
+/** A message reduced to its shape: role + size. Never content. */
+export interface StructuralMessage {
+  role: string;
+  bytes: number;
+}
+
+/** Normalised provider error extracted from a non-2xx provider response. */
+export interface ProviderErrorShape {
+  statusCode: number;
+  type?: string | null;
+  code?: string | null;
+  param?: string | null;
+  message: string;
+}
+
+/** Content-free view of the failed request sent to the Healing service. */
+export interface StructuralRequest {
+  provider: string;
+  model: string;
+  params: Record<string, unknown>;
+  tools?: Array<Record<string, unknown>>;
+  messages: StructuralMessage[];
+}
+
+/** Body of `POST /heal`. */
+export interface HealRequest {
+  requestId: string;
+  tenantId: string;
+  agentId?: string | null;
+  request: StructuralRequest;
+  error: ProviderErrorShape;
+  maxWaitMs?: number;
+}
+
+/** Response from `POST /heal`. */
+export type HealResponse =
+  | {
+      outcome: 'patch';
+      catalogVersion: number;
+      patchRef: string;
+      issueRef: string;
+      operations: Operation[];
+      riskClass: 'auto_safe' | 'semantic';
+      matchConditions?: Record<string, unknown>;
+    }
+  | { outcome: 'pending'; issueRef: string; retryAfterMs: number }
+  | { outcome: 'unpatchable'; issueRef: string | null; reason: string };
+
+/** Body of `POST /heal/outcome`. */
+export interface HealOutcomeReport {
+  requestId: string;
+  patchRef: string;
+  issueRef: string;
+  tenantId: string;
+  agentId?: string | null;
+  outcome: 'healed' | 'failed';
+  mode: 'post_error' | 'preflight';
+  attempt?: number;
+  latencyMs?: number;
+}

--- a/packages/healing-engine/src/index.ts
+++ b/packages/healing-engine/src/index.ts
@@ -1,0 +1,18 @@
+export { applyOperations, UnknownOperationError } from './applicator';
+export type { ApplyResult } from './applicator';
+export {
+  KNOWN_OPERATION_TYPES,
+  SEMANTIC_OPS,
+  riskClassFor,
+  isKnownOperationType,
+} from './operation';
+export type { Operation, OperationType } from './operation';
+export { CATALOG_VERSION } from './contract';
+export type {
+  HealRequest,
+  HealResponse,
+  HealOutcomeReport,
+  StructuralRequest,
+  StructuralMessage,
+  ProviderErrorShape,
+} from './contract';

--- a/packages/healing-engine/src/operation.ts
+++ b/packages/healing-engine/src/operation.ts
@@ -1,0 +1,51 @@
+/**
+ * The deterministic operation catalog — the ONLY things a healing patch may do.
+ * This mirrors the Healing service's catalog (the `/heal` API returns these);
+ * the applicator below executes them. Dependency-free by design.
+ */
+export type Operation =
+  | { type: 'rename_param'; from: string; to: string }
+  | { type: 'drop_param'; param: string }
+  | { type: 'clamp_param'; param: string; max: number }
+  | { type: 'strip_schema_keys'; keys: string[] }
+  | { type: 'remap_model'; from: string; to: string }
+  | { type: 'reorder_messages'; rule: 'alternate' | 'user_first' }
+  | { type: 'inject_field'; path: string; value: unknown }
+  | { type: 'trim_context'; strategy: 'drop_oldest' | 'summarize'; targetTokens: number }
+  | { type: 'drop_orphan_tool_messages' }
+  | { type: 'strip_message_keys'; keys: string[] }
+  | { type: 'ensure_array_items' }
+  | { type: 'drop_oversized_content'; maxBytes: number };
+
+export type OperationType = Operation['type'];
+
+/** Every operation type the applicator can execute. Anything else is rejected. */
+export const KNOWN_OPERATION_TYPES: ReadonlySet<string> = new Set<OperationType>([
+  'rename_param',
+  'drop_param',
+  'clamp_param',
+  'strip_schema_keys',
+  'remap_model',
+  'reorder_messages',
+  'inject_field',
+  'trim_context',
+  'drop_orphan_tool_messages',
+  'strip_message_keys',
+  'ensure_array_items',
+  'drop_oversized_content',
+]);
+
+/** Operations that change request meaning. The Healing service gates these to
+ * human review and never auto-activates them; listed here for transparency. */
+export const SEMANTIC_OPS: ReadonlySet<string> = new Set([
+  'trim_context',
+  'drop_oversized_content',
+]);
+
+export function riskClassFor(ops: Operation[]): 'auto_safe' | 'semantic' {
+  return ops.some((o) => SEMANTIC_OPS.has(o.type)) ? 'semantic' : 'auto_safe';
+}
+
+export function isKnownOperationType(type: unknown): type is OperationType {
+  return typeof type === 'string' && KNOWN_OPERATION_TYPES.has(type);
+}

--- a/packages/healing-engine/tsconfig.cjs.json
+++ b/packages/healing-engine/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs"
+  }
+}

--- a/packages/healing-engine/tsconfig.esm.json
+++ b/packages/healing-engine/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "outDir": "dist/esm"
+  }
+}

--- a/packages/healing-engine/tsconfig.json
+++ b/packages/healing-engine/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}


### PR DESCRIPTION
### 💭 Why
When a provider rejects a request with a fixable 4xx (deprecated model, bad param, tool/message shape), Manifest just falls back or fails. Healing repairs the request and retries the same provider first.

### ✨ What changed
- New `manifest-healing-engine` package: deterministic operation catalog + applicator (fail-safe on unknown ops).
- Proxy: on a request-side 4xx (chat_completions), if the agent has healing on, call the Healing service, apply the returned ops, retry once, then report the outcome.
- Per-agent activation (`agent_healing_enabled`) with a dashboard toggle, mirroring provider activation.
- The healer receives only a structural request plus the error, never provider keys or prompt content.

### 👤 For users
Agents with healing enabled auto-recover from common provider rejections instead of erroring out.

### 🔧 For operators
- New migration `agent_healing_enabled`.
- New env `HEALING_API_URL` (optional `HEALING_API_TOKEN`, `HEALING_TIMEOUT_MS`). Inert until set and an agent is toggled on, so merging changes nothing by default.

### 📝 Notes
- `manifest-healing-engine` is the package the external Healing service will share for an identical applicator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-heal recoverable provider errors by applying deterministic fixes and retrying the same provider once for `chat_completions`. Inert by default; enable via `HEALING_API_URL` and a per‑agent dashboard toggle.

- **New Features**
  - Added `manifest-healing-engine`: deterministic operation catalog and applicator (fail‑safe on unknown ops).
  - Proxy: on request‑side 4xx, call the Healing service, apply ops locally, retry once, then report outcome.
  - Per‑agent activation API and UI toggle on the Providers page.
  - Privacy: the healer sees only structural request + error (no provider keys or prompt content).

- **Migration**
  - New table `agent_healing_enabled` (migration `1796000000000-AddAgentHealingEnabled`).
  - New env: `HEALING_API_URL` (optional `HEALING_API_TOKEN`, `HEALING_TIMEOUT_MS`). No change until set and an agent is enabled.

<sup>Written for commit d873965ce458e255dce801f48996b7758d9334eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

