### PR TITLE
fix: clarify OpenCode Go quota labels

### DIFF
--- a/.changeset/opencode-go-quota-label.md
+++ b/.changeset/opencode-go-quota-label.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Clarify OpenCode Go per-request subscription values as quota usage instead of extra billing.

--- a/packages/frontend/src/services/formatters.ts
+++ b/packages/frontend/src/services/formatters.ts
@@ -27,16 +27,16 @@ export function formatCost(n: number): string | null {
 }
 
 /**
- * Format a per-request subscription cost (e.g. OpenCode Go's docs-attributed
- * USD per call) as a compact `$0.0136/req` label. Returns null for a missing,
- * zero, or negative value so callers fall back to a flat-fee label.
+ * Format a per-request subscription quota burn rate (e.g. OpenCode Go's
+ * docs-attributed USD per call) as a compact included-plan label. Returns null
+ * for a missing, zero, or negative value so callers fall back to a flat-fee label.
  */
 export function formatPerRequestCost(cost: number | null | undefined): string | null {
   if (cost == null) return null;
   const n = Number(cost);
   if (!Number.isFinite(n) || n <= 0) return null;
-  if (n < 0.0001) return '< $0.0001/req';
-  return `$${n.toFixed(4)}/req`;
+  if (n < 0.0001) return 'Included (< $0.0001 quota/req)';
+  return `Included ($${n.toFixed(4)} quota/req)`;
 }
 
 /**

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -471,7 +471,7 @@ describe('HeaderTierCard', () => {
     expect(container.querySelector('.routing-card__key-chip')?.textContent).toContain('Personal');
   });
 
-  it('shows the per-request cost for per-request subscriptions', () => {
+  it('shows the included per-request quota burn rate for per-request subscriptions', () => {
     const tierSub = {
       ...baseTier,
       override_route: {
@@ -501,8 +501,7 @@ describe('HeaderTierCard', () => {
         onFallbacksUpdate={vi.fn()}
       />
     ));
-    expect(container.textContent).toContain('$0.0136/req');
-    expect(container.textContent).not.toContain('Included in subscription');
+    expect(container.textContent).toContain('Included ($0.0136 quota/req)');
   });
 
   it('renders a + Add model button when override_route is null', () => {

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -721,7 +721,7 @@ describe('ModelPickerModal', () => {
     expect(container.textContent).toContain('Runs on your machine');
   });
 
-  it('renders the per-request cost instead of "Included in subscription" when present', () => {
+  it('renders the included per-request quota burn rate when present', () => {
     const gatewayProviders: RoutingProvider[] = [
       {
         id: 'p4',
@@ -752,8 +752,7 @@ describe('ModelPickerModal', () => {
         onClose={vi.fn()}
       />
     ));
-    expect(container.textContent).toContain('$0.0136/req');
-    expect(container.textContent).not.toContain('Included in subscription');
+    expect(container.textContent).toContain('Included ($0.0136 quota/req)');
   });
 
   it('filters the list by group name when search matches the group label', () => {

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -688,8 +688,7 @@ describe('RoutingTierCard', () => {
         })}
       />
     ));
-    expect(container.textContent).toContain('$0.0136/req');
-    expect(container.textContent).not.toContain('Included in subscription');
+    expect(container.textContent).toContain('Included ($0.0136 quota/req)');
   });
 
   it('renders the custom-provider letter in the chip when override_route is custom', () => {

--- a/packages/frontend/tests/services/formatters.test.ts
+++ b/packages/frontend/tests/services/formatters.test.ts
@@ -41,11 +41,11 @@ describe("formatCost", () => {
 
 describe("formatPerRequestCost", () => {
   it("formats a per-request cost with 4 decimals", () => {
-    expect(formatPerRequestCost(0.013636)).toBe("$0.0136/req");
-    expect(formatPerRequestCost(0.05)).toBe("$0.0500/req");
+    expect(formatPerRequestCost(0.013636)).toBe("Included ($0.0136 quota/req)");
+    expect(formatPerRequestCost(0.05)).toBe("Included ($0.0500 quota/req)");
   });
   it("returns a floor label for tiny positive costs", () => {
-    expect(formatPerRequestCost(0.00001)).toBe("< $0.0001/req");
+    expect(formatPerRequestCost(0.00001)).toBe("Included (< $0.0001 quota/req)");
   });
   it("returns null for missing, zero, negative, or non-finite values", () => {
     expect(formatPerRequestCost(null)).toBeNull();


### PR DESCRIPTION
### ✨ What changed
- OpenCode Go per-request subscription labels now say `Included (... quota/req)`.
- Tests cover the picker, tier cards, and shared formatter text.

### 💭 Why
The old `$.../req` label looked like extra billing. It is quota burn from OpenCode Go included subscription limits.

### 👤 For users
OpenCode Go models no longer mix included rows with bare price-looking rows.

### 🔧 For operators
No migrations or config changes.