### PR TITLE
fix: preserve DeepSeek reasoning tool turns

### DIFF
--- a/.changeset/deepseek-reasoning-fallback.md
+++ b/.changeset/deepseek-reasoning-fallback.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Restore dropped `reasoning_content` on DeepSeek-compatible tool-call follow-up turns, including fallback requests where clients stripped provider-specific reasoning fields. Manifest now caches streamed and non-streamed assistant tool-call reasoning by session and first `tool_call.id`, and replays only exact DeepSeek-style `reasoning_content` for the same tool-call id. If no exact value is recoverable, Manifest injects an empty `reasoning_content` only as a last resort for DeepSeek-compatible assistant tool-call turns. Other reasoning fields such as `reasoning`, `reasoning_text`, and `reasoning_details` are treated as provider-specific and are not translated across formats. Normal assistant turns without tool calls are not cached or replayed by content fingerprint.

--- a/packages/backend/src/entities/reasoning-content-cache-entry.entity.ts
+++ b/packages/backend/src/entities/reasoning-content-cache-entry.entity.ts
@@ -3,7 +3,7 @@ import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
 
 /**
  * Short-lived shared cache for OpenAI-compatible reasoning traces that must be
- * replayed on tool-call follow-up turns.
+ * replayed on follow-up turns.
  */
 @Entity('reasoning_content_cache')
 @Index(['expires_at'])

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -353,6 +353,72 @@ describe('provider-client-converters', () => {
       expect(messages[0]).toHaveProperty('reasoning_content', 'cached reasoning');
     });
 
+    it('injects empty reasoning_content for compatible tool-call messages when no reasoning is recoverable', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const lookup = jest.fn(() => null);
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-v4-flash', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).toHaveBeenCalledWith('call_1');
+      expect(messages[0]).toHaveProperty('reasoning_content', '');
+    });
+
+    it('does not map reasoning aliases to reasoning_content for compatible tool-call messages', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            reasoning: 'plain provider reasoning',
+            reasoning_text: 'provider reasoning',
+            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-v4-flash');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).toHaveProperty('reasoning_content', '');
+      expect(messages[0]).not.toHaveProperty('reasoning');
+      expect(messages[0]).not.toHaveProperty('reasoning_text');
+    });
+
+    it('does not flatten reasoning_details to reasoning_content for compatible tool-call messages', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            reasoning_details: [
+              {
+                type: 'reasoning.text',
+                text: 'provider-specific reasoning',
+                signature: 'sig-abc',
+                format: 'anthropic-claude-v1',
+              },
+            ],
+            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-v4-flash');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).toHaveProperty('reasoning_content', '');
+      expect(messages[0]).not.toHaveProperty('reasoning_details');
+    });
+
     it('does not re-inject cached reasoning_content for strict providers', () => {
       const body = {
         messages: [
@@ -369,6 +435,27 @@ describe('provider-client-converters', () => {
       const messages = result.messages as any[];
 
       expect(lookup).not.toHaveBeenCalled();
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
+    });
+
+    it('strips reasoning_text for strict providers', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            reasoning: 'plain provider reasoning',
+            reasoning_text: 'provider reasoning',
+            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'mistral', 'mistral-large');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).not.toHaveProperty('reasoning_text');
+      expect(messages[0]).not.toHaveProperty('reasoning');
       expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
@@ -390,6 +477,26 @@ describe('provider-client-converters', () => {
 
       expect(lookup).not.toHaveBeenCalled();
       expect(messages[0]).toHaveProperty('reasoning_content', 'client reasoning');
+    });
+
+    it('replaces empty reasoning_content with cached reasoning when available', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            reasoning_content: '',
+            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const lookup = jest.fn(() => 'cached reasoning');
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-v4-flash', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).toHaveBeenCalledWith('call_1');
+      expect(messages[0]).toHaveProperty('reasoning_content', 'cached reasoning');
     });
 
     it('does not re-inject cached reasoning_content without tool calls', () => {
@@ -1061,6 +1168,25 @@ describe('provider-client-converters', () => {
 
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith('call_1', 'I should use a tool.');
+    });
+
+    it('does not store reasoning_content for completed assistant messages without tool calls', () => {
+      const callback = jest.fn();
+      const transform = createReasoningContentStreamTransformer(callback);
+
+      transform(
+        JSON.stringify({
+          choices: [{ delta: { reasoning_content: 'I should calculate. ' }, finish_reason: null }],
+        }),
+      );
+      transform(
+        JSON.stringify({
+          choices: [{ delta: { content: 'The answer is 42.' }, finish_reason: null }],
+        }),
+      );
+      transform(JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] }));
+
+      expect(callback).not.toHaveBeenCalled();
     });
 
     it('updates cached reasoning_content if more reasoning arrives after the tool call id', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -1010,6 +1010,33 @@ describe('proxy-response-handler', () => {
         undefined,
       );
     });
+
+    it('does not configure assistant-message reasoning cache callbacks for streams without tool calls', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta({ provider: 'deepseek', model: 'deepseek-chat' });
+      const reasoningCache = { store: jest.fn() };
+      const sessionKey = 'sess-reasoning-stream';
+      const transformer = jest.fn((chunk: string) => `data: ${chunk}\n\n`);
+      client.createReasoningContentStreamTransformer.mockReturnValue(transformer);
+
+      await handleStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        sessionKey,
+        undefined,
+        'chat_completions',
+        reasoningCache as any,
+      );
+
+      expect(client.createReasoningContentStreamTransformer.mock.calls[0][2]).toBeUndefined();
+      expect(reasoningCache.store).not.toHaveBeenCalled();
+    });
   });
 
   /* ── handleNonStreamResponse ── */
@@ -1631,6 +1658,43 @@ describe('proxy-response-handler', () => {
         'call_1',
         'I should call the tool.',
       );
+      expect(res.json).toHaveBeenCalledWith(body);
+    });
+
+    it('does not cache reasoning_content from compatible non-stream assistant responses without tool calls', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const reasoningCache = { store: jest.fn() };
+      const sessionKey = 'sess-reasoning-json';
+      const body = {
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'The answer is 42.',
+              reasoning_content: 'I checked the arithmetic.',
+            },
+          },
+        ],
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta({ provider: 'deepseek', model: 'deepseek-chat' });
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        sessionKey,
+        undefined,
+        'chat_completions',
+        reasoningCache as any,
+      );
+
+      expect(reasoningCache.store).not.toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith(body);
     });
 

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -162,6 +162,75 @@ describe('ReasoningContentCache', () => {
     expect(originalMessages[0].reasoning_content).toBeUndefined();
   });
 
+  it('does not re-inject reasoning_content into assistant messages without tool calls', async () => {
+    const body = {
+      messages: [{ role: 'assistant', content: 'The answer is 42.' }],
+    };
+
+    const result = await cache.reinjectMissingReasoningContent(
+      body,
+      'session-1',
+      'deepseek',
+      'deepseek-v4-flash',
+    );
+
+    expect(result).toBe(body);
+    expect((body.messages[0] as Record<string, unknown>).reasoning_content).toBeUndefined();
+  });
+
+  it('does not re-inject cached reasoning_content when a tool call id is repeated in one request', async () => {
+    cache.store('session-1', 'call_1', 'cached thinking');
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+        { role: 'tool', tool_call_id: 'call_1', content: '{}' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.reinjectMissingReasoningContent(
+      body,
+      'session-1',
+      'deepseek',
+      'deepseek-v4-flash',
+    );
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBeUndefined();
+    expect(messages[2].reasoning_content).toBeUndefined();
+    expect(result).toBe(body);
+  });
+
+  it('does not re-inject reasoning_content into strict providers', async () => {
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.reinjectMissingReasoningContent(
+      body,
+      'session-1',
+      'mistral',
+      'mistral-large',
+    );
+
+    expect(result).toBe(body);
+    expect((body.messages[0] as Record<string, unknown>).reasoning_content).toBeUndefined();
+  });
+
   it('does not query shared cache for strict providers', async () => {
     const repo = makeRepo();
     const sharedCache = new ReasoningContentCache(repo);

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -283,25 +283,31 @@ function sanitizeOpenAiMessages(
     if (!preserveReasoningContent) {
       delete cleaned.reasoning_content;
     }
+    if (endpointKey !== 'openrouter') {
+      delete cleaned.reasoning;
+    }
+    delete cleaned.reasoning_text;
     if (!preserveReasoningDetails) {
       delete cleaned.reasoning_details;
     }
 
     if (
       preserveReasoningContent &&
-      !cleaned.reasoning_content &&
       Array.isArray(cleaned.tool_calls) &&
       cleaned.tool_calls.length > 0 &&
-      reasoningContentLookup
+      !hasNonEmptyReasoningContent(cleaned)
     ) {
       const firstToolCall = cleaned.tool_calls[0];
       const firstToolCallId =
         firstToolCall && typeof firstToolCall === 'object' && !Array.isArray(firstToolCall)
           ? (firstToolCall as Record<string, unknown>).id
           : undefined;
-      if (typeof firstToolCallId === 'string') {
+      if (reasoningContentLookup && typeof firstToolCallId === 'string') {
         const cached = reasoningContentLookup(firstToolCallId);
         if (cached) cleaned.reasoning_content = cached;
+      }
+      if (!hasNonEmptyReasoningContent(cleaned)) {
+        cleaned.reasoning_content = '';
       }
     }
 
@@ -322,6 +328,10 @@ function sanitizeOpenAiMessages(
 
     return cleaned;
   });
+}
+
+function hasNonEmptyReasoningContent(message: Record<string, unknown>): boolean {
+  return typeof message.reasoning_content === 'string' && message.reasoning_content.length > 0;
 }
 
 function normalizeDeepSeekMaxTokens(body: Record<string, unknown>): void {

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -444,14 +444,17 @@ function cacheReasoningContent(
   const reasoningContent = message.reasoning_content;
   if (typeof reasoningContent !== 'string' || !reasoningContent) return;
   const toolCalls = message.tool_calls;
-  if (!Array.isArray(toolCalls) || toolCalls.length === 0) return;
-  const firstToolCall = toolCalls[0];
-  const firstToolCallId =
-    firstToolCall && typeof firstToolCall === 'object' && !Array.isArray(firstToolCall)
-      ? (firstToolCall as Record<string, unknown>).id
-      : undefined;
-  if (typeof firstToolCallId !== 'string' || !firstToolCallId) return;
-  cache.store(sessionKey, firstToolCallId, reasoningContent);
+  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+    const firstToolCall = toolCalls[0];
+    const firstToolCallId =
+      firstToolCall && typeof firstToolCall === 'object' && !Array.isArray(firstToolCall)
+        ? (firstToolCall as Record<string, unknown>).id
+        : undefined;
+    if (typeof firstToolCallId === 'string' && firstToolCallId) {
+      cache.store(sessionKey, firstToolCallId, reasoningContent);
+      return;
+    }
+  }
 }
 
 export async function handleNonStreamResponse(

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -13,10 +13,10 @@ const TTL_MS = 30 * 60 * 1000; // 30 minutes
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 /**
  * Hard ceiling on turns held in the in-memory layer. The key embeds an
- * upstream-generated tool call id (unique per turn), so the in-memory keyspace
- * is unbounded and the lazy TTL sweep — which only runs on writes — cannot cap a
- * burst. Oldest entries are evicted FIFO; the shared DB layer is pruned
- * separately by `expires_at`.
+ * upstream-generated tool call id, so the in-memory keyspace is unbounded and
+ * the lazy TTL sweep — which only runs on writes — cannot cap a burst. Oldest
+ * entries are evicted FIFO; the shared DB layer is pruned separately by
+ * `expires_at`.
  */
 export const MAX_CACHE_ENTRIES = 10_000;
 
@@ -26,8 +26,10 @@ export const MAX_CACHE_ENTRIES = 10_000;
  * DeepSeek-compatible reasoning providers require assistant tool-call turns to
  * be replayed with the same `reasoning_content` they returned. Generic
  * OpenAI-compatible SDKs often drop that provider-specific field when they
- * rebuild conversation history, so Manifest caches it by the first tool call id
- * and restores it before forwarding the next turn to a compatible provider.
+ * rebuild conversation history, so Manifest caches tool turns by the first tool
+ * call id. Normal assistant turns are intentionally not cached for replay:
+ * DeepSeek does not require them, and content-based matching can attach
+ * reasoning to the wrong visible turn.
  */
 @Injectable()
 export class ReasoningContentCache {
@@ -43,15 +45,16 @@ export class ReasoningContentCache {
 
   /** Store the reasoning_content string for an assistant tool-call turn. */
   store(sessionKey: string, firstToolCallId: string, content: string): void {
+    this.storeByCacheKey(sessionKey, firstToolCallId, content);
+  }
+
+  private storeByCacheKey(sessionKey: string, cacheKey: string, content: string): void {
     if (!content) return;
     this.maybeCleanup();
     const expiresAt = Date.now() + TTL_MS;
-    this.cache.set(`${sessionKey}:${firstToolCallId}`, {
-      content,
-      expiresAt,
-    });
+    this.cache.set(`${sessionKey}:${cacheKey}`, { content, expiresAt });
     this.evictOverflow();
-    void this.persist(sessionKey, firstToolCallId, content, expiresAt);
+    void this.persist(sessionKey, cacheKey, content, expiresAt);
   }
 
   /** Retrieve cached reasoning_content, or null if not found/expired. */
@@ -65,12 +68,12 @@ export class ReasoningContentCache {
     return entry.content;
   }
 
-  async retrieveMany(sessionKey: string, firstToolCallIds: string[]): Promise<Map<string, string>> {
+  async retrieveMany(sessionKey: string, cacheKeys: string[]): Promise<Map<string, string>> {
     this.maybeCleanup();
     const result = new Map<string, string>();
     const missing: string[] = [];
 
-    for (const id of [...new Set(firstToolCallIds)]) {
+    for (const id of [...new Set(cacheKeys)]) {
       const local = this.retrieve(sessionKey, id);
       if (local) {
         result.set(id, local);
@@ -120,19 +123,20 @@ export class ReasoningContentCache {
     const messages = body.messages;
     if (!Array.isArray(messages)) return body;
 
-    const ids = messages
-      .map((message) => firstToolCallIdMissingReasoning(message))
-      .filter((id): id is string => typeof id === 'string');
-    if (ids.length === 0) return body;
+    const keysByIndex = messages.map((message) => reasoningReplayKeyMissingReasoning(message));
+    const keys = keysByIndex.filter((id): id is string => typeof id === 'string');
+    if (keys.length === 0) return body;
+    const repeatedKeys = repeatedReplayKeys(keys);
 
-    const cached = await this.retrieveMany(sessionKey, ids);
+    const cached = await this.retrieveMany(sessionKey, keys);
     if (cached.size === 0) return body;
 
     let changed = false;
-    const nextMessages = messages.map((message) => {
-      const id = firstToolCallIdMissingReasoning(message);
-      if (!id) return message;
-      const content = cached.get(id);
+    const nextMessages = messages.map((message, index) => {
+      const key = keysByIndex[index];
+      if (!key) return message;
+      if (repeatedKeys.has(key)) return message;
+      const content = cached.get(key);
       if (!content) return message;
       changed = true;
       return { ...(message as Record<string, unknown>), reasoning_content: content };
@@ -236,4 +240,16 @@ function firstToolCallIdMissingReasoning(message: unknown): string | null {
   }
   const id = (firstToolCall as Record<string, unknown>).id;
   return typeof id === 'string' && id ? id : null;
+}
+
+function reasoningReplayKeyMissingReasoning(message: unknown): string | null {
+  return firstToolCallIdMissingReasoning(message);
+}
+
+function repeatedReplayKeys(keys: string[]): Set<string> {
+  const counts = new Map<string, number>();
+  for (const key of keys) {
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return new Set([...counts.entries()].filter(([, count]) => count > 1).map(([key]) => key));
 }


### PR DESCRIPTION
### ✨ What changed
- Cache DeepSeek reasoning only by first `tool_call.id`.
- Skip cached replay when a `tool_call.id` repeats in one request.
- Add empty `reasoning_content` fallback for required tool-call turns.
- Stop translating other provider reasoning fields into DeepSeek format.

### 💭 Why
DeepSeek thinking mode rejects follow-up tool-call turns when `reasoning_content` is missing. Replaying by visible assistant text can attach reasoning to the wrong turn.

### 👤 For users
DeepSeek V4 Flash fallback handles stripped tool-call reasoning without leaking another turn's reasoning.

### 📝 Notes
Closes #2219.
Focused proxy tests pass: 3 suites, 183 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves DeepSeek tool-call reasoning by caching only by the first `tool_call.id` and replaying it only for the same ID. Prevents follow-up turns from failing when `reasoning_content` is missing and avoids attaching reasoning to the wrong turn.

- **Bug Fixes**
  - Cache `reasoning_content` only for assistant tool-call turns (streaming and JSON), keyed by first `tool_call.id`; no caching for messages without tool calls.
  - Skip replay when a `tool_call.id` repeats within the same request to avoid ambiguous matches.
  - For DeepSeek-compatible providers, inject empty `reasoning_content` when none is recoverable and replace empty with a cached value when available.
  - Stop translating provider fields (`reasoning`, `reasoning_text`, `reasoning_details`) into DeepSeek format; strip them for strict providers.
  - Closes #2219.

<sup>Written for commit 16f0cc90e89f340a3273666fb8e9e53cf7b0e519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

