### PR TITLE
fix: refresh OpenCode Go from live catalog

### DIFF
--- a/.changeset/opencode-go-quota-label.md
+++ b/.changeset/opencode-go-quota-label.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Clarify OpenCode Go per-request subscription values as quota usage instead of extra billing.
+Refresh OpenCode Go models from the live OpenCode catalog and clarify per-request subscription values as quota usage instead of extra billing.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -3101,7 +3101,7 @@ describe('ModelDiscoveryService', () => {
   /* ── models.dev fallback in discoverModels ── */
 
   describe('models.dev fallback in discoverModels', () => {
-    it('uses models.dev as the primary OpenCode Go catalog and preserves gateway model ids', async () => {
+    it('uses the live OpenCode Go catalog before models.dev fallback', async () => {
       mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) =>
         providerId === 'opencode-go'
           ? [
@@ -3117,20 +3117,37 @@ describe('ModelDiscoveryService', () => {
             ]
           : [],
       );
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'opencode-go/glm-5.2',
+          displayName: 'opencode-go/glm-5.2',
+          provider: 'opencode-go',
+          contextWindow: 200000,
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          capabilityReasoning: true,
+          capabilityCode: true,
+        }),
+      ]);
 
       const result = await service.discoverModels(
         makeProvider({ provider: 'opencode-go', auth_type: 'subscription' }),
       );
 
-      expect(fetcher.fetch).not.toHaveBeenCalled();
-      expect(mockModelsDevSync.getModelsForProvider).toHaveBeenCalledWith('opencode-go');
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'opencode-go',
+        'decrypted-key',
+        'subscription',
+        undefined,
+      );
+      expect(mockModelsDevSync.getModelsForProvider).not.toHaveBeenCalledWith('opencode-go');
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         expect.objectContaining({
           id: 'opencode-go/glm-5.2',
-          displayName: 'GLM-5.2',
+          displayName: 'opencode-go/glm-5.2',
           provider: 'opencode-go',
-          contextWindow: 1000000,
+          contextWindow: 200000,
           inputPricePerToken: 0,
           outputPricePerToken: 0,
           capabilityReasoning: true,
@@ -3175,17 +3192,14 @@ describe('ModelDiscoveryService', () => {
       );
     });
 
-    it('refreshes models.dev before a forced OpenCode Go provider refresh', async () => {
-      mockModelsDevSync.getModelsForProvider.mockReturnValue([
-        {
-          id: 'glm-5.2',
-          name: 'GLM-5.2',
-          contextWindow: 1000000,
-          inputPricePerToken: 0.0000014,
-          outputPricePerToken: 0.0000044,
-          reasoning: true,
-          toolCall: true,
-        },
+    it('refreshes metadata and fetches live OpenCode Go models on forced refresh', async () => {
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'opencode-go/glm-5.2',
+          provider: 'opencode-go',
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+        }),
       ]);
 
       await service.discoverModels(
@@ -3194,7 +3208,13 @@ describe('ModelDiscoveryService', () => {
       );
 
       expect(mockModelsDevSync.refreshCache).toHaveBeenCalledTimes(1);
-      expect(fetcher.fetch).not.toHaveBeenCalled();
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'opencode-go',
+        'decrypted-key',
+        'subscription',
+        undefined,
+        { forceRefresh: true },
+      );
     });
 
     it('falls back to the OpenCode Go docs catalog when forced models.dev refresh fails', async () => {
@@ -3223,14 +3243,14 @@ describe('ModelDiscoveryService', () => {
       warnSpy.mockRestore();
     });
 
-    it('falls back to the OpenCode Go docs catalog when models.dev has no catalog entry', async () => {
+    it('uses the OpenCode Go provider fetch when models.dev has no catalog entry', async () => {
       fetcher.fetch.mockResolvedValue([makeModel({ id: 'opencode-go/glm-5.1' })]);
 
       const result = await service.discoverModels(
         makeProvider({ provider: 'opencode-go', auth_type: 'subscription' }),
       );
 
-      expect(mockModelsDevSync.getModelsForProvider).toHaveBeenCalledWith('opencode-go');
+      expect(mockModelsDevSync.getModelsForProvider).not.toHaveBeenCalledWith('opencode-go');
       expect(fetcher.fetch).toHaveBeenCalledWith(
         'opencode-go',
         'decrypted-key',

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -53,7 +53,7 @@ function modelsDevModelIdPrefix(providerId: string): string | undefined {
 
 function prefersModelsDevCatalog(providerId: string): boolean {
   const lower = providerId.toLowerCase();
-  return lower === 'opencode-go' || lower === 'opencode-zen';
+  return lower === 'opencode-zen';
 }
 
 /** 2-minute TTL for the per-agent discovered-model list, matching RoutingCacheService. */

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2109,35 +2109,52 @@ describe('ProviderModelFetcherService', () => {
   });
 
   describe('opencode-go provider', () => {
-    it('delegates to the catalog service instead of hitting the network', async () => {
+    it('fetches the live OpenCode Go /models catalog and namespaces model ids', async () => {
       const catalog = {
-        list: jest.fn().mockResolvedValue([
-          { id: 'glm-5.1', displayName: 'GLM-5.1', format: 'openai' as const },
-          { id: 'minimax-m2.7', displayName: 'MiniMax M2.7', format: 'anthropic' as const },
-        ]),
+        list: jest.fn().mockResolvedValue([]),
+        refresh: jest
+          .fn()
+          .mockResolvedValue([
+            { id: 'glm-5.1', displayName: 'GLM-5.1', format: 'openai' as const },
+          ]),
       };
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'glm-5.2', object: 'model', owned_by: 'opencode' },
+            { id: 'glm-5.1', object: 'model', owned_by: 'opencode' },
+          ],
+        }),
+      });
       const withCatalog = new ProviderModelFetcherService(
         catalog as unknown as ConstructorParameters<typeof ProviderModelFetcherService>[0],
       );
 
       const result = await withCatalog.fetch('opencode-go', 'og-token', 'subscription');
 
-      expect(fetchSpy).not.toHaveBeenCalled();
-      expect(catalog.list).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://opencode.ai/zen/go/v1/models',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer og-token' }),
+        }),
+      );
+      expect(catalog.list).not.toHaveBeenCalled();
+      expect(catalog.refresh).not.toHaveBeenCalled();
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual(
         expect.objectContaining({
-          id: 'opencode-go/glm-5.1',
-          displayName: 'GLM-5.1',
+          id: 'opencode-go/glm-5.2',
+          displayName: 'opencode-go/glm-5.2',
           provider: 'opencode-go',
           inputPricePerToken: 0,
           outputPricePerToken: 0,
         }),
       );
-      expect(result[1].id).toBe('opencode-go/minimax-m2.7');
+      expect(result[1].id).toBe('opencode-go/glm-5.1');
     });
 
-    it('forces a catalog refresh when requested', async () => {
+    it('falls back to a refreshed docs catalog when live /models is empty', async () => {
       const catalog = {
         list: jest.fn().mockResolvedValue([]),
         refresh: jest
@@ -2149,12 +2166,21 @@ describe('ProviderModelFetcherService', () => {
       const withCatalog = new ProviderModelFetcherService(
         catalog as unknown as ConstructorParameters<typeof ProviderModelFetcherService>[0],
       );
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
 
       const result = await withCatalog.fetch('opencode-go', 'og-token', 'subscription', undefined, {
         forceRefresh: true,
       });
 
-      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://opencode.ai/zen/go/v1/models',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer og-token' }),
+        }),
+      );
       expect(catalog.refresh).toHaveBeenCalledTimes(1);
       expect(catalog.list).not.toHaveBeenCalled();
       expect(result[0]).toEqual(
@@ -2166,10 +2192,15 @@ describe('ProviderModelFetcherService', () => {
       );
     });
 
-    it('returns [] when no catalog service is wired up', async () => {
+    it('uses live models even when no docs catalog service is wired up', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ id: 'glm-5.2' }] }),
+      });
+
       const result = await service.fetch('opencode-go', 'og-token', 'subscription');
-      expect(result).toEqual([]);
-      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.map((m) => m.id)).toEqual(['opencode-go/glm-5.2']);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2192,6 +2192,52 @@ describe('ProviderModelFetcherService', () => {
       );
     });
 
+    it('falls back to the docs catalog when live /models returns an error', async () => {
+      const catalog = {
+        list: jest
+          .fn()
+          .mockResolvedValue([
+            { id: 'glm-5.1', displayName: 'GLM-5.1', format: 'openai' as const },
+          ]),
+        refresh: jest.fn().mockResolvedValue([]),
+      };
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      });
+      const withCatalog = new ProviderModelFetcherService(
+        catalog as unknown as ConstructorParameters<typeof ProviderModelFetcherService>[0],
+      );
+
+      const result = await withCatalog.fetch('opencode-go', 'og-token', 'subscription');
+
+      expect(catalog.list).toHaveBeenCalledTimes(1);
+      expect(catalog.refresh).not.toHaveBeenCalled();
+      expect(result.map((m) => m.id)).toEqual(['opencode-go/glm-5.1']);
+    });
+
+    it('falls back to the docs catalog when live /models throws', async () => {
+      const catalog = {
+        list: jest
+          .fn()
+          .mockResolvedValue([
+            { id: 'glm-5.1', displayName: 'GLM-5.1', format: 'openai' as const },
+          ]),
+        refresh: jest.fn().mockResolvedValue([]),
+      };
+      fetchSpy.mockRejectedValue(new Error('network down'));
+      const withCatalog = new ProviderModelFetcherService(
+        catalog as unknown as ConstructorParameters<typeof ProviderModelFetcherService>[0],
+      );
+
+      const result = await withCatalog.fetch('opencode-go', 'og-token', 'subscription');
+
+      expect(catalog.list).toHaveBeenCalledTimes(1);
+      expect(catalog.refresh).not.toHaveBeenCalled();
+      expect(result.map((m) => m.id)).toEqual(['opencode-go/glm-5.1']);
+    });
+
     it('uses live models even when no docs catalog service is wired up', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -41,6 +41,7 @@ const KILO_GATEWAY_BASE = 'https://api.kilo.ai/api/gateway';
 const FIREWORKS_MODELS_URL = 'https://api.fireworks.ai/v1/accounts/fireworks/models';
 const FIREWORKS_MODELS_PAGE_SIZE = 200;
 const FIREWORKS_MODELS_MAX_PAGES = 20;
+const OPENCODE_GO_MODELS_URL = 'https://opencode.ai/zen/go/v1/models';
 
 /* ── Generic parser factory ── */
 
@@ -731,7 +732,7 @@ export class ProviderModelFetcherService {
     } else if (configKey === 'zai' && authType === 'subscription') {
       configKey = 'zai-subscription';
     } else if (configKey === 'opencode-go') {
-      return this.fetchOpencodeGoCatalog(options?.forceRefresh === true);
+      return this.fetchOpencodeGoModels(apiKey, options?.forceRefresh === true);
     } else if (configKey === 'gemini' && authType === 'subscription') {
       // CodeAssist (`cloudcode-pa.googleapis.com`) does not expose a
       // `/models` endpoint; the discovery fallback chain pulls Gemini
@@ -881,7 +882,54 @@ export class ProviderModelFetcherService {
     return `${FIREWORKS_MODELS_URL}?${params.toString()}`;
   }
 
-  private async fetchOpencodeGoCatalog(forceRefresh = false): Promise<DiscoveredModel[]> {
+  private async fetchOpencodeGoModels(
+    apiKey: string,
+    forceRefresh = false,
+  ): Promise<DiscoveredModel[]> {
+    const live = await this.fetchOpencodeGoLiveModels(apiKey);
+    if (live.length > 0) return live;
+    return this.fetchOpencodeGoDocsCatalog(forceRefresh);
+  }
+
+  private async fetchOpencodeGoLiveModels(apiKey: string): Promise<DiscoveredModel[]> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(OPENCODE_GO_MODELS_URL, {
+        headers: apiKey ? bearerHeaders(apiKey) : {},
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        this.logger.warn(`OpenCode Go returned ${res.status} from ${OPENCODE_GO_MODELS_URL}`);
+        return [];
+      }
+
+      const body = await res.json();
+      const models = parseOpenAI(body, 'opencode-go').map((model) => {
+        const id = `opencode-go/${model.id}`;
+        return {
+          ...model,
+          id,
+          displayName: id,
+          provider: 'opencode-go',
+          contextWindow: OPENCODE_GO_CONTEXT_WINDOW,
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          capabilityReasoning: true,
+          capabilityCode: true,
+        };
+      });
+      return filterNonChatModels(models, 'opencode-go');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Failed to fetch OpenCode Go models: ${message}`);
+      return [];
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async fetchOpencodeGoDocsCatalog(forceRefresh = false): Promise<DiscoveredModel[]> {
     if (!this.opencodeGoCatalog) return [];
     const entries = forceRefresh
       ? await this.opencodeGoCatalog.refresh()

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -187,8 +187,8 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionLabel: 'OpenCode Go (beta)',
     subscriptionAuthMode: 'token' as const,
     subscriptionKeyPlaceholder: 'Paste your OpenCode API key',
-    // Model list is discovered from models.dev; the backend docs catalog remains
-    // as a fallback for request-quota cost and endpoint-format metadata.
+    // Model list is discovered from OpenCode Go's live /models endpoint; models.dev
+    // and the docs catalog provide metadata, quota cost, and fallback data.
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
       supportsPromptCaching: false,


### PR DESCRIPTION
### ✨ What changed
- OpenCode Go discovery now reads the live `/zen/go/v1/models` catalog first.
- Docs catalog remains a fallback for quota cost and endpoint format metadata.
- Per-request subscription labels now say `Included (... quota/req)`.

### 💭 Why
The previous path could keep serving stale OpenCode Go models. Refresh should pick up models that OpenCode itself exposes, including GLM-5.2.

### 👤 For users
Refreshing OpenCode Go models should reveal newly published models without waiting on bundled or cached catalog data.

### 🔧 For operators
No migrations or config changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
OpenCode Go model discovery now uses the live `https://opencode.ai/zen/go/v1/models` first, with docs/`models.dev` as metadata and fallback. This fixes stale lists and surfaces new models immediately (e.g., GLM-5.2).

- **Bug Fixes**
  - Fetch the live catalog with the user's key and only fall back to docs/`models.dev` when live is empty or errors; supports forced refresh and keeps namespaced IDs, with tests covering live-first and fallback paths.
  - Update per-request subscription labels to “Included (... quota/req)”.

<sup>Written for commit 13dd22ffc72971d2071c286e95224be743316352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

