### PR TITLE
fix: allow deleting inactive subscriptions

### DIFF
--- a/.changeset/delete-inactive-subscriptions.md
+++ b/.changeset/delete-inactive-subscriptions.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Allow inactive subscription connections to be deleted from the provider detail page, including stale duplicate rows left by upgrades.

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -21,6 +21,7 @@ describe('ProviderController', () => {
   let mockResolveAgent: Record<string, jest.Mock>;
   let mockTierService: Record<string, jest.Mock>;
   let mockPricingSync: Record<string, jest.Mock>;
+  let mockCacheManager: { clear: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -53,6 +54,9 @@ describe('ProviderController', () => {
     mockPricingSync = {
       getAll: jest.fn().mockReturnValue(new Map([['model-1', {}]])),
     };
+    mockCacheManager = {
+      clear: jest.fn().mockResolvedValue(true),
+    };
 
     controller = new ProviderController(
       mockProviderService as unknown as ProviderService,
@@ -61,6 +65,7 @@ describe('ProviderController', () => {
       mockResolveAgent as unknown as ResolveAgentService,
       mockTierService as unknown as TierService,
       mockPricingSync as unknown as PricingSyncService,
+      mockCacheManager as never,
     );
   });
 
@@ -671,6 +676,7 @@ describe('ProviderController', () => {
         undefined,
       );
       expect(result).toEqual({ ok: true, notifications: 3 });
+      expect(mockCacheManager.clear).toHaveBeenCalled();
     });
 
     it('should return zero notifications when none cleared', async () => {

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -4,12 +4,15 @@ import {
   Controller,
   Delete,
   Get,
+  Inject,
   Param,
   Patch,
   Post,
   Put,
   Query,
 } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 import { TenantCtx, TenantContext } from '../common/decorators/tenant-context.decorator';
 import { ProviderService } from './routing-core/provider.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
@@ -39,6 +42,7 @@ export class ProviderController {
     private readonly resolveAgentService: ResolveAgentService,
     private readonly tierService: TierService,
     private readonly pricingSync: PricingSyncService,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
   @Get(':agentName/status')
@@ -240,6 +244,7 @@ export class ProviderController {
       query.authType,
       query.label,
     );
+    await this.cacheManager.clear();
     return { ok: true, notifications };
   }
 }

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -51,7 +51,7 @@ const makeRepo = (agents: AgentRow[] = ['agent-1']) => ({
   delete: jest.fn().mockResolvedValue(undefined),
   remove: jest.fn().mockResolvedValue(undefined),
   update: jest.fn().mockResolvedValue(undefined),
-  manager: { transaction: jest.fn() },
+  manager: { transaction: jest.fn(), getRepository: jest.fn() },
   createQueryBuilder: jest.fn().mockReturnValue(makeQueryBuilder(agents)),
 });
 
@@ -583,6 +583,40 @@ describe('ProviderService — route-only cleanup paths', () => {
       ).resolves.toEqual({ notifications: [] });
 
       expect(providerRepo.remove).toHaveBeenCalledWith(target);
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+      expect(routingCache.invalidateTenant).toHaveBeenCalledWith('tenant-1');
+    });
+
+    it('deletes exact usage history before hard-deleting an inactive labeled key', async () => {
+      const messageRepo = makeRepo();
+      const target = {
+        id: 'inactive-sub',
+        agent_id: null,
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        label: 'Old Claude',
+        priority: 0,
+        is_active: false,
+      } as unknown as TenantProvider;
+      providerRepo.find.mockImplementation(async (options?: { order?: unknown }) =>
+        options?.order ? [] : [target],
+      );
+      providerRepo.manager.getRepository.mockReturnValue(messageRepo);
+      tierRepo.find.mockResolvedValue([]);
+      specRepo.find.mockResolvedValue([]);
+      headerTierRepo.find.mockResolvedValue([]);
+
+      await expect(
+        svc.removeProvider('agent-1', 'tenant-1', 'anthropic', 'subscription', 'Old Claude'),
+      ).resolves.toEqual({ notifications: [] });
+
+      expect(messageRepo.delete).toHaveBeenCalledWith({
+        tenant_id: 'tenant-1',
+        tenant_provider_id: 'inactive-sub',
+      });
+      expect(providerRepo.remove).toHaveBeenCalledWith(target);
+      expect(providerRepo.save).not.toHaveBeenCalled();
+      expect(providerRepo.findOne).not.toHaveBeenCalled();
       expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
       expect(routingCache.invalidateTenant).toHaveBeenCalledWith('tenant-1');
     });

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -589,6 +589,14 @@ describe('ProviderService — route-only cleanup paths', () => {
 
     it('deletes exact usage history before hard-deleting an inactive labeled key', async () => {
       const messageRepo = makeRepo();
+      const enabledRepo = makeRepo();
+      const messages = [
+        { id: 'target-1', tenant_id: 'tenant-1', tenant_provider_id: 'inactive-sub' },
+        { id: 'target-2', tenant_id: 'tenant-1', tenant_provider_id: 'inactive-sub' },
+        { id: 'other-tenant', tenant_id: 'tenant-2', tenant_provider_id: 'inactive-sub' },
+        { id: 'other-key', tenant_id: 'tenant-1', tenant_provider_id: 'active-sub' },
+        { id: 'legacy-null', tenant_id: 'tenant-1', tenant_provider_id: null },
+      ];
       const target = {
         id: 'inactive-sub',
         agent_id: null,
@@ -601,20 +609,54 @@ describe('ProviderService — route-only cleanup paths', () => {
       providerRepo.find.mockImplementation(async (options?: { order?: unknown }) =>
         options?.order ? [] : [target],
       );
+      messageRepo.delete.mockImplementation(async ({ tenant_id, tenant_provider_id }) => {
+        const before = messages.length;
+        for (let index = messages.length - 1; index >= 0; index -= 1) {
+          const message = messages[index];
+          if (
+            message.tenant_id === tenant_id &&
+            message.tenant_provider_id === tenant_provider_id
+          ) {
+            messages.splice(index, 1);
+          }
+        }
+        return { affected: before - messages.length, raw: [] };
+      });
       providerRepo.manager.getRepository.mockReturnValue(messageRepo);
       tierRepo.find.mockResolvedValue([]);
       specRepo.find.mockResolvedValue([]);
       headerTierRepo.find.mockResolvedValue([]);
+      const localSvc = new ProviderService(
+        providerRepo as unknown as Repository<TenantProvider>,
+        tierRepo as unknown as Repository<TierAssignment>,
+        specRepo as unknown as Repository<SpecificityAssignment>,
+        makeRepo() as unknown as Repository<Agent>,
+        headerTierRepo as unknown as Repository<HeaderTier>,
+        pricingCache as unknown as ModelPricingCacheService,
+        routingCache as unknown as RoutingCacheService,
+        enabledRepo as unknown as Repository<AgentEnabledProvider>,
+      );
 
       await expect(
-        svc.removeProvider('agent-1', 'tenant-1', 'anthropic', 'subscription', 'Old Claude'),
+        localSvc.removeProvider('agent-1', 'tenant-1', 'anthropic', 'subscription', 'Old Claude'),
       ).resolves.toEqual({ notifications: [] });
 
       expect(messageRepo.delete).toHaveBeenCalledWith({
         tenant_id: 'tenant-1',
         tenant_provider_id: 'inactive-sub',
       });
+      expect(messages).toEqual([
+        { id: 'other-tenant', tenant_id: 'tenant-2', tenant_provider_id: 'inactive-sub' },
+        { id: 'other-key', tenant_id: 'tenant-1', tenant_provider_id: 'active-sub' },
+        { id: 'legacy-null', tenant_id: 'tenant-1', tenant_provider_id: null },
+      ]);
+      expect(messageRepo.delete.mock.invocationCallOrder[0]).toBeLessThan(
+        providerRepo.remove.mock.invocationCallOrder[0],
+      );
       expect(providerRepo.remove).toHaveBeenCalledWith(target);
+      expect(enabledRepo.delete).toHaveBeenCalledWith({
+        tenant_provider_id: In(['inactive-sub']),
+      });
       expect(providerRepo.save).not.toHaveBeenCalled();
       expect(providerRepo.findOne).not.toHaveBeenCalled();
       expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -13,6 +13,7 @@ import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 import { Agent } from '../../entities/agent.entity';
 import { HeaderTier } from '../../entities/header-tier.entity';
+import { AgentMessage } from '../../entities/agent-message.entity';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { RoutingCacheService } from './routing-cache.service';
 import { randomUUID } from 'crypto';
@@ -90,6 +91,12 @@ export class ProviderService {
   ): Repository<AgentEnabledProvider> | null {
     if (!this.enabledProviderRepo) return null;
     return manager ? manager.getRepository(AgentEnabledProvider) : this.enabledProviderRepo;
+  }
+
+  private agentMessageRepo(manager?: EntityManager): Repository<AgentMessage> {
+    return manager
+      ? manager.getRepository(AgentMessage)
+      : this.providerRepo.manager.getRepository(AgentMessage);
   }
 
   /**
@@ -951,10 +958,12 @@ export class ProviderService {
   /**
    * Delete a single labeled key from a provider's chain. If it was the last
    * key for the (agent, provider, auth_type) tuple, falls through to the
-   * existing whole-provider teardown. Routes pinned to this key block deletion.
+   * existing whole-provider teardown. Routes pinned to an active key block
+   * deletion; inactive keys are already disconnected, so deleting them clears
+   * stale label pins and removes the row.
    */
   private async removeKeyByLabel(
-    agentId: string,
+    agentId: string | null,
     tenantId: string,
     provider: string,
     authType: AuthType | undefined,
@@ -970,6 +979,20 @@ export class ProviderService {
     const target = matching.find((r) => r.label.toLowerCase() === label.toLowerCase());
     if (!target) throw new NotFoundException('Provider key not found');
 
+    if (!target.is_active) {
+      await this.relabelOverrides(tenantId, provider, target.auth_type, target.label, null);
+      await this.agentMessageRepo(manager).delete({
+        tenant_id: tenantId,
+        tenant_provider_id: target.id,
+      });
+      await repo.remove(target);
+      await this.deleteProviderAccess([target.id], manager);
+      await this.renumberPriorities(tenantId, provider, target.auth_type, manager);
+      if (agentId !== null) this.routingCache.invalidateAgent(agentId);
+      this.routingCache.invalidateTenant(tenantId);
+      return { notifications: [] };
+    }
+
     const stillHasOtherKeys = matching.some(
       (r) => r.id !== target.id && r.is_active && isManifestUsableProvider(r),
     );
@@ -984,7 +1007,7 @@ export class ProviderService {
     await repo.remove(target);
     await this.deleteProviderAccess([target.id], manager);
     await this.renumberPriorities(tenantId, provider, target.auth_type, manager);
-    this.routingCache.invalidateAgent(agentId);
+    if (agentId !== null) this.routingCache.invalidateAgent(agentId);
     this.routingCache.invalidateTenant(tenantId);
     return { notifications: [] };
   }

--- a/packages/frontend/src/pages/providers/ConnectionDetail.tsx
+++ b/packages/frontend/src/pages/providers/ConnectionDetail.tsx
@@ -367,6 +367,7 @@ const ConnectionDetail: Component = () => {
   const [renameError, setRenameError] = createSignal('');
   const [refreshingModels, setRefreshingModels] = createSignal(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = createSignal(false);
+  const [deleteConfirmName, setDeleteConfirmName] = createSignal('');
   const [deletingConnection, setDeletingConnection] = createSignal(false);
   const [agents] = createResource(async () => {
     try {
@@ -383,7 +384,29 @@ const ConnectionDetail: Component = () => {
     if (c) setRenameValue(c.label);
     setRenameError('');
     setShowDeleteConfirm(false);
+    setDeleteConfirmName('');
     setShowManageModal(true);
+  };
+
+  const closeManageModal = () => {
+    setShowManageModal(false);
+    setShowDeleteConfirm(false);
+    setDeleteConfirmName('');
+  };
+
+  const openDeleteConfirm = () => {
+    setDeleteConfirmName('');
+    setShowDeleteConfirm(true);
+  };
+
+  const closeDeleteConfirm = () => {
+    setShowDeleteConfirm(false);
+    setDeleteConfirmName('');
+  };
+
+  const deleteConfirmMatches = () => {
+    const c = conn();
+    return !!c && deleteConfirmName() === c.label;
   };
 
   const handleRename = async () => {
@@ -399,7 +422,7 @@ const ConnectionDetail: Component = () => {
       return;
     }
     if (newLabel === c.label) {
-      setShowManageModal(false);
+      closeManageModal();
       return;
     }
     setRenaming(true);
@@ -407,7 +430,7 @@ const ConnectionDetail: Component = () => {
     try {
       await renameProviderKey(firstAgentName(), c.provider, c.label, newLabel, c.auth_type as any);
       toast.success('Connection renamed');
-      setShowManageModal(false);
+      closeManageModal();
       refetchDetail();
     } catch (e: any) {
       setRenameError(e?.message ?? 'Failed to rename');
@@ -419,6 +442,7 @@ const ConnectionDetail: Component = () => {
   const handleDisconnect = async () => {
     const c = conn();
     if (!c) return;
+    if (!c.is_active && !deleteConfirmMatches()) return;
     const agent = firstAgentName();
     if (!agent) {
       toast.error(
@@ -877,10 +901,10 @@ const ConnectionDetail: Component = () => {
                     <div
                       class="modal-overlay"
                       onClick={(e) => {
-                        if (e.target === e.currentTarget) setShowManageModal(false);
+                        if (e.target === e.currentTarget) closeManageModal();
                       }}
                       onKeyDown={(e) => {
-                        if (e.key === 'Escape') setShowManageModal(false);
+                        if (e.key === 'Escape') closeManageModal();
                       }}
                     >
                       <div
@@ -910,7 +934,7 @@ const ConnectionDetail: Component = () => {
                           </div>
                           <button
                             type="button"
-                            onClick={() => setShowManageModal(false)}
+                            onClick={closeManageModal}
                             style="background: none; border: none; cursor: pointer; padding: 4px; color: hsl(var(--muted-foreground)); font-size: 18px; line-height: 1;"
                             aria-label="Close"
                           >
@@ -980,13 +1004,10 @@ const ConnectionDetail: Component = () => {
 
                           {/* Actions */}
                           <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 16px; border-top: 1px solid hsl(var(--border));">
-                            <button class="btn btn--destructive btn--sm" onClick={handleDisconnect}>
+                            <button class="btn btn--danger btn--sm" onClick={handleDisconnect}>
                               Disconnect
                             </button>
-                            <button
-                              class="btn btn--outline btn--sm"
-                              onClick={() => setShowManageModal(false)}
-                            >
+                            <button class="btn btn--outline btn--sm" onClick={closeManageModal}>
                               Done
                             </button>
                           </div>
@@ -997,43 +1018,69 @@ const ConnectionDetail: Component = () => {
                             when={showDeleteConfirm()}
                             fallback={
                               <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 12px; border-top: 1px solid hsl(var(--border));">
-                                <button
-                                  class="btn btn--destructive btn--sm"
-                                  onClick={() => setShowDeleteConfirm(true)}
-                                >
+                                <button class="btn btn--danger btn--sm" onClick={openDeleteConfirm}>
                                   Delete
                                 </button>
-                                <button
-                                  class="btn btn--outline btn--sm"
-                                  onClick={() => setShowManageModal(false)}
-                                >
+                                <button class="btn btn--outline btn--sm" onClick={closeManageModal}>
                                   Close
                                 </button>
                               </div>
                             }
                           >
                             <div
-                              style="padding-top: 12px; border-top: 1px solid hsl(var(--border));"
+                              class="connection-delete-confirmation"
                               role="alertdialog"
-                              aria-label="Delete connection confirmation"
+                              aria-labelledby="delete-connection-confirm-title"
+                              aria-describedby="delete-connection-confirm-copy"
                             >
-                              <p style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); margin: 0 0 12px;">
-                                Deleting this connection will remove its usage history.
-                              </p>
-                              <div style="display: flex; justify-content: flex-end; gap: 8px;">
+                              <div class="connection-delete-confirmation__warning">
+                                <h3
+                                  id="delete-connection-confirm-title"
+                                  class="connection-delete-confirmation__title"
+                                >
+                                  Delete usage history?
+                                </h3>
+                                <p
+                                  id="delete-connection-confirm-copy"
+                                  class="connection-delete-confirmation__copy"
+                                >
+                                  This will permanently delete this inactive connection and its
+                                  usage history. This action cannot be undone.
+                                </p>
+                              </div>
+                              <label
+                                for="delete-connection-confirm-input"
+                                class="connection-delete-confirmation__label"
+                              >
+                                Type the connection name to confirm
+                              </label>
+                              <input
+                                id="delete-connection-confirm-input"
+                                class="provider-detail__input"
+                                type="text"
+                                value={deleteConfirmName()}
+                                onInput={(e) => setDeleteConfirmName(e.currentTarget.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter' && deleteConfirmMatches()) {
+                                    handleDisconnect();
+                                  }
+                                }}
+                                placeholder={c.label}
+                              />
+                              <div class="connection-delete-confirmation__footer">
                                 <button
                                   class="btn btn--outline btn--sm"
-                                  onClick={() => setShowDeleteConfirm(false)}
+                                  onClick={closeDeleteConfirm}
                                   disabled={deletingConnection()}
                                 >
                                   Cancel
                                 </button>
                                 <button
-                                  class="btn btn--destructive btn--sm"
+                                  class="btn btn--danger btn--sm"
                                   onClick={handleDisconnect}
-                                  disabled={deletingConnection()}
+                                  disabled={!deleteConfirmMatches() || deletingConnection()}
                                 >
-                                  {deletingConnection() ? 'Deleting...' : 'Confirm'}
+                                  {deletingConnection() ? 'Deleting...' : 'Delete connection'}
                                 </button>
                               </div>
                             </div>
@@ -1047,10 +1094,10 @@ const ConnectionDetail: Component = () => {
                   <div
                     class="modal-overlay"
                     onClick={(e) => {
-                      if (e.target === e.currentTarget) setShowManageModal(false);
+                      if (e.target === e.currentTarget) closeManageModal();
                     }}
                     onKeyDown={(e) => {
-                      if (e.key === 'Escape') setShowManageModal(false);
+                      if (e.key === 'Escape') closeManageModal();
                     }}
                   >
                     <div
@@ -1064,12 +1111,12 @@ const ConnectionDetail: Component = () => {
                         agentName={firstAgentName()}
                         initialData={customProviderData()!}
                         onCreated={() => {
-                          setShowManageModal(false);
+                          closeManageModal();
                           refetchDetail();
                         }}
-                        onBack={() => setShowManageModal(false)}
+                        onBack={closeManageModal}
                         onDeleted={() => {
-                          setShowManageModal(false);
+                          closeManageModal();
                           navigate(backLink());
                         }}
                       />

--- a/packages/frontend/src/pages/providers/ConnectionDetail.tsx
+++ b/packages/frontend/src/pages/providers/ConnectionDetail.tsx
@@ -366,6 +366,8 @@ const ConnectionDetail: Component = () => {
   const [renaming, setRenaming] = createSignal(false);
   const [renameError, setRenameError] = createSignal('');
   const [refreshingModels, setRefreshingModels] = createSignal(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = createSignal(false);
+  const [deletingConnection, setDeletingConnection] = createSignal(false);
   const [agents] = createResource(async () => {
     try {
       const res = await getAgents();
@@ -380,6 +382,7 @@ const ConnectionDetail: Component = () => {
     const c = conn();
     if (c) setRenameValue(c.label);
     setRenameError('');
+    setShowDeleteConfirm(false);
     setShowManageModal(true);
   };
 
@@ -418,15 +421,20 @@ const ConnectionDetail: Component = () => {
     if (!c) return;
     const agent = firstAgentName();
     if (!agent) {
-      toast.error('Create at least one harness before disconnecting a provider.');
+      toast.error(
+        `Create at least one harness before ${c.is_active ? 'disconnecting' : 'deleting'} a provider.`,
+      );
       return;
     }
+    setDeletingConnection(true);
     try {
       await disconnectProvider(agent, c.provider, c.auth_type as any, c.label);
       toast.success('Connection removed');
       navigate(backLink());
     } catch (e: any) {
       toast.error(e?.message ?? 'Failed to disconnect');
+    } finally {
+      setDeletingConnection(false);
     }
   };
 
@@ -985,14 +993,51 @@ const ConnectionDetail: Component = () => {
                         </Show>
 
                         <Show when={!c.is_active}>
-                          <div style="display: flex; justify-content: flex-end; padding-top: 12px; border-top: 1px solid hsl(var(--border));">
-                            <button
-                              class="btn btn--outline btn--sm"
-                              onClick={() => setShowManageModal(false)}
+                          <Show
+                            when={showDeleteConfirm()}
+                            fallback={
+                              <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 12px; border-top: 1px solid hsl(var(--border));">
+                                <button
+                                  class="btn btn--destructive btn--sm"
+                                  onClick={() => setShowDeleteConfirm(true)}
+                                >
+                                  Delete
+                                </button>
+                                <button
+                                  class="btn btn--outline btn--sm"
+                                  onClick={() => setShowManageModal(false)}
+                                >
+                                  Close
+                                </button>
+                              </div>
+                            }
+                          >
+                            <div
+                              style="padding-top: 12px; border-top: 1px solid hsl(var(--border));"
+                              role="alertdialog"
+                              aria-label="Delete connection confirmation"
                             >
-                              Close
-                            </button>
-                          </div>
+                              <p style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); margin: 0 0 12px;">
+                                Deleting this connection will remove its usage history.
+                              </p>
+                              <div style="display: flex; justify-content: flex-end; gap: 8px;">
+                                <button
+                                  class="btn btn--outline btn--sm"
+                                  onClick={() => setShowDeleteConfirm(false)}
+                                  disabled={deletingConnection()}
+                                >
+                                  Cancel
+                                </button>
+                                <button
+                                  class="btn btn--destructive btn--sm"
+                                  onClick={handleDisconnect}
+                                  disabled={deletingConnection()}
+                                >
+                                  {deletingConnection() ? 'Deleting...' : 'Confirm'}
+                                </button>
+                              </div>
+                            </div>
+                          </Show>
                         </Show>
                       </div>
                     </div>

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -381,7 +381,7 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
     }> = [];
     for (const summary of connectedSummaries()) {
       for (const connection of summary.connections) {
-        if (!connection.is_active && !hasUsage(summary)) continue;
+        if (!connection.is_active && props.kind !== 'subscriptions' && !hasUsage(summary)) continue;
         rows.push({
           summary,
           connection,

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -687,6 +687,52 @@ tr:hover .connection-label-cell__edit,
   background: hsl(var(--destructive) / 0.08);
 }
 
+.connection-delete-confirmation {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 16px;
+  border-top: 1px solid hsl(var(--border));
+}
+
+.connection-delete-confirmation__warning {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: hsl(var(--destructive) / 0.06);
+  border: 1px solid hsl(var(--destructive) / 0.22);
+  border-radius: var(--radius);
+}
+
+.connection-delete-confirmation__title {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  color: hsl(var(--foreground));
+}
+
+.connection-delete-confirmation__copy {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+
+.connection-delete-confirmation__label {
+  color: hsl(var(--foreground));
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.connection-delete-confirmation__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+
 .provider-detail__disconnect-icon {
   width: 2rem;
   height: 2rem;

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -1030,6 +1030,62 @@ describe('ConnectionDetail (analytics)', () => {
     expect(screen.getByText(/Subscriptions/)).toBeDefined();
   });
 
+  it('requires typing an inactive connection name before deleting usage history', async () => {
+    routerState.params = { connectionId: 'conn-anthropic' };
+    apiMocks.getConnectionDetail.mockResolvedValue({
+      ...connectionDetail,
+      connection: {
+        ...connectionDetail.connection,
+        id: 'conn-anthropic',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        label: 'Default',
+        key_prefix: null,
+        cached_model_count: 0,
+        is_active: false,
+      },
+    });
+
+    const { container } = render(() => <ConnectionDetail />);
+    await waitFor(() => expect(screen.getByText('Inactive')).toBeDefined());
+
+    fireEvent.click(screen.getByText('Manage'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    const dialog = screen.getByRole('alertdialog', { name: 'Delete usage history?' });
+    expect(dialog).toBeDefined();
+    expect(dialog.textContent).not.toContain('Connection');
+    expect(dialog.textContent).not.toContain('Default');
+    expect(dialog.textContent).not.toContain('Enter Default exactly.');
+    expect(container.querySelector('.connection-delete-confirmation__target')).toBeNull();
+    expect(container.querySelector('.connection-delete-confirmation__hint')).toBeNull();
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete connection',
+    }) as HTMLButtonElement;
+    expect(deleteButton.disabled).toBe(true);
+
+    const confirmInput = screen.getByLabelText(
+      'Type the connection name to confirm',
+    ) as HTMLInputElement;
+    fireEvent.input(confirmInput, { target: { value: 'Wrong' } });
+    expect(deleteButton.disabled).toBe(true);
+    expect(apiMocks.disconnectProvider).not.toHaveBeenCalled();
+
+    fireEvent.input(confirmInput, { target: { value: 'Default' } });
+    expect(deleteButton.disabled).toBe(false);
+    fireEvent.click(deleteButton);
+
+    await waitFor(() =>
+      expect(apiMocks.disconnectProvider).toHaveBeenCalledWith(
+        'demo-agent',
+        'anthropic',
+        'subscription',
+        'Default',
+      ),
+    );
+    expect(routerState.navigate).toHaveBeenCalledWith('/providers/subscriptions');
+  });
+
   it('shows a loading state until the connection detail resolves', async () => {
     let resolveDetail!: (value: unknown) => void;
     apiMocks.getConnectionDetail.mockReturnValue(
@@ -1503,14 +1559,11 @@ describe('ConnectionDetail (analytics)', () => {
     expect(screen.getByText('Delete')).toBeDefined();
     fireEvent.click(screen.getByText('Delete'));
 
-    expect(
-      screen.getByText('Deleting this connection will remove its usage history.'),
-    ).toBeDefined();
+    expect(screen.getByRole('alertdialog', { name: 'Delete usage history?' })).toBeDefined();
+    expect(screen.getByLabelText('Type the connection name to confirm')).toBeDefined();
     fireEvent.click(screen.getByText('Cancel'));
 
-    expect(
-      screen.queryByText('Deleting this connection will remove its usage history.'),
-    ).toBeNull();
+    expect(screen.queryByRole('alertdialog', { name: 'Delete usage history?' })).toBeNull();
     expect(screen.getByText('Delete')).toBeDefined();
     fireEvent.click(screen.getByText('Close'));
 
@@ -1537,10 +1590,15 @@ describe('ConnectionDetail (analytics)', () => {
 
     fireEvent.click(screen.getByText('Manage'));
     fireEvent.click(screen.getByText('Delete'));
-    expect(
-      screen.getByText('Deleting this connection will remove its usage history.'),
-    ).toBeDefined();
-    fireEvent.click(screen.getByText('Confirm'));
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete connection',
+    }) as HTMLButtonElement;
+    expect(deleteButton.disabled).toBe(true);
+    fireEvent.input(screen.getByLabelText('Type the connection name to confirm'), {
+      target: { value: 'Old Claude' },
+    });
+    expect(deleteButton.disabled).toBe(false);
+    fireEvent.click(deleteButton);
 
     await waitFor(() =>
       expect(apiMocks.disconnectProvider).toHaveBeenCalledWith(

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -1482,7 +1482,7 @@ describe('ConnectionDetail (analytics)', () => {
     expect(dashCell).toBeDefined();
   });
 
-  it('closes the manage modal for an inactive connection via the Close button', async () => {
+  it('requires confirmation before deleting an inactive connection', async () => {
     routerState.params = { connectionId: 'conn-inactive' };
     apiMocks.getConnectionDetail.mockResolvedValue({
       ...connectionDetail,
@@ -1498,12 +1498,58 @@ describe('ConnectionDetail (analytics)', () => {
     await waitFor(() => expect(screen.getAllByText('Stale').length).toBeGreaterThan(0));
 
     fireEvent.click(screen.getByText('Manage'));
-    // Inactive connections expose a single Close button (line 987) instead of the
-    // active Done/Disconnect/Refresh controls.
     expect(screen.getByText('Connection name')).toBeDefined();
     expect(screen.queryByText('Disconnect')).toBeNull();
+    expect(screen.getByText('Delete')).toBeDefined();
+    fireEvent.click(screen.getByText('Delete'));
+
+    expect(
+      screen.getByText('Deleting this connection will remove its usage history.'),
+    ).toBeDefined();
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(
+      screen.queryByText('Deleting this connection will remove its usage history.'),
+    ).toBeNull();
+    expect(screen.getByText('Delete')).toBeDefined();
     fireEvent.click(screen.getByText('Close'));
 
     await waitFor(() => expect(screen.queryByText('Connection name')).toBeNull());
+    expect(apiMocks.disconnectProvider).not.toHaveBeenCalled();
+  });
+
+  it('deletes an inactive subscription connection and navigates back on success', async () => {
+    routerState.params = { connectionId: 'conn-inactive-subscription' };
+    apiMocks.getConnectionDetail.mockResolvedValue({
+      ...connectionDetail,
+      connection: {
+        ...connectionDetail.connection,
+        id: 'conn-inactive-subscription',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        is_active: false,
+        label: 'Old Claude',
+      },
+    });
+
+    render(() => <ConnectionDetail />);
+    await waitFor(() => expect(screen.getAllByText('Old Claude').length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByText('Manage'));
+    fireEvent.click(screen.getByText('Delete'));
+    expect(
+      screen.getByText('Deleting this connection will remove its usage history.'),
+    ).toBeDefined();
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() =>
+      expect(apiMocks.disconnectProvider).toHaveBeenCalledWith(
+        'demo-agent',
+        'anthropic',
+        'subscription',
+        'Old Claude',
+      ),
+    );
+    expect(routerState.navigate).toHaveBeenCalledWith('/providers/subscriptions');
   });
 });

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -259,6 +259,35 @@ describe('provider pages', () => {
     });
   });
 
+  it('renders inactive subscription rows even when they have no usage', async () => {
+    mockGetGlobalProviders.mockResolvedValue({
+      ...globalProvidersResponse,
+      providers: [
+        ...globalProvidersResponse.providers,
+        {
+          provider: 'anthropic',
+          auth_type: 'subscription',
+          connection_count: 1,
+          connections: [connection('sub-old-claude', 'Old Claude', false)],
+          total_models: 0,
+          consumption_tokens: 0,
+          consumption_messages: 0,
+          consumption_cost: 0,
+          last_used_at: null,
+          sparkline_7d: [],
+        },
+      ],
+    });
+
+    render(() => <Subscriptions />);
+
+    await waitFor(() => expect(screen.getByText('Old Claude')).toBeDefined());
+    expect(screen.getAllByText('Inactive').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByText('Old Claude').closest('tr')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/providers/connections/sub-old-claude');
+  });
+
   it('deep-links the connect modal to a specific provider when added from its row', async () => {
     render(() => <Subscriptions />);
 


### PR DESCRIPTION
### ✨ What changed
- Inactive subscription rows now stay visible on the Subscriptions page even when they have no usage.
- Inactive provider connections show a Delete action in the connection detail manage modal.
- Labeled inactive provider rows are hard-deleted instead of soft-disconnecting again.

### 💭 Why
Upgrades can leave duplicate inactive subscription rows. They looked disconnected but had no cleanup path.

### 👤 For users
Inactive duplicate subscriptions can now be deleted.

### 📝 Notes
Fixes #2294

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow deleting inactive subscription connections from the provider detail page with name confirmation. Deleting also removes matching usage, clears stale label pins, and refreshes dashboards. Fixes #2294.

- **Bug Fixes**
  - Backend: Hard-delete inactive labeled keys after clearing label overrides and related `AgentMessage` usage; renumber priorities; skip agent cache invalidation when `agentId` is null; clear app cache via `CACHE_MANAGER` after deletion to update dashboards.
  - UI: Manage modal adds Delete with type-to-confirm for inactive connections; warns usage history will be removed; shows a deleting state; navigates back after delete.
  - Tests: Added coverage for the confirm-to-delete flow, usage-history removal, controller cache clear, and rendering inactive subscriptions with no usage.

<sup>Written for commit 3d414fe49638b488ddefc6aaf945bd1335534b5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

