### PR TITLE
fix: scope Anthropic thinking replay

### DIFF
--- a/.changeset/sour-actors-decide.md
+++ b/.changeset/sour-actors-decide.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Prevent Anthropic signed thinking blocks from being replayed into incompatible fallback attempts. Cached thinking is now scoped to the provider, auth type, and model that produced it, so an incompatible fallback omits stale signatures while a later compatible Anthropic attempt can restore them.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -1443,6 +1443,45 @@ describe('Anthropic Adapter', () => {
         expect(content[2].id).toBe('toolu_first');
       });
 
+      it('passes the route context to thinkingLookup', () => {
+        const thinkingBlock = {
+          type: 'thinking',
+          thinking: 'cached reasoning',
+          signature: 'sig_cached',
+        };
+        const routeContext = {
+          provider: 'anthropic',
+          authType: 'subscription',
+          model: 'claude-sonnet-4-5-20250929',
+        };
+        const lookup = jest.fn().mockReturnValue([thinkingBlock]);
+
+        toAnthropicRequest(
+          {
+            messages: [
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'toolu_first',
+                    type: 'function',
+                    function: { name: 'search', arguments: '{}' },
+                  },
+                ],
+              },
+            ],
+          },
+          'claude-sonnet-4-5-20250929',
+          {
+            thinkingLookup: lookup,
+            thinkingRouteContext: routeContext,
+          },
+        );
+
+        expect(lookup).toHaveBeenCalledWith('toolu_first', routeContext);
+      });
+
       it('prepends multiple cached blocks in the order they were cached', () => {
         const b1 = { type: 'thinking', thinking: 'one', signature: 's1' };
         const b2 = { type: 'redacted_thinking', data: 'opaque' };
@@ -2231,6 +2270,32 @@ describe('Anthropic Adapter', () => {
       const content = assistant.content as Array<Record<string, unknown>>;
       expect(content[0]).toEqual({ type: 'thinking', thinking: 'searching', signature: 'sig' });
       expect(content[1]).toMatchObject({ type: 'tool_use', id: 'call_1' });
+    });
+
+    it('passes the route context when replaying cached thinking blocks', () => {
+      const cached = [{ type: 'thinking' as const, thinking: 'searching', signature: 'sig' }];
+      const routeContext = {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      };
+      const lookup = jest.fn().mockReturnValue(cached);
+
+      applyAnthropicMessagesMutations(
+        {
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                { type: 'tool_use', id: 'call_1', name: 'web_search', input: { q: 'cats' } },
+              ],
+            },
+          ],
+        },
+        { thinkingLookup: lookup, thinkingRouteContext: routeContext },
+      );
+
+      expect(lookup).toHaveBeenCalledWith('call_1', routeContext);
     });
 
     it('does not duplicate thinking blocks the client already echoed', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1,5 +1,6 @@
 import { ProviderClient } from '../provider-client';
 import { buildCustomEndpoint } from '../provider-endpoints';
+import { ThinkingBlockCache, type ThinkingBlockRouteContext } from '../thinking-block-cache';
 import type { ProviderModelRegistryService } from '../../../model-discovery/provider-model-registry.service';
 
 const mockFetch = jest.fn();
@@ -684,6 +685,80 @@ describe('ProviderClient', () => {
       expect(sentBody.max_tokens).toBeDefined();
       // toAnthropicRequest correctly maps temperature from the original body
       expect(sentBody.temperature).toBe(0.7);
+    });
+
+    it('replays cached thinking only for a compatible Anthropic route context', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const thinkingBlock = {
+        type: 'thinking',
+        thinking: 'cached reasoning',
+        signature: 'sig_cached',
+      };
+      const cache = new ThinkingBlockCache();
+      cache.store('sess-1', 'toolu_first', [thinkingBlock], {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      });
+      const thinkingLookup = jest.fn(
+        (firstToolUseId: string, routeContext?: ThinkingBlockRouteContext) =>
+          cache.retrieve('sess-1', firstToolUseId, routeContext),
+      );
+      const continuationBody = {
+        messages: [
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'toolu_first',
+                type: 'function',
+                function: { name: 'search', arguments: '{"q":"cats"}' },
+              },
+            ],
+          },
+        ],
+      };
+
+      await client.forward({
+        provider: 'anthropic',
+        apiKey: 'oauth-token',
+        model: 'claude-opus-4-1-20250805',
+        body: continuationBody,
+        stream: false,
+        authType: 'subscription',
+        thinkingLookup,
+      });
+
+      await client.forward({
+        provider: 'anthropic',
+        apiKey: 'oauth-token',
+        model: 'claude-sonnet-4-5-20250929',
+        body: continuationBody,
+        stream: false,
+        authType: 'subscription',
+        thinkingLookup,
+      });
+
+      const firstSent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const firstContent = firstSent.messages[0].content as Array<Record<string, unknown>>;
+      expect(firstContent.some((block) => block.type === 'thinking')).toBe(false);
+
+      const secondSent = JSON.parse(mockFetch.mock.calls[1][1].body);
+      const secondContent = secondSent.messages[0].content as Array<Record<string, unknown>>;
+      expect(secondContent[0]).toEqual(thinkingBlock);
+      expect(secondContent[1]).toMatchObject({ type: 'tool_use', id: 'toolu_first' });
+      expect(thinkingLookup).toHaveBeenNthCalledWith(1, 'toolu_first', {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-opus-4-1-20250805',
+      });
+      expect(thinkingLookup).toHaveBeenNthCalledWith(2, 'toolu_first', {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      });
     });
 
     it('sets stream=true in body when streaming', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -212,6 +212,38 @@ describe('ProxyFallbackService', () => {
       expect(result.response.ok).toBe(true);
     });
 
+    it('passes Anthropic thinking lookup with route-specific replay context', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+      const thinkingLookup = jest.fn();
+
+      await service.tryForwardToProvider({
+        provider: 'anthropic',
+        apiKey: 'sk-ant',
+        model: 'anthropic/claude-sonnet-4.5',
+        body,
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'subscription',
+        thinkingLookup,
+      });
+
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinkingLookup,
+          thinkingRouteContext: {
+            provider: 'anthropic',
+            authType: 'subscription',
+            model: 'anthropic/claude-sonnet-4.5',
+          },
+        }),
+      );
+    });
+
     it.each([
       {
         provider: 'openai',

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -550,7 +550,11 @@ describe('proxy-response-handler', () => {
       const { res } = mockResponse();
       const forward = mockForward({ isAnthropic: true });
       const client = mockProviderClient();
-      const meta = makeMeta();
+      const meta = makeMeta({
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      });
       const thinkingCache = { store: jest.fn() };
       const sessionKey = 'sess-anthro-stream';
 
@@ -576,6 +580,11 @@ describe('proxy-response-handler', () => {
         'sess-anthro-stream',
         'toolu_stream',
         blocks,
+        {
+          provider: 'anthropic',
+          authType: 'subscription',
+          model: 'claude-sonnet-4-5-20250929',
+        },
       );
     });
 
@@ -1096,7 +1105,11 @@ describe('proxy-response-handler', () => {
         usage: { input_tokens: 50, output_tokens: 12, cache_read_input_tokens: 0 },
       };
       const forward = mockForward(body, { isAnthropic: true });
-      const meta = makeMeta();
+      const meta = makeMeta({
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      });
       const thinkingCache = { store: jest.fn() };
 
       const usage = await handleNonStreamResponse(
@@ -1137,7 +1150,11 @@ describe('proxy-response-handler', () => {
         usage: { input_tokens: 1, output_tokens: 1 },
       };
       const forward = mockForward(body, { isAnthropic: true });
-      const meta = makeMeta();
+      const meta = makeMeta({
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      });
       const thinkingCache = { store: jest.fn() };
 
       await handleNonStreamResponse(
@@ -1152,9 +1169,16 @@ describe('proxy-response-handler', () => {
         'messages',
       );
 
-      expect(thinkingCache.store).toHaveBeenCalledWith('sess-x', 'toolu_1', [
-        { type: 'thinking', thinking: 'searching...', signature: 'sig' },
-      ]);
+      expect(thinkingCache.store).toHaveBeenCalledWith(
+        'sess-x',
+        'toolu_1',
+        [{ type: 'thinking', thinking: 'searching...', signature: 'sig' }],
+        {
+          provider: 'anthropic',
+          authType: 'subscription',
+          model: 'claude-sonnet-4-5-20250929',
+        },
+      );
     });
 
     it('should convert Anthropic response', async () => {
@@ -1162,7 +1186,11 @@ describe('proxy-response-handler', () => {
       const client = mockProviderClient();
       client.convertAnthropicResponse.mockReturnValue({});
       const forward = mockForward({}, { isAnthropic: true });
-      const meta = makeMeta();
+      const meta = makeMeta({
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      });
 
       const usage = await handleNonStreamResponse(
         res as any,
@@ -1191,7 +1219,11 @@ describe('proxy-response-handler', () => {
       });
 
       const forward = mockForward({}, { isAnthropic: true });
-      const meta = makeMeta();
+      const meta = makeMeta({
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      });
 
       await handleNonStreamResponse(
         res as any,
@@ -1205,9 +1237,16 @@ describe('proxy-response-handler', () => {
       );
 
       expect(thinkingCache.store).toHaveBeenCalledTimes(1);
-      expect(thinkingCache.store).toHaveBeenCalledWith('sess-anthro', 'toolu_01', [
-        { type: 'thinking', thinking: 'reason', signature: 's' },
-      ]);
+      expect(thinkingCache.store).toHaveBeenCalledWith(
+        'sess-anthro',
+        'toolu_01',
+        [{ type: 'thinking', thinking: 'reason', signature: 's' }],
+        {
+          provider: 'anthropic',
+          authType: 'subscription',
+          model: 'claude-sonnet-4-5-20250929',
+        },
+      );
 
       // The internal side-channel is stripped before the body reaches the client.
       const sentBody = res.json.mock.calls[0][0];

--- a/packages/backend/src/routing/proxy/__tests__/thinking-block-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/thinking-block-cache.spec.ts
@@ -22,6 +22,75 @@ describe('ThinkingBlockCache', () => {
     expect(retrieved).toBe(blocks);
   });
 
+  it('retrieves route-scoped blocks only for the same provider auth and model', () => {
+    const blocks: ThinkingBlock[] = [
+      { type: 'thinking', thinking: 'reasoning...', signature: 'sig_1' },
+    ];
+    const routeContext = {
+      provider: 'anthropic',
+      authType: 'subscription',
+      model: 'claude-sonnet-4-5-20250929',
+    };
+
+    cache.store('session-1', 'toolu_1', blocks, routeContext);
+
+    expect(cache.retrieve('session-1', 'toolu_1', routeContext)).toBe(blocks);
+    expect(
+      cache.retrieve('session-1', 'toolu_1', {
+        provider: 'anthropic',
+        authType: 'api_key',
+        model: 'claude-sonnet-4-5-20250929',
+      }),
+    ).toBeNull();
+    expect(
+      cache.retrieve('session-1', 'toolu_1', {
+        provider: 'minimax',
+        authType: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      }),
+    ).toBeNull();
+    expect(
+      cache.retrieve('session-1', 'toolu_1', {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-opus-4-1-20250805',
+      }),
+    ).toBeNull();
+
+    // Incompatible attempts do not consume or mutate the cached blocks.
+    expect(cache.retrieve('session-1', 'toolu_1', routeContext)).toBe(blocks);
+  });
+
+  it('normalizes route context case and defaults missing auth type to api_key', () => {
+    const blocks: ThinkingBlock[] = [{ type: 'thinking', thinking: 'ok', signature: 'sig' }];
+    cache.store('session-1', 'toolu_1', blocks, {
+      provider: 'Anthropic',
+      model: 'Claude-Sonnet-4-5-20250929',
+    });
+
+    expect(
+      cache.retrieve('session-1', 'toolu_1', {
+        provider: 'anthropic',
+        authType: 'api_key',
+        model: 'claude-sonnet-4-5-20250929',
+      }),
+    ).toBe(blocks);
+  });
+
+  it('does not replay an unscoped entry into a scoped lookup', () => {
+    const blocks: ThinkingBlock[] = [{ type: 'thinking', thinking: 'legacy', signature: 'sig' }];
+    cache.store('session-1', 'toolu_1', blocks);
+
+    expect(
+      cache.retrieve('session-1', 'toolu_1', {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-sonnet-4-5-20250929',
+      }),
+    ).toBeNull();
+    expect(cache.retrieve('session-1', 'toolu_1')).toBe(blocks);
+  });
+
   it('returns null for a non-existent key', () => {
     expect(cache.retrieve('no-session', 'no-tool')).toBeNull();
   });

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -6,7 +6,7 @@
 import { randomUUID } from 'crypto';
 
 import { OpenAIMessage, ThinkingBlockLookup } from './proxy-types';
-import type { ThinkingBlock } from './thinking-block-cache';
+import type { ThinkingBlock, ThinkingBlockRouteContext } from './thinking-block-cache';
 
 interface ContentBlock {
   type: string;
@@ -200,6 +200,7 @@ function toContentBlocks(content: unknown, includeImages = false): ContentBlock[
 function convertMessage(
   msg: OpenAIMessage,
   thinkingLookup?: ThinkingBlockLookup,
+  thinkingRouteContext?: ThinkingBlockRouteContext,
 ): { role: 'user' | 'assistant'; content: ContentBlock[] } | null {
   if (msg.role === 'system' || msg.role === 'developer') return null;
 
@@ -228,7 +229,9 @@ function convertMessage(
     // tool_call ids back unchanged.
     const firstToolCallId = Array.isArray(msg.tool_calls) && msg.tool_calls[0]?.id;
     if (thinkingLookup && typeof firstToolCallId === 'string' && firstToolCallId) {
-      const cached = thinkingLookup(firstToolCallId);
+      const cached = thinkingRouteContext
+        ? thinkingLookup(firstToolCallId, thinkingRouteContext)
+        : thinkingLookup(firstToolCallId);
       if (cached) {
         for (const block of cached) blocks.push(block as ContentBlock);
       }
@@ -271,6 +274,8 @@ export interface AnthropicRequestOptions {
   injectSubscriptionIdentity?: boolean;
   /** Lookup for re-injecting cached extended-thinking blocks. */
   thinkingLookup?: ThinkingBlockLookup;
+  /** Route context for replaying only compatible cached thinking blocks. */
+  thinkingRouteContext?: ThinkingBlockRouteContext;
   /** Resolved Anthropic upstream model, used for model-specific body normalization. */
   targetModel?: string;
 }
@@ -293,7 +298,10 @@ export function toAnthropicRequest(
   }
 
   const thinkingLookup = options?.thinkingLookup;
-  const converted = messages.map((msg) => convertMessage(msg, thinkingLookup)).filter(Boolean);
+  const thinkingRouteContext = options?.thinkingRouteContext;
+  const converted = messages
+    .map((msg) => convertMessage(msg, thinkingLookup, thinkingRouteContext))
+    .filter(Boolean);
   const result: Record<string, unknown> = {
     messages: converted,
     max_tokens: (body.max_tokens as number) || 4096,
@@ -426,6 +434,7 @@ export function applyAnthropicMessagesMutations(
   }
 
   const thinkingLookup = options?.thinkingLookup;
+  const thinkingRouteContext = options?.thinkingRouteContext;
   if (thinkingLookup && Array.isArray(body.messages)) {
     result.messages = (body.messages as Array<Record<string, unknown>>).map((m) => {
       if (m.role !== 'assistant' || !Array.isArray(m.content)) return m;
@@ -441,7 +450,9 @@ export function applyAnthropicMessagesMutations(
         (b) => b.type === 'thinking' || b.type === 'redacted_thinking',
       );
       if (alreadyHasThinking) return m;
-      const cached = thinkingLookup(firstToolUse.id);
+      const cached = thinkingRouteContext
+        ? thinkingLookup(firstToolUse.id, thinkingRouteContext)
+        : thinkingLookup(firstToolUse.id);
       if (!cached || cached.length === 0) return m;
       return { ...m, content: [...(cached as ContentBlock[]), ...content] };
     });

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -146,6 +146,7 @@ export class ProviderClient {
     const { url, headers, requestBody } = this.buildRequest({
       endpoint,
       endpointKey,
+      provider,
       bareModel,
       model,
       apiKey,
@@ -156,6 +157,7 @@ export class ProviderClient {
       stream,
       signatureLookup: opts.signatureLookup,
       thinkingLookup: opts.thinkingLookup,
+      thinkingRouteContext: opts.thinkingRouteContext,
       reasoningContentLookup: opts.reasoningContentLookup,
       providerResource: opts.providerResource,
     });
@@ -336,6 +338,7 @@ export class ProviderClient {
   private buildRequest(ctx: {
     endpoint: ProviderEndpoint;
     endpointKey: string;
+    provider: string;
     bareModel: string;
     model: string;
     apiKey: string;
@@ -346,6 +349,7 @@ export class ProviderClient {
     stream: boolean;
     signatureLookup?: ForwardOptions['signatureLookup'];
     thinkingLookup?: ForwardOptions['thinkingLookup'];
+    thinkingRouteContext?: ForwardOptions['thinkingRouteContext'];
     reasoningContentLookup?: ForwardOptions['reasoningContentLookup'];
     providerResource?: string;
   }): { url: string; headers: Record<string, string>; requestBody: Record<string, unknown> } {
@@ -385,6 +389,11 @@ export class ProviderClient {
     if (endpoint.format === 'anthropic') {
       const injectSubscriptionIdentity =
         authType === 'subscription' && !endpoint.skipSubscriptionIdentity;
+      const thinkingRouteContext = ctx.thinkingRouteContext ?? {
+        provider: ctx.provider,
+        authType,
+        model: ctx.model,
+      };
       // When the inbound request is already Anthropic Messages
       // (`POST /v1/messages`) and the resolved upstream is also Anthropic,
       // skip the OpenAI translation round-trip and apply only the additive
@@ -399,11 +408,13 @@ export class ProviderClient {
           ? applyAnthropicMessagesMutations(body, {
               injectSubscriptionIdentity,
               thinkingLookup: ctx.thinkingLookup,
+              thinkingRouteContext,
               targetModel: bareModel,
             })
           : toAnthropicRequest(requestSource, bareModel, {
               injectSubscriptionIdentity,
               thinkingLookup: ctx.thinkingLookup,
+              thinkingRouteContext,
             });
       requestBody.model = bareModel;
       if (stream) requestBody.stream = true;

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -635,6 +635,15 @@ export class ProxyFallbackService {
       apiMode: opts.apiMode,
       signatureLookup,
       thinkingLookup,
+      ...(thinkingLookup
+        ? {
+            thinkingRouteContext: {
+              provider,
+              authType,
+              model: opts.model,
+            },
+          }
+        : {}),
       reasoningContentLookup,
       providerResource,
     });

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -25,7 +25,11 @@ import {
 } from './anthropic-messages-adapter';
 import type { ProxyApiMode } from './proxy-types';
 import type { ThoughtSignatureCache } from './thought-signature-cache';
-import type { ThinkingBlockCache, ThinkingBlock } from './thinking-block-cache';
+import type {
+  ThinkingBlockCache,
+  ThinkingBlock,
+  ThinkingBlockRouteContext,
+} from './thinking-block-cache';
 import type { ReasoningContentCache } from './reasoning-content-cache';
 import type { ExtractedSignature } from './google-adapter';
 import {
@@ -43,6 +47,14 @@ const logger = new Logger('ProxyResponseHandler');
 
 function recordSafely(promise: Promise<unknown>, label: string): void {
   promise.catch((e) => logger.warn(`Failed to record ${label}: ${e}`));
+}
+
+function thinkingRouteContext(meta: RoutingMeta): ThinkingBlockRouteContext {
+  return {
+    provider: meta.provider,
+    authType: meta.auth_type,
+    model: meta.model,
+  };
 }
 
 export function buildMetaHeaders(meta: RoutingMeta): Record<string, string> {
@@ -344,7 +356,7 @@ export async function handleStreamResponse(
     const onThinkingBlocks =
       thinkingCache && sessionKey
         ? (firstToolUseId: string, blocks: ThinkingBlock[]) => {
-            thinkingCache.store(sessionKey, firstToolUseId, blocks);
+            thinkingCache.store(sessionKey, firstToolUseId, blocks, thinkingRouteContext(meta));
           }
         : undefined;
     const anthropicTransformer = providerClient.createAnthropicStreamTransformer(
@@ -480,7 +492,12 @@ export async function handleNonStreamResponse(
     const anthropicData = (await forward.response.json()) as Record<string, unknown>;
     const extracted = extractThinkingBlocksFromMessagesResponse(anthropicData);
     if (extracted && thinkingCache && sessionKey) {
-      thinkingCache.store(sessionKey, extracted.firstToolUseId, extracted.blocks);
+      thinkingCache.store(
+        sessionKey,
+        extracted.firstToolUseId,
+        extracted.blocks,
+        thinkingRouteContext(meta),
+      );
     }
     responseBody = anthropicData;
   } else if (forward.isAnthropic) {
@@ -490,7 +507,12 @@ export async function handleNonStreamResponse(
       | ExtractedThinkingBlocks
       | undefined;
     if (extracted && thinkingCache && sessionKey) {
-      thinkingCache.store(sessionKey, extracted.firstToolUseId, extracted.blocks);
+      thinkingCache.store(
+        sessionKey,
+        extracted.firstToolUseId,
+        extracted.blocks,
+        thinkingRouteContext(meta),
+      );
     }
     delete (responseBody as Record<string, unknown>)._extractedThinkingBlocks;
   } else if (forward.isChatGpt) {

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -1,6 +1,6 @@
 import type { IncomingHttpHeaders } from 'http';
 import { ProviderEndpoint } from './provider-endpoints';
-import type { ThinkingBlock } from './thinking-block-cache';
+import type { ThinkingBlock, ThinkingBlockRouteContext } from './thinking-block-cache';
 import { CallerAttribution } from './caller-classifier';
 
 /**
@@ -15,7 +15,10 @@ export type SignatureLookup = (toolCallId: string) => string | null;
  * stripped by the client. Called with the first tool_use id from the
  * assistant turn; returns the ordered block sequence or null.
  */
-export type ThinkingBlockLookup = (firstToolUseId: string) => ThinkingBlock[] | null;
+export type ThinkingBlockLookup = (
+  firstToolUseId: string,
+  routeContext?: ThinkingBlockRouteContext,
+) => ThinkingBlock[] | null;
 
 /**
  * Optional lookup to re-inject cached reasoning_content strings that were
@@ -55,6 +58,8 @@ export interface ForwardOptions {
   signatureLookup?: SignatureLookup;
   /** Lookup for re-injecting cached thinking blocks (Anthropic only). */
   thinkingLookup?: ThinkingBlockLookup;
+  /** Route scope used to decide whether cached Anthropic thinking can be replayed. */
+  thinkingRouteContext?: ThinkingBlockRouteContext;
   /** Lookup for re-injecting cached reasoning_content (DeepSeek-compatible providers). */
   reasoningContentLookup?: ReasoningContentLookup;
   /**

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -232,8 +232,10 @@ export class ProxyService {
 
     const signatureLookup = (toolCallId: string) =>
       this.signatureCache.retrieve(sessionKey, toolCallId);
-    const thinkingLookup = (firstToolUseId: string) =>
-      this.thinkingCache.retrieve(sessionKey, firstToolUseId);
+    const thinkingLookup: ThinkingBlockLookup = (firstToolUseId, routeContext) =>
+      routeContext
+        ? this.thinkingCache.retrieve(sessionKey, firstToolUseId, routeContext)
+        : this.thinkingCache.retrieve(sessionKey, firstToolUseId);
     const reasoningContentLookup = (firstToolCallId: string) =>
       this.reasoningCache.retrieve(sessionKey, firstToolCallId);
 

--- a/packages/backend/src/routing/proxy/thinking-block-cache.ts
+++ b/packages/backend/src/routing/proxy/thinking-block-cache.ts
@@ -7,8 +7,29 @@ export interface ThinkingBlock {
   [key: string]: unknown;
 }
 
+/**
+ * Route that produced an Anthropic extended-thinking prelude.
+ *
+ * Anthropic signs thinking blocks for a specific continuation context. We
+ * only replay cached blocks into outbound attempts that resolve to the same
+ * provider/auth/model tuple, so fallback attempts on another route do not
+ * send stale signatures.
+ */
+export interface ThinkingBlockRouteContext {
+  provider: string;
+  authType?: string | null;
+  model: string;
+}
+
+interface NormalizedThinkingBlockRouteContext {
+  provider: string;
+  authType: string;
+  model: string;
+}
+
 interface CachedThinkingBlocks {
   blocks: ThinkingBlock[];
+  routeContext?: NormalizedThinkingBlockRouteContext;
   expiresAt: number;
 }
 
@@ -20,6 +41,30 @@ const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
  * only runs on `store()` — cannot cap a burst. Oldest entries are evicted FIFO.
  */
 export const MAX_CACHE_ENTRIES = 10_000;
+
+function normalizeRouteContext(
+  routeContext?: ThinkingBlockRouteContext | null,
+): NormalizedThinkingBlockRouteContext | undefined {
+  if (!routeContext) return undefined;
+  return {
+    provider: routeContext.provider.trim().toLowerCase(),
+    authType: (routeContext.authType ?? 'api_key').trim().toLowerCase(),
+    model: routeContext.model.trim().toLowerCase(),
+  };
+}
+
+function routeContextMatches(
+  stored: NormalizedThinkingBlockRouteContext | undefined,
+  requested: NormalizedThinkingBlockRouteContext | undefined,
+): boolean {
+  if (!requested) return true;
+  if (!stored) return false;
+  return (
+    stored.provider === requested.provider &&
+    stored.authType === requested.authType &&
+    stored.model === requested.model
+  );
+}
 
 /**
  * In-memory cache for Anthropic extended-thinking content blocks.
@@ -47,11 +92,18 @@ export class ThinkingBlockCache {
   private lastCleanup = Date.now();
 
   /** Store the ordered thinking block sequence for an assistant turn. */
-  store(sessionKey: string, firstToolUseId: string, blocks: ThinkingBlock[]): void {
+  store(
+    sessionKey: string,
+    firstToolUseId: string,
+    blocks: ThinkingBlock[],
+    routeContext?: ThinkingBlockRouteContext,
+  ): void {
     if (blocks.length === 0) return;
     this.maybeCleanup();
+    const normalizedRouteContext = normalizeRouteContext(routeContext);
     this.cache.set(`${sessionKey}:${firstToolUseId}`, {
       blocks,
+      ...(normalizedRouteContext ? { routeContext: normalizedRouteContext } : {}),
       expiresAt: Date.now() + TTL_MS,
     });
     this.evictOverflow();
@@ -67,13 +119,18 @@ export class ThinkingBlockCache {
   }
 
   /** Retrieve the cached thinking blocks, or null if not found/expired. */
-  retrieve(sessionKey: string, firstToolUseId: string): ThinkingBlock[] | null {
+  retrieve(
+    sessionKey: string,
+    firstToolUseId: string,
+    routeContext?: ThinkingBlockRouteContext,
+  ): ThinkingBlock[] | null {
     const entry = this.cache.get(`${sessionKey}:${firstToolUseId}`);
     if (!entry) return null;
     if (Date.now() > entry.expiresAt) {
       this.cache.delete(`${sessionKey}:${firstToolUseId}`);
       return null;
     }
+    if (!routeContextMatches(entry.routeContext, normalizeRouteContext(routeContext))) return null;
     return entry.blocks;
   }
 


### PR DESCRIPTION
### ✨ What changed
- Cache Anthropic thinking blocks with provider, auth type, and model scope.
- Replay cached thinking only into matching Anthropic outbound attempts.
- Keep cached blocks available for a later compatible fallback.
- Add a patch changeset for `manifest`.

### 💭 Why
Anthropic signs thinking blocks for a specific continuation route. Replaying those blocks after a fallback changed model or auth could trigger `Invalid signature in thinking block`.

### 👤 For users
Anthropic tool-use continuations can fall back without poisoning later compatible attempts.

### 🔧 For operators
No migration or env var changes.

### 📝 Notes
Fixes #2291

Validation: `npx jest --runInBand src/routing/proxy/__tests__/thinking-block-cache.spec.ts src/routing/proxy/__tests__/anthropic-adapter.spec.ts src/routing/proxy/__tests__/provider-client.spec.ts src/routing/proxy/__tests__/proxy-response-handler.spec.ts`
Validation: `npm run build --workspace=manifest-backend`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Anthropic thinking block replay to the exact provider, auth type, and model to prevent invalid signature errors after fallbacks. Cached blocks persist and only replay on compatible Anthropic attempts. Fixes #2291.

- **Bug Fixes**
  - Cache stores thinking blocks with normalized route context (provider/auth/model); matching is case-insensitive and missing auth defaults to `api_key`.
  - Route context is passed through `proxy-fallback.service`, `provider-client`, `anthropic-adapter`, and response handlers (stream and non-stream); the lookup signature now accepts an optional route context.
  - Incompatible attempts skip stale signatures and don’t consume entries (unscoped entries won’t satisfy scoped lookups); compatible retries restore blocks.

<sup>Written for commit 687c2b710aedd04a548bb1bc0441df0f99c60bc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

