### PR TITLE
fix: refresh OpenCode Zen models from models.dev

### DIFF
--- a/.changeset/opencode-go-cache-refresh.md
+++ b/.changeset/opencode-go-cache-refresh.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-OpenCode Go model discovery now uses the models.dev catalog first, and manual refreshes refresh the models.dev cache before falling back to the OpenCode Go docs catalog.
+OpenCode Go and Zen model discovery now use the models.dev catalog first, and manual refreshes refresh the models.dev cache before OpenCode Go falls back to its docs catalog.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -3139,6 +3139,42 @@ describe('ModelDiscoveryService', () => {
       );
     });
 
+    it('uses models.dev as the primary OpenCode Zen catalog and preserves token pricing', async () => {
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) =>
+        providerId === 'opencode-zen'
+          ? [
+              {
+                id: 'ring-2.6-1t-free',
+                name: 'Ring 2.6 1T Free',
+                contextWindow: 200000,
+                inputPricePerToken: 0.000001,
+                outputPricePerToken: 0.000002,
+                reasoning: true,
+                toolCall: true,
+              },
+            ]
+          : [],
+      );
+
+      const result = await service.discoverModels(makeProvider({ provider: 'opencode-zen' }));
+
+      expect(fetcher.fetch).not.toHaveBeenCalled();
+      expect(mockModelsDevSync.getModelsForProvider).toHaveBeenCalledWith('opencode-zen');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          id: 'opencode-zen/ring-2.6-1t-free',
+          displayName: 'Ring 2.6 1T Free',
+          provider: 'opencode-zen',
+          contextWindow: 200000,
+          inputPricePerToken: 0.000001,
+          outputPricePerToken: 0.000002,
+          capabilityReasoning: true,
+          capabilityCode: true,
+        }),
+      );
+    });
+
     it('refreshes models.dev before a forced OpenCode Go provider refresh', async () => {
       mockModelsDevSync.getModelsForProvider.mockReturnValue([
         {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -52,7 +52,8 @@ function modelsDevModelIdPrefix(providerId: string): string | undefined {
 }
 
 function prefersModelsDevCatalog(providerId: string): boolean {
-  return providerId.toLowerCase() === 'opencode-go';
+  const lower = providerId.toLowerCase();
+  return lower === 'opencode-go' || lower === 'opencode-zen';
 }
 
 /** 2-minute TTL for the per-agent discovered-model list, matching RoutingCacheService. */


### PR DESCRIPTION
### ✨ What changed
- OpenCode Zen discovery now uses the `models.dev` Zen catalog first.
- Zen model IDs keep the `opencode-zen/` gateway prefix.
- Zen keeps token pricing from `models.dev` instead of Go's quota-cost behavior.
- The existing OpenCode changeset now mentions both Go and Zen.

### 💭 Why
PR #2332 covered Go and merged before the Zen follow-up landed. Zen uses the same OpenCode catalog source in `models.dev`, so it should avoid stale `/models` results too.

### 👤 For users
Refreshing OpenCode Zen models can pick up newly published `models.dev` entries immediately.

### 📝 Notes
Follow-up to #2332.
Focused backend tests and formatting checks passed locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
OpenCode Zen model discovery now uses the `models.dev` catalog as the primary source, preserving token pricing and keeping `opencode-zen/`-prefixed IDs. Adds a focused test and updates the changeset; OpenCode Go still refreshes the `models.dev` cache first and then falls back to its docs catalog.

<sup>Written for commit f224aad8bbf0925078e6348997efd197f53b2fce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

