### PR TITLE
fix: stop bad API keys from hammering the database

### DIFF
--- a/.changeset/agent-key-storm-and-sse-throttle.md
+++ b/.changeset/agent-key-storm-and-sse-throttle.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Stop a wrong or revoked agent key from hammering the database and flooding the logs. Every request bearing a bad `mnfst_` key used to run a fresh indexed DB lookup and emit a warning, so one misconfigured agent in a retry loop sustained DB load and log noise indefinitely. Rejected keys are now cached for 30s (cleared the moment a key is created or rotated), collapsing a storm to one lookup and one log line per window. Separately, the dashboard live-update stream (`/api/v1/events`) no longer counts against the global rate limiter, so heavy dashboard use can't trip a 429 that severs the stream.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "test": "turbo test",
     "start": "node packages/backend/dist/main.js",
     "check:api-prefix": "node scripts/check-api-prefix.js",
+    "railway:http-logs": "node scripts/railway-http-logs.js",
+    "test:scripts": "node --test scripts/*.test.js",
     "lint": "eslint packages/shared/src packages/backend/src packages/frontend/src",
     "format": "prettier --write 'packages/*/src/**/*.{ts,tsx,css}'",
     "changeset": "changeset",

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -748,4 +748,153 @@ describe('AgentKeyAuthGuard', () => {
 
     expect(mockGetMany).toHaveBeenCalledTimes(1);
   });
+
+  describe('negative cache (rejected-key storm protection)', () => {
+    const negativeCacheOf = (g: AgentKeyAuthGuard) =>
+      (g as unknown as { negativeCache: Map<string, number> }).negativeCache;
+
+    it('serves a repeated bad key from the negative cache without a second DB lookup or log', async () => {
+      mockGetMany.mockResolvedValue([]); // unknown key — DB returns no candidates
+      const logger = (guard as unknown as { logger: { warn: jest.Mock } }).logger;
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      const { ctx: ctx1 } = makeContext({ authorization: 'Bearer mnfst_bad-key-storm' });
+      await expect(guard.canActivate(ctx1)).rejects.toThrow('Invalid API key');
+      // First miss pays the DB lookup and logs once.
+      expect(mockGetMany).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      mockCreateQueryBuilder.mockClear();
+      mockGetMany.mockClear();
+      warnSpy.mockClear();
+
+      const { ctx: ctx2 } = makeContext({ authorization: 'Bearer mnfst_bad-key-storm' });
+      await expect(guard.canActivate(ctx2)).rejects.toThrow('Invalid API key');
+      // The repeat is served from the negative cache: no DB query, no log line.
+      expect(mockCreateQueryBuilder).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('records a rejected unknown key (hashed, not plaintext) for the configured TTL', async () => {
+      const token = 'mnfst_record-bad-key';
+      const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key');
+
+      const negCache = negativeCacheOf(guard);
+      expect(negCache.has(testCacheKey(token))).toBe(true);
+      // Stored under the hash, never the raw token.
+      expect(negCache.has(token)).toBe(false);
+      const ttl = negCache.get(testCacheKey(token))! - Date.now();
+      expect(ttl).toBeGreaterThan(30 * 1000 - 2000);
+      expect(ttl).toBeLessThanOrEqual(30 * 1000 + 100);
+    });
+
+    it('LRU-touches a negative entry on a cache hit (moves it to the tail)', async () => {
+      const { ctx } = makeContext({ authorization: 'Bearer mnfst_neg-lru-key' });
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key');
+
+      const negCache = negativeCacheOf(guard);
+      negCache.set(testCacheKey('mnfst_neg-other'), Date.now() + 999_999);
+      expect(Array.from(negCache.keys())[0]).toBe(testCacheKey('mnfst_neg-lru-key'));
+
+      const { ctx: ctx2 } = makeContext({ authorization: 'Bearer mnfst_neg-lru-key' });
+      await expect(guard.canActivate(ctx2)).rejects.toThrow('Invalid API key');
+      // After the touch the rejected key sits behind the other entry.
+      expect(Array.from(negCache.keys())[1]).toBe(testCacheKey('mnfst_neg-lru-key'));
+    });
+
+    it('drops a stale negative entry and re-checks the DB so a since-created key works', async () => {
+      const token = 'mnfst_was-bad-now-good';
+      const negCache = negativeCacheOf(guard);
+      // An already-expired negative entry from an earlier rejection.
+      negCache.set(testCacheKey(token), Date.now() - 1000);
+
+      // The key now exists in the DB (created after that rejection).
+      mockGetMany.mockResolvedValue([
+        {
+          id: 'key-revived',
+          tenant_id: 'tenant-1',
+          agent_id: 'agent-1',
+          key_hash: hashKey(token),
+          expires_at: null,
+          agent: { name: 'test-agent' },
+          tenant: { owner_user_id: 'user-1' },
+        },
+      ]);
+
+      const { ctx, req } = makeContext({ authorization: `Bearer ${token}` });
+      expect(await guard.canActivate(ctx)).toBe(true);
+      expect(req.ingestionContext).toBeDefined();
+      expect(negCache.has(testCacheKey(token))).toBe(false);
+    });
+
+    it('evicts the oldest negative entry when the negative cache is full', async () => {
+      const negCache = negativeCacheOf(guard);
+      const firstHash = testCacheKey('mnfst_neg-filler-0');
+      for (let i = 0; i < 10_000; i++) {
+        negCache.set(testCacheKey(`mnfst_neg-filler-${i}`), Date.now() + 999_999);
+      }
+      expect(negCache.size).toBe(10_000);
+
+      const token = 'mnfst_neg-overflow-key';
+      const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key');
+
+      expect(negCache.has(firstHash)).toBe(false);
+      expect(negCache.has(testCacheKey(token))).toBe(true);
+      expect(negCache.size).toBeLessThanOrEqual(10_000);
+    });
+
+    it('evictExpired also sweeps expired negative-cache entries but keeps live ones', async () => {
+      const negCache = negativeCacheOf(guard);
+      const expiredHash = testCacheKey('mnfst_neg-expired');
+      const liveHash = testCacheKey('mnfst_neg-live');
+      negCache.set(expiredHash, Date.now() - 1000);
+      negCache.set(liveHash, Date.now() + 999_999);
+
+      // A successful validation runs evictExpired() before caching, which now
+      // sweeps the negative cache too.
+      const token = 'mnfst_valid-triggers-evict';
+      mockGetMany.mockResolvedValue([
+        {
+          id: 'key-ev',
+          tenant_id: 'tenant-1',
+          agent_id: 'agent-1',
+          key_hash: hashKey(token),
+          expires_at: null,
+          agent: { name: 'test-agent' },
+          tenant: { owner_user_id: 'user-1' },
+        },
+      ]);
+      const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+      await guard.canActivate(ctx);
+
+      expect(negCache.has(expiredHash)).toBe(false);
+      expect(negCache.has(liveHash)).toBe(true);
+    });
+
+    it('invalidateCache removes the negative entry so a re-created key is not stuck', async () => {
+      const token = 'mnfst_inv-neg-key';
+      const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key');
+
+      const negCache = negativeCacheOf(guard);
+      expect(negCache.has(testCacheKey(token))).toBe(true);
+
+      guard.invalidateCache(token);
+      expect(negCache.has(testCacheKey(token))).toBe(false);
+    });
+
+    it('clearCache empties the negative cache', async () => {
+      const token = 'mnfst_clear-neg-key';
+      const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key');
+
+      const negCache = negativeCacheOf(guard);
+      expect(negCache.size).toBe(1);
+
+      guard.clearCache();
+      expect(negCache.size).toBe(0);
+    });
+  });
 });

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -48,6 +48,16 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
   // directly when keys rotate or deactivate.
   private readonly CACHE_TTL_MS = 5 * 60 * 1000;
   private readonly MAX_CACHE_SIZE = 10_000;
+  // Maps a rejected token's hash to when its rejection stops being trusted.
+  // Without this, every request bearing a wrong/revoked mnfst_ key runs a
+  // fresh indexed DB lookup AND emits a warn log — so a single misconfigured
+  // agent in a retry loop sustains DB load and floods the logs indefinitely.
+  // The TTL is deliberately much shorter than CACHE_TTL_MS so a key that gets
+  // created or reactivated starts working quickly; key mutations also clear
+  // this via clearCache()/invalidateCache(), so a created key is never stuck.
+  private negativeCache = new Map<string, number>();
+  private readonly NEGATIVE_CACHE_TTL_MS = 30 * 1000;
+  private readonly MAX_NEGATIVE_CACHE_SIZE = 10_000;
   private readonly cleanupTimer: ReturnType<typeof setInterval>;
 
   constructor(
@@ -124,11 +134,17 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
   }
 
   invalidateCache(key: string) {
-    this.cache.delete(cacheKey(key));
+    const hashed = cacheKey(key);
+    this.cache.delete(hashed);
+    // Drop any negative entry too, so re-creating or rotating a key that was
+    // briefly rejected (e.g. a client raced ahead of key creation) takes
+    // effect immediately instead of waiting out the negative TTL.
+    this.negativeCache.delete(hashed);
   }
 
   clearCache() {
     this.cache.clear();
+    this.negativeCache.clear();
   }
 
   private setContext(request: Request, ctx: IngestionContext): void {
@@ -146,6 +162,23 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
   private async validateMnfstToken(request: Request, token: string): Promise<boolean> {
     const hashed = cacheKey(token);
     const now = Date.now();
+
+    // Negative cache first: a recently-rejected token short-circuits here
+    // without touching the DB or emitting a log line. This is what collapses
+    // a wrong/revoked-key storm to one DB lookup + one warn per TTL window.
+    const negativeExpiry = this.negativeCache.get(hashed);
+    if (negativeExpiry !== undefined && negativeExpiry > now) {
+      // LRU touch — re-insert to move to tail of insertion order.
+      this.negativeCache.delete(hashed);
+      this.negativeCache.set(hashed, negativeExpiry);
+      throw new UnauthorizedException('Invalid API key');
+    }
+    if (negativeExpiry !== undefined) {
+      // Stale negative entry — drop it and re-check against the DB so a key
+      // that has since been created/reactivated can authenticate again.
+      this.negativeCache.delete(hashed);
+    }
+
     const cached = this.cache.get(hashed);
     // A key whose own expiry has passed must stop authenticating immediately,
     // even if its cache entry is still inside the 5-min TTL. Drop the stale
@@ -188,6 +221,9 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
     const keyRecord = candidates.find((c) => verifyKey(token, c.key_hash));
 
     if (!keyRecord) {
+      // Remember the rejection so an identical repeat is served from the
+      // negative cache (no DB, no log) until the short TTL lapses.
+      this.rememberInvalid(hashed);
       // Log only the fixed prefix — even leaking the next character or two
       // narrows the search space if these warnings end up in a SIEM that
       // retains them indefinitely.
@@ -269,10 +305,23 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
     return ctx;
   }
 
+  private rememberInvalid(hashed: string): void {
+    this.evictExpired();
+    while (this.negativeCache.size >= this.MAX_NEGATIVE_CACHE_SIZE) {
+      const firstKey = this.negativeCache.keys().next().value;
+      if (firstKey === undefined) break;
+      this.negativeCache.delete(firstKey);
+    }
+    this.negativeCache.set(hashed, Date.now() + this.NEGATIVE_CACHE_TTL_MS);
+  }
+
   private evictExpired() {
     const now = Date.now();
     for (const [key, entry] of this.cache) {
       if (entry.expiresAt <= now) this.cache.delete(key);
+    }
+    for (const [key, expiresAt] of this.negativeCache) {
+      if (expiresAt <= now) this.negativeCache.delete(key);
     }
   }
 }

--- a/packages/backend/src/sse/sse.controller.spec.ts
+++ b/packages/backend/src/sse/sse.controller.spec.ts
@@ -26,6 +26,16 @@ describe('SseController', () => {
     controller = module.get<SseController>(SseController);
   });
 
+  it('is excluded from the global throttler so the live stream is not rate-limited', () => {
+    // `@SkipThrottle()` (no args) defaults to `{ default: true }`, which the
+    // decorator stores as Reflect metadata under `${THROTTLER_SKIP}${key}` —
+    // i.e. the literal `THROTTLER:SKIPdefault`. The ThrottlerGuard reads this
+    // to bypass the limiter. Asserting it here pins the behavior: the SSE
+    // stream (one long-lived connection + EventSource reconnects) must never
+    // count against the 100-req/60s budget shared with dashboard polling.
+    expect(Reflect.getMetadata('THROTTLER:SKIPdefault', SseController)).toBe(true);
+  });
+
   it('subscribes to the bus scoped to the request tenant', () => {
     controller.events({ tenantId: 'tenant-1', userId: 'user-1' });
     expect(forTenant).toHaveBeenCalledWith('tenant-1');

--- a/packages/backend/src/sse/sse.controller.ts
+++ b/packages/backend/src/sse/sse.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Sse } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import { Observable } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { TenantCtx, TenantContext } from '../common/decorators/tenant-context.decorator';
@@ -9,6 +10,13 @@ interface MessageEvent {
   type: string;
 }
 
+// `/api/v1/events` is one long-lived connection per dashboard tab, and the
+// browser's EventSource auto-reconnects every few seconds whenever it drops.
+// Counting those against the global 100-req/60s-per-IP ThrottlerGuard — a
+// budget already shared with the dashboard's analytics polling — risks 429s
+// that sever the live stream and then trigger more reconnects. The proxy opts
+// out of the global limiter the same way; the SSE stream should too.
+@SkipThrottle()
 @Controller('api/v1')
 export class SseController {
   constructor(private readonly eventBus: IngestEventBusService) {}

--- a/scripts/railway-http-logs.js
+++ b/scripts/railway-http-logs.js
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Railway HTTP-log aggregator.
+ *
+ * Pulls a deployment's edge HTTP request logs from Railway's public GraphQL
+ * API and prints a status×path breakdown — the "top offending routes" view the
+ * Observability UI can't produce (it has no server-side GROUP BY). Use it to
+ * turn the raw 2xx/3xx/4xx metric split into "which status on which route".
+ *
+ * Usage:
+ *   RAILWAY_API_TOKEN=... RAILWAY_DEPLOYMENT_ID=... node scripts/railway-http-logs.js \
+ *     --start 2026-06-24T00:00:00Z --end 2026-06-24T01:00:00Z \
+ *     --filter '@httpStatus:401 OR @httpStatus:404' --top 30
+ *
+ * Flags (all optional except token + deployment, which may come from env):
+ *   --token <t>        Railway API token        (env RAILWAY_API_TOKEN / RAILWAY_TOKEN)
+ *   --deployment <id>  Deployment id            (env RAILWAY_DEPLOYMENT_ID)
+ *   --start <iso>      Window start (ISO 8601)
+ *   --end <iso>        Window end (ISO 8601)
+ *   --filter <expr>    Railway log filter, e.g. '@httpStatus:401'
+ *   --limit <n>        Max records to fetch     (default 5000)
+ *   --top <n>          Rows in the status×path table (default 25)
+ *
+ * Note: the GraphQL field/arg names below follow Railway's public API. The API
+ * evolves — if a field errors, confirm the current names via GraphQL
+ * introspection and adjust HTTP_LOGS_QUERY. The aggregation tolerates a few
+ * common field-name variants so a rename doesn't silently zero the counts.
+ */
+
+const RAILWAY_GRAPHQL_ENDPOINT = 'https://backboard.railway.app/graphql/v2';
+
+const HTTP_LOGS_QUERY = `query HttpLogs($deploymentId: String!, $startDate: String, $endDate: String, $filter: String, $limit: Int) {
+  httpLogs(deploymentId: $deploymentId, startDate: $startDate, endDate: $endDate, filter: $filter, limit: $limit) {
+    timestamp
+    method
+    path
+    host
+    httpStatus
+    clientUa
+    srcIp
+    upstreamRqDuration
+  }
+}`;
+
+/** Bucket a numeric status into its class label. */
+function statusClass(status) {
+  const s = Number(status);
+  if (!Number.isFinite(s)) return 'other';
+  if (s >= 200 && s < 300) return '2xx';
+  if (s >= 300 && s < 400) return '3xx';
+  if (s >= 400 && s < 500) return '4xx';
+  if (s >= 500 && s < 600) return '5xx';
+  return 'other';
+}
+
+/** Read the status off a record, tolerant to a few Railway field-name variants. */
+function getStatus(record) {
+  return Number(record.httpStatus ?? record.status ?? record.statusCode);
+}
+
+/** Read the path, dropping the query string so /x?a=1 and /x?a=2 aggregate together. */
+function getPath(record) {
+  const raw = String(record.path ?? record.requestPath ?? record.url ?? '');
+  const q = raw.indexOf('?');
+  return q === -1 ? raw : raw.slice(0, q);
+}
+
+/**
+ * Group records into per-status counts, per-class counts, and a (status, path)
+ * table sorted by count desc. Records without a finite status are ignored.
+ */
+function aggregate(records) {
+  const byStatus = {};
+  const pairs = new Map();
+  let total = 0;
+  for (const r of records) {
+    const status = getStatus(r);
+    if (!Number.isFinite(status)) continue;
+    total += 1;
+    byStatus[status] = (byStatus[status] || 0) + 1;
+    const path = getPath(r);
+    const key = `${status} ${path}`;
+    const existing = pairs.get(key);
+    if (existing) existing.count += 1;
+    else pairs.set(key, { status, path, count: 1 });
+  }
+  const byStatusPath = Array.from(pairs.values()).sort(
+    (a, b) => b.count - a.count || a.status - b.status,
+  );
+  const byClass = {};
+  for (const [status, count] of Object.entries(byStatus)) {
+    const cls = statusClass(status);
+    byClass[cls] = (byClass[cls] || 0) + count;
+  }
+  return { total, byStatus, byClass, byStatusPath };
+}
+
+/** Render an aggregate as a human-readable report. */
+function formatReport(agg, options = {}) {
+  const top = options.top ?? 25;
+  const lines = [];
+  lines.push(`Total HTTP log records: ${agg.total}`);
+  lines.push('');
+  lines.push('By status class:');
+  for (const cls of ['2xx', '3xx', '4xx', '5xx', 'other']) {
+    if (agg.byClass[cls]) {
+      const pct = agg.total ? ((agg.byClass[cls] / agg.total) * 100).toFixed(1) : '0.0';
+      lines.push(`  ${cls}  ${agg.byClass[cls]}  (${pct}%)`);
+    }
+  }
+  lines.push('');
+  lines.push(`Top ${top} (status x path):`);
+  lines.push('  count  status  path');
+  for (const row of agg.byStatusPath.slice(0, top)) {
+    lines.push(
+      `  ${String(row.count).padStart(5)}  ${String(row.status).padStart(6)}  ${row.path}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+/** Parse argv (process.argv.slice(2)) + env into a config object. */
+function parseArgs(argv, env = {}) {
+  const a = {};
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === '--token') a.token = argv[++i];
+    else if (flag === '--deployment' || flag === '-d') a.deploymentId = argv[++i];
+    else if (flag === '--start') a.start = argv[++i];
+    else if (flag === '--end') a.end = argv[++i];
+    else if (flag === '--filter' || flag === '-f') a.filter = argv[++i];
+    else if (flag === '--limit' || flag === '-l') a.limit = Number(argv[++i]);
+    else if (flag === '--top' || flag === '-t') a.top = Number(argv[++i]);
+  }
+  return {
+    token: a.token ?? env.RAILWAY_API_TOKEN ?? env.RAILWAY_TOKEN,
+    deploymentId: a.deploymentId ?? env.RAILWAY_DEPLOYMENT_ID,
+    start: a.start,
+    end: a.end,
+    filter: a.filter,
+    limit: Number.isFinite(a.limit) ? a.limit : 5000,
+    top: Number.isFinite(a.top) ? a.top : 25,
+  };
+}
+
+/** Fetch raw HTTP-log records from Railway. fetchImpl is injectable for testing. */
+async function fetchHttpLogs(config, fetchImpl = globalThis.fetch) {
+  if (!config.token) {
+    throw new Error('Missing Railway API token (--token or RAILWAY_API_TOKEN)');
+  }
+  if (!config.deploymentId) {
+    throw new Error('Missing deployment id (--deployment or RAILWAY_DEPLOYMENT_ID)');
+  }
+  const res = await fetchImpl(RAILWAY_GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${config.token}`,
+    },
+    body: JSON.stringify({
+      query: HTTP_LOGS_QUERY,
+      variables: {
+        deploymentId: config.deploymentId,
+        startDate: config.start,
+        endDate: config.end,
+        filter: config.filter,
+        limit: config.limit,
+      },
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Railway API HTTP ${res.status}: ${text.slice(0, 500)}`);
+  }
+  const json = await res.json();
+  if (json.errors && json.errors.length) {
+    throw new Error(`Railway GraphQL error: ${JSON.stringify(json.errors)}`);
+  }
+  const logs = json.data && json.data.httpLogs;
+  return Array.isArray(logs) ? logs : [];
+}
+
+// CLI entrypoint — thin glue over the exported, unit-tested units
+// (parseArgs / fetchHttpLogs / aggregate / formatReport).
+async function main() {
+  const config = parseArgs(process.argv.slice(2), process.env);
+  let records;
+  try {
+    records = await fetchHttpLogs(config);
+  } catch (err) {
+    console.error(err.message);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(formatReport(aggregate(records), { top: config.top }));
+}
+
+// Only runs when invoked directly, not when imported by the test file.
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  RAILWAY_GRAPHQL_ENDPOINT,
+  HTTP_LOGS_QUERY,
+  statusClass,
+  getStatus,
+  getPath,
+  aggregate,
+  formatReport,
+  parseArgs,
+  fetchHttpLogs,
+};

--- a/scripts/railway-http-logs.test.js
+++ b/scripts/railway-http-logs.test.js
@@ -1,0 +1,209 @@
+'use strict';
+
+// Run with: node --test scripts/   (Node's built-in test runner; no jest needed)
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  RAILWAY_GRAPHQL_ENDPOINT,
+  HTTP_LOGS_QUERY,
+  statusClass,
+  getStatus,
+  getPath,
+  aggregate,
+  formatReport,
+  parseArgs,
+  fetchHttpLogs,
+} = require('./railway-http-logs');
+
+test('statusClass buckets each status into its class', () => {
+  assert.equal(statusClass(204), '2xx');
+  assert.equal(statusClass(301), '3xx');
+  assert.equal(statusClass(404), '4xx');
+  assert.equal(statusClass(503), '5xx');
+  assert.equal(statusClass(100), 'other');
+  assert.equal(statusClass(700), 'other');
+  assert.equal(statusClass('nope'), 'other');
+});
+
+test('getStatus tolerates httpStatus / status / statusCode variants', () => {
+  assert.equal(getStatus({ httpStatus: 401 }), 401);
+  assert.equal(getStatus({ status: 404 }), 404);
+  assert.equal(getStatus({ statusCode: 429 }), 429);
+  assert.ok(Number.isNaN(getStatus({})));
+});
+
+test('getPath strips the query string and tolerates path / url variants', () => {
+  assert.equal(getPath({ path: '/v1/chat/completions' }), '/v1/chat/completions');
+  assert.equal(getPath({ path: '/api/v1/messages?page=2&range=30d' }), '/api/v1/messages');
+  assert.equal(getPath({ url: '/assets/app.js?v=abc' }), '/assets/app.js');
+  assert.equal(getPath({}), '');
+});
+
+test('aggregate counts by status, by class, and by (status, path) sorted desc', () => {
+  const records = [
+    { httpStatus: 401, path: '/v1/chat/completions' },
+    { httpStatus: 401, path: '/v1/chat/completions' },
+    { httpStatus: 401, path: '/v1/chat/completions' },
+    { httpStatus: 404, path: '/wp-login.php' },
+    { httpStatus: 302, path: '/api/auth/sign-in/social' },
+    { httpStatus: 200, path: '/api/v1/overview' },
+  ];
+  const agg = aggregate(records);
+
+  assert.equal(agg.total, 6);
+  assert.equal(agg.byStatus['401'], 3);
+  assert.equal(agg.byClass['4xx'], 4); // three 401 + one 404
+  assert.equal(agg.byClass['3xx'], 1);
+  assert.equal(agg.byClass['2xx'], 1);
+
+  // Most frequent (status, path) pair comes first.
+  assert.deepEqual(agg.byStatusPath[0], {
+    status: 401,
+    path: '/v1/chat/completions',
+    count: 3,
+  });
+});
+
+test('aggregate ignores records with a non-finite status', () => {
+  const agg = aggregate([{ path: '/x' }, { httpStatus: 'oops', path: '/y' }, { httpStatus: 500 }]);
+  assert.equal(agg.total, 1);
+  assert.equal(agg.byClass['5xx'], 1);
+});
+
+test('aggregate groups the same path with differing query strings together', () => {
+  const agg = aggregate([
+    { httpStatus: 404, path: '/api/v1/agents/a?x=1' },
+    { httpStatus: 404, path: '/api/v1/agents/a?x=2' },
+  ]);
+  assert.equal(agg.byStatusPath.length, 1);
+  assert.equal(agg.byStatusPath[0].count, 2);
+});
+
+test('formatReport renders totals, class lines, and a capped top table', () => {
+  // Distinct counts so ordering is unambiguous: 401(3) > 404(2) > 302(1).
+  const agg = aggregate([
+    { httpStatus: 401, path: '/v1/chat/completions' },
+    { httpStatus: 401, path: '/v1/chat/completions' },
+    { httpStatus: 401, path: '/v1/chat/completions' },
+    { httpStatus: 404, path: '/wp-login.php' },
+    { httpStatus: 404, path: '/wp-login.php' },
+    { httpStatus: 302, path: '/api/auth/x' },
+  ]);
+  const report = formatReport(agg, { top: 2 });
+
+  assert.match(report, /Total HTTP log records: 6/);
+  assert.match(report, /4xx {2}5 {2}\(83\.3%\)/); // three 401 + two 404
+  assert.match(report, /3xx {2}1 {2}\(16\.7%\)/);
+  assert.match(report, /Top 2 \(status x path\):/);
+  assert.match(report, /401 {2}\/v1\/chat\/completions/);
+  // Capped at 2 rows → the lowest-count pair (302) is excluded.
+  assert.ok(!report.includes('/api/auth/x'));
+});
+
+test('formatReport defaults top to 25 and handles an empty aggregate', () => {
+  const report = formatReport(aggregate([]));
+  assert.match(report, /Total HTTP log records: 0/);
+  assert.match(report, /Top 25 \(status x path\):/);
+});
+
+test('parseArgs reads flags, applies env fallback, and sets defaults', () => {
+  const cfg = parseArgs(
+    ['--deployment', 'dep-1', '--filter', '@httpStatus:401', '--limit', '100', '--top', '5'],
+    { RAILWAY_API_TOKEN: 'tok-env' },
+  );
+  assert.equal(cfg.token, 'tok-env');
+  assert.equal(cfg.deploymentId, 'dep-1');
+  assert.equal(cfg.filter, '@httpStatus:401');
+  assert.equal(cfg.limit, 100);
+  assert.equal(cfg.top, 5);
+
+  // Defaults when flags are absent.
+  const def = parseArgs([], {});
+  assert.equal(def.limit, 5000);
+  assert.equal(def.top, 25);
+  assert.equal(def.token, undefined);
+
+  // Explicit --token and short flags win / are honored.
+  const cfg2 = parseArgs(['--token', 'tok-cli', '-d', 'dep-2', '-f', 'x', '-l', '7', '-t', '3'], {
+    RAILWAY_TOKEN: 'tok-env2',
+  });
+  assert.equal(cfg2.token, 'tok-cli');
+  assert.equal(cfg2.deploymentId, 'dep-2');
+});
+
+test('fetchHttpLogs posts the right query/variables and returns httpLogs', async () => {
+  const calls = [];
+  const fakeFetch = async (url, init) => {
+    calls.push({ url, init });
+    return {
+      ok: true,
+      async json() {
+        return { data: { httpLogs: [{ httpStatus: 404, path: '/x' }] } };
+      },
+    };
+  };
+
+  const records = await fetchHttpLogs(
+    { token: 'tok', deploymentId: 'dep-1', start: 'S', end: 'E', filter: 'F', limit: 42 },
+    fakeFetch,
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, RAILWAY_GRAPHQL_ENDPOINT);
+  assert.equal(calls[0].init.headers.Authorization, 'Bearer tok');
+  const body = JSON.parse(calls[0].init.body);
+  assert.equal(body.query, HTTP_LOGS_QUERY);
+  assert.deepEqual(body.variables, {
+    deploymentId: 'dep-1',
+    startDate: 'S',
+    endDate: 'E',
+    filter: 'F',
+    limit: 42,
+  });
+  assert.deepEqual(records, [{ httpStatus: 404, path: '/x' }]);
+});
+
+test('fetchHttpLogs returns [] when the API yields no logs array', async () => {
+  const fakeFetch = async () => ({ ok: true, async json() { return { data: {} }; } });
+  const records = await fetchHttpLogs({ token: 't', deploymentId: 'd' }, fakeFetch);
+  assert.deepEqual(records, []);
+});
+
+test('fetchHttpLogs throws on missing token or deployment', async () => {
+  await assert.rejects(() => fetchHttpLogs({ deploymentId: 'd' }, async () => {}), /Missing Railway API token/);
+  await assert.rejects(() => fetchHttpLogs({ token: 't' }, async () => {}), /Missing deployment id/);
+});
+
+test('fetchHttpLogs surfaces HTTP and GraphQL errors', async () => {
+  const httpErr = async () => ({ ok: false, status: 403, async text() { return 'forbidden'; } });
+  await assert.rejects(
+    () => fetchHttpLogs({ token: 't', deploymentId: 'd' }, httpErr),
+    /Railway API HTTP 403: forbidden/,
+  );
+
+  const gqlErr = async () => ({
+    ok: true,
+    async json() {
+      return { errors: [{ message: 'bad field' }] };
+    },
+  });
+  await assert.rejects(
+    () => fetchHttpLogs({ token: 't', deploymentId: 'd' }, gqlErr),
+    /Railway GraphQL error/,
+  );
+});
+
+test('fetchHttpLogs tolerates a text() failure on a non-ok response', async () => {
+  const fakeFetch = async () => ({
+    ok: false,
+    status: 500,
+    async text() {
+      throw new Error('stream broke');
+    },
+  });
+  await assert.rejects(
+    () => fetchHttpLogs({ token: 't', deploymentId: 'd' }, fakeFetch),
+    /Railway API HTTP 500: $/,
+  );
+});


### PR DESCRIPTION
### 💭 Why
A response-code audit turned up two sources of wasteful non-2xx load. A wrong or revoked `mnfst_` key hit the DB and logged a warning on every request, so one misconfigured agent in a retry loop hammered the database and flooded the logs. Separately, the dashboard live stream shared the global rate-limit budget with analytics polling, so heavy use could 429 and sever the stream.

### ✨ What changed
- Negative-cache rejected agent keys for 30s (bounded LRU, cleared on key create/rotate).
- A repeated bad key short-circuits with no DB lookup and no log line.
- Exempt the SSE stream (`/api/v1/events`) from the global throttler, matching the proxy.
- Add `scripts/railway-http-logs.js` to break Railway HTTP logs down by status code and route.

### 👤 For users
Heavy dashboard use no longer risks a 429 that drops live updates.

### 🔧 For operators
Far fewer DB hits and log lines when an agent retries with a bad key. No migrations or config changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops bad `mnfst_` API keys from hammering the database and removes rate limiting from the dashboard SSE stream to avoid 429 drops. Also adds a small tool to analyze Railway HTTP logs by status and path.

- **Bug Fixes**
  - Cache rejected agent keys for 30s (bounded LRU). Repeated bad keys short-circuit with no DB lookup and no log; cache is cleared on key create/rotate.
  - Exempt `/api/v1/events` from the global throttler (`@SkipThrottle`) so the live stream isn’t counted against the shared request budget.

- **New Features**
  - Added `scripts/railway-http-logs.js` (+ tests) to print a status×path breakdown from Railway logs. New scripts: `railway:http-logs` and `test:scripts`.

<sup>Written for commit 060db8fc5028c9d41c2d589dce1de3a14cc675e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

