### PR TITLE
feat(openrouter): forward x-session-key as x-session-id for sticky routing and prompt cache

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -5,7 +5,7 @@ import {
   resolveEndpointKey,
   PROVIDER_ENDPOINTS,
 } from '../provider-endpoints';
-import { resolveSubscriptionEndpointKey } from '../provider-hooks';
+import { buildProviderExtraHeaders, resolveSubscriptionEndpointKey } from '../provider-hooks';
 
 describe('buildCustomEndpoint', () => {
   it('strips trailing /v1 from base URL to avoid double /v1', () => {
@@ -763,5 +763,31 @@ describe('gemini-subscription endpoint', () => {
 
   it('buildStreamPath returns the streamGenerateContent path', () => {
     expect(ep.buildStreamPath!('gemini-2.5-pro')).toBe('/v1internal:streamGenerateContent');
+  });
+});
+
+describe('buildProviderExtraHeaders', () => {
+  it('returns x-grok-conv-id for xai', () => {
+    expect(buildProviderExtraHeaders('xai', 'sess-abc')).toEqual({
+      'x-grok-conv-id': 'sess-abc',
+    });
+  });
+
+  it('returns x-session-id for openrouter', () => {
+    expect(buildProviderExtraHeaders('openrouter', 'ba44c58a-a1f5-4cc7-bc2a-9394d266cc2b')).toEqual(
+      { 'x-session-id': 'ba44c58a-a1f5-4cc7-bc2a-9394d266cc2b' },
+    );
+  });
+
+  it('is case-insensitive for provider name', () => {
+    expect(buildProviderExtraHeaders('OpenRouter', 'sess-xyz')).toEqual({
+      'x-session-id': 'sess-xyz',
+    });
+  });
+
+  it('returns undefined for providers with no extra headers', () => {
+    expect(buildProviderExtraHeaders('anthropic', 'sess-abc')).toBeUndefined();
+    expect(buildProviderExtraHeaders('openai', 'sess-abc')).toBeUndefined();
+    expect(buildProviderExtraHeaders('unknown', 'sess-abc')).toBeUndefined();
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -779,6 +779,10 @@ describe('buildProviderExtraHeaders', () => {
     );
   });
 
+  it('does not forward the fallback default session id to openrouter', () => {
+    expect(buildProviderExtraHeaders('openrouter', 'default')).toBeUndefined();
+  });
+
   it('is case-insensitive for provider name', () => {
     expect(buildProviderExtraHeaders('OpenRouter', 'sess-xyz')).toEqual({
       'x-session-id': 'sess-xyz',

--- a/packages/backend/src/routing/proxy/provider-hooks.ts
+++ b/packages/backend/src/routing/proxy/provider-hooks.ts
@@ -39,6 +39,7 @@ const PROVIDER_EXTRA_HEADER_BUILDERS: Record<
   (sessionKey: string) => Record<string, string>
 > = {
   xai: (sessionKey) => ({ 'x-grok-conv-id': sessionKey }),
+  openrouter: (sessionKey) => ({ 'x-session-id': sessionKey }),
 };
 
 export function buildProviderExtraHeaders(

--- a/packages/backend/src/routing/proxy/provider-hooks.ts
+++ b/packages/backend/src/routing/proxy/provider-hooks.ts
@@ -36,10 +36,11 @@ export function resolveSubscriptionEndpointKey(endpointKey: string): string | un
  */
 const PROVIDER_EXTRA_HEADER_BUILDERS: Record<
   string,
-  (sessionKey: string) => Record<string, string>
+  (sessionKey: string) => Record<string, string> | undefined
 > = {
   xai: (sessionKey) => ({ 'x-grok-conv-id': sessionKey }),
-  openrouter: (sessionKey) => ({ 'x-session-id': sessionKey }),
+  openrouter: (sessionKey) =>
+    sessionKey === 'default' ? undefined : { 'x-session-id': sessionKey },
 };
 
 export function buildProviderExtraHeaders(


### PR DESCRIPTION
## Summary

When Manifest routes requests through OpenRouter, the `x-session-key` header (forwarded by agents like OpenWebUI via `FORWARD_SESSION_INFO_HEADER_CHAT_ID=X-Session-Key`) is consumed internally but never passed upstream.

OpenRouter supports an [`x-session-id` header](https://openrouter.ai/docs/guides/best-practices/prompt-caching) (equivalent to `session_id` in the request body) that provides two concrete benefits:

1. **Sticky routing** — pins all requests in the same conversation to the same provider, maximising prompt cache hits
2. **Observability grouping** — groups requests as a session in the OpenRouter console

## Root cause

`provider-endpoints.ts` builds OpenRouter's upstream headers without `x-session-id`. The `sessionKey` is already threaded through `ForwardOptions` → `proxy-fallback.service.ts` → `buildProviderExtraHeaders`, so the plumbing is in place — the `xai` entry in `PROVIDER_EXTRA_HEADER_BUILDERS` already uses the exact same pattern for `x-grok-conv-id`.

## Change

Added a single entry to `PROVIDER_EXTRA_HEADER_BUILDERS` in `provider-hooks.ts`, mirroring the existing `xai` pattern:

```ts
// before
xai: (sessionKey) => ({ 'x-grok-conv-id': sessionKey }),

// after
xai: (sessionKey) => ({ 'x-grok-conv-id': sessionKey }),
openrouter: (sessionKey) => ({ 'x-session-id': sessionKey }),
```

## Impact

- Prompt cache hits increase across a conversation when routing through OpenRouter → **direct cost reduction**
- Sessions become visible and grouped in the OpenRouter console
- Zero risk: `x-session-id` is ignored by OpenRouter if no prior context exists for the session

## Testing

Added 4 tests to `provider-endpoints.spec.ts` covering:
- `openrouter` returns `x-session-id` with the session key value
- Case-insensitive provider name match
- `xai` still works as before
- Providers with no extra headers return `undefined`

Closes / related to #1930