### PR TITLE
fix: show selected harness custom tiers

### DIFF
--- a/.changeset/messages-custom-tier-filter.md
+++ b/.changeset/messages-custom-tier-filter.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show custom and task-specific tiers in the Messages tab Tiers filter when a harness is selected from the global Messages view.

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -200,14 +200,18 @@ const MessageLog: Component = () => {
     (name) => getRoutingStatus(decodeURIComponent(name)),
   );
 
+  const tierMetadataAgentName = createMemo(
+    () => agentFilter() || (params.agentName ? decodeURIComponent(params.agentName) : ''),
+  );
+
   const [specificityAssignments] = createResource(
-    () => params.agentName,
-    (name) => getSpecificityAssignments(decodeURIComponent(name)),
+    () => ({ agentName: tierMetadataAgentName() }),
+    ({ agentName }) => (agentName ? getSpecificityAssignments(agentName) : Promise.resolve([])),
   );
 
   const [headerTiers] = createResource(
-    () => params.agentName,
-    (name) => listHeaderTiers(decodeURIComponent(name)),
+    () => ({ agentName: tierMetadataAgentName() }),
+    ({ agentName }) => (agentName ? listHeaderTiers(agentName) : Promise.resolve([])),
   );
 
   const hasProviders = () => routingStatus()?.enabled === true;

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -39,7 +39,7 @@ const mockGetRoutingStatus = vi.fn();
 const mockListHeaderTiers = vi.fn();
 const mockSetMessageFeedback = vi.fn();
 const mockClearMessageFeedback = vi.fn();
-vi.mock("../../src/services/api.js", () => ({
+vi.mock('../../src/services/api.js', () => ({
   getMessages: (...args: unknown[]) => mockGetMessages(...args),
   getMessageFilterOptions: (...args: unknown[]) => mockGetMessageFilterOptions(...args),
   getAgents: (...args: unknown[]) => mockGetAgents(...args),
@@ -897,7 +897,7 @@ describe('MessageLog', () => {
     });
   });
 
-  it("shows the per-request cost for OpenCode Go subscription messages", async () => {
+  it('shows the per-request cost for OpenCode Go subscription messages', async () => {
     const dataWithPerRequestSub = {
       ...messagesData,
       items: [{ ...messagesData.items[0], auth_type: 'subscription', cost: 0.013636 }],
@@ -907,10 +907,8 @@ describe('MessageLog', () => {
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       // Per-request subscriptions (OpenCode Go) carry real costs — don't hide them.
-      expect(container.textContent).toContain("$0.01");
-      expect(
-        container.querySelector('[title^="Per-request subscription cost:"]'),
-      ).not.toBeNull();
+      expect(container.textContent).toContain('$0.01');
+      expect(container.querySelector('[title^="Per-request subscription cost:"]')).not.toBeNull();
     });
   });
 
@@ -1253,8 +1251,8 @@ describe('MessageLog', () => {
     });
   });
 
-  describe("Tier filter", () => {
-    it("renders a Tier select with Playground among the options", async () => {
+  describe('Tier filter', () => {
+    it('renders a Tier select with Playground among the options', async () => {
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
@@ -1456,6 +1454,33 @@ describe('MessageLog', () => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
         expect(lastQ.agent_name).toBe('agent-alpha');
+      });
+    });
+
+    it('loads custom tier options for the selected agent in global mode', async () => {
+      mockAgentName = '';
+      mockGetMessages.mockResolvedValue(messagesData);
+      mockListHeaderTiers.mockResolvedValue([{ id: 'ht-premium', name: 'Premium' }]);
+
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        const agentSelect = container.querySelectorAll(
+          '[data-testid="select"]',
+        )[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain('agent-alpha');
+      });
+
+      const agentSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: 'agent-alpha' } });
+
+      await vi.waitFor(() => {
+        expect(mockListHeaderTiers).toHaveBeenCalledWith('agent-alpha');
+        const tierSelect = container.querySelectorAll(
+          '[data-testid="select"]',
+        )[2] as HTMLSelectElement;
+        expect(tierSelect.textContent).toContain('Premium');
       });
     });
 


### PR DESCRIPTION
### ✨ What changed
- Load tier metadata from the selected Messages harness.
- Cover global harness custom tier options in MessageLog tests.

### 💭 Why
Global Messages filtered rows by harness, but the Tiers dropdown only knew route-scoped tiers. Custom and task-specific tiers were missing after selecting a harness.

### 👤 For users
Custom tiers now appear in Messages when filtering by a harness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Messages Tiers filter to load custom and task-specific tiers from the selected harness/agent in the global Messages view. Users now see the correct tier options after choosing a harness.

- **Bug Fixes**
  - Load tier metadata based on the selected agent (filter or query param) instead of route-only tiers.
  - Skip tier metadata requests when no agent is selected.
  - Add tests for custom tier options in global mode.

<sup>Written for commit 8df89b71ad8ccbfc4520e2878eb9521a7dddb224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

