### PR TITLE
fix: support Qwen workspace endpoints

### DIFF
--- a/.changeset/alibaba-frankfurt-endpoint.md
+++ b/.changeset/alibaba-frankfurt-endpoint.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Support Alibaba Cloud Model Studio compatible-mode endpoint URLs for Qwen API-key connections, including workspace-scoped Frankfurt endpoints.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1679,6 +1679,24 @@ describe('ModelDiscoveryService', () => {
       expect(provider.cached_models).toEqual([]);
     });
 
+    it('routes Qwen discovery to a stored Alibaba Model Studio base URL', async () => {
+      fetcher.fetch.mockResolvedValue([]);
+      mockPricingSync.getAll.mockReturnValue(new Map());
+
+      const provider = makeProvider({
+        provider: 'qwen',
+        region: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode',
+      });
+      await service.discoverModels(provider);
+
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'qwen',
+        'decrypted-key',
+        'api_key',
+        'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode',
+      );
+    });
+
     it('should stamp authType as api_key for regular providers', async () => {
       const models = [makeModel({ id: 'gpt-4o' })];
       fetcher.fetch.mockResolvedValue(models);

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -13,7 +13,7 @@ import { computeQualityScore } from '../database/quality-score.util';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { parseOAuthTokenBlob } from '../routing/oauth/core';
-import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../routing/qwen-region';
+import { getQwenCompatibleBaseUrl, isQwenResolvedEndpoint } from '../routing/qwen-region';
 import {
   getBedrockMantleBaseUrl,
   isBedrockProvider,
@@ -161,7 +161,7 @@ export class ModelDiscoveryService {
         }
       }
     }
-    if (isQwenProvider(provider.provider) && isQwenResolvedRegion(provider.region)) {
+    if (isQwenProvider(provider.provider) && isQwenResolvedEndpoint(provider.region)) {
       endpointOverride = getQwenCompatibleBaseUrl(provider.region);
     }
     if (isBedrockProvider(provider.provider) && isBedrockRegion(provider.region)) {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1236,6 +1236,27 @@ describe('ProviderModelFetcherService', () => {
     warnSpy.mockRestore();
   });
 
+  it('fetches Qwen models from an Alibaba Model Studio compatible-mode base URL', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await service.fetch(
+      'qwen',
+      'sk-qwen',
+      'api_key',
+      'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/models',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer sk-qwen' },
+      }),
+    );
+  });
+
   /* ── Anthropic provider ── */
 
   describe('parseAnthropic (via anthropic provider)', () => {

--- a/packages/backend/src/routing/dto/routing.dto.ts
+++ b/packages/backend/src/routing/dto/routing.dto.ts
@@ -80,6 +80,14 @@ export class ConnectProviderDto {
 
   @IsOptional()
   @IsString()
+  baseUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  base_url?: string;
+
+  @IsOptional()
+  @IsString()
   @IsNotEmpty()
   @MaxLength(MAX_PROVIDER_KEY_LABEL_LENGTH)
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -119,6 +119,16 @@ describe('ProviderController', () => {
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
+    it('rejects baseUrl for non-Qwen providers', async () => {
+      await expect(
+        controller.upsertProvider(mockCtx, mockAgentName, {
+          provider: 'openai',
+          authType: 'api_key',
+          baseUrl: 'https://api.openai.com/v1',
+        } as never),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
     it('accepts snake-case Qwen base_url on connect', async () => {
       mockProviderService.upsertProvider.mockResolvedValueOnce({
         provider: {

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -74,6 +74,83 @@ describe('ProviderController', () => {
         } as never),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
+
+    it('passes a Qwen baseUrl through the region slot for storage', async () => {
+      mockProviderService.upsertProvider.mockResolvedValueOnce({
+        provider: {
+          id: 'p1',
+          provider: 'qwen',
+          auth_type: 'api_key',
+          is_active: true,
+          label: 'Default',
+          priority: 0,
+          region: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode',
+        },
+        isNew: false,
+      });
+
+      await controller.upsertProvider(mockCtx, mockAgentName, {
+        provider: 'qwen',
+        authType: 'api_key',
+        apiKey: 'sk-qwen',
+        baseUrl: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+      } as never);
+
+      expect(mockProviderService.upsertProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        TEST_TENANT_ID,
+        'qwen',
+        'sk-qwen',
+        'api_key',
+        'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+        undefined,
+        'user-1',
+      );
+    });
+
+    it('rejects Qwen requests that send both region and baseUrl', async () => {
+      await expect(
+        controller.upsertProvider(mockCtx, mockAgentName, {
+          provider: 'qwen',
+          authType: 'api_key',
+          region: 'auto',
+          baseUrl: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+        } as never),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('accepts snake-case Qwen base_url on connect', async () => {
+      mockProviderService.upsertProvider.mockResolvedValueOnce({
+        provider: {
+          id: 'p1',
+          provider: 'qwen',
+          auth_type: 'api_key',
+          is_active: true,
+          label: 'Default',
+          priority: 0,
+          region: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode',
+        },
+        isNew: false,
+      });
+
+      await controller.upsertProvider(mockCtx, mockAgentName, {
+        provider: 'qwen',
+        authType: 'api_key',
+        apiKey: 'sk-qwen',
+        base_url: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+      } as never);
+
+      expect(mockProviderService.upsertProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        TEST_TENANT_ID,
+        'qwen',
+        'sk-qwen',
+        'api_key',
+        'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+        undefined,
+        'user-1',
+      );
+    });
   });
 
   /* ── getStatus ── */

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -26,7 +26,7 @@ import {
   RenameProviderKeyDto,
   ReorderProviderKeysDto,
 } from './dto/routing.dto';
-import { isQwenRegion } from './qwen-region';
+import { QWEN_REGION_VALIDATION_MESSAGE, isQwenRegion } from './qwen-region';
 import { getSubscriptionEndpointRegionConfig } from './subscription-region';
 import { isBedrockProvider, isBedrockRegion } from './bedrock-region';
 
@@ -105,15 +105,25 @@ export class ProviderController {
     });
     const lowerProvider = body.provider.toLowerCase();
     const isQwenProvider = lowerProvider === 'qwen' || lowerProvider === 'alibaba';
+    const qwenBaseUrl = body.baseUrl ?? body.base_url;
+    const qwenRegion = qwenBaseUrl ?? body.region;
     const subscriptionRegionConfig = getSubscriptionEndpointRegionConfig(
       lowerProvider,
       body.authType,
     );
 
-    if (body.region !== undefined) {
+    if (qwenBaseUrl !== undefined && !isQwenProvider) {
+      throw new BadRequestException('baseUrl is only supported for Alibaba/Qwen providers');
+    }
+
+    if (qwenBaseUrl !== undefined && body.region !== undefined) {
+      throw new BadRequestException('Use either region or baseUrl for Alibaba/Qwen providers');
+    }
+
+    if (qwenRegion !== undefined || body.region !== undefined) {
       if (isQwenProvider) {
-        if (!isQwenRegion(body.region)) {
-          throw new BadRequestException('region must be one of: auto, singapore, us, beijing');
+        if (!isQwenRegion(qwenRegion)) {
+          throw new BadRequestException(QWEN_REGION_VALIDATION_MESSAGE);
         }
       } else if (isBedrockProvider(lowerProvider) && (body.authType ?? 'api_key') === 'api_key') {
         if (!isBedrockRegion(body.region)) {
@@ -144,7 +154,7 @@ export class ProviderController {
       body.provider,
       body.apiKey,
       body.authType,
-      body.region,
+      qwenRegion,
       body.label,
       ctx.userId,
     );

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
@@ -146,6 +146,19 @@ describe('resolveForwardEndpoint', () => {
     expect(out.customEndpoint).toBeDefined();
   });
 
+  it('builds the qwen endpoint from a stored Alibaba Model Studio base URL', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'qwen',
+      authType: 'api_key',
+      model: 'qwen-max',
+      providerRegion: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode',
+    });
+    expect(out.forwardModel).toBe('qwen-max');
+    expect(out.customEndpoint?.baseUrl).toBe(
+      'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode',
+    );
+  });
+
   it('builds the AWS Bedrock Mantle endpoint for a selected region', () => {
     const out = resolveForwardEndpoint({
       provider: 'bedrock',

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
@@ -22,7 +22,7 @@ import { CustomProviderService } from '../custom-provider/custom-provider.servic
 import { normalizeMinimaxSubscriptionBaseUrl } from '../provider-base-url';
 import { getBedrockMantleBaseUrl, isBedrockRegion } from '../bedrock-region';
 import { MINIMAX_BASE_URLS } from '../oauth/minimax/minimax-oauth-helpers';
-import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../qwen-region';
+import { getQwenCompatibleBaseUrl, isQwenResolvedEndpoint } from '../qwen-region';
 import {
   getXiaomiTokenPlanBaseUrl,
   isXiaomiProviderId,
@@ -118,7 +118,7 @@ export function resolveForwardEndpoint(
     }
   } else if (resolveEndpointKey(provider) === 'bedrock' && isBedrockRegion(providerRegion)) {
     customEndpoint = buildEndpointOverride(getBedrockMantleBaseUrl(providerRegion), 'bedrock');
-  } else if (resolveEndpointKey(provider) === 'qwen' && isQwenResolvedRegion(providerRegion)) {
+  } else if (resolveEndpointKey(provider) === 'qwen' && isQwenResolvedEndpoint(providerRegion)) {
     customEndpoint = buildEndpointOverride(getQwenCompatibleBaseUrl(providerRegion), 'qwen');
   } else if (authType === 'subscription' && lower === 'minimax') {
     // OAuth tokens carry the region in resource_url; pasted Coding Plan tokens

--- a/packages/backend/src/routing/qwen-region.spec.ts
+++ b/packages/backend/src/routing/qwen-region.spec.ts
@@ -69,6 +69,40 @@ describe('qwen-region', () => {
     ).toBeNull();
   });
 
+  it('accepts Alibaba workspace endpoints in every supported region code', () => {
+    for (const regionCode of [
+      'cn-beijing',
+      'ap-southeast-1',
+      'ap-northeast-1',
+      'cn-hongkong',
+      'eu-central-1',
+    ]) {
+      expect(
+        normalizeQwenCompatibleBaseUrl(
+          `https://workspace-123.${regionCode}.maas.aliyuncs.com/compatible-mode/v1`,
+        ),
+      ).toBe(`https://workspace-123.${regionCode}.maas.aliyuncs.com/compatible-mode`);
+    }
+  });
+
+  it('rejects malformed Alibaba workspace base urls', () => {
+    const invalidUrls = [
+      'http://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode',
+      'https://user@workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode',
+      'https://workspace-123.eu-central-1.maas.aliyuncs.com:8443/compatible-mode',
+      'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode?x=1',
+      'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode#models',
+      'https://workspace-123.eu-central-1.maas.aliyuncs.com/not-compatible-mode',
+      'https://work_space.eu-central-1.maas.aliyuncs.com/compatible-mode',
+      'https://workspace-123.eu-central-1.mars.aliyuncs.com/compatible-mode',
+      'https://workspace-123.eu-central-1.maas.aliyuncs.net/compatible-mode',
+    ];
+
+    for (const invalidUrl of invalidUrls) {
+      expect(normalizeQwenCompatibleBaseUrl(invalidUrl)).toBeNull();
+    }
+  });
+
   it('detects the first region whose models endpoint succeeds', async () => {
     const fetchMock = jest
       .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()

--- a/packages/backend/src/routing/qwen-region.spec.ts
+++ b/packages/backend/src/routing/qwen-region.spec.ts
@@ -12,6 +12,9 @@ describe('qwen-region', () => {
     expect(isQwenRegion('singapore')).toBe(true);
     expect(isQwenRegion('us')).toBe(true);
     expect(isQwenRegion('beijing')).toBe(true);
+    expect(
+      isQwenRegion('https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1'),
+    ).toBe(true);
     expect(isQwenRegion('moon')).toBe(false);
   });
 
@@ -32,6 +35,11 @@ describe('qwen-region', () => {
     expect(getQwenCompatibleBaseUrl('beijing')).toBe(
       'https://dashscope.aliyuncs.com/compatible-mode',
     );
+    expect(
+      getQwenCompatibleBaseUrl(
+        'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+      ),
+    ).toBe('https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode');
   });
 
   it('defaults to Beijing when region is unset', () => {
@@ -43,7 +51,22 @@ describe('qwen-region', () => {
     expect(
       normalizeQwenCompatibleBaseUrl('https://dashscope-intl.aliyuncs.com/compatible-mode/'),
     ).toBe('https://dashscope-intl.aliyuncs.com/compatible-mode');
+    expect(
+      normalizeQwenCompatibleBaseUrl(
+        'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/',
+      ),
+    ).toBe('https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode');
     expect(normalizeQwenCompatibleBaseUrl('https://example.com/compatible-mode')).toBeNull();
+    expect(
+      normalizeQwenCompatibleBaseUrl(
+        'https://workspace-123.eu-central-1.maas.aliyuncs.com.evil.test/compatible-mode',
+      ),
+    ).toBeNull();
+    expect(
+      normalizeQwenCompatibleBaseUrl(
+        'https://workspace-123.eu-west-3.maas.aliyuncs.com/compatible-mode',
+      ),
+    ).toBeNull();
   });
 
   it('detects the first region whose models endpoint succeeds', async () => {

--- a/packages/backend/src/routing/qwen-region.ts
+++ b/packages/backend/src/routing/qwen-region.ts
@@ -7,11 +7,22 @@ const QWEN_REGION_BASE_URLS = {
 } as const;
 
 const QWEN_ALLOWED_BASE_URLS: ReadonlySet<string> = new Set(Object.values(QWEN_REGION_BASE_URLS));
+const QWEN_WORKSPACE_REGION_CODES: ReadonlySet<string> = new Set([
+  'cn-beijing',
+  'ap-southeast-1',
+  'ap-northeast-1',
+  'cn-hongkong',
+  'eu-central-1',
+]);
 const QWEN_REGION_DETECTION_ORDER = ['singapore', 'us', 'beijing'] as const;
 const QWEN_DETECTION_TIMEOUT_MS = 3000;
+const QWEN_WORKSPACE_HOST_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+export const QWEN_REGION_VALIDATION_MESSAGE =
+  'Qwen region must be one of: auto, singapore, us, beijing, or a valid Alibaba Cloud Model Studio compatible-mode base URL';
 
 export type QwenResolvedRegion = keyof typeof QWEN_REGION_BASE_URLS;
-export type QwenRegion = 'auto' | QwenResolvedRegion;
+export type QwenRegion = string;
 
 function buildModelsUrl(region: QwenResolvedRegion): string {
   return `${QWEN_REGION_BASE_URLS[region]}/v1/models`;
@@ -24,17 +35,61 @@ export function isQwenResolvedRegion(
 }
 
 export function isQwenRegion(value: string | null | undefined): value is QwenRegion {
-  return value === 'auto' || isQwenResolvedRegion(value);
+  return value === 'auto' || isQwenResolvedRegion(value) || !!normalizeQwenCompatibleBaseUrl(value);
 }
 
 export function getQwenCompatibleBaseUrl(region?: string | null): string {
+  const endpoint = normalizeQwenCompatibleBaseUrl(region);
+  if (endpoint) return endpoint;
   if (isQwenResolvedRegion(region)) return QWEN_REGION_BASE_URLS[region];
   return QWEN_REGION_BASE_URLS.beijing;
 }
 
-export function normalizeQwenCompatibleBaseUrl(baseUrl: string): string | null {
-  const normalized = normalizeProviderBaseUrl(baseUrl);
-  return QWEN_ALLOWED_BASE_URLS.has(normalized) ? normalized : null;
+export function normalizeQwenCompatibleBaseUrl(baseUrl: string | null | undefined): string | null {
+  if (!baseUrl) return null;
+  try {
+    const url = new URL(baseUrl);
+    if (
+      url.protocol !== 'https:' ||
+      url.username ||
+      url.password ||
+      url.port ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+
+    const normalized = normalizeProviderBaseUrl(`${url.origin}${url.pathname}`);
+    if (QWEN_ALLOWED_BASE_URLS.has(normalized)) return normalized;
+
+    const normalizedUrl = new URL(normalized);
+    if (normalizedUrl.pathname !== '/compatible-mode') return null;
+
+    const parts = normalizedUrl.hostname.split('.');
+    if (parts.length !== 5) return null;
+
+    const [workspaceId, regionCode, service, domain, tld] = parts;
+    if (
+      !workspaceId ||
+      !regionCode ||
+      service !== 'maas' ||
+      domain !== 'aliyuncs' ||
+      tld !== 'com'
+    ) {
+      return null;
+    }
+    if (!QWEN_WORKSPACE_HOST_RE.test(workspaceId)) return null;
+    if (!QWEN_WORKSPACE_REGION_CODES.has(regionCode)) return null;
+
+    return normalized;
+  } catch {
+    return null;
+  }
+}
+
+export function isQwenResolvedEndpoint(value: string | null | undefined): value is string {
+  return isQwenResolvedRegion(value) || !!normalizeQwenCompatibleBaseUrl(value);
 }
 
 export async function detectQwenRegion(

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.region.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.region.spec.ts
@@ -84,6 +84,11 @@ describe('ProviderService — Qwen region resolution', () => {
 
   it('keeps an existing resolved region when neither region nor key is given', async () => {
     expect(await resolve(undefined, undefined, { region: 'us' })).toBe('us');
+    expect(
+      await resolve(undefined, undefined, {
+        region: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode',
+      }),
+    ).toBe('https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode');
     expect(await resolve(undefined, undefined, null)).toBeNull();
   });
 
@@ -93,6 +98,12 @@ describe('ProviderService — Qwen region resolution', () => {
 
   it('returns a concrete requested region unchanged', async () => {
     expect(await resolve('singapore', undefined)).toBe('singapore');
+  });
+
+  it('normalizes a valid Alibaba Model Studio base URL', async () => {
+    await expect(
+      resolve('https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1', undefined),
+    ).resolves.toBe('https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode');
   });
 
   it('auto-detects using a decrypted stored key', async () => {

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -22,7 +22,13 @@ import {
   isSupportedSubscriptionProvider,
 } from '../../common/utils/subscription-support';
 import type { AuthType, ModelRoute } from 'manifest-shared';
-import { detectQwenRegion, isQwenRegion, isQwenResolvedRegion } from '../qwen-region';
+import {
+  QWEN_REGION_VALIDATION_MESSAGE,
+  detectQwenRegion,
+  isQwenRegion,
+  isQwenResolvedEndpoint,
+  normalizeQwenCompatibleBaseUrl,
+} from '../qwen-region';
 import {
   DEFAULT_BEDROCK_REGION,
   detectBedrockRegionFromApiKey,
@@ -527,18 +533,20 @@ export class ProviderService {
       if (apiKey) {
         return this.detectQwenRegionOrThrow(apiKey);
       }
-      return isQwenResolvedRegion(existing?.region) ? existing.region : null;
+      return isQwenResolvedEndpoint(existing?.region) ? existing.region : null;
     }
 
     if (!isQwenRegion(requestedRegion)) {
-      throw new BadRequestException('Qwen region must be one of: auto, singapore, us, beijing');
+      throw new BadRequestException(QWEN_REGION_VALIDATION_MESSAGE);
     }
 
+    const qwenEndpoint = normalizeQwenCompatibleBaseUrl(requestedRegion);
+    if (qwenEndpoint) return qwenEndpoint;
     if (requestedRegion !== 'auto') return requestedRegion;
 
     const keyToProbe = await this.getQwenDetectionKey(apiKey, existing);
     if (!keyToProbe) {
-      return isQwenResolvedRegion(existing?.region) ? existing.region : null;
+      return isQwenResolvedEndpoint(existing?.region) ? existing.region : null;
     }
 
     return this.detectQwenRegionOrThrow(keyToProbe);

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -10,7 +10,7 @@ import {
   type Accessor,
   type Setter,
 } from 'solid-js';
-import type { ProviderDef } from '../services/providers.js';
+import type { ProviderDef, SubscriptionEndpointRegion } from '../services/providers.js';
 import { validateApiKey, validateSubscriptionKey } from '../services/provider-utils.js';
 import {
   connectProvider,
@@ -29,6 +29,24 @@ import { toast } from '../services/toast-store.js';
 
 export const MAX_KEYS_PER_PROVIDER = 5;
 const MAX_LABEL_LENGTH = 50;
+const WORKSPACE_ID_PLACEHOLDER = '<workspace-id>';
+
+function baseUrlPlaceholderMatches(
+  placeholder: string | undefined,
+  baseUrl: string | null | undefined,
+): boolean {
+  if (!placeholder || !baseUrl) return false;
+  try {
+    const placeholderUrl = new URL(placeholder.replace(WORKSPACE_ID_PLACEHOLDER, 'workspace'));
+    const baseUrlObject = new URL(baseUrl);
+    const placeholderHostTail = placeholderUrl.hostname.split('.').slice(1).join('.');
+    const baseUrlHostTail = baseUrlObject.hostname.split('.').slice(1).join('.');
+
+    return !!placeholderHostTail && placeholderHostTail === baseUrlHostTail;
+  } catch {
+    return false;
+  }
+}
 
 export interface ProviderKeyFormProps {
   provDef: ProviderDef;
@@ -82,8 +100,18 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
       : (props.provDef.apiKeyEndpointRegions ?? []);
   const hasEndpointRegions = () => endpointRegions().length > 0;
   const defaultEndpointRegion = () => endpointRegions()[0]?.value;
+  const customEndpointOptions = () =>
+    endpointRegions().filter((region) => !!region.baseUrlPlaceholder);
+  const customEndpointOption = () =>
+    customEndpointOptions().find((region) => region.value === 'custom') ??
+    customEndpointOptions()[0];
+  const customEndpointOptionForValue = (value: string | null | undefined) =>
+    customEndpointOptions().find((region) =>
+      baseUrlPlaceholderMatches(region.baseUrlPlaceholder, value),
+    ) ?? customEndpointOption();
   const endpointRegionLabel = (value: string | null | undefined) =>
-    endpointRegions().find((region) => region.value === value)?.label;
+    endpointRegions().find((region) => region.value === value)?.label ??
+    (value ? customEndpointOptionForValue(value)?.label : undefined);
   const whereToGetUrl = () =>
     props.isSubMode()
       ? getSubscriptionProviderKeyUrl(props.provId)
@@ -111,17 +139,28 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   const isListMode = () => supportsMultiKey() && activeKeys().length > 1;
   const savedEndpointRegion = () => activeKeys()[0]?.region;
   const [selectedEndpointRegion, setSelectedEndpointRegion] = createSignal<string | undefined>();
+  const [customEndpointUrl, setCustomEndpointUrl] = createSignal('');
 
   createEffect(() => {
     if (!hasEndpointRegions()) {
       setSelectedEndpointRegion(undefined);
+      setCustomEndpointUrl('');
       return;
     }
     if (props.connected()) {
       if (activeKeys().length > 0) {
-        setSelectedEndpointRegion(savedEndpointRegion() ?? defaultEndpointRegion());
+        const saved = savedEndpointRegion();
+        const customOption = saved ? customEndpointOptionForValue(saved) : customEndpointOption();
+        if (saved && !endpointRegions().some((region) => region.value === saved) && customOption) {
+          setSelectedEndpointRegion(customOption.value);
+          setCustomEndpointUrl(saved);
+        } else {
+          setSelectedEndpointRegion(saved ?? defaultEndpointRegion());
+          if (saved !== customOption?.value) setCustomEndpointUrl('');
+        }
       } else {
         setSelectedEndpointRegion(undefined);
+        setCustomEndpointUrl('');
       }
       return;
     }
@@ -132,11 +171,22 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   });
 
   const displayedEndpointRegion = () => selectedEndpointRegion() ?? defaultEndpointRegion();
+  const selectedEndpointRegionOption = () =>
+    endpointRegions().find((region) => region.value === displayedEndpointRegion());
+  const isCustomEndpointSelected = () => !!selectedEndpointRegionOption()?.baseUrlPlaceholder;
   const endpointRegionPayload = () => {
     if (!hasEndpointRegions()) return undefined;
+    if (isCustomEndpointSelected()) return customEndpointUrl().trim() || undefined;
     const selected = selectedEndpointRegion();
     if (selected) return selected;
     return props.connected() ? undefined : defaultEndpointRegion();
+  };
+  const validateEndpointRegion = () => {
+    if (isCustomEndpointSelected() && !customEndpointUrl().trim()) {
+      props.setValidationError('Base URL is required');
+      return false;
+    }
+    return true;
   };
 
   const EndpointRegionSelect = (selectProps: { id: string; disabled?: boolean }) => (
@@ -156,6 +206,36 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
             {(region) => <option value={region.value}>{region.label}</option>}
           </For>
         </select>
+        <Show when={selectedEndpointRegionOption()?.baseUrlPlaceholder}>
+          {(placeholder) => (
+            <>
+              <label
+                class="provider-detail__label"
+                for={`${selectProps.id}-base-url`}
+                style="margin-top: 8px;"
+              >
+                Base URL
+              </label>
+              <input
+                id={`${selectProps.id}-base-url`}
+                class="provider-detail__input"
+                classList={{
+                  'provider-detail__input--error':
+                    props.validationError() === 'Base URL is required',
+                }}
+                type="url"
+                autocomplete="off"
+                placeholder={placeholder()}
+                value={customEndpointUrl()}
+                disabled={selectProps.disabled}
+                onInput={(e) => {
+                  setCustomEndpointUrl(e.currentTarget.value);
+                  props.setValidationError(null);
+                }}
+              />
+            </>
+          )}
+        </Show>
       </div>
     </Show>
   );
@@ -166,6 +246,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   };
 
   const handleConnect = async (label?: string) => {
+    if (!validateEndpointRegion()) return;
     const result = props.isSubMode()
       ? validateSubscriptionKey(props.provDef, props.keyInput())
       : validateApiKey(props.provDef, props.keyInput());
@@ -194,6 +275,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   };
 
   const handleUpdateKey = async (label?: string) => {
+    if (!validateEndpointRegion()) return;
     const result = props.isSubMode()
       ? validateSubscriptionKey(props.provDef, props.keyInput())
       : validateApiKey(props.provDef, props.keyInput());
@@ -506,7 +588,7 @@ export interface AddAnotherKeyActionProps {
   open?: Accessor<boolean>;
   setOpen?: Setter<boolean>;
   isSubscription?: boolean;
-  endpointRegions?: { value: string; label: string }[];
+  endpointRegions?: SubscriptionEndpointRegion[];
   initialEndpointRegion?: string;
 }
 
@@ -522,9 +604,16 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
   const [endpointRegion, setEndpointRegion] = createSignal<string | undefined>(
     props.initialEndpointRegion ?? props.endpointRegions?.[0]?.value,
   );
+  const [customEndpointUrl, setCustomEndpointUrl] = createSignal('');
   let apiKeyInputRef: HTMLInputElement | undefined;
 
   const defaultLabel = () => suggestNextProviderKeyLabel(props.existingLabels());
+  const selectedEndpointRegionOption = () =>
+    props.endpointRegions?.find((region) => region.value === endpointRegion());
+  const customEndpointPayload = () => {
+    if (!selectedEndpointRegionOption()?.baseUrlPlaceholder) return endpointRegion();
+    return customEndpointUrl().trim() || undefined;
+  };
 
   // Sync label suggestion when opened externally and auto-focus the API key field.
   // Use `on()` with explicit deps to avoid tracking label/endpointRegion signals,
@@ -545,12 +634,17 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
   );
 
   const submit = async () => {
+    if (selectedEndpointRegionOption()?.baseUrlPlaceholder && !customEndpointUrl().trim()) {
+      toast.error('Base URL is required');
+      return;
+    }
     const labelToUse = (label().trim() || defaultLabel()).slice(0, MAX_LABEL_LENGTH);
-    const ok = await props.onAdd(labelToUse, apiKey().trim(), endpointRegion());
+    const ok = await props.onAdd(labelToUse, apiKey().trim(), customEndpointPayload());
     if (ok) {
       setIsOpen(false);
       setLabel('');
       setApiKey('');
+      setCustomEndpointUrl('');
     }
   };
 
@@ -616,6 +710,29 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
               {(region) => <option value={region.value}>{region.label}</option>}
             </For>
           </select>
+          <Show when={selectedEndpointRegionOption()?.baseUrlPlaceholder}>
+            {(placeholder) => (
+              <>
+                <label
+                  class="provider-detail__label"
+                  for="add-key-base-url"
+                  style="margin-top: 8px;"
+                >
+                  Base URL
+                </label>
+                <input
+                  id="add-key-base-url"
+                  class="provider-detail__input"
+                  type="url"
+                  autocomplete="off"
+                  placeholder={placeholder()}
+                  value={customEndpointUrl()}
+                  disabled={props.busy()}
+                  onInput={(e) => setCustomEndpointUrl(e.currentTarget.value)}
+                />
+              </>
+            )}
+          </Show>
         </Show>
         <label class="provider-detail__label" for="add-key-value" style="margin-top: 8px;">
           {props.credentialOwnerName()} {props.credentialNoun()}
@@ -683,7 +800,7 @@ interface KeyChainViewProps {
   whereToGetUrl: () => string | undefined;
   addKeyOpen?: Accessor<boolean>;
   setAddKeyOpen?: Setter<boolean>;
-  endpointRegions: { value: string; label: string }[];
+  endpointRegions: SubscriptionEndpointRegion[];
   endpointRegionLabel: (value: string | null | undefined) => string | undefined;
   onUpdate: () => void;
   onDelete: (label: string) => void;

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -61,6 +61,8 @@ export function connectProvider(
     authType?: AuthType;
     label?: string;
     region?: string;
+    baseUrl?: string;
+    base_url?: string;
   },
 ) {
   return fetchMutate<{

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -5,6 +5,7 @@ import { SHARED_PROVIDER_BY_ID, type SharedProviderEntry } from 'manifest-shared
 export interface SubscriptionEndpointRegion {
   value: string;
   label: string;
+  baseUrlPlaceholder?: string;
 }
 
 export interface ProviderDef {
@@ -111,6 +112,36 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   qwen: {
     initial: 'Al',
     subtitle: 'Qwen, DeepSeek, Kimi, GLM via Alibaba Cloud',
+    apiKeyEndpointRegions: [
+      { value: 'auto', label: 'Auto-detect' },
+      { value: 'beijing', label: 'China (Beijing)' },
+      { value: 'singapore', label: 'Singapore' },
+      { value: 'us', label: 'United States' },
+      {
+        value: 'workspace-cn-hongkong',
+        label: 'China (Hong Kong)',
+        baseUrlPlaceholder:
+          'https://<workspace-id>.cn-hongkong.maas.aliyuncs.com/compatible-mode/v1',
+      },
+      {
+        value: 'workspace-eu-central-1',
+        label: 'Germany (Frankfurt)',
+        baseUrlPlaceholder:
+          'https://<workspace-id>.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+      },
+      {
+        value: 'workspace-ap-northeast-1',
+        label: 'Japan (Tokyo)',
+        baseUrlPlaceholder:
+          'https://<workspace-id>.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1',
+      },
+      {
+        value: 'custom',
+        label: 'Custom endpoint',
+        baseUrlPlaceholder:
+          'https://<workspace-id>.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+      },
+    ],
     supportsSubscription: true,
     subscriptionLabel: 'Qwen Token Plan',
     subscriptionAuthMode: 'token',

--- a/packages/frontend/tests/components/ProviderKeyForm.test.tsx
+++ b/packages/frontend/tests/components/ProviderKeyForm.test.tsx
@@ -1234,6 +1234,65 @@ describe('ProviderKeyForm', () => {
       });
     });
 
+    it('list-mode AddAnotherKey sends a named Qwen workspace endpoint URL', async () => {
+      const def = makeProviderDef({
+        id: 'qwen',
+        name: 'Alibaba Cloud',
+        apiKeyEndpointRegions: [
+          { value: 'auto', label: 'Auto-detect' },
+          {
+            value: 'workspace-ap-northeast-1',
+            label: 'Japan (Tokyo)',
+            baseUrlPlaceholder:
+              'https://<workspace-id>.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1',
+          },
+        ],
+      });
+      const { container, getByText } = mount({
+        provDef: def,
+        provId: 'qwen',
+        connected: true,
+        addKeyOpen: true,
+        providers: [
+          makeProvider({
+            id: 'q1',
+            provider: 'qwen',
+            label: 'Personal',
+            priority: 0,
+            region: 'auto',
+          }),
+          makeProvider({
+            id: 'q2',
+            provider: 'qwen',
+            label: 'Work',
+            priority: 1,
+            region: 'auto',
+          }),
+        ],
+      });
+
+      const endpoint = container.querySelector('#add-key-endpoint') as HTMLSelectElement;
+      fireEvent.change(endpoint, { target: { value: 'workspace-ap-northeast-1' } });
+      fireEvent.input(screen.getByLabelText('Base URL'), {
+        target: {
+          value: 'https://workspace-123.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1',
+        },
+      });
+      const apiKeyInput = container.querySelector('#add-key-value') as HTMLInputElement;
+      fireEvent.input(apiKeyInput, { target: { value: 'sk-third' } });
+      fireEvent.click(getByText('Add key'));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'qwen',
+        apiKey: 'sk-third',
+        authType: 'api_key',
+        label: 'Key 3',
+        region: 'https://workspace-123.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1',
+      });
+    });
+
     it('handleAddKey returns false when connectProvider rejects', async () => {
       connectProviderMock.mockRejectedValueOnce(new Error('bad'));
       const def = makeProviderDef({ id: 'openai', name: 'OpenAI' });

--- a/packages/frontend/tests/components/ProviderKeyForm.test.tsx
+++ b/packages/frontend/tests/components/ProviderKeyForm.test.tsx
@@ -372,6 +372,143 @@ describe('ProviderKeyForm', () => {
         region: 'eu-west-1',
       });
     });
+
+    it('sends a custom Alibaba API-key endpoint URL as the provider region', async () => {
+      const def = makeProviderDef({
+        id: 'qwen',
+        name: 'Alibaba Cloud',
+        apiKeyEndpointRegions: [
+          { value: 'auto', label: 'Auto-detect' },
+          {
+            value: 'custom',
+            label: 'Custom endpoint',
+            baseUrlPlaceholder:
+              'https://<workspace-id>.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+          },
+        ],
+      });
+      const { container } = mount({
+        provDef: def,
+        provId: 'qwen',
+        isSubMode: false,
+        selectedAuthType: 'api_key',
+        keyInput: 'sk-qwen-key',
+      });
+
+      const endpoint = container.querySelector('#qwen-subscription-endpoint') as HTMLSelectElement;
+      fireEvent.change(endpoint, { target: { value: 'custom' } });
+      fireEvent.input(screen.getByLabelText('Base URL'), {
+        target: {
+          value: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+        },
+      });
+
+      const connectBtn = container.querySelector('.provider-detail__action') as HTMLButtonElement;
+      fireEvent.click(connectBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'qwen',
+        apiKey: 'sk-qwen-key',
+        authType: 'api_key',
+        region: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+      });
+    });
+
+    it('sends a named Alibaba workspace endpoint URL as the provider region', async () => {
+      const def = makeProviderDef({
+        id: 'qwen',
+        name: 'Alibaba Cloud',
+        apiKeyEndpointRegions: [
+          { value: 'auto', label: 'Auto-detect' },
+          {
+            value: 'workspace-eu-central-1',
+            label: 'Germany (Frankfurt)',
+            baseUrlPlaceholder:
+              'https://<workspace-id>.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+          },
+        ],
+      });
+      const { container } = mount({
+        provDef: def,
+        provId: 'qwen',
+        isSubMode: false,
+        selectedAuthType: 'api_key',
+        keyInput: 'sk-qwen-key',
+      });
+
+      const endpoint = container.querySelector('#qwen-subscription-endpoint') as HTMLSelectElement;
+      fireEvent.change(endpoint, { target: { value: 'workspace-eu-central-1' } });
+      fireEvent.input(screen.getByLabelText('Base URL'), {
+        target: {
+          value: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+        },
+      });
+
+      const connectBtn = container.querySelector('.provider-detail__action') as HTMLButtonElement;
+      fireEvent.click(connectBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'qwen',
+        apiKey: 'sk-qwen-key',
+        authType: 'api_key',
+        region: 'https://workspace-123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+      });
+    });
+
+    it('selects the matching named Alibaba workspace region for a saved endpoint', () => {
+      const def = makeProviderDef({
+        id: 'qwen',
+        name: 'Alibaba Cloud',
+        apiKeyEndpointRegions: [
+          { value: 'auto', label: 'Auto-detect' },
+          {
+            value: 'workspace-eu-central-1',
+            label: 'Germany (Frankfurt)',
+            baseUrlPlaceholder:
+              'https://<workspace-id>.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+          },
+          {
+            value: 'workspace-ap-northeast-1',
+            label: 'Japan (Tokyo)',
+            baseUrlPlaceholder:
+              'https://<workspace-id>.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1',
+          },
+          {
+            value: 'custom',
+            label: 'Custom endpoint',
+            baseUrlPlaceholder:
+              'https://<workspace-id>.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+          },
+        ],
+      });
+      const { container } = mount({
+        provDef: def,
+        provId: 'qwen',
+        connected: true,
+        editing: true,
+        keyInput: 'sk-new-qwen-key',
+        providers: [
+          makeProvider({
+            provider: 'qwen',
+            region: 'https://workspace-123.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1',
+          }),
+        ],
+      });
+
+      const endpoint = container.querySelector(
+        '#qwen-subscription-endpoint-edit',
+      ) as HTMLSelectElement;
+      const baseUrl = screen.getByLabelText('Base URL') as HTMLInputElement;
+
+      expect(endpoint.value).toBe('workspace-ap-northeast-1');
+      expect(baseUrl.value).toBe(
+        'https://workspace-123.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1',
+      );
+    });
   });
 
   describe('handleUpdateKey toast labels', () => {

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -171,12 +171,14 @@ describe('ProviderSelectModal', () => {
   let onClose: ReturnType<typeof vi.fn>;
   let onUpdate: ReturnType<typeof vi.fn>;
 
-  const renderModal = (props: {
-    providers?: RoutingProvider[];
-    customProviders?: unknown[];
-    deepLink?: DeepLink;
-    customProviderPrefill?: unknown;
-  } = {}) =>
+  const renderModal = (
+    props: {
+      providers?: RoutingProvider[];
+      customProviders?: unknown[];
+      deepLink?: DeepLink;
+      customProviderPrefill?: unknown;
+    } = {},
+  ) =>
     render(() => (
       <ProviderSelectModal
         providers={props.providers ?? []}
@@ -298,7 +300,7 @@ describe('ProviderSelectModal', () => {
       expect(screen.getByLabelText('Current API key (masked)')).toBeDefined();
     });
 
-    it('sends Alibaba API keys without a region override and relies on backend auto-detection', async () => {
+    it('sends Alibaba API keys with auto region detection selected', async () => {
       openApiKey('qwen');
       fireEvent.input(screen.getByLabelText('Alibaba Cloud API key'), {
         target: { value: VALID_QWEN_KEY },
@@ -310,6 +312,7 @@ describe('ProviderSelectModal', () => {
           provider: 'qwen',
           apiKey: VALID_QWEN_KEY,
           authType: 'api_key',
+          region: 'auto',
         });
       });
     });

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -514,6 +514,33 @@ describe('PROVIDERS', () => {
 
   it('Qwen supports Token Plan subscription with token flow', () => {
     const qwen = PROVIDERS.find((p) => p.id === 'qwen')!;
+    expect(qwen.apiKeyEndpointRegions?.[0]).toEqual({
+      value: 'auto',
+      label: 'Auto-detect',
+    });
+    expect(qwen.apiKeyEndpointRegions).toContainEqual({
+      value: 'workspace-cn-hongkong',
+      label: 'China (Hong Kong)',
+      baseUrlPlaceholder: 'https://<workspace-id>.cn-hongkong.maas.aliyuncs.com/compatible-mode/v1',
+    });
+    expect(qwen.apiKeyEndpointRegions).toContainEqual({
+      value: 'workspace-eu-central-1',
+      label: 'Germany (Frankfurt)',
+      baseUrlPlaceholder:
+        'https://<workspace-id>.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+    });
+    expect(qwen.apiKeyEndpointRegions).toContainEqual({
+      value: 'workspace-ap-northeast-1',
+      label: 'Japan (Tokyo)',
+      baseUrlPlaceholder:
+        'https://<workspace-id>.ap-northeast-1.maas.aliyuncs.com/compatible-mode/v1',
+    });
+    expect(qwen.apiKeyEndpointRegions).toContainEqual({
+      value: 'custom',
+      label: 'Custom endpoint',
+      baseUrlPlaceholder:
+        'https://<workspace-id>.eu-central-1.maas.aliyuncs.com/compatible-mode/v1',
+    });
     expect(qwen.supportsSubscription).toBe(true);
     expect(qwen.subscriptionLabel).toBe('Qwen Token Plan');
     expect(qwen.subscriptionAuthMode).toBe('token');


### PR DESCRIPTION
### ✨ What changed
- Accept Alibaba Model Studio workspace base URLs for Qwen keys.
- Use stored Qwen endpoints for discovery and proxy requests.
- Add named Qwen workspace choices for Frankfurt, Tokyo, and Hong Kong.

### 💭 Why
Alibaba Model Studio Frankfurt keys use workspace-scoped `*.maas.aliyuncs.com` endpoints that auto-detection could not infer.

### 👤 For users
Qwen API-key setup can use Frankfurt, Tokyo, and Hong Kong workspace endpoints.

### 📝 Notes
Closes #2302

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Alibaba Model Studio workspace base URLs for `qwen` API keys, enabling Frankfurt, Tokyo, Hong Kong, and custom endpoints with strict validation and correct routing. Closes #2302.

- **New Features**
  - Accept `baseUrl`/`base_url` for `qwen` on connect; stored in the region field and validated (supports `auto`, `singapore`, `us`, `beijing`, or HTTPS `compatible-mode` workspace URLs). Rejects requests that include both `region` and `baseUrl`; `baseUrl` is only allowed for `qwen`/`alibaba`.
  - Normalize workspace endpoints to the `/compatible-mode` base and route model discovery and proxy requests through it.
  - Frontend adds workspace choices for Frankfurt, Tokyo, Hong Kong, and a “Custom endpoint”; shows a required “Base URL” field for these options and auto-selects the matching option for saved endpoints.
  - Expanded tests covering DTOs, controller, endpoint resolver, region utils and normalization, services, and UI flows.

<sup>Written for commit 81d7f5e600b926b941785eb77a1684cf0b8990bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

