### PR TITLE
fix: stop a slow memory leak from unbounded caches

### DIFF
--- a/.changeset/bound-response-cache.md
+++ b/.changeset/bound-response-cache.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Stop a slow memory climb on long-running servers. The global dashboard response cache used cache-manager's default in-memory store, which has no size limit and only drops entries when their exact URL is requested again. High-cardinality dashboard URLs (filters, cursors, time ranges) piled up for the life of the process. It now uses a bounded LRU store with a hard entry cap plus an active sweep of expired entries. Three proxy session caches (Anthropic thinking blocks, Gemini thought signatures, DeepSeek reasoning content) were also uncapped and now evict their oldest entries once a ceiling is reached.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1069,6 +1069,18 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.9.tgz",
+      "integrity": "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.1",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
     "node_modules/@cacheable/utils": {
       "version": "2.4.1",
       "license": "MIT",
@@ -2696,6 +2708,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@keyv/serialize": {
@@ -5892,6 +5920,19 @@
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
+      "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.1",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
       }
     },
     "node_modules/call-bind": {
@@ -10016,6 +10057,8 @@
     },
     "node_modules/keyv": {
       "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -11374,6 +11417,24 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
       "license": "MIT"
     },
     "node_modules/qs": {
@@ -14138,6 +14199,7 @@
         "@react-email/render": "^2.0.4",
         "better-auth": "^1.6.11",
         "cache-manager": "^7.2.8",
+        "cacheable": "^2.3.5",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "compression": "^1.8.1",
@@ -14911,7 +14973,7 @@
       }
     },
     "packages/manifest": {
-      "version": "6.9.2"
+      "version": "6.11.0"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,7 +21,6 @@
     "backfill:message-providers:prod": "node dist/database/backfills/backfill-message-providers.cli.js"
   },
   "dependencies": {
-    "manifest-shared": "*",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.0",
@@ -35,12 +34,14 @@
     "@react-email/render": "^2.0.4",
     "better-auth": "^1.6.11",
     "cache-manager": "^7.2.8",
+    "cacheable": "^2.3.5",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "compression": "^1.8.1",
     "eventsource-parser": "^3.1.0",
     "express-rate-limit": "^8.5.1",
     "helmet": "^8.1.0",
+    "manifest-shared": "*",
     "pg": "^8.13.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { appConfig } from './config/app.config';
 import { resolveFrontendDir } from './common/utils/frontend-path';
 import { DASHBOARD_CACHE_TTL_MS } from './common/constants/cache.constants';
+import { buildDashboardCacheStore } from './common/cache/dashboard-cache.factory';
 import { ApiKeyGuard } from './common/guards/api-key.guard';
 import { ApiKey } from './entities/api-key.entity';
 import { SessionGuard } from './auth/session.guard';
@@ -54,7 +55,11 @@ const serveStaticImports = frontendPath
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true, load: [appConfig] }),
-    CacheModule.register({ isGlobal: true, ttl: DASHBOARD_CACHE_TTL_MS }),
+    CacheModule.register({
+      isGlobal: true,
+      ttl: DASHBOARD_CACHE_TTL_MS,
+      stores: [buildDashboardCacheStore()],
+    }),
     ...serveStaticImports,
     ThrottlerModule.forRoot([
       {

--- a/packages/backend/src/common/cache/dashboard-cache.factory.spec.ts
+++ b/packages/backend/src/common/cache/dashboard-cache.factory.spec.ts
@@ -1,0 +1,29 @@
+import { buildDashboardCacheStore } from './dashboard-cache.factory';
+import { DASHBOARD_CACHE_MAX_ENTRIES } from '../constants/cache.constants';
+
+describe('buildDashboardCacheStore', () => {
+  it('stores and retrieves values', async () => {
+    const store = buildDashboardCacheStore();
+
+    await store.set('/api/v1/overview', { ok: true });
+
+    expect(await store.get('/api/v1/overview')).toEqual({ ok: true });
+  });
+
+  it('enforces the LRU cap so write-once unique keys cannot grow unbounded', async () => {
+    const store = buildDashboardCacheStore();
+
+    // Simulate the dashboard pattern: many unique URL keys, each written once.
+    // Insert sequentially so least-recently-used order is deterministic.
+    const overflow = 100;
+    for (let i = 0; i < DASHBOARD_CACHE_MAX_ENTRIES + overflow; i++) {
+      await store.set(`/api/v1/costs?cursor=${i}`, i);
+    }
+
+    // The oldest keys are LRU-evicted once the cap is exceeded; recent ones stay.
+    expect(await store.get('/api/v1/costs?cursor=0')).toBeUndefined();
+    expect(
+      await store.get(`/api/v1/costs?cursor=${DASHBOARD_CACHE_MAX_ENTRIES + overflow - 1}`),
+    ).toBe(DASHBOARD_CACHE_MAX_ENTRIES + overflow - 1);
+  }, 20000);
+});

--- a/packages/backend/src/common/cache/dashboard-cache.factory.ts
+++ b/packages/backend/src/common/cache/dashboard-cache.factory.ts
@@ -1,0 +1,31 @@
+import { createKeyv, type Keyv } from 'cacheable';
+import {
+  DASHBOARD_CACHE_MAX_ENTRIES,
+  DASHBOARD_CACHE_SWEEP_MS,
+  DASHBOARD_CACHE_TTL_MS,
+} from '../constants/cache.constants';
+
+/**
+ * Builds the bounded in-memory store for the global response cache
+ * (`CacheModule`).
+ *
+ * cache-manager@7's default store is an unbounded `Keyv` Map with lazy-only
+ * expiry: it has no size cap and never sweeps, so an entry is dropped only when
+ * its exact key is read again. The dashboard interceptors key by full request
+ * URL, so high-cardinality query strings (ranges, cursors, filters, timestamps)
+ * are written once and rarely re-read with an identical URL — their entries are
+ * never evicted and heap climbs monotonically across the process lifetime.
+ *
+ * `createKeyv` returns a `Keyv` backed by `CacheableMemory`, adding a hard LRU
+ * cap (`lruSize`) plus an active, `unref`'d sweep of expired entries
+ * (`checkInterval`). Using the helper (rather than a hand-built `new Keyv()`)
+ * yields the `Keyv` instance `@nestjs/cache-manager` recognises via
+ * `instanceof Keyv`, so it is used as-is instead of being rejected.
+ */
+export function buildDashboardCacheStore(): Keyv {
+  return createKeyv({
+    ttl: DASHBOARD_CACHE_TTL_MS,
+    lruSize: DASHBOARD_CACHE_MAX_ENTRIES,
+    checkInterval: DASHBOARD_CACHE_SWEEP_MS,
+  });
+}

--- a/packages/backend/src/common/constants/cache.constants.ts
+++ b/packages/backend/src/common/constants/cache.constants.ts
@@ -1,4 +1,13 @@
 export const DASHBOARD_CACHE_TTL_MS = 30_000;
+/**
+ * Hard cap on entries in the global response cache. cache-manager@7's default
+ * in-memory store is an unbounded Keyv Map; the dashboard interceptors key by
+ * full request URL, so without a cap high-cardinality query strings accumulate
+ * forever. Oldest entries are LRU-evicted once this ceiling is reached.
+ */
+export const DASHBOARD_CACHE_MAX_ENTRIES = 5_000;
+/** Interval (ms) for the active sweep of expired global response-cache entries. */
+export const DASHBOARD_CACHE_SWEEP_MS = 60_000;
 export const AGENT_LIST_CACHE_TTL_MS = 60_000;
 export const MODEL_PRICES_CACHE_TTL_MS = 300_000;
 export const PUBLIC_STATS_CACHE_TTL_MS = 86_400_000;

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -1,6 +1,6 @@
 import type { Repository } from 'typeorm';
 import { ReasoningContentCacheEntry } from '../../../entities/reasoning-content-cache-entry.entity';
-import { ReasoningContentCache } from '../reasoning-content-cache';
+import { ReasoningContentCache, MAX_CACHE_ENTRIES } from '../reasoning-content-cache';
 
 const makeRepo = () =>
   ({
@@ -183,6 +183,18 @@ describe('ReasoningContentCache', () => {
 
     expect(result).toBe(body);
     expect(repo.find).not.toHaveBeenCalled();
+  });
+
+  it('evicts the oldest in-memory entries once MAX_CACHE_ENTRIES is exceeded', () => {
+    for (let i = 0; i < MAX_CACHE_ENTRIES + 5; i++) {
+      cache.store('session', `call_${i}`, `content-${i}`);
+    }
+
+    // The five oldest entries are evicted FIFO; the cap holds and recent entries survive.
+    expect(cache.retrieve('session', 'call_0')).toBeNull();
+    expect(cache.retrieve('session', 'call_4')).toBeNull();
+    expect(cache.retrieve('session', 'call_5')).not.toBeNull();
+    expect(cache.retrieve('session', `call_${MAX_CACHE_ENTRIES + 4}`)).not.toBeNull();
   });
 
   it('evicts expired entries lazily when cleanup interval has elapsed', () => {

--- a/packages/backend/src/routing/proxy/__tests__/thinking-block-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/thinking-block-cache.spec.ts
@@ -1,4 +1,4 @@
-import { ThinkingBlockCache, ThinkingBlock } from '../thinking-block-cache';
+import { ThinkingBlockCache, ThinkingBlock, MAX_CACHE_ENTRIES } from '../thinking-block-cache';
 
 describe('ThinkingBlockCache', () => {
   let cache: ThinkingBlockCache;
@@ -100,6 +100,19 @@ describe('ThinkingBlockCache', () => {
     cache.store('session-1', 'toolu_1', newBlocks);
 
     expect(cache.retrieve('session-1', 'toolu_1')).toBe(newBlocks);
+  });
+
+  it('evicts the oldest entries once MAX_CACHE_ENTRIES is exceeded', () => {
+    const block: ThinkingBlock[] = [{ type: 'thinking', thinking: 't', signature: 's' }];
+    for (let i = 0; i < MAX_CACHE_ENTRIES + 5; i++) {
+      cache.store('session', `toolu_${i}`, block);
+    }
+
+    // The five oldest entries are evicted FIFO; the cap holds and recent entries survive.
+    expect(cache.retrieve('session', 'toolu_0')).toBeNull();
+    expect(cache.retrieve('session', 'toolu_4')).toBeNull();
+    expect(cache.retrieve('session', 'toolu_5')).not.toBeNull();
+    expect(cache.retrieve('session', `toolu_${MAX_CACHE_ENTRIES + 4}`)).not.toBeNull();
   });
 
   describe('maybeCleanup (lazy eviction)', () => {

--- a/packages/backend/src/routing/proxy/__tests__/thought-signature-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/thought-signature-cache.spec.ts
@@ -1,4 +1,4 @@
-import { ThoughtSignatureCache } from '../thought-signature-cache';
+import { ThoughtSignatureCache, MAX_CACHE_ENTRIES } from '../thought-signature-cache';
 
 describe('ThoughtSignatureCache', () => {
   let cache: ThoughtSignatureCache;
@@ -81,6 +81,18 @@ describe('ThoughtSignatureCache', () => {
     cache.store('session-1', 'tc-1', 'new-sig');
 
     expect(cache.retrieve('session-1', 'tc-1')).toBe('new-sig');
+  });
+
+  it('evicts the oldest entries once MAX_CACHE_ENTRIES is exceeded', () => {
+    for (let i = 0; i < MAX_CACHE_ENTRIES + 5; i++) {
+      cache.store('session', `tc-${i}`, `sig-${i}`);
+    }
+
+    // The five oldest entries are evicted FIFO; the cap holds and recent entries survive.
+    expect(cache.retrieve('session', 'tc-0')).toBeNull();
+    expect(cache.retrieve('session', 'tc-4')).toBeNull();
+    expect(cache.retrieve('session', 'tc-5')).not.toBeNull();
+    expect(cache.retrieve('session', `tc-${MAX_CACHE_ENTRIES + 4}`)).not.toBeNull();
   });
 
   describe('maybeCleanup (lazy eviction)', () => {

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -11,6 +11,14 @@ interface CachedReasoningContent {
 
 const TTL_MS = 30 * 60 * 1000; // 30 minutes
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+/**
+ * Hard ceiling on turns held in the in-memory layer. The key embeds an
+ * upstream-generated tool call id (unique per turn), so the in-memory keyspace
+ * is unbounded and the lazy TTL sweep — which only runs on writes — cannot cap a
+ * burst. Oldest entries are evicted FIFO; the shared DB layer is pruned
+ * separately by `expires_at`.
+ */
+export const MAX_CACHE_ENTRIES = 10_000;
 
 /**
  * In-memory cache for OpenAI-compatible `reasoning_content` strings.
@@ -42,6 +50,7 @@ export class ReasoningContentCache {
       content,
       expiresAt,
     });
+    this.evictOverflow();
     void this.persist(sessionKey, firstToolCallId, content, expiresAt);
   }
 
@@ -92,6 +101,7 @@ export class ReasoningContentCache {
           expiresAt: new Date(row.expires_at).getTime(),
         });
       }
+      this.evictOverflow();
       if (expired.length > 0) void this.deleteExpired(sessionKey, expired);
     } catch (err) {
       this.logger.warn(`Failed to read shared reasoning_content cache: ${String(err)}`);
@@ -141,6 +151,15 @@ export class ReasoningContentCache {
       void this.repo.delete({ session_key: sessionKey }).catch((err) => {
         this.logger.warn(`Failed to clear shared reasoning_content cache: ${String(err)}`);
       });
+    }
+  }
+
+  /** Bound the in-memory cache to MAX_CACHE_ENTRIES, evicting oldest (FIFO) first. */
+  private evictOverflow(): void {
+    while (this.cache.size > MAX_CACHE_ENTRIES) {
+      // size > cap (> 0) guarantees a first key exists.
+      const oldest = this.cache.keys().next().value as string;
+      this.cache.delete(oldest);
     }
   }
 

--- a/packages/backend/src/routing/proxy/thinking-block-cache.ts
+++ b/packages/backend/src/routing/proxy/thinking-block-cache.ts
@@ -14,6 +14,12 @@ interface CachedThinkingBlocks {
 
 const TTL_MS = 30 * 60 * 1000; // 30 minutes
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+/**
+ * Hard ceiling on cached turns. The key embeds an upstream-generated tool-use id
+ * (unique per turn), so the keyspace is unbounded and the lazy TTL sweep — which
+ * only runs on `store()` — cannot cap a burst. Oldest entries are evicted FIFO.
+ */
+export const MAX_CACHE_ENTRIES = 10_000;
 
 /**
  * In-memory cache for Anthropic extended-thinking content blocks.
@@ -48,6 +54,16 @@ export class ThinkingBlockCache {
       blocks,
       expiresAt: Date.now() + TTL_MS,
     });
+    this.evictOverflow();
+  }
+
+  /** Bound the cache to MAX_CACHE_ENTRIES, evicting oldest (FIFO) entries first. */
+  private evictOverflow(): void {
+    while (this.cache.size > MAX_CACHE_ENTRIES) {
+      // size > cap (> 0) guarantees a first key exists.
+      const oldest = this.cache.keys().next().value as string;
+      this.cache.delete(oldest);
+    }
   }
 
   /** Retrieve the cached thinking blocks, or null if not found/expired. */

--- a/packages/backend/src/routing/proxy/thought-signature-cache.ts
+++ b/packages/backend/src/routing/proxy/thought-signature-cache.ts
@@ -5,6 +5,13 @@ interface CachedSignature {
 
 const TTL_MS = 30 * 60 * 1000; // 30 minutes
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+/**
+ * Hard ceiling on cached signatures. The key embeds an upstream-generated tool
+ * call id (unique per turn), so the keyspace is unbounded and the lazy TTL sweep
+ * — which only runs on `store()` — cannot cap a burst. Oldest entries are
+ * evicted FIFO.
+ */
+export const MAX_CACHE_ENTRIES = 10_000;
 
 /**
  * In-memory cache for Google Gemini thought_signature values.
@@ -29,6 +36,16 @@ export class ThoughtSignatureCache {
       signature,
       expiresAt: Date.now() + TTL_MS,
     });
+    this.evictOverflow();
+  }
+
+  /** Bound the cache to MAX_CACHE_ENTRIES, evicting oldest (FIFO) entries first. */
+  private evictOverflow(): void {
+    while (this.cache.size > MAX_CACHE_ENTRIES) {
+      // size > cap (> 0) guarantees a first key exists.
+      const oldest = this.cache.keys().next().value as string;
+      this.cache.delete(oldest);
+    }
   }
 
   /** Retrieve a cached thought_signature, or null if not found/expired. */


### PR DESCRIPTION
### 💭 Why
On Railway, per-replica memory climbed all day and only reset on deploy. That is the shape of a slow leak masked by frequent deploys.

### ✨ What changed
- Global response cache now uses a bounded LRU store (5k entry cap + 60s expiry sweep) instead of cache-manager's unbounded default Keyv Map.
- Three proxy session caches (thinking blocks, thought signatures, reasoning content) get a 10k hard cap with FIFO eviction.

### 🔧 For operators
After deploy, the 7d/30d memory graph should plateau within an hour or two instead of climbing all day. A heap snapshot should show the cache Map entry count holding flat at the cap rather than growing.

### 📝 Notes
Adds the `cacheable` dependency (cache-manager's companion package) for the bounded store. Audited SSE, sync/pricing caches, and the hand-rolled caches too: those were already bounded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound in-memory caches to stop a slow memory climb on long‑running servers. The dashboard response cache now uses a capped LRU store and proxy session caches evict old entries, keeping per‑replica memory flat.

- **Bug Fixes**
  - Switched the global dashboard response cache to a bounded LRU store (5k entry cap, 60s expiry sweep) via `buildDashboardCacheStore`.
  - Capped three proxy session caches (thinking blocks, thought signatures, reasoning content) at 10k entries with FIFO eviction.
  - Added tests to verify LRU/FIFO eviction and basic store/retrieve behavior.

- **Dependencies**
  - Added `cacheable` to provide a bounded `Keyv`-compatible in-memory store.

<sup>Written for commit bc292b4ee43a1e5dc114c6bc6364c905b85e9f74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

