### PR TITLE
fix: refresh OpenCode gateway models from models.dev

### DIFF
--- a/.changeset/opencode-go-cache-refresh.md
+++ b/.changeset/opencode-go-cache-refresh.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+OpenCode Go model discovery now uses the models.dev catalog first, and manual refreshes refresh the models.dev cache before falling back to the OpenCode Go docs catalog.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -269,6 +269,36 @@ const MOCK_API_RESPONSE = {
       },
     },
   },
+  'opencode-go': {
+    id: 'opencode-go',
+    name: 'OpenCode Go',
+    models: {
+      'glm-5.2': {
+        id: 'glm-5.2',
+        name: 'GLM-5.2',
+        reasoning: true,
+        tool_call: true,
+        cost: { input: 1.4, output: 4.4, cache_read: 0.26 },
+        limit: { context: 1000000, output: 131072 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
+  opencode: {
+    id: 'opencode',
+    name: 'OpenCode Zen',
+    models: {
+      'ring-2.6-1t-free': {
+        id: 'ring-2.6-1t-free',
+        name: 'Ring 2.6 1T Free',
+        reasoning: true,
+        tool_call: true,
+        cost: { input: 0, output: 0 },
+        limit: { context: 200000, output: 32768 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
   'unknown-provider': {
     id: 'unknown-provider',
     name: 'Unknown',
@@ -303,8 +333,9 @@ describe('ModelsDevSyncService', () => {
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
       // anthropic: 2, google: 1 (audio excluded), openai: 1, deepseek: 1,
-      // fireworks: 1, mistral: 6, xai: 3, bedrock: 8, groq: 2, nvidia: 1 = 26
-      expect(count).toBe(26);
+      // fireworks: 1, mistral: 6, xai: 3, bedrock: 8, groq: 2,
+      // nvidia: 1, opencode-go: 1, opencode: 1 = 28
+      expect(count).toBe(28);
     });
 
     it('should filter out non-text-output models', async () => {
@@ -627,6 +658,13 @@ describe('ModelsDevSyncService', () => {
       expect(ids).toContain('claude-sonnet-4-6');
     });
 
+    it('should map OpenCode providers to their models.dev provider IDs', () => {
+      expect(service.getModelsForProvider('opencode-go').map((m) => m.id)).toEqual(['glm-5.2']);
+      expect(service.getModelsForProvider('opencode-zen').map((m) => m.id)).toEqual([
+        'ring-2.6-1t-free',
+      ]);
+    });
+
     it('should return empty array for unmapped provider', () => {
       expect(service.getModelsForProvider('nonexistent')).toEqual([]);
     });
@@ -638,6 +676,8 @@ describe('ModelsDevSyncService', () => {
       expect(service.isProviderSupported('gemini')).toBe(true);
       expect(service.isProviderSupported('nvidia')).toBe(true);
       expect(service.isProviderSupported('qwen')).toBe(true);
+      expect(service.isProviderSupported('opencode-go')).toBe(true);
+      expect(service.isProviderSupported('opencode-zen')).toBe(true);
       expect(service.isProviderSupported('fireworks')).toBe(true);
       expect(service.isProviderSupported('bedrock')).toBe(true);
     });

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -28,6 +28,8 @@ const PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
   zai: 'zai',
   copilot: 'github-copilot',
   groq: 'groq',
+  'opencode-go': 'opencode-go',
+  'opencode-zen': 'opencode',
 };
 
 const SUPPORTED_PROVIDERS = new Set(Object.keys(PROVIDER_ID_MAP));

--- a/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
@@ -84,7 +84,11 @@ describe('ModelDiscoveryService — boundary conditions', () => {
   let fetcher: { fetch: jest.Mock };
   let mockPricingSync: { lookupPricing: jest.Mock; getAll: jest.Mock };
   let mockModelRegistry: { registerModels: jest.Mock; getConfirmedModels: jest.Mock };
-  let mockModelsDevSync: { lookupModel: jest.Mock; getModelsForProvider: jest.Mock };
+  let mockModelsDevSync: {
+    lookupModel: jest.Mock;
+    getModelsForProvider: jest.Mock;
+    refreshCache: jest.Mock;
+  };
   let mockCopilotTokenService: { getCopilotToken: jest.Mock };
 
   beforeEach(() => {
@@ -98,6 +102,7 @@ describe('ModelDiscoveryService — boundary conditions', () => {
     mockModelsDevSync = {
       lookupModel: jest.fn().mockReturnValue(null),
       getModelsForProvider: jest.fn().mockReturnValue([]),
+      refreshCache: jest.fn().mockResolvedValue(0),
     };
     mockModelRegistry = {
       registerModels: jest.fn(),

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -95,7 +95,11 @@ describe('ModelDiscoveryService', () => {
     registerModels: jest.Mock;
     getConfirmedModels: jest.Mock;
   };
-  let mockModelsDevSync: { lookupModel: jest.Mock; getModelsForProvider: jest.Mock };
+  let mockModelsDevSync: {
+    lookupModel: jest.Mock;
+    getModelsForProvider: jest.Mock;
+    refreshCache: jest.Mock;
+  };
   let mockCopilotTokenService: { getCopilotToken: jest.Mock };
 
   beforeEach(() => {
@@ -109,6 +113,7 @@ describe('ModelDiscoveryService', () => {
     mockModelsDevSync = {
       lookupModel: jest.fn().mockReturnValue(null),
       getModelsForProvider: jest.fn().mockReturnValue([]),
+      refreshCache: jest.fn().mockResolvedValue(0),
     };
     mockModelRegistry = {
       registerModels: jest.fn(),
@@ -472,6 +477,39 @@ describe('ModelDiscoveryService', () => {
       expect(fetcher.fetch).toHaveBeenCalledTimes(1);
     });
 
+    it('passes forceRefresh through to provider discovery when requested', async () => {
+      const providers = [
+        makeProvider({ id: 'p1', provider: 'opencode-go', auth_type: 'subscription' }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'opencode-go/glm-5.2' })]);
+
+      await service.discoverAllForAgent('tenant-1', { forceRefresh: true });
+
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'opencode-go',
+        'decrypted-key',
+        'subscription',
+        undefined,
+        { forceRefresh: true },
+      );
+    });
+
+    it('refreshes models.dev once for a forced all-provider refresh', async () => {
+      const providers = [
+        makeProvider({ id: 'p1', provider: 'openai' }),
+        makeProvider({ id: 'p2', provider: 'anthropic' }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+
+      await service.discoverAllForAgent('tenant-1', { forceRefresh: true });
+
+      expect(mockModelsDevSync.refreshCache).toHaveBeenCalledTimes(1);
+      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'decrypted-key', 'api_key', undefined, {
+        forceRefresh: true,
+      });
+    });
+
     it('should not throw when individual discovery fails', async () => {
       const providers = [
         makeProvider({ id: 'p1', provider: 'openai' }),
@@ -529,6 +567,9 @@ describe('ModelDiscoveryService', () => {
       const result = await service.refreshProvider('tenant-1', 'openai', 'api_key');
       expect(providerRepo.findOne).toHaveBeenCalledWith({
         where: { tenant_id: 'tenant-1', provider: 'openai', is_active: true, auth_type: 'api_key' },
+      });
+      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'decrypted-key', 'api_key', undefined, {
+        forceRefresh: true,
       });
       expect(result.ok).toBe(true);
       expect(result.model_count).toBe(2);
@@ -3060,6 +3101,109 @@ describe('ModelDiscoveryService', () => {
   /* ── models.dev fallback in discoverModels ── */
 
   describe('models.dev fallback in discoverModels', () => {
+    it('uses models.dev as the primary OpenCode Go catalog and preserves gateway model ids', async () => {
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) =>
+        providerId === 'opencode-go'
+          ? [
+              {
+                id: 'glm-5.2',
+                name: 'GLM-5.2',
+                contextWindow: 1000000,
+                inputPricePerToken: 0.0000014,
+                outputPricePerToken: 0.0000044,
+                reasoning: true,
+                toolCall: true,
+              },
+            ]
+          : [],
+      );
+
+      const result = await service.discoverModels(
+        makeProvider({ provider: 'opencode-go', auth_type: 'subscription' }),
+      );
+
+      expect(fetcher.fetch).not.toHaveBeenCalled();
+      expect(mockModelsDevSync.getModelsForProvider).toHaveBeenCalledWith('opencode-go');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          id: 'opencode-go/glm-5.2',
+          displayName: 'GLM-5.2',
+          provider: 'opencode-go',
+          contextWindow: 1000000,
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          capabilityReasoning: true,
+          capabilityCode: true,
+        }),
+      );
+    });
+
+    it('refreshes models.dev before a forced OpenCode Go provider refresh', async () => {
+      mockModelsDevSync.getModelsForProvider.mockReturnValue([
+        {
+          id: 'glm-5.2',
+          name: 'GLM-5.2',
+          contextWindow: 1000000,
+          inputPricePerToken: 0.0000014,
+          outputPricePerToken: 0.0000044,
+          reasoning: true,
+          toolCall: true,
+        },
+      ]);
+
+      await service.discoverModels(
+        makeProvider({ provider: 'opencode-go', auth_type: 'subscription' }),
+        { forceRefresh: true },
+      );
+
+      expect(mockModelsDevSync.refreshCache).toHaveBeenCalledTimes(1);
+      expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the OpenCode Go docs catalog when forced models.dev refresh fails', async () => {
+      const warnSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+      mockModelsDevSync.refreshCache.mockRejectedValue(new Error('models.dev unavailable'));
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'opencode-go/glm-5.2' })]);
+
+      const result = await service.discoverModels(
+        makeProvider({ provider: 'opencode-go', auth_type: 'subscription' }),
+        { forceRefresh: true },
+      );
+
+      expect(mockModelsDevSync.refreshCache).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'models.dev refresh failed during manual model discovery: models.dev unavailable',
+      );
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'opencode-go',
+        'decrypted-key',
+        'subscription',
+        undefined,
+        { forceRefresh: true },
+      );
+      expect(result[0].id).toBe('opencode-go/glm-5.2');
+
+      warnSpy.mockRestore();
+    });
+
+    it('falls back to the OpenCode Go docs catalog when models.dev has no catalog entry', async () => {
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'opencode-go/glm-5.1' })]);
+
+      const result = await service.discoverModels(
+        makeProvider({ provider: 'opencode-go', auth_type: 'subscription' }),
+      );
+
+      expect(mockModelsDevSync.getModelsForProvider).toHaveBeenCalledWith('opencode-go');
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'opencode-go',
+        'decrypted-key',
+        'subscription',
+        undefined,
+      );
+      expect(result[0].id).toBe('opencode-go/glm-5.1');
+    });
+
     it('should try models.dev before OpenRouter when native API returns empty', async () => {
       fetcher.fetch.mockResolvedValue([]);
       mockModelsDevSync.getModelsForProvider.mockReturnValue([

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -46,12 +46,26 @@ function isQwenProvider(providerId: string): boolean {
   return lower === 'qwen' || lower === 'alibaba';
 }
 
+function modelsDevModelIdPrefix(providerId: string): string | undefined {
+  const lower = providerId.toLowerCase();
+  return lower === 'opencode-go' || lower === 'opencode-zen' ? lower : undefined;
+}
+
+function prefersModelsDevCatalog(providerId: string): boolean {
+  return providerId.toLowerCase() === 'opencode-go';
+}
+
 /** 2-minute TTL for the per-agent discovered-model list, matching RoutingCacheService. */
 const MODELS_CACHE_TTL_MS = 120_000;
 
 interface ModelsCacheEntry {
   data: DiscoveredModel[];
   expiresAt: number;
+}
+
+interface DiscoverModelsOptions {
+  forceRefresh?: boolean;
+  skipModelsDevRefresh?: boolean;
 }
 
 @Injectable()
@@ -91,7 +105,10 @@ export class ModelDiscoveryService {
     private readonly enabledProviderRepo: Repository<AgentEnabledProvider> | null = null,
   ) {}
 
-  async discoverModels(provider: TenantProvider): Promise<DiscoveredModel[]> {
+  async discoverModels(
+    provider: TenantProvider,
+    options: DiscoverModelsOptions = {},
+  ): Promise<DiscoveredModel[]> {
     let apiKey = '';
     let endpointOverride: string | undefined;
     const lowerProvider = provider.provider.toLowerCase();
@@ -164,10 +181,35 @@ export class ModelDiscoveryService {
       endpointOverride = getXiaomiTokenPlanBaseUrl(provider.region);
     }
 
+    if (options.forceRefresh && !options.skipModelsDevRefresh) {
+      await this.refreshModelsDevCache();
+    }
+
     let raw: DiscoveredModel[];
 
     const useCuratedSubscriptionModels =
       provider.auth_type === 'subscription' && (!apiKey || lowerProvider === 'anthropic');
+
+    const fetchProviderModels = () =>
+      options.forceRefresh
+        ? this.fetcher.fetch(provider.provider, apiKey, provider.auth_type, endpointOverride, {
+            forceRefresh: true,
+          })
+        : this.fetcher.fetch(provider.provider, apiKey, provider.auth_type, endpointOverride);
+
+    const buildModelsDevModels = () => {
+      const models = buildModelsDevFallback(this.modelsDevSync, provider.provider, {
+        idPrefix: modelsDevModelIdPrefix(provider.provider),
+      });
+      if (lowerProvider !== 'opencode-go') return models;
+      // OpenCode Go is surfaced as a subscription gateway with per-request
+      // quota cost from the docs catalog, not token pricing from models.dev.
+      return models.map((model) => ({
+        ...model,
+        inputPricePerToken: 0,
+        outputPricePerToken: 0,
+      }));
+    };
 
     // Subscription providers without a token use curated fallback. Anthropic
     // subscription discovery is also static so connecting Claude Code does
@@ -179,13 +221,15 @@ export class ModelDiscoveryService {
           `Subscription provider ${provider.provider} — using ${raw.length} curated models`,
         );
       }
+    } else if (prefersModelsDevCatalog(provider.provider)) {
+      raw = buildModelsDevModels();
+      if (raw.length > 0) {
+        this.logger.log(`Using ${raw.length} models from models.dev for ${provider.provider}`);
+      } else {
+        raw = await fetchProviderModels();
+      }
     } else {
-      raw = await this.fetcher.fetch(
-        provider.provider,
-        apiKey,
-        provider.auth_type,
-        endpointOverride,
-      );
+      raw = await fetchProviderModels();
 
       // Register confirmed model IDs from native API for future fallback filtering
       if (raw.length > 0 && this.modelRegistry) {
@@ -205,9 +249,9 @@ export class ModelDiscoveryService {
         }
       }
 
-      // If native API returned no models, try models.dev first (native IDs), then OpenRouter
+      // If native API returned no models, try models.dev first, then OpenRouter.
       if (raw.length === 0) {
-        raw = buildModelsDevFallback(this.modelsDevSync, provider.provider);
+        raw = buildModelsDevModels();
         if (raw.length > 0) {
           this.logger.log(
             `Native API returned 0 models for ${provider.provider} — using ${raw.length} models from models.dev`,
@@ -277,7 +321,13 @@ export class ModelDiscoveryService {
     return filtered;
   }
 
-  async discoverAllForAgent(tenantId: string): Promise<void> {
+  async discoverAllForAgent(tenantId: string, options: DiscoverModelsOptions = {}): Promise<void> {
+    if (options.forceRefresh) {
+      await this.refreshModelsDevCache();
+    }
+    const discoveryOptions = options.forceRefresh
+      ? { ...options, skipModelsDevRefresh: true }
+      : options;
     const providers = await this.providerRepo.find({
       where: { tenant_id: tenantId, is_active: true },
     });
@@ -285,11 +335,21 @@ export class ModelDiscoveryService {
       providers
         .filter((p) => !p.provider.startsWith('custom:'))
         .map((p) =>
-          this.discoverModels(p).catch((err) => {
+          this.discoverModels(p, discoveryOptions).catch((err) => {
             this.logger.warn(`Discovery failed for ${p.provider}: ${err}`);
           }),
         ),
     );
+  }
+
+  private async refreshModelsDevCache(): Promise<void> {
+    if (!this.modelsDevSync) return;
+    try {
+      await this.modelsDevSync.refreshCache();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`models.dev refresh failed during manual model discovery: ${message}`);
+    }
   }
 
   async refreshProvider(
@@ -328,7 +388,7 @@ export class ModelDiscoveryService {
     }
 
     try {
-      const models = await this.discoverModels(provider);
+      const models = await this.discoverModels(provider, { forceRefresh: true });
       return {
         ok: models.length > 0,
         model_count: models.length,

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -619,6 +619,26 @@ describe('buildModelsDevFallback', () => {
     expect(buildModelsDevFallback(mockSync, 'unknown')).toEqual([]);
   });
 
+  it('should prefix model ids for gateway providers when requested', () => {
+    const mockSync = {
+      getModelsForProvider: jest.fn().mockReturnValue([
+        {
+          id: 'glm-5.2',
+          name: 'GLM-5.2',
+          inputPricePerToken: 0.0000014,
+          outputPricePerToken: 0.0000044,
+        },
+      ]),
+    };
+
+    const result = buildModelsDevFallback(mockSync, 'opencode-go', {
+      idPrefix: 'opencode-go',
+    });
+
+    expect(result[0].id).toBe('opencode-go/glm-5.2');
+    expect(result[0].provider).toBe('opencode-go');
+  });
+
   it('should use default context window when not provided', () => {
     const mockSync = {
       getModelsForProvider: jest

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -166,11 +166,13 @@ export function buildModelsDevFallback(
     }[];
   } | null,
   providerId: string,
+  options: { idPrefix?: string } = {},
 ): DiscoveredModel[] {
   if (!modelsDevSync) return [];
   const entries = modelsDevSync.getModelsForProvider(providerId);
+  const idPrefix = options.idPrefix;
   return entries.map((e) => ({
-    id: e.id,
+    id: idPrefix ? `${idPrefix}/${e.id}` : e.id,
     displayName: e.name || e.id,
     provider: providerId,
     contextWindow: e.contextWindow ?? DEFAULT_CONTEXT_WINDOW,

--- a/packages/backend/src/model-discovery/opencode-go-catalog.service.spec.ts
+++ b/packages/backend/src/model-discovery/opencode-go-catalog.service.spec.ts
@@ -246,6 +246,41 @@ describe('OpencodeGoCatalogService', () => {
       expect(ra).toBe(rb);
     });
 
+    it('refreshes from the live source even when list() has a warm cache', async () => {
+      const refreshedMdx = [
+        '---',
+        'title: Go',
+        '---',
+        '',
+        '| Model | requests per 5 hour | requests per week | requests per month |',
+        '| ----- | ------------------- | ----------------- | ------------------ |',
+        '| GLM-5.2 | 880 | 2,150 | 4,300 |',
+        '',
+        '| Model | Model ID | Endpoint | AI SDK Package |',
+        '| ----- | -------- | -------- | -------------- |',
+        `| GLM-5.2 | glm-5.2 | ${OAI} | ${OAI_SDK} |`,
+        '',
+      ].join('\n');
+      fetchSpy
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: async () => SAMPLE_MDX,
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: async () => refreshedMdx,
+        } as Response);
+
+      await service.list();
+      const refreshed = await service.refresh();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(refreshed.map((e) => e.id)).toEqual(['glm-5.2']);
+      expect(service.getCostPerRequest('glm-5.2')).toBeCloseTo(OPENCODE_GO_BUDGET_5H_USD / 880, 12);
+    });
+
     it('warms the catalog via onModuleInit so the cost index is ready before the first proxy call', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,

--- a/packages/backend/src/model-discovery/opencode-go-catalog.service.ts
+++ b/packages/backend/src/model-discovery/opencode-go-catalog.service.ts
@@ -79,10 +79,27 @@ export class OpencodeGoCatalogService implements OnModuleInit {
       // fetching. Share its result so we don't issue a duplicate request.
       return this.inflight;
     }
-    this.inflight = this.fetchAndCache(now).finally(() => {
-      this.inflight = null;
+    return this.startFetch(now);
+  }
+
+  /**
+   * Force a live catalog fetch even when the one-hour cache is warm. Manual
+   * model refreshes use this so users can pick up newly published OpenCode Go
+   * models without restarting the backend.
+   */
+  async refresh(): Promise<OpencodeGoCatalogEntry[]> {
+    return this.startFetch(Date.now());
+  }
+
+  private startFetch(now: number): Promise<OpencodeGoCatalogEntry[]> {
+    const request = this.fetchAndCache(now);
+    const tracked = request.finally(() => {
+      if (this.inflight === tracked) {
+        this.inflight = null;
+      }
     });
-    return this.inflight;
+    this.inflight = tracked;
+    return tracked;
   }
 
   private async fetchAndCache(now: number): Promise<OpencodeGoCatalogEntry[]> {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2137,6 +2137,35 @@ describe('ProviderModelFetcherService', () => {
       expect(result[1].id).toBe('opencode-go/minimax-m2.7');
     });
 
+    it('forces a catalog refresh when requested', async () => {
+      const catalog = {
+        list: jest.fn().mockResolvedValue([]),
+        refresh: jest
+          .fn()
+          .mockResolvedValue([
+            { id: 'glm-5.2', displayName: 'GLM-5.2', format: 'openai' as const },
+          ]),
+      };
+      const withCatalog = new ProviderModelFetcherService(
+        catalog as unknown as ConstructorParameters<typeof ProviderModelFetcherService>[0],
+      );
+
+      const result = await withCatalog.fetch('opencode-go', 'og-token', 'subscription', undefined, {
+        forceRefresh: true,
+      });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(catalog.refresh).toHaveBeenCalledTimes(1);
+      expect(catalog.list).not.toHaveBeenCalled();
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          id: 'opencode-go/glm-5.2',
+          displayName: 'GLM-5.2',
+          provider: 'opencode-go',
+        }),
+      );
+    });
+
     it('returns [] when no catalog service is wired up', async () => {
       const result = await service.fetch('opencode-go', 'og-token', 'subscription');
       expect(result).toEqual([]);

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -693,6 +693,10 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
 
 const OPENCODE_GO_CONTEXT_WINDOW = 200000;
 
+export interface ProviderModelFetchOptions {
+  forceRefresh?: boolean;
+}
+
 @Injectable()
 export class ProviderModelFetcherService {
   private readonly logger = new Logger(ProviderModelFetcherService.name);
@@ -708,6 +712,7 @@ export class ProviderModelFetcherService {
     apiKey: string,
     authType?: string,
     endpointOverride?: string,
+    options?: ProviderModelFetchOptions,
   ): Promise<DiscoveredModel[]> {
     let configKey = providerId.toLowerCase();
     // OpenAI subscription tokens use a different models endpoint
@@ -726,7 +731,7 @@ export class ProviderModelFetcherService {
     } else if (configKey === 'zai' && authType === 'subscription') {
       configKey = 'zai-subscription';
     } else if (configKey === 'opencode-go') {
-      return this.fetchOpencodeGoCatalog();
+      return this.fetchOpencodeGoCatalog(options?.forceRefresh === true);
     } else if (configKey === 'gemini' && authType === 'subscription') {
       // CodeAssist (`cloudcode-pa.googleapis.com`) does not expose a
       // `/models` endpoint; the discovery fallback chain pulls Gemini
@@ -876,9 +881,11 @@ export class ProviderModelFetcherService {
     return `${FIREWORKS_MODELS_URL}?${params.toString()}`;
   }
 
-  private async fetchOpencodeGoCatalog(): Promise<DiscoveredModel[]> {
+  private async fetchOpencodeGoCatalog(forceRefresh = false): Promise<DiscoveredModel[]> {
     if (!this.opencodeGoCatalog) return [];
-    const entries = await this.opencodeGoCatalog.list();
+    const entries = forceRefresh
+      ? await this.opencodeGoCatalog.refresh()
+      : await this.opencodeGoCatalog.list();
     return entries.map((entry) => ({
       id: `opencode-go/${entry.id}`,
       displayName: entry.displayName,

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -163,11 +163,13 @@ describe('ModelController', () => {
   /* ── refreshModels ── */
 
   describe('refreshModels', () => {
-    it('should call discoverAllForAgent and return ok', async () => {
+    it('forces provider catalogs to refresh and returns ok', async () => {
       const result = await controller.refreshModels(mockCtx, mockAgentName);
 
       expect(mockResolveAgent.resolve).toHaveBeenCalledWith('tenant-1', 'test-agent');
-      expect(mockDiscoveryService.discoverAllForAgent).toHaveBeenCalledWith('tenant-1');
+      expect(mockDiscoveryService.discoverAllForAgent).toHaveBeenCalledWith('tenant-1', {
+        forceRefresh: true,
+      });
       expect(result).toEqual({ ok: true });
     });
   });

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -83,7 +83,7 @@ export class ModelController {
   @Post(':agentName/refresh-models')
   async refreshModels(@TenantCtx() ctx: TenantContext, @Param() params: AgentNameParamDto) {
     const agent = await this.resolveAgentService.resolve(ctx.tenantId, params.agentName);
-    await this.discoveryService.discoverAllForAgent(agent.tenant_id);
+    await this.discoveryService.discoverAllForAgent(agent.tenant_id, { forceRefresh: true });
     return { ok: true };
   }
 

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -187,8 +187,8 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionLabel: 'OpenCode Go (beta)',
     subscriptionAuthMode: 'token' as const,
     subscriptionKeyPlaceholder: 'Paste your OpenCode API key',
-    // Model list is fetched dynamically from the public OpenCode Go docs source;
-    // see OpencodeGoCatalogService in the backend.
+    // Model list is discovered from models.dev; the backend docs catalog remains
+    // as a fallback for request-quota cost and endpoint-format metadata.
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
       supportsPromptCaching: false,


### PR DESCRIPTION
### ✨ What changed
- OpenCode Go and Zen discovery use their `models.dev` catalogs first.
- Manual model refreshes refresh the `models.dev` cache before discovery.
- OpenCode Go docs stay as fallback plus endpoint-format and quota-cost metadata.
- Tests cover provider mapping, prefixed gateway IDs, refresh wiring, fallback, and Zen pricing.

### 💭 Why
OpenCode publishes Go and Zen catalogs in `models.dev`. That keeps new models like `glm-5.2` and Zen catalog changes out of stale local cache paths.

### 👤 For users
Refreshing OpenCode Go or Zen models can pick up newly published `models.dev` entries immediately.

### 📝 Notes
Focused backend tests and formatting checks passed locally.