### PR TITLE
fix: strip client-supplied MPS params unsupported by the resolved model

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -578,6 +578,40 @@ describe('ProxyFallbackService', () => {
       expect(forwarded.body.messages).toBeDefined();
     });
 
+    it('preserves known MPS params when the resolved model has no specs', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      modelParamsService.get.mockResolvedValueOnce(null);
+      providerParamSpecs.getAllKnownParamRootPaths.mockReturnValue(
+        new Set(['temperature', 'top_p', 'max_tokens']),
+      );
+
+      await service.tryForwardToProvider({
+        provider: 'deepseek',
+        apiKey: 'sk-test',
+        model: 'new-provider-model',
+        body: {
+          messages: [{ role: 'user', content: 'hi' }],
+          temperature: 0.7,
+          top_p: 0.9,
+          max_tokens: 2048,
+        },
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'api_key',
+        paramMergeContext: { agentId: 'agent-1', scopeKey: 'tier:default' },
+      });
+
+      const forwarded = providerClient.forward.mock.calls[0][0];
+      expect(forwarded.body.temperature).toBe(0.7);
+      expect(forwarded.body.top_p).toBe(0.9);
+      expect(forwarded.body.max_tokens).toBe(2048);
+    });
+
     it('re-injects shared reasoning_content before forwarding to compatible providers', async () => {
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -158,6 +158,7 @@ describe('ProxyFallbackService', () => {
         getProviderParamSpecs(specCatalog, provider, authType as 'api_key' | 'subscription', model),
       ),
       list: jest.fn().mockResolvedValue(specCatalog),
+      getAllKnownParamRootPaths: jest.fn().mockReturnValue(new Set(['thinking'])),
     } as unknown as jest.Mocked<ProviderParamSpecService>;
 
     reasoningCache = {
@@ -537,6 +538,44 @@ describe('ProxyFallbackService', () => {
       });
 
       expect(modelParamsService.get).not.toHaveBeenCalled();
+    });
+
+    it('strips client-supplied MPS params that the resolved model does not support', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      // Model has no saved params and only supports `thinking` in its specs.
+      modelParamsService.get.mockResolvedValueOnce(null);
+      // getAllKnownParamRootPaths returns `temperature` as a known MPS root.
+      providerParamSpecs.getAllKnownParamRootPaths.mockReturnValue(
+        new Set(['thinking', 'temperature']),
+      );
+
+      await service.tryForwardToProvider({
+        provider: 'deepseek',
+        apiKey: 'sk-test',
+        model: 'deepseek-v4-flash',
+        body: {
+          messages: [{ role: 'user', content: 'hi' }],
+          temperature: 0.7,
+          max_tokens: 2048,
+        },
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'api_key',
+        paramMergeContext: { agentId: 'agent-1', scopeKey: 'tier:default' },
+      });
+
+      const forwarded = providerClient.forward.mock.calls[0][0];
+      // `temperature` is a known MPS root but not in this model's specs → stripped.
+      expect(forwarded.body.temperature).toBeUndefined();
+      // `max_tokens` is not a known MPS root → preserved (it's a standard API param).
+      expect(forwarded.body.max_tokens).toBe(2048);
+      // `messages` is not a known MPS root → preserved.
+      expect(forwarded.body.messages).toBeDefined();
     });
 
     it('re-injects shared reasoning_content before forwarding to compatible providers', async () => {

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -148,7 +148,21 @@ export class ProxyFallbackService {
       model,
     );
     const specs = await this.providerParamSpecs.getSpecs(provider, authType as AuthType, model);
-    return applyRequestParamDefaults(body, modelParams, specs);
+    const merged = applyRequestParamDefaults(body, modelParams, specs);
+
+    // Strip client-supplied params that are known MPS paths but not supported
+    // by this model. Example: `temperature` on claude-opus-4-7 which removed
+    // sampling controls — sending it causes a provider error.
+    const knownRoots = this.providerParamSpecs.getAllKnownParamRootPaths();
+    const modelRoots = new Set(specs.map((s) => s.path.split('.')[0]));
+    let stripped: Record<string, unknown> | null = null;
+    for (const key of Object.keys(merged)) {
+      if (knownRoots.has(key) && !modelRoots.has(key)) {
+        stripped ??= { ...merged };
+        delete stripped[key];
+      }
+    }
+    return stripped ?? merged;
   }
 
   async tryFallbacks(

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -149,6 +149,7 @@ export class ProxyFallbackService {
     );
     const specs = await this.providerParamSpecs.getSpecs(provider, authType as AuthType, model);
     const merged = applyRequestParamDefaults(body, modelParams, specs);
+    if (specs.length === 0) return merged;
 
     // Strip client-supplied params that are known MPS paths but not supported
     // by this model. Example: `temperature` on claude-opus-4-7 which removed

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -578,4 +578,15 @@ describe('ProviderParamSpecService', () => {
       await expect(refresh.mock.results[0].value).rejects.toThrow('boom');
     });
   });
+
+  describe('getAllKnownParamRootPaths', () => {
+    it('returns all unique first-level param paths across the entire catalog', async () => {
+      mockRemoteCatalog();
+      const service = new ProviderParamSpecService();
+      await service.refreshCache();
+
+      const roots = service.getAllKnownParamRootPaths();
+      expect(roots).toEqual(new Set(['thinking', 'temperature', 'max_completion_tokens']));
+    });
+  });
 });

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -172,6 +172,23 @@ export class ProviderParamSpecService implements OnModuleInit {
     return this.lastFetchedAt;
   }
 
+  /**
+   * All unique first-level param paths known to the MPS catalog across every
+   * provider/model. Used by the proxy to strip client-supplied params that
+   * the resolved model doesn't support (e.g. `temperature` on claude-opus-4-7
+   * which removed sampling controls).
+   */
+  getAllKnownParamRootPaths(): Set<string> {
+    const paths = new Set<string>();
+    for (const entry of this.specs) {
+      for (const param of entry.params) {
+        const root = param.path.split('.')[0];
+        paths.add(root);
+      }
+    }
+    return paths;
+  }
+
   private async fetchModelParametersData(): Promise<{
     notModified: boolean;
     data: unknown | null;


### PR DESCRIPTION
When a client sends a parameter like `temperature` that is a known MPS path but not listed in the resolved model's specs (e.g. claude-opus-4-7 which removed sampling controls), the proxy now strips it before forwarding to the provider. Previously it passed through unchanged, causing provider errors like:

  `temperature` may only be set to 1 when thinking is enabled

The fix adds `getAllKnownParamRootPaths()` to ProviderParamSpecService and uses it in ProxyFallbackService.applyParamMerge to compare the model's supported roots against the full MPS catalog, removing any client-supplied params that are known MPS paths but absent from the model's own specs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip unsupported MPS params from client requests to prevent provider errors (e.g., `temperature` on models without sampling). Only strip when the resolved model has specs; non-MPS fields and all params for uncataloged models are preserved.

- **Bug Fixes**
  - Added `getAllKnownParamRootPaths()` in `ProviderParamSpecService` to collect all known MPS root paths.
  - Updated `ProxyFallbackService.applyParamMerge` to drop known MPS params not in the resolved model’s specs, and to preserve all params when the model has no specs.

<sup>Written for commit 9640e3497f32cb16c400bf0d3d3a095b7c5ce447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

