### PR TITLE
Add 90d and 365d analytics range options

### DIFF
--- a/packages/backend/src/common/dto/range-query.dto.spec.ts
+++ b/packages/backend/src/common/dto/range-query.dto.spec.ts
@@ -10,7 +10,7 @@ describe('RangeQueryDto', () => {
   });
 
   it('validates with all accepted ranges', async () => {
-    for (const range of ['1h', '6h', '24h', '7d', '30d']) {
+    for (const range of ['1h', '6h', '24h', '7d', '30d', '90d', '365d']) {
       const dto = plainToInstance(RangeQueryDto, { range });
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);

--- a/packages/backend/src/common/utils/range.util.spec.ts
+++ b/packages/backend/src/common/utils/range.util.spec.ts
@@ -7,6 +7,8 @@ describe('rangeToInterval', () => {
     ['24h', '24 hours'],
     ['7d', '7 days'],
     ['30d', '30 days'],
+    ['90d', '90 days'],
+    ['365d', '365 days'],
   ])('maps %s to %s', (input, expected) => {
     expect(rangeToInterval(input)).toBe(expected);
   });
@@ -24,6 +26,8 @@ describe('rangeToPreviousInterval', () => {
     ['24h', '48 hours'],
     ['7d', '14 days'],
     ['30d', '60 days'],
+    ['90d', '180 days'],
+    ['365d', '730 days'],
   ])('maps %s to %s', (input, expected) => {
     expect(rangeToPreviousInterval(input)).toBe(expected);
   });
@@ -43,6 +47,8 @@ describe('isHourlyRange', () => {
   it('returns false for daily ranges', () => {
     expect(isHourlyRange('7d')).toBe(false);
     expect(isHourlyRange('30d')).toBe(false);
+    expect(isHourlyRange('90d')).toBe(false);
+    expect(isHourlyRange('365d')).toBe(false);
   });
 
   it('returns false for unknown ranges', () => {

--- a/packages/backend/src/common/utils/range.util.ts
+++ b/packages/backend/src/common/utils/range.util.ts
@@ -2,7 +2,7 @@
  * The set of analytics range tokens accepted by range-query DTOs. Single
  * source of truth so DTO validation and {@link rangeToInterval} cannot drift.
  */
-export const RANGE_VALUES = ['1h', '6h', '24h', '7d', '30d'] as const;
+export const RANGE_VALUES = ['1h', '6h', '24h', '7d', '30d', '90d', '365d'] as const;
 export type RangeValue = (typeof RANGE_VALUES)[number];
 
 export function rangeToInterval(range: string): string {
@@ -17,6 +17,10 @@ export function rangeToInterval(range: string): string {
       return '7 days';
     case '30d':
       return '30 days';
+    case '90d':
+      return '90 days';
+    case '365d':
+      return '365 days';
     default:
       return '24 hours';
   }
@@ -34,6 +38,10 @@ export function rangeToPreviousInterval(range: string): string {
       return '14 days';
     case '30d':
       return '60 days';
+    case '90d':
+      return '180 days';
+    case '365d':
+      return '730 days';
     default:
       return '48 hours';
   }

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -114,6 +114,8 @@ const RANGE_OPTIONS = [
   { label: 'Last 24 hours', value: '24h' },
   { label: 'Last 7 days', value: '7d' },
   { label: 'Last 30 days', value: '30d' },
+  { label: 'Last 90 days', value: '90d' },
+  { label: 'Last 365 days', value: '365d' },
 ];
 
 const GROUP_OPTIONS = [
@@ -127,7 +129,7 @@ const GROUP_STORAGE_KEY = 'manifest_global_group';
 function loadRange(): string {
   try {
     const v = localStorage.getItem(RANGE_STORAGE_KEY);
-    if (v === '24h' || v === '7d' || v === '30d') return v;
+    if (v === '24h' || v === '7d' || v === '30d' || v === '90d' || v === '365d') return v;
   } catch {
     /* ignore */
   }

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -204,7 +204,7 @@ const Overview: Component = () => {
     }
   });
 
-  const SMART_RANGES: string[] = ['30d', '7d', '24h'];
+  const SMART_RANGES: string[] = ['365d', '90d', '30d', '7d', '24h'];
 
   // Step the chart range down to the next bucket while it has no data, but only
   // after a fetch resolves — `defer: true` skips the no-op run at mount where
@@ -354,6 +354,8 @@ const Overview: Component = () => {
                 { label: 'Last 24 hours', value: '24h' },
                 { label: 'Last 7 days', value: '7d' },
                 { label: 'Last 30 days', value: '30d' },
+                { label: 'Last 90 days', value: '90d' },
+                { label: 'Last 365 days', value: '365d' },
               ]}
             />
           </Show>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -204,7 +204,7 @@ const Overview: Component = () => {
     }
   });
 
-  const SMART_RANGES: string[] = ['365d', '90d', '30d', '7d', '24h'];
+  const SMART_RANGES: string[] = ['30d', '7d', '24h'];
 
   // Step the chart range down to the next bucket while it has no data, but only
   // after a fetch resolves — `defer: true` skips the no-op run at mount where

--- a/packages/frontend/src/pages/providers/ConnectionDetail.tsx
+++ b/packages/frontend/src/pages/providers/ConnectionDetail.tsx
@@ -162,9 +162,9 @@ const ConnectionDetail: Component = () => {
   const savedRange = () => {
     try {
       const v = sessionStorage.getItem(rangeKey());
-      // Restore any persisted range, including '24h' (previously dropped, so a
-      // saved 24h selection silently reset to the 7d default on reload).
-      if (v === '24h' || v === '7d' || v === '30d') return v;
+      // Restore any persisted range, including longer windows, so saved
+      // selections survive reload instead of silently resetting to the 7d default.
+      if (v === '24h' || v === '7d' || v === '30d' || v === '90d' || v === '365d') return v;
     } catch {
       /* ignore */
     }
@@ -619,6 +619,8 @@ const ConnectionDetail: Component = () => {
                       { label: 'Last 24 hours', value: '24h' },
                       { label: 'Last 7 days', value: '7d' },
                       { label: 'Last 30 days', value: '30d' },
+                      { label: 'Last 90 days', value: '90d' },
+                      { label: 'Last 365 days', value: '365d' },
                     ]}
                   />
                   <button class="btn btn--outline btn--sm" onClick={openManageModal}>

--- a/packages/frontend/src/services/chart-utils.ts
+++ b/packages/frontend/src/services/chart-utils.ts
@@ -116,22 +116,26 @@ export function formatLegendTokens(_u: uPlot, val: number): string {
 
 const RANGE_MAP: Record<string, number> = {
   '1h': 3600,
+  '6h': 21600,
   '24h': 86400,
   '7d': 604800,
   '30d': 2592000,
+  '90d': 7776000,
+  '365d': 31536000,
 };
 
-const MULTI_DAY_RANGES = new Set(['7d', '30d']);
-const INTRADAY_RANGES = new Set(['1h', '24h']);
+const MULTI_DAY_RANGES = new Set(['7d', '30d', '90d', '365d']);
+const INTRADAY_RANGES = new Set(['1h', '6h', '24h']);
+const MAX_MULTIDAY_AXIS_LABELS = 10;
 
-const RANGE_DAYS: Record<string, number> = { '7d': 7, '30d': 30 };
-const RANGE_HOURS: Record<string, number> = { '24h': 24 };
+const RANGE_DAYS: Record<string, number> = { '7d': 7, '30d': 30, '90d': 90, '365d': 365 };
+const RANGE_HOURS: Record<string, number> = { '6h': 6, '24h': 24 };
 
 export function rangeToSeconds(range: string): number {
   return RANGE_MAP[range] ?? 86400;
 }
 
-/** Slot width in seconds. Daily for 7d/30d, hourly otherwise. */
+/** Slot width in seconds. Daily for multi-day ranges, hourly otherwise. */
 export function binWidthSeconds(range: string | undefined): number {
   return MULTI_DAY_RANGES.has(range ?? '') ? 86400 : 3600;
 }
@@ -139,8 +143,8 @@ export function binWidthSeconds(range: string | undefined): number {
 /**
  * Fill missing days/hours in sparse backend data so charts have
  * evenly spaced data points. For multi-day ranges, fills one point per
- * calendar day. For the 24h range, fills one point per hour up to the
- * current hour.
+ * calendar day. For hourly ranges, fills one point per hour up to the current
+ * hour.
  */
 export function fillDailyGaps<T extends Record<string, unknown>>(
   data: T[],
@@ -248,7 +252,10 @@ export function createBaseAxes(axisColor: string, gridColor: string, range?: str
       // Thin labels for multi-day ranges so they don't overlap
       if (multiDay) {
         const uniqueLabels = deduped.filter((l) => l !== '');
-        const step = uniqueLabels.length > 20 ? 5 : uniqueLabels.length > 14 ? 3 : 1;
+        const step =
+          uniqueLabels.length > MAX_MULTIDAY_AXIS_LABELS
+            ? Math.ceil(uniqueLabels.length / MAX_MULTIDAY_AXIS_LABELS)
+            : 1;
         if (step > 1) {
           let count = 0;
           return deduped.map((l) => {

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -545,10 +545,51 @@ const connectionAnalytics = {
   message_usage: overviewResponse.message_usage,
 };
 
+function makeMemoryStorage() {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    getItem(key: string) {
+      return data.has(key) ? data.get(key)! : null;
+    },
+    key(index: number) {
+      return Array.from(data.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    setItem(key: string, value: string) {
+      data.set(key, String(value));
+    },
+  };
+}
+
+function ensureStorageLike(kind: 'localStorage' | 'sessionStorage') {
+  const current = globalThis[kind] as Partial<Storage> | undefined;
+  const ready =
+    current &&
+    typeof current.getItem === 'function' &&
+    typeof current.setItem === 'function' &&
+    typeof current.removeItem === 'function' &&
+    typeof current.clear === 'function';
+  if (ready) return current;
+  const replacement = makeMemoryStorage();
+  Object.defineProperty(globalThis, kind, { configurable: true, value: replacement });
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, kind, { configurable: true, value: replacement });
+  }
+  return replacement;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  localStorage.clear();
-  sessionStorage.clear();
+  ensureStorageLike('localStorage').clear();
+  ensureStorageLike('sessionStorage').clear();
   routerState.navigate.mockReset();
   routerState.params = { connectionId: 'conn-openai' };
   mockIsSelfHosted = true;
@@ -679,8 +720,8 @@ describe('GlobalOverview (analytics)', () => {
     fireEvent.change(selects[0]!, { target: { value: 'agent' } });
     expect(localStorage.getItem('manifest_global_group')).toBe('agent');
 
-    fireEvent.change(selects[1]!, { target: { value: '30d' } });
-    expect(localStorage.getItem('manifest_global_range')).toBe('30d');
+    fireEvent.change(selects[1]!, { target: { value: '90d' } });
+    expect(localStorage.getItem('manifest_global_range')).toBe('90d');
 
     // After grouping by harness, the filter trigger lists harnesses.
     await waitFor(() => expect(screen.getByText('1 of 2 harnesses')).toBeDefined());
@@ -836,9 +877,9 @@ describe('GlobalOverview (analytics)', () => {
     await waitFor(() => expect(screen.getByTestId('provider-chart-card')).toBeDefined());
 
     const selects = screen.getAllByRole('combobox');
-    // group → harness, range → 30d both attempt to persist and swallow errors
+    // group → harness, range → 365d both attempt to persist and swallow errors
     fireEvent.change(selects[0]!, { target: { value: 'agent' } });
-    fireEvent.change(selects[1]!, { target: { value: '30d' } });
+    fireEvent.change(selects[1]!, { target: { value: '365d' } });
 
     await waitFor(() => expect(screen.getByText('All harnesses (2)')).toBeDefined());
     fireEvent.click(screen.getByText('All harnesses (2)'));
@@ -932,8 +973,8 @@ describe('ConnectionDetail (analytics)', () => {
     render(() => <ConnectionDetail />);
     await waitFor(() => expect(screen.getAllByText('Default').length).toBeGreaterThan(0));
 
-    fireEvent.change(screen.getByDisplayValue('Last 7 days'), { target: { value: '30d' } });
-    expect(sessionStorage.getItem('chart-range:conn-openai')).toBe('30d');
+    fireEvent.change(screen.getByDisplayValue('Last 7 days'), { target: { value: '365d' } });
+    expect(sessionStorage.getItem('chart-range:conn-openai')).toBe('365d');
 
     fireEvent.click(screen.getByText('Messages chart'));
     expect(sessionStorage.getItem('chart-view:conn-openai')).toBe('messages');

--- a/packages/frontend/tests/services/chart-utils.test.ts
+++ b/packages/frontend/tests/services/chart-utils.test.ts
@@ -72,9 +72,12 @@ afterEach(() => {
 describe('rangeToSeconds', () => {
   it('returns correct seconds for known ranges', () => {
     expect(rangeToSeconds('1h')).toBe(3600);
+    expect(rangeToSeconds('6h')).toBe(21600);
     expect(rangeToSeconds('24h')).toBe(86400);
     expect(rangeToSeconds('7d')).toBe(604800);
     expect(rangeToSeconds('30d')).toBe(2592000);
+    expect(rangeToSeconds('90d')).toBe(7776000);
+    expect(rangeToSeconds('365d')).toBe(31536000);
   });
 
   it('defaults to 86400 for unknown range', () => {
@@ -95,6 +98,11 @@ describe('isMultiDayRange', () => {
 
   it('returns true for 30d', () => {
     expect(isMultiDayRange('30d')).toBe(true);
+  });
+
+  it('returns true for 90d and 365d', () => {
+    expect(isMultiDayRange('90d')).toBe(true);
+    expect(isMultiDayRange('365d')).toBe(true);
   });
 
   it('returns false for 24h', () => {
@@ -127,6 +135,11 @@ describe('formatAxisTimestamp', () => {
     expect(formatAxisTimestamp(epoch, '24h')).toBe(localHHMM(epoch));
   });
 
+  it('shows HH:MM for 6h range', () => {
+    const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
+    expect(formatAxisTimestamp(epoch, '6h')).toBe(localHHMM(epoch));
+  });
+
   it('shows Mon Day for 7d range', () => {
     const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
     expect(formatAxisTimestamp(epoch, '7d')).toBe(localMonDay(epoch));
@@ -135,6 +148,12 @@ describe('formatAxisTimestamp', () => {
   it('shows Mon Day for 30d range', () => {
     const epoch = Date.UTC(2024, 11, 25, 8, 0) / 1000;
     expect(formatAxisTimestamp(epoch, '30d')).toBe(localMonDay(epoch));
+  });
+
+  it('shows Mon Day for 90d and 365d ranges', () => {
+    const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
+    expect(formatAxisTimestamp(epoch, '90d')).toBe(localMonDay(epoch));
+    expect(formatAxisTimestamp(epoch, '365d')).toBe(localMonDay(epoch));
   });
 
   it('pads single-digit hours and minutes', () => {
@@ -401,6 +420,8 @@ describe('binWidthSeconds', () => {
   it('returns one day for multi-day ranges', () => {
     expect(binWidthSeconds('7d')).toBe(86400);
     expect(binWidthSeconds('30d')).toBe(86400);
+    expect(binWidthSeconds('90d')).toBe(86400);
+    expect(binWidthSeconds('365d')).toBe(86400);
   });
 
   it('returns one hour for intraday and unknown ranges', () => {
@@ -502,9 +523,11 @@ describe('createBaseAxes', () => {
     expect(formatted[1]).toBe('');
   });
 
-  it('adds splits function for multi-day ranges (7d, 30d)', () => {
+  it('adds splits function for multi-day ranges', () => {
     expect(typeof (createBaseAxes('#aaa', '#eee', '7d')[0] as any).splits).toBe('function');
     expect(typeof (createBaseAxes('#aaa', '#eee', '30d')[0] as any).splits).toBe('function');
+    expect(typeof (createBaseAxes('#aaa', '#eee', '90d')[0] as any).splits).toBe('function');
+    expect(typeof (createBaseAxes('#aaa', '#eee', '365d')[0] as any).splits).toBe('function');
   });
 
   it('does not add splits function for intraday or undefined ranges', () => {
@@ -522,7 +545,7 @@ describe('createBaseAxes', () => {
     expect(result).toEqual([100, 200, 300]);
   });
 
-  it('values callback thins labels to every 5th for 30d range with 31 unique days', () => {
+  it('values callback thins labels to a bounded count for 30d range with 31 unique days', () => {
     const axes = createBaseAxes('#aaa', '#eee', '30d');
     const mockU = { scales: {} } as any;
     // Generate 31 unique day epochs (one per day)
@@ -532,13 +555,12 @@ describe('createBaseAxes', () => {
     }
     const result = (axes[0].values as Function)(mockU, vals);
     const nonEmpty = result.filter((l: string) => l !== '');
-    // 31 unique labels, step=5 → labels at index 0,5,10,15,20,25,30 = 7 labels
-    expect(nonEmpty).toHaveLength(7);
+    expect(nonEmpty.length).toBeLessThanOrEqual(10);
     // First label should be Jan 1
     expect(nonEmpty[0]).toBe(localMonDay(vals[0]));
   });
 
-  it('values callback thins labels to every 3rd for 30d range with 16 unique days', () => {
+  it('values callback thins labels to a bounded count for 30d range with 16 unique days', () => {
     const axes = createBaseAxes('#aaa', '#eee', '30d');
     const mockU = { scales: {} } as any;
     // Generate 16 unique day epochs
@@ -548,8 +570,19 @@ describe('createBaseAxes', () => {
     }
     const result = (axes[0].values as Function)(mockU, vals);
     const nonEmpty = result.filter((l: string) => l !== '');
-    // 16 unique labels, step=3 → labels at index 0,3,6,9,12,15 = 6 labels
-    expect(nonEmpty).toHaveLength(6);
+    expect(nonEmpty.length).toBeLessThanOrEqual(10);
+  });
+
+  it('values callback keeps 365d labels readable', () => {
+    const axes = createBaseAxes('#aaa', '#eee', '365d');
+    const mockU = { scales: {} } as any;
+    const vals: number[] = [];
+    for (let i = 0; i < 366; i++) {
+      vals.push(new Date(2024, 0, 1 + i, 0, 0).getTime() / 1000);
+    }
+    const result = (axes[0].values as Function)(mockU, vals);
+    const nonEmpty = result.filter((l: string) => l !== '');
+    expect(nonEmpty.length).toBeLessThanOrEqual(10);
   });
 
   it('values callback does not thin labels for 7d range with 8 unique days', () => {
@@ -951,6 +984,12 @@ describe('fillDailyGaps', () => {
     expect(result).toHaveLength(25);
   });
 
+  it('fills 7 hourly slots for 6h range', () => {
+    const zeroHour = (hour: string) => ({ hour, cost: 0 });
+    const result = fillDailyGaps([], '6h', 'hour', zeroHour);
+    expect(result).toHaveLength(7);
+  });
+
   it('preserves existing hourly data for 24h range', () => {
     const now = new Date();
     now.setMinutes(0, 0, 0);
@@ -991,6 +1030,16 @@ describe('fillDailyGaps', () => {
   it('fills 31 days for 30d range', () => {
     const result = fillDailyGaps([], '30d', 'date', zeroCost);
     expect(result).toHaveLength(31);
+  });
+
+  it('fills 91 days for 90d range', () => {
+    const result = fillDailyGaps([], '90d', 'date', zeroCost);
+    expect(result).toHaveLength(91);
+  });
+
+  it('fills 366 days for 365d range', () => {
+    const result = fillDailyGaps([], '365d', 'date', zeroCost);
+    expect(result).toHaveLength(366);
   });
 
   it('fills 8 days for 7d range', () => {


### PR DESCRIPTION
## Summary

This PR extends analytics range support beyond 30 days by adding:

- `90d`
- `365d`

It updates both backend range parsing and frontend range selectors/storage guards so these longer windows can be selected and persist across reloads.

## Changes

### Backend
- Extend `RANGE_VALUES` in `packages/backend/src/common/utils/range.util.ts`
- Add interval mapping:
  - `90d` → `90 days`
  - `365d` → `365 days`
- Add previous-interval mapping:
  - `90d` → `180 days`
  - `365d` → `730 days`

### Frontend
Update analytics range selectors in:
- `packages/frontend/src/pages/GlobalOverview.tsx`
- `packages/frontend/src/pages/Overview.tsx`
- `packages/frontend/src/pages/providers/ConnectionDetail.tsx`

Also update persisted-range restore logic so saved `90d` / `365d` selections are preserved after reload instead of falling back to shorter defaults.

### Tests
Updated `packages/frontend/tests/pages/ProviderOverviewPages.test.tsx` to cover persistence paths using the new range values.

Also harden the test storage setup so the page test does not depend on a runtime-provided `localStorage` implementation exposing the full `Storage` API.

## Verification

Passed:
- `cd packages/shared && npm run build`
- `cd packages/frontend && npm test -- tests/pages/ProviderOverviewPages.test.tsx`
- `cd packages/frontend && npm run build`

Note:
- Vitest still emits `--localstorage-file was provided without a valid path` in this environment, but the targeted analytics page test now passes (`49/49`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `90d` and `365d` analytics ranges across backend and UI. Selections persist after reloads, and charts stay readable for these longer windows; tests cover the new ranges, storage, and chart utilities.

- **New Features**
  - Extended backend `RANGE_VALUES` with `90d` and `365d`, including interval and previous-interval mappings.
  - Added new options to range selectors on `packages/frontend/src/pages/GlobalOverview.tsx`, `packages/frontend/src/pages/Overview.tsx`, and `packages/frontend/src/pages/providers/ConnectionDetail.tsx`.
  - Updated `SMART_RANGES` in `packages/frontend/src/pages/Overview.tsx` so charts try `365d`/`90d` before shorter windows when auto-stepping ranges.

- **Bug Fixes**
  - Improved chart legibility for multi-day ranges in `packages/frontend/src/services/chart-utils.ts` by capping x-axis labels to a readable count (≤10) for `90d`/`365d`.
  - Extended chart utils to handle `6h`, `90d`, and `365d` in range seconds, bin widths, gap filling, and axis formatting to align with backend ranges.

<sup>Written for commit 4c40e217a7e2882469642799887a4b7e545dbf4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

