### PR TITLE
feat: expose agent models from /v1/models

### DIFF
--- a/.changeset/real-v1-models-list.md
+++ b/.changeset/real-v1-models-list.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Expose authenticated agent models from `/v1/models` using the OpenAI-compatible model list shape.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -7,6 +7,7 @@ import { ThoughtSignatureCache } from '../thought-signature-cache';
 import { ThinkingBlockCache } from '../thinking-block-cache';
 import { ReasoningContentCache } from '../reasoning-content-cache';
 import { ResponsesSseError } from '../chatgpt-adapter';
+import type { DiscoveredModel } from '../../../model-discovery/model-fetcher';
 
 /**
  * Flush enough microtasks for the recorder's fire-and-forget chain to
@@ -74,6 +75,22 @@ function mockRequest(
   };
 }
 
+function makeDiscoveredModel(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
+  return {
+    id: 'gpt-4o',
+    displayName: 'GPT-4o',
+    provider: 'openai',
+    contextWindow: 128000,
+    inputPricePerToken: 0.0000025,
+    outputPricePerToken: 0.00001,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 4,
+    authType: 'api_key',
+    ...overrides,
+  };
+}
+
 describe('ProxyController', () => {
   let controller: ProxyController;
   let proxyService: { proxyRequest: jest.Mock };
@@ -103,6 +120,7 @@ describe('ProxyController', () => {
     manager: { transaction: jest.Mock };
   };
   let mockPricingCache: { getByModel: jest.Mock };
+  let modelDiscovery: { getModelsForAgent: jest.Mock };
   let recorder: ProxyMessageRecorder;
 
   beforeEach(() => {
@@ -137,6 +155,9 @@ describe('ProxyController', () => {
     };
     mockMessageManager.getRepository.mockReturnValue(mockMessageRepo);
     mockPricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
+    modelDiscovery = {
+      getModelsForAgent: jest.fn().mockResolvedValue([]),
+    };
     const mockCustomProviders = {
       canonicalizeAgentMessageKeys: jest
         .fn()
@@ -166,6 +187,7 @@ describe('ProxyController', () => {
       new ThoughtSignatureCache(),
       new ThinkingBlockCache(),
       new ReasoningContentCache(),
+      modelDiscovery as never,
     );
   });
 
@@ -173,20 +195,64 @@ describe('ProxyController', () => {
     recorder.onModuleDestroy();
   });
 
-  it('should expose /v1/models with the Manifest auto route', () => {
-    expect(controller.models()).toEqual({
+  it('should expose /v1/models as an OpenAI-compatible list with the Manifest auto route', async () => {
+    await expect(controller.models(mockRequest({}) as never)).resolves.toEqual({
       object: 'list',
       data: [
         {
           id: 'auto',
           object: 'model',
-          type: 'model',
-          display_name: 'Manifest Auto',
+          created: 0,
+          owned_by: 'manifest',
         },
       ],
-      has_more: false,
-      first_id: 'auto',
-      last_id: 'auto',
+    });
+    expect(modelDiscovery.getModelsForAgent).toHaveBeenCalledWith('tenant-1', 'agent-1');
+  });
+
+  it('should include authenticated agent models using provider-qualified ids', async () => {
+    modelDiscovery.getModelsForAgent.mockResolvedValue([
+      makeDiscoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'api_key' }),
+      makeDiscoveredModel({ id: 'gpt-4o', provider: 'openrouter', authType: 'api_key' }),
+      makeDiscoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'subscription' }),
+      makeDiscoveredModel({
+        id: 'opencode-go/glm-5.1',
+        provider: 'opencode-go',
+        authType: 'subscription',
+      }),
+      makeDiscoveredModel({
+        id: 'custom:provider-1/model-a',
+        provider: 'custom:provider-1',
+        authType: 'api_key',
+      }),
+      makeDiscoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'api_key' }),
+    ]);
+
+    await expect(controller.models(mockRequest({}) as never)).resolves.toEqual({
+      object: 'list',
+      data: [
+        { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
+        { id: 'openai/gpt-4o', object: 'model', created: 0, owned_by: 'openai' },
+        { id: 'openrouter/gpt-4o', object: 'model', created: 0, owned_by: 'openrouter' },
+        {
+          id: 'openai/gpt-4o-subscription',
+          object: 'model',
+          created: 0,
+          owned_by: 'openai',
+        },
+        {
+          id: 'opencode-go/glm-5.1-subscription',
+          object: 'model',
+          created: 0,
+          owned_by: 'opencode-go',
+        },
+        {
+          id: 'custom:provider-1/model-a',
+          object: 'model',
+          created: 0,
+          owned_by: 'custom:provider-1',
+        },
+      ],
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
@@ -94,6 +94,7 @@ describe('ProxyController streaming abort', () => {
   };
   let providerClient: Record<string, jest.Mock>;
   let mockMessageRepo: { insert: jest.Mock; findOne: jest.Mock; find: jest.Mock };
+  let modelDiscovery: { getModelsForAgent: jest.Mock };
   let recorder: ProxyMessageRecorder;
 
   beforeEach(() => {
@@ -117,6 +118,9 @@ describe('ProxyController streaming abort', () => {
       findOne: jest.fn().mockResolvedValue(null),
       find: jest.fn().mockResolvedValue([]),
     };
+    modelDiscovery = {
+      getModelsForAgent: jest.fn().mockResolvedValue([]),
+    };
     recorder = makeRecorder(mockMessageRepo);
     controller = new ProxyController(
       proxyService as never,
@@ -126,6 +130,7 @@ describe('ProxyController streaming abort', () => {
       new ThoughtSignatureCache(),
       new ThinkingBlockCache(),
       new ReasoningContentCache(),
+      modelDiscovery as never,
     );
   });
 

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -21,6 +21,8 @@ import { ProxyMessageRecorder } from './proxy-message-recorder';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { ReasoningContentCache } from './reasoning-content-cache';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import type { DiscoveredModel } from '../../model-discovery/model-fetcher';
 import { classifyCaller } from './caller-classifier';
 import { sanitizeRequestHeaders } from './request-headers';
 import {
@@ -41,6 +43,32 @@ import { redactInlineImageDataUrls } from './inline-image-redaction';
 
 const MAX_SEEN_TENANTS = 10_000;
 const SEEN_TENANT_TTL_MS = 24 * 60 * 60 * 1000;
+const MODEL_CREATED_UNKNOWN = 0;
+const SUBSCRIPTION_MODEL_SUFFIX = '-subscription';
+
+interface OpenAiModelObject {
+  id: string;
+  object: 'model';
+  created: number;
+  owned_by: string;
+}
+
+interface OpenAiModelList {
+  object: 'list';
+  data: OpenAiModelObject[];
+}
+
+function openAiModelId(model: DiscoveredModel): string {
+  const provider = model.provider.toLowerCase();
+  if (provider.startsWith('custom:')) return model.id;
+
+  const prefix = `${provider}/`;
+  const routeId = model.id.toLowerCase().startsWith(prefix) ? model.id : `${provider}/${model.id}`;
+  if (model.authType !== 'subscription' || routeId.endsWith(SUBSCRIPTION_MODEL_SUFFIX)) {
+    return routeId;
+  }
+  return `${routeId}${SUBSCRIPTION_MODEL_SUFFIX}`;
+}
 
 @Controller('v1')
 @Public()
@@ -59,23 +87,42 @@ export class ProxyController {
     private readonly signatureCache: ThoughtSignatureCache,
     private readonly thinkingCache: ThinkingBlockCache,
     private readonly reasoningCache: ReasoningContentCache,
+    private readonly modelDiscovery: ModelDiscoveryService,
   ) {}
 
   @Get('models')
-  models(): Record<string, unknown> {
+  async models(
+    @Req() req: Request & { ingestionContext: IngestionContext },
+  ): Promise<OpenAiModelList> {
+    const models = await this.modelDiscovery.getModelsForAgent(
+      req.ingestionContext.tenantId,
+      req.ingestionContext.agentId,
+    );
+    const data: OpenAiModelObject[] = [
+      {
+        id: 'auto',
+        object: 'model',
+        created: MODEL_CREATED_UNKNOWN,
+        owned_by: 'manifest',
+      },
+    ];
+    const seen = new Set(data.map((model) => model.id));
+
+    for (const model of models) {
+      const id = openAiModelId(model);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      data.push({
+        id,
+        object: 'model',
+        created: MODEL_CREATED_UNKNOWN,
+        owned_by: model.provider,
+      });
+    }
+
     return {
       object: 'list',
-      data: [
-        {
-          id: 'auto',
-          object: 'model',
-          type: 'model',
-          display_name: 'Manifest Auto',
-        },
-      ],
-      has_more: false,
-      first_id: 'auto',
-      last_id: 'auto',
+      data,
     };
   }
 

--- a/packages/backend/test/proxy.e2e-spec.ts
+++ b/packages/backend/test/proxy.e2e-spec.ts
@@ -91,6 +91,27 @@ afterAll(async () => {
 const api = () => request(app.getHttpServer());
 const bearer = (r: request.Test) => r.set('Authorization', `Bearer ${TEST_OTLP_KEY}`);
 
+describe('Proxy E2E — /v1/models', () => {
+  it('rejects unauthenticated requests with HTTP 401', async () => {
+    const res = await api().get('/v1/models').expect(401);
+
+    expect(res.body.error.type).toBe('auth_error');
+    expect(res.body.error.message).toContain('Missing the Authorization header');
+  });
+
+  it('lists the authenticated agent models using the OpenAI-compatible shape', async () => {
+    const res = await bearer(api().get('/v1/models')).expect(200);
+
+    expect(res.body).toEqual({
+      object: 'list',
+      data: [
+        { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
+        { id: 'openai/gpt-4o-mini', object: 'model', created: 0, owned_by: 'openai' },
+      ],
+    });
+  });
+});
+
 describe('Proxy E2E — /v1/chat/completions', () => {
   // Supertest doesn't set Accept by default, and these requests omit
   // `stream: true`, so the exception filter classifies them as non-chat


### PR DESCRIPTION
### ✨ What changed
- `/v1/models` returns `auto` plus cached models for the authenticated agent.
- Model objects now use OpenAI fields: `id`, `object`, `created`, `owned_by`.
- Provider-qualified IDs distinguish duplicate model names across providers.

### 💭 Why
OpenAI-compatible SDKs expect `/v1/models` to list usable model IDs, not only `auto`.

### 👤 For users
SDK model listing now shows connected agent models without provider refreshes.

### 📝 Notes
Direct routing for these IDs stays in a follow-up PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the authenticated agent’s models from `/v1/models` using the OpenAI-compatible list shape. SDKs can now list usable model IDs (including `auto`) without provider refreshes.

- **New Features**
  - `/v1/models` returns `auto` plus the agent’s models from the auth context.
  - OpenAI-compatible objects: `id`, `object`, `created` (0), `owned_by`; IDs are provider-qualified (e.g., `openai/gpt-4o`), add `-subscription` for subscription auth, custom providers keep raw IDs; duplicates are deduped.
  - Requires auth; unauthenticated requests return 401.

<sup>Written for commit 6b2ff17650763e936af56df09ab58b6cb847d790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

