### PR TITLE
feat: make proxy message cap configurable

### DIFF
--- a/.changeset/max-messages-env.md
+++ b/.changeset/max-messages-env.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Allow self-hosted installs to tune the proxy message-count limit with MANIFEST_MAX_MESSAGES.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -40,6 +40,10 @@ BETTER_AUTH_SECRET=
 # Set strictly below your client's timeout so the fallback chain has room to run.
 # PROVIDER_TIMEOUT_MS=180000
 
+# Maximum number of messages accepted in one proxy request.
+# Raise for self-hosted long-running agent sessions with dense tool use.
+# MANIFEST_MAX_MESSAGES=1000
+
 # Timeout (ms) to wait for the first chunk from a streaming response before
 # considering it stalled and trying a fallback provider.
 # STREAM_WARMUP_MS=15000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       # Ollama runs elsewhere (e.g. on another host on your LAN).
       - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
       - PROVIDER_TIMEOUT_MS=${PROVIDER_TIMEOUT_MS:-180000}
+      - MANIFEST_MAX_MESSAGES=${MANIFEST_MAX_MESSAGES:-1000}
       - STREAM_WARMUP_MS=${STREAM_WARMUP_MS:-15000}
       - SEED_DATA=false
       - NODE_ENV=production

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -33,6 +33,9 @@ BETTER_AUTH_URL=http://localhost:3001
 # Per-attempt timeout (ms) for upstream provider requests in the LLM proxy.
 # Set strictly below your client's timeout so the fallback chain has room to run.
 # PROVIDER_TIMEOUT_MS=180000
+# Maximum number of messages accepted in one proxy request.
+# Raise for self-hosted long-running agent sessions with dense tool use.
+# MANIFEST_MAX_MESSAGES=1000
 # Timeout (ms) to wait for the first chunk from a streaming response before
 # considering it stalled and trying a fallback provider.
 # STREAM_WARMUP_MS=15000

--- a/packages/backend/src/routing/proxy/__tests__/message-limit.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/message-limit.spec.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_MAX_MESSAGES_PER_REQUEST, parseMaxMessagesPerRequest } from '../message-limit';
+
+describe('parseMaxMessagesPerRequest', () => {
+  it('defaults to 1000 when env var is unset', () => {
+    expect(parseMaxMessagesPerRequest(undefined)).toBe(DEFAULT_MAX_MESSAGES_PER_REQUEST);
+  });
+
+  it('uses the configured value when env var is a positive integer', () => {
+    expect(parseMaxMessagesPerRequest('2500')).toBe(2500);
+  });
+
+  it.each(['2500abc', '2500.5', '2_500', ' 2500', 'abc'])(
+    'falls back to 1000 when env var is not digits-only: %s',
+    (rawValue) => {
+      expect(parseMaxMessagesPerRequest(rawValue)).toBe(DEFAULT_MAX_MESSAGES_PER_REQUEST);
+    },
+  );
+
+  it('falls back to 1000 when env var is zero', () => {
+    expect(parseMaxMessagesPerRequest('0')).toBe(DEFAULT_MAX_MESSAGES_PER_REQUEST);
+  });
+
+  it('falls back to 1000 when env var exceeds safe integer range', () => {
+    expect(parseMaxMessagesPerRequest('9007199254740992')).toBe(DEFAULT_MAX_MESSAGES_PER_REQUEST);
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -211,6 +211,45 @@ describe('ProxyService — orchestration', () => {
       );
     });
 
+    it('uses MANIFEST_MAX_MESSAGES when validating oversized payloads', async () => {
+      configService = {
+        get: jest.fn((key: string) => (key === 'MANIFEST_MAX_MESSAGES' ? '1001' : undefined)),
+      } as unknown as ConfigService;
+      svc = new ProxyService(
+        resolveService as unknown as ResolveService,
+        providerKeyService as unknown as ProviderKeyService,
+        tierService as unknown as TierService,
+        openaiOauth as unknown as OpenaiOauthService,
+        minimaxOauth as unknown as MinimaxOauthService,
+        anthropicOauth as unknown as AnthropicOauthService,
+        geminiOauth as unknown as GeminiOauthService,
+        kiroOauth as unknown as KiroOauthService,
+        xaiOauth as unknown as XaiOauthService,
+        momentum as unknown as SessionMomentumService,
+        limitCheck as unknown as LimitCheckService,
+        fallbackService as unknown as ProxyFallbackService,
+        configService,
+        signatureCache,
+        thinkingCache,
+        reasoningCache,
+        modelParamsService as unknown as AgentModelParamsService,
+        providerParamSpecs as unknown as ProviderParamSpecService,
+      );
+      const messages = Array.from({ length: 1001 }, () => ({ role: 'user', content: 'x' }));
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: null,
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+
+      await expect(
+        svc.proxyRequest(baseOpts({ body: { messages } as never })),
+      ).resolves.toBeDefined();
+    });
+
     it('replaces null content with empty string', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',

--- a/packages/backend/src/routing/proxy/message-limit.ts
+++ b/packages/backend/src/routing/proxy/message-limit.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_MAX_MESSAGES_PER_REQUEST = 1000;
+
+export function parseMaxMessagesPerRequest(rawValue?: string): number {
+  const value = rawValue ?? '';
+  if (!/^\d+$/.test(value)) {
+    return DEFAULT_MAX_MESSAGES_PER_REQUEST;
+  }
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_MESSAGES_PER_REQUEST;
+}

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -57,6 +57,7 @@ import { peekStream, STREAM_WARMUP_MS } from './stream-warmup';
 import { toChatCompletionsRequest } from './responses-adapter';
 import { messagesToChatCompletionsRequest } from './anthropic-messages-adapter';
 import { effectiveRoutesForResponseMode } from '../routing-core/response-mode-guard';
+import { parseMaxMessagesPerRequest } from './message-limit';
 
 type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>>;
 
@@ -69,7 +70,6 @@ type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>>;
  */
 const SCORING_EXCLUDED_ROLES = new Set(['system', 'developer']);
 const SCORING_RECENT_MESSAGES = 10;
-const MAX_MESSAGES_PER_REQUEST = 1000;
 
 export interface RoutingMeta {
   tier: TierSlot;
@@ -138,6 +138,7 @@ export interface ProxyResult {
 @Injectable()
 export class ProxyService {
   private readonly logger = new Logger(ProxyService.name);
+  private readonly maxMessagesPerRequest: number;
 
   constructor(
     private readonly resolveService: ResolveService,
@@ -158,7 +159,11 @@ export class ProxyService {
     private readonly reasoningCache: ReasoningContentCache,
     private readonly modelParamsService: AgentModelParamsService,
     private readonly providerParamSpecs: ProviderParamSpecService,
-  ) {}
+  ) {
+    this.maxMessagesPerRequest = parseMaxMessagesPerRequest(
+      this.config.get<string>('MANIFEST_MAX_MESSAGES'),
+    );
+  }
 
   async proxyRequest(opts: ProxyRequestOptions): Promise<ProxyResult> {
     const { agentId, tenantId, body, sessionKey, agentName, signal, specificityOverride, headers } =
@@ -408,8 +413,10 @@ export class ProxyService {
       throw new BadRequestException(formatManifestError('M300'));
     }
     sanitizeNullContent(messages as Record<string, unknown>[]);
-    if (messages.length > MAX_MESSAGES_PER_REQUEST) {
-      throw new BadRequestException(formatManifestError('M301', { max: MAX_MESSAGES_PER_REQUEST }));
+    if (messages.length > this.maxMessagesPerRequest) {
+      throw new BadRequestException(
+        formatManifestError('M301', { max: this.maxMessagesPerRequest }),
+      );
     }
   }
 


### PR DESCRIPTION
### ✨ What changed
- Added `MANIFEST_MAX_MESSAGES` for proxy message-count validation.
- Docker self-host config forwards the env var with a `1000` default.
- Added parser and proxy regressions.

### 💭 Why
Self-hosted agent sessions can exceed 1000 message entries before token context is full.

### 👤 For users
Requests above 1000 messages can be accepted when operators raise the cap.

### 🔧 For operators
Set `MANIFEST_MAX_MESSAGES=<count>` in backend or Docker env.
Invalid or empty values fall back to `1000`.

### 📝 Notes
Closes #2299
Validation: focused backend Jest, backend typecheck/build, compose config, diff check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the proxy message cap configurable via the MANIFEST_MAX_MESSAGES env var so self‑hosted installs can accept more than 1000 messages per request. Default stays 1000 with a safe fallback; addresses Linear #2299.

- **New Features**
  - Backend reads MANIFEST_MAX_MESSAGES and enforces it during request validation.
  - Added strict parser with unit tests; invalid or out-of-range values fall back to 1000.
  - `docker-compose.yml` and `.env.example` forward the env with a `1000` default.

- **Migration**
  - Optional: set MANIFEST_MAX_MESSAGES to a higher integer to allow larger payloads for long-running agent sessions.

<sup>Written for commit fbf816042e201b3fe81e8feb7fb6f35561526e1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

