### PR TITLE
fix: stop rolling deploys from dropping requests

### DIFF
--- a/.changeset/zero-downtime-deploy-drain.md
+++ b/.changeset/zero-downtime-deploy-drain.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Stop rolling deploys from dropping requests. During a deploy the old replicas got SIGTERM and closed their socket immediately while the Railway edge was still routing to them, so a chunk of requests failed for the length of the deploy window. The server now drains on SIGTERM: the health probe at /api/v1/health reports 503 so the edge deregisters the replica, and the process keeps serving for SHUTDOWN_DRAIN_MS (default 10s) before closing connections. railway.toml gains overlapSeconds and drainingSeconds so the new deployment overlaps the old one and the drain finishes before SIGKILL.

--- a/packages/backend/src/config/app.config.spec.ts
+++ b/packages/backend/src/config/app.config.spec.ts
@@ -97,6 +97,18 @@ describe('appConfig', () => {
     expect(config.runMigrationsOnBoot).toBe(false);
   });
 
+  it('defaults shutdownDrainMs to 10000 when SHUTDOWN_DRAIN_MS is unset', async () => {
+    delete process.env['SHUTDOWN_DRAIN_MS'];
+    const config = await loadConfig();
+    expect(config.shutdownDrainMs).toBe(10000);
+  });
+
+  it('reads SHUTDOWN_DRAIN_MS from env', async () => {
+    process.env['SHUTDOWN_DRAIN_MS'] = '0';
+    const config = await loadConfig();
+    expect(config.shutdownDrainMs).toBe(0);
+  });
+
   it('throws when DATABASE_URL is missing in production', async () => {
     delete process.env['DATABASE_URL'];
     process.env['NODE_ENV'] = 'production';

--- a/packages/backend/src/config/app.config.ts
+++ b/packages/backend/src/config/app.config.ts
@@ -41,6 +41,13 @@ export const appConfig = registerAs('app', () => ({
   // (Railway) where a pre-deploy step migrates once over a direct connection, so
   // replicas never migrate concurrently over PgBouncer.
   runMigrationsOnBoot: process.env['RUN_MIGRATIONS_ON_BOOT'] !== 'false',
+  // Graceful-shutdown drain window (ms). On a real termination signal in
+  // production the server keeps accepting traffic for this long — while the
+  // health probe reports 503 — so the platform edge (Railway) deregisters this
+  // replica before its socket closes, instead of refusing requests it is still
+  // routing during the post-SIGTERM deregistration lag (the rolling-deploy 5xx
+  // spike). Must be shorter than Railway's `drainingSeconds`. 0 disables it.
+  shutdownDrainMs: Number(process.env['SHUTDOWN_DRAIN_MS'] ?? 10000),
   // When true, /api/v1/public/* endpoints expose aggregate stats without auth.
   // Off by default — only Manifest Cloud's marketing homepage should enable it.
   publicStatsEnabled: process.env['MANIFEST_PUBLIC_STATS'] === 'true',

--- a/packages/backend/src/health/health.controller.spec.ts
+++ b/packages/backend/src/health/health.controller.spec.ts
@@ -1,10 +1,19 @@
+import { ServiceUnavailableException } from '@nestjs/common';
 import { HealthController } from './health.controller';
+import { ShutdownService } from './shutdown.service';
+
+/** Build a HealthController with a stub ShutdownService in the given state. */
+function makeController(isShuttingDown = false): HealthController {
+  return new HealthController({
+    isShuttingDown: () => isShuttingDown,
+  } as unknown as ShutdownService);
+}
 
 describe('HealthController', () => {
   let controller: HealthController;
 
   beforeEach(() => {
-    controller = new HealthController();
+    controller = makeController();
   });
 
   afterEach(() => {
@@ -29,6 +38,32 @@ describe('HealthController', () => {
     expect(result).not.toHaveProperty('version');
   });
 
+  describe('draining', () => {
+    it('throws 503 ServiceUnavailable while shutting down so the edge stops routing', () => {
+      const drainingController = makeController(true);
+      expect(() => drainingController.getHealth()).toThrow(ServiceUnavailableException);
+    });
+
+    it('reports shutting_down status and uptime in the 503 body', () => {
+      const fixedNow = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+      const drainingController = makeController(true);
+
+      let caught: ServiceUnavailableException | undefined;
+      try {
+        drainingController.getHealth();
+      } catch (err) {
+        caught = err as ServiceUnavailableException;
+      }
+
+      expect(caught).toBeInstanceOf(ServiceUnavailableException);
+      expect(caught?.getResponse()).toMatchObject({
+        status: 'shutting_down',
+        uptime_seconds: 0,
+      });
+    });
+  });
+
   describe('uptime calculation', () => {
     it('returns 0 uptime on the first call immediately after construction', () => {
       // Pin Date.now() to a fixed point before construction so the constructor
@@ -36,7 +71,7 @@ describe('HealthController', () => {
       const fixedNow = 1_700_000_000_000;
       jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
 
-      const freshController = new HealthController();
+      const freshController = makeController();
       const result = freshController.getHealth();
 
       expect(result.uptime_seconds).toBe(0);
@@ -47,7 +82,7 @@ describe('HealthController', () => {
       const constructionTime = 1_700_000_000_000;
       const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(constructionTime);
 
-      const freshController = new HealthController();
+      const freshController = makeController();
 
       dateNowSpy.mockReturnValue(constructionTime + 5_000);
       const firstCall = freshController.getHealth();
@@ -64,7 +99,7 @@ describe('HealthController', () => {
       const constructionTime = 1_700_000_000_000;
       const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(constructionTime);
 
-      const freshController = new HealthController();
+      const freshController = makeController();
 
       // 999ms after construction is still less than 1s — floor to 0.
       dateNowSpy.mockReturnValue(constructionTime + 999);
@@ -87,7 +122,7 @@ describe('HealthController', () => {
       const constructionTime = 1_700_000_000_000;
       const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(constructionTime);
 
-      const freshController = new HealthController();
+      const freshController = makeController();
 
       // Clock jumps backward by 10s.
       dateNowSpy.mockReturnValue(constructionTime - 10_000);
@@ -104,7 +139,7 @@ describe('HealthController', () => {
       const constructionTime = 1_700_000_000_000;
       const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(constructionTime);
 
-      const freshController = new HealthController();
+      const freshController = makeController();
 
       // Clock has not advanced at all between construction and call.
       dateNowSpy.mockReturnValue(constructionTime);

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -1,16 +1,23 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, ServiceUnavailableException } from '@nestjs/common';
 import { Public } from '../common/decorators/public.decorator';
+import { ShutdownService } from './shutdown.service';
 
 @Controller('api/v1')
 export class HealthController {
   private readonly startTime = Date.now();
 
+  constructor(private readonly shutdown: ShutdownService) {}
+
   @Public()
   @Get('health')
   getHealth() {
-    return {
-      status: 'healthy',
-      uptime_seconds: Math.floor((Date.now() - this.startTime) / 1000),
-    };
+    const uptime_seconds = Math.floor((Date.now() - this.startTime) / 1000);
+    if (this.shutdown.isShuttingDown()) {
+      // The process is draining before shutdown. Report unhealthy so the
+      // platform edge stops routing new traffic to this replica while the
+      // server keeps serving in-flight requests through the drain window.
+      throw new ServiceUnavailableException({ status: 'shutting_down', uptime_seconds });
+    }
+    return { status: 'healthy', uptime_seconds };
   }
 }

--- a/packages/backend/src/health/health.module.ts
+++ b/packages/backend/src/health/health.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { HealthController } from './health.controller';
+import { ShutdownService } from './shutdown.service';
 
 @Module({
   controllers: [HealthController],
+  providers: [ShutdownService],
 })
 export class HealthModule {}

--- a/packages/backend/src/health/shutdown.service.spec.ts
+++ b/packages/backend/src/health/shutdown.service.spec.ts
@@ -1,0 +1,78 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ShutdownService } from './shutdown.service';
+
+/** Build a ShutdownService over a fake ConfigService returning the given values. */
+function makeService(values: { shutdownDrainMs?: number; nodeEnv?: string }): ShutdownService {
+  const config = {
+    get: jest.fn((key: string) => {
+      if (key === 'app.shutdownDrainMs') return values.shutdownDrainMs;
+      if (key === 'app.nodeEnv') return values.nodeEnv;
+      return undefined;
+    }),
+  } as unknown as ConfigService;
+  return new ShutdownService(config);
+}
+
+describe('ShutdownService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('is not shutting down before any signal', () => {
+    const service = makeService({ shutdownDrainMs: 10000, nodeEnv: 'production' });
+    expect(service.isShuttingDown()).toBe(false);
+  });
+
+  it('flips isShuttingDown but skips the drain on a programmatic close (no signal)', async () => {
+    const service = makeService({ shutdownDrainMs: 10000, nodeEnv: 'production' });
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+
+    await service.beforeApplicationShutdown();
+
+    expect(service.isShuttingDown()).toBe(true);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips the drain outside production even on a real signal', async () => {
+    const service = makeService({ shutdownDrainMs: 10000, nodeEnv: 'development' });
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+
+    await service.beforeApplicationShutdown('SIGTERM');
+
+    expect(service.isShuttingDown()).toBe(true);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips the drain when the configured window is zero', async () => {
+    const service = makeService({ shutdownDrainMs: 0, nodeEnv: 'production' });
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+
+    await service.beforeApplicationShutdown('SIGTERM');
+
+    expect(service.isShuttingDown()).toBe(true);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('defaults the drain window to 0 when config returns undefined', async () => {
+    const service = makeService({ shutdownDrainMs: undefined, nodeEnv: 'production' });
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+
+    await service.beforeApplicationShutdown('SIGTERM');
+
+    expect(service.isShuttingDown()).toBe(true);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('drains for the configured window on a real signal in production', async () => {
+    const service = makeService({ shutdownDrainMs: 5, nodeEnv: 'production' });
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+    await service.beforeApplicationShutdown('SIGTERM');
+
+    expect(service.isShuttingDown()).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('draining for 5ms'));
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5);
+  });
+});

--- a/packages/backend/src/health/shutdown.service.ts
+++ b/packages/backend/src/health/shutdown.service.ts
@@ -1,0 +1,51 @@
+import { BeforeApplicationShutdown, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Tracks shutdown state and, on a real termination signal in production, holds
+ * the process open for a drain window before NestJS closes the HTTP server.
+ *
+ * Why this exists: on a rolling deploy the platform (Railway) sends SIGTERM to
+ * an old replica and only then deregisters it from the edge. If the server
+ * closes its socket immediately, requests the edge is still routing during that
+ * deregistration lag hit a closed connection and surface as 5xx — the spike
+ * seen during deploy windows. Keeping the server accepting traffic for a few
+ * seconds — while {@link isShuttingDown} flips the health probe to 503 — lets
+ * the edge notice and stop routing before any request is dropped.
+ *
+ * NestJS calls `beforeApplicationShutdown()` after `onModuleDestroy()` and
+ * *before* it closes the HTTP server, and TypeORM closes its connection later in
+ * `onApplicationShutdown()`, so both the server and the database stay up for the
+ * whole drain — requests served during the window behave normally.
+ */
+@Injectable()
+export class ShutdownService implements BeforeApplicationShutdown {
+  private readonly logger = new Logger(ShutdownService.name);
+  private shuttingDown = false;
+
+  constructor(private readonly config: ConfigService) {}
+
+  /** True once a shutdown signal has been received. Read by the health probe. */
+  isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
+
+  async beforeApplicationShutdown(signal?: string): Promise<void> {
+    // Flip readiness first so the health probe reports 503 immediately, even
+    // when the drain itself is skipped below.
+    this.shuttingDown = true;
+
+    const drainMs = this.config.get<number>('app.shutdownDrainMs') ?? 0;
+    const isProduction = this.config.get<string>('app.nodeEnv') === 'production';
+
+    // Only drain on a real signal in production. A programmatic `app.close()`
+    // (signal is undefined, e.g. tests) and dev / self-hosted single-instance
+    // restarts have no edge to wait for, so blocking would only slow shutdown.
+    if (!signal || !isProduction || drainMs <= 0) {
+      return;
+    }
+
+    this.logger.log(`Received ${signal} — draining for ${drainMs}ms before closing connections.`);
+    await new Promise<void>((resolve) => setTimeout(resolve, drainMs));
+  }
+}

--- a/railway.toml
+++ b/railway.toml
@@ -10,5 +10,13 @@ startCommand = "npm start"
 preDeployCommand = "npm run migration:run:prod --workspace=packages/backend"
 healthcheckPath = "/api/v1/health"
 healthcheckTimeout = 300
+# Zero-downtime rolling deploys. The new deployment runs alongside the old one
+# for `overlapSeconds` (edge shifts traffic over) before the old replica is sent
+# SIGTERM. `drainingSeconds` is the SIGTERM→SIGKILL grace; it MUST exceed the
+# app's own drain window (SHUTDOWN_DRAIN_MS, default 10s — the server keeps
+# serving and reports 503 on /api/v1/health so the edge deregisters it) plus a
+# margin for in-flight requests to finish, or the drain gets cut short.
+overlapSeconds = 20
+drainingSeconds = 30
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
### 💭 Why
Rolling deploys spiked the request error rate to ~20% during each deploy window. Old replicas closed their socket the moment Railway sent SIGTERM, while the edge was still routing to them, so requests hit a dead connection.

### ✨ What changed
- New `ShutdownService` drains on SIGTERM (production, real signal only).
- `/api/v1/health` returns 503 while draining so the edge deregisters the replica.
- Process keeps serving for `SHUTDOWN_DRAIN_MS` (default 10s) before NestJS closes connections.
- `railway.toml` adds `overlapSeconds=20` and `drainingSeconds=30` for graceful rollout.

### 🔧 For operators
The code and `railway.toml` ship the fix on merge. Two things to verify in the Railway dashboard (they live outside the repo):
1. Set `RUN_MIGRATIONS_ON_BOOT=false` so replicas skip boot migrations (the pre-deploy step already migrates once over a direct connection).
2. Confirm the replica count under Settings, since overlap only helps with 2+ replicas.

Optional: `SHUTDOWN_DRAIN_MS` (default 10000). Keep it below `drainingSeconds` (30000).

### 📝 Notes
Migrations were already wired correctly (pre-deploy, direct connection, advisory lock). This PR only closes the shutdown/readiness gap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents dropped requests during rolling deploys by adding a graceful shutdown drain and health-based deregistration. Old replicas now serve during drain while `/api/v1/health` returns 503 so the edge stops routing.

- **Bug Fixes**
  - Added `ShutdownService` to drain on SIGTERM in production for `SHUTDOWN_DRAIN_MS` (default 10s).
  - `/api/v1/health` returns 503 while draining; uptime and status included in the body.
  - New config `shutdownDrainMs` with tests; wired `ShutdownService` into `HealthModule`.
  - Updated `railway.toml`: `overlapSeconds=20`, `drainingSeconds=30`.

- **Migration**
  - In Railway: set `RUN_MIGRATIONS_ON_BOOT=false` and ensure 2+ replicas.
  - Optional: tune `SHUTDOWN_DRAIN_MS` (keep <= `drainingSeconds`).

<sup>Written for commit 26be5ccd530350a3e8bbfbef4771eeccbae2d1c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

