### PR TITLE
feat: route explicit model IDs

### DIFF
--- a/.changeset/v1-model-routing.md
+++ b/.changeset/v1-model-routing.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Route explicit provider-qualified model IDs from the OpenAI-compatible API.

--- a/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
@@ -1,0 +1,80 @@
+import type { DiscoveredModel } from '../../../model-discovery/model-fetcher';
+import { openAiModelId, routeForOpenAiModelId } from '../openai-model-id';
+
+function model(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
+  return {
+    id: 'gpt-4o',
+    displayName: 'GPT-4o',
+    provider: 'openai',
+    contextWindow: 128000,
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 4,
+    authType: 'api_key',
+    ...overrides,
+  };
+}
+
+describe('OpenAI model ids', () => {
+  it('formats provider-qualified API-key model ids', () => {
+    expect(openAiModelId(model({ id: 'gpt-4o-mini', provider: 'openai' }))).toBe(
+      'openai/gpt-4o-mini',
+    );
+  });
+
+  it('adds the subscription suffix for subscription routes', () => {
+    expect(openAiModelId(model({ id: 'gpt-5.5', authType: 'subscription' }))).toBe(
+      'openai/gpt-5.5-subscription',
+    );
+    expect(openAiModelId(model({ id: 'gpt-5.5-subscription', authType: 'subscription' }))).toBe(
+      'openai/gpt-5.5-subscription',
+    );
+  });
+
+  it('preserves provider-prefixed provider-native model ids', () => {
+    expect(
+      openAiModelId(
+        model({
+          id: 'opencode-go/glm-5.1',
+          provider: 'opencode-go',
+          authType: 'subscription',
+        }),
+      ),
+    ).toBe('opencode-go/glm-5.1-subscription');
+  });
+
+  it('leaves custom model ids unchanged', () => {
+    expect(
+      openAiModelId(
+        model({
+          id: 'custom:provider-1/model-a',
+          provider: 'custom:provider-1',
+        }),
+      ),
+    ).toBe('custom:provider-1/model-a');
+  });
+
+  it('resolves listed ids back to routable provider/auth/model triples', () => {
+    const route = routeForOpenAiModelId('openrouter/anthropic/claude-sonnet-4.5', [
+      model({
+        id: 'anthropic/claude-sonnet-4.5',
+        provider: 'openrouter',
+        authType: 'api_key',
+      }),
+    ]);
+
+    expect(route).toEqual({
+      provider: 'openrouter',
+      authType: 'api_key',
+      model: 'anthropic/claude-sonnet-4.5',
+    });
+  });
+
+  it('returns null for unlisted or auth-less ids', () => {
+    expect(routeForOpenAiModelId('openai/gpt-4o', [])).toBeNull();
+    expect(routeForOpenAiModelId('openai/gpt-4o', [model({ id: 'gpt-4o-mini' })])).toBeNull();
+    expect(routeForOpenAiModelId('openai/gpt-4o', [model({ authType: undefined })])).toBeNull();
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -24,6 +24,8 @@ import type { ThinkingBlockCache } from '../thinking-block-cache';
 import type { ReasoningContentCache } from '../reasoning-content-cache';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
 import type { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
+import type { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
+import type { DiscoveredModel } from '../../../model-discovery/model-fetcher';
 
 /**
  * Stream-warmup helper is mocked because the real implementation depends on
@@ -45,6 +47,22 @@ const route = (provider: string, authType: ModelRoute['authType'], model: string
 
 const okResponse = (status = 200) =>
   new Response('{"ok":true}', { status, headers: { 'content-type': 'application/json' } });
+
+function discoveredModel(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
+  return {
+    id: 'gpt-4o',
+    displayName: 'GPT-4o',
+    provider: 'openai',
+    contextWindow: 128000,
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 4,
+    authType: 'api_key',
+    ...overrides,
+  };
+}
 
 const specCatalog: ProviderParamSpecCatalog = [
   {
@@ -97,6 +115,7 @@ describe('ProxyService — orchestration', () => {
   let modelParamsService: { get: jest.Mock; list: jest.Mock; set: jest.Mock; delete: jest.Mock };
   let providerParamSpecs: { getSpecs: jest.Mock; list: jest.Mock };
   let svc: ProxyService;
+  let modelDiscovery: jest.Mocked<Pick<ModelDiscoveryService, 'getModelsForAgent'>>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -104,6 +123,9 @@ describe('ProxyService — orchestration', () => {
     resolveService = {
       resolve: jest.fn(),
       resolveForTier: jest.fn(),
+    };
+    modelDiscovery = {
+      getModelsForAgent: jest.fn().mockResolvedValue([]),
     };
     providerKeyService = {
       getProviderApiKey: jest.fn().mockResolvedValue('decrypted-key'),
@@ -161,6 +183,7 @@ describe('ProxyService — orchestration', () => {
 
     svc = new ProxyService(
       resolveService as unknown as ResolveService,
+      modelDiscovery as unknown as ModelDiscoveryService,
       providerKeyService as unknown as ProviderKeyService,
       tierService as unknown as TierService,
       openaiOauth as unknown as OpenaiOauthService,
@@ -217,6 +240,7 @@ describe('ProxyService — orchestration', () => {
       } as unknown as ConfigService;
       svc = new ProxyService(
         resolveService as unknown as ResolveService,
+        modelDiscovery as unknown as ModelDiscoveryService,
         providerKeyService as unknown as ProviderKeyService,
         tierService as unknown as TierService,
         openaiOauth as unknown as OpenaiOauthService,
@@ -362,6 +386,235 @@ describe('ProxyService — orchestration', () => {
       const result = await svc.proxyRequest(baseOpts());
       const body = await result.forward.response.text();
       expect(body).toContain('M100');
+    });
+  });
+
+  describe('explicit OpenAI-compatible model routing', () => {
+    beforeEach(() => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('anthropic', 'api_key', 'claude-sonnet-4-5'),
+        fallback_routes: [route('gemini', 'api_key', 'gemini-2.5-flash')],
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(200),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+    });
+
+    it('routes a provider-qualified API-key model from the authenticated model list', async () => {
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({ id: 'gpt-4o-mini', provider: 'openai', authType: 'api_key' }),
+      ]);
+
+      const result = await svc.proxyRequest(
+        baseOpts({
+          body: {
+            model: 'openai/gpt-4o-mini',
+            messages: [{ role: 'user', content: 'hi' }],
+            temperature: 0.2,
+          },
+        }),
+      );
+
+      expect(modelDiscovery.getModelsForAgent).toHaveBeenCalledWith('tenant-1', 'agent-1');
+      expect(resolveService.resolve).not.toHaveBeenCalled();
+      expect(providerKeyService.selectProviderKey).toHaveBeenCalledWith(
+        'tenant-1',
+        'openai',
+        'api_key',
+        undefined,
+        'agent-1',
+      );
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openai',
+          authType: 'api_key',
+          model: 'gpt-4o-mini',
+          body: expect.objectContaining({ temperature: 0.2 }),
+          paramMergeContext: undefined,
+        }),
+      );
+      expect(modelParamsService.get).not.toHaveBeenCalled();
+      expect(providerParamSpecs.getSpecs).not.toHaveBeenCalled();
+      expect(result.meta).toMatchObject({
+        tier: 'default',
+        provider: 'openai',
+        auth_type: 'api_key',
+        model: 'gpt-4o-mini',
+      });
+      expect(result.meta.request_params).toBeNull();
+    });
+
+    it('routes subscription IDs by removing only the SDK suffix', async () => {
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({ id: 'gpt-5.5', provider: 'openai', authType: 'subscription' }),
+      ]);
+
+      await svc.proxyRequest(
+        baseOpts({
+          body: {
+            model: 'openai/gpt-5.5-subscription',
+            messages: [{ role: 'user', content: 'hi' }],
+          },
+        }),
+      );
+
+      expect(providerKeyService.selectProviderKey).toHaveBeenCalledWith(
+        'tenant-1',
+        'openai',
+        'subscription',
+        undefined,
+        'agent-1',
+      );
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openai',
+          authType: 'subscription',
+          model: 'gpt-5.5',
+        }),
+      );
+    });
+
+    it('preserves slash-containing provider-native model IDs', async () => {
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({
+          id: 'anthropic/claude-sonnet-4.5',
+          provider: 'openrouter',
+          authType: 'api_key',
+        }),
+      ]);
+
+      await svc.proxyRequest(
+        baseOpts({
+          body: {
+            model: 'openrouter/anthropic/claude-sonnet-4.5',
+            messages: [{ role: 'user', content: 'hi' }],
+          },
+        }),
+      );
+
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openrouter',
+          authType: 'api_key',
+          model: 'anthropic/claude-sonnet-4.5',
+        }),
+      );
+    });
+
+    it('routes custom model IDs unchanged', async () => {
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({
+          id: 'custom:provider-1/model-a',
+          provider: 'custom:provider-1',
+          authType: 'api_key',
+        }),
+      ]);
+
+      await svc.proxyRequest(
+        baseOpts({
+          body: {
+            model: 'custom:provider-1/model-a',
+            messages: [{ role: 'user', content: 'hi' }],
+          },
+        }),
+      );
+
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'custom:provider-1',
+          authType: 'api_key',
+          model: 'custom:provider-1/model-a',
+        }),
+      );
+    });
+
+    it('leaves auto on the existing resolver path', async () => {
+      await svc.proxyRequest(
+        baseOpts({
+          body: { model: 'auto', messages: [{ role: 'user', content: 'hi' }] },
+        }),
+      );
+
+      expect(modelDiscovery.getModelsForAgent).not.toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'anthropic',
+          authType: 'api_key',
+          model: 'claude-sonnet-4-5',
+        }),
+      );
+    });
+
+    it('does not silently auto-route unlisted model IDs', async () => {
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({ id: 'gpt-4o-mini', provider: 'openai', authType: 'api_key' }),
+      ]);
+
+      const result = await svc.proxyRequest(
+        baseOpts({
+          body: { model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] },
+        }),
+      );
+      const body = await result.forward.response.text();
+
+      expect(resolveService.resolve).not.toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      expect(body).toContain('M101');
+    });
+
+    it('does not treat the Anthropic Messages model field as an SDK routing override', async () => {
+      await svc.proxyRequest(
+        baseOpts({
+          apiMode: 'messages',
+          body: {
+            model: 'claude-haiku-4-5',
+            max_tokens: 32,
+            messages: [{ role: 'user', content: 'hi' }],
+          },
+        }),
+      );
+
+      expect(modelDiscovery.getModelsForAgent).not.toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'anthropic',
+          authType: 'api_key',
+          model: 'claude-sonnet-4-5',
+        }),
+      );
+    });
+
+    it('does not trigger Manifest fallbacks for explicit model failures', async () => {
+      modelDiscovery.getModelsForAgent.mockResolvedValue([
+        discoveredModel({ id: 'gpt-4o-mini', provider: 'openai', authType: 'api_key' }),
+      ]);
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: new Response('upstream broken', { status: 502 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      const result = await svc.proxyRequest(
+        baseOpts({
+          body: { model: 'openai/gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] },
+        }),
+      );
+
+      expect(fallbackService.tryFallbacks).not.toHaveBeenCalled();
+      expect(result.forward.response.status).toBe(502);
+      expect(result.meta).toMatchObject({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+      });
+      expect(result.meta.fallbackFromModel).toBeUndefined();
     });
   });
 

--- a/packages/backend/src/routing/proxy/openai-model-id.ts
+++ b/packages/backend/src/routing/proxy/openai-model-id.ts
@@ -1,0 +1,33 @@
+import type { ModelRoute } from 'manifest-shared';
+import type { DiscoveredModel } from '../../model-discovery/model-fetcher';
+
+export const OPENAI_MODEL_ID_AUTO = 'auto';
+const SUBSCRIPTION_MODEL_SUFFIX = '-subscription';
+
+export function openAiModelId(model: DiscoveredModel): string {
+  const provider = model.provider.toLowerCase();
+  if (provider.startsWith('custom:')) return model.id;
+
+  const prefix = `${provider}/`;
+  const routeId = model.id.toLowerCase().startsWith(prefix) ? model.id : `${provider}/${model.id}`;
+  if (model.authType !== 'subscription' || routeId.endsWith(SUBSCRIPTION_MODEL_SUFFIX)) {
+    return routeId;
+  }
+  return `${routeId}${SUBSCRIPTION_MODEL_SUFFIX}`;
+}
+
+export function routeForOpenAiModelId(
+  modelId: string,
+  models: readonly DiscoveredModel[],
+): ModelRoute | null {
+  for (const model of models) {
+    if (!model.authType) continue;
+    if (openAiModelId(model) !== modelId) continue;
+    return {
+      provider: model.provider,
+      authType: model.authType,
+      model: model.id,
+    };
+  }
+  return null;
+}

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -22,7 +22,6 @@ import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { ReasoningContentCache } from './reasoning-content-cache';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
-import type { DiscoveredModel } from '../../model-discovery/model-fetcher';
 import { classifyCaller } from './caller-classifier';
 import { sanitizeRequestHeaders } from './request-headers';
 import {
@@ -40,11 +39,11 @@ import { formatManifestError } from '../../common/errors/error-codes';
 import type { ProxyApiMode } from './proxy-types';
 import { ResponsesSseError } from './chatgpt-adapter';
 import { redactInlineImageDataUrls } from './inline-image-redaction';
+import { openAiModelId } from './openai-model-id';
 
 const MAX_SEEN_TENANTS = 10_000;
 const SEEN_TENANT_TTL_MS = 24 * 60 * 60 * 1000;
 const MODEL_CREATED_UNKNOWN = 0;
-const SUBSCRIPTION_MODEL_SUFFIX = '-subscription';
 
 interface OpenAiModelObject {
   id: string;
@@ -56,18 +55,6 @@ interface OpenAiModelObject {
 interface OpenAiModelList {
   object: 'list';
   data: OpenAiModelObject[];
-}
-
-function openAiModelId(model: DiscoveredModel): string {
-  const provider = model.provider.toLowerCase();
-  if (provider.startsWith('custom:')) return model.id;
-
-  const prefix = `${provider}/`;
-  const routeId = model.id.toLowerCase().startsWith(prefix) ? model.id : `${provider}/${model.id}`;
-  if (model.authType !== 'subscription' || routeId.endsWith(SUBSCRIPTION_MODEL_SUFFIX)) {
-    return routeId;
-  }
-  return `${routeId}${SUBSCRIPTION_MODEL_SUFFIX}`;
 }
 
 @Controller('v1')

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ResolveService } from '../resolve/resolve.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import {
   ProviderKeyService,
   SYNTHETIC_OLLAMA_PROVIDER_ID,
@@ -58,8 +59,11 @@ import { toChatCompletionsRequest } from './responses-adapter';
 import { messagesToChatCompletionsRequest } from './anthropic-messages-adapter';
 import { effectiveRoutesForResponseMode } from '../routing-core/response-mode-guard';
 import { parseMaxMessagesPerRequest } from './message-limit';
+import { OPENAI_MODEL_ID_AUTO, routeForOpenAiModelId } from './openai-model-id';
 
-type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>>;
+type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>> & {
+  explicit_model_override?: boolean;
+};
 
 /**
  * Roles excluded from scoring. AI agents (OpenClaw, Hermes, and
@@ -142,6 +146,7 @@ export class ProxyService {
 
   constructor(
     private readonly resolveService: ResolveService,
+    private readonly modelDiscovery: ModelDiscoveryService,
     private readonly providerKeyService: ProviderKeyService,
     private readonly tierService: TierService,
     private readonly openaiOauth: OpenaiOauthService,
@@ -202,6 +207,7 @@ export class ProxyService {
       sessionKey,
       specificityOverride,
       headers,
+      apiMode,
     );
     const responseMode = resolved.response_mode ?? DEFAULT_RESPONSE_MODE;
     const stream = body.stream === true || responseMode === 'stream';
@@ -244,12 +250,15 @@ export class ProxyService {
     // own (provider, auth_type, model) tuple in the model-params service.
     // Pass the agentId here as a thin context bag; the storage is already
     // route-scoped, so no per-provider filter is needed downstream.
+    const explicitModelOverride = resolved.explicit_model_override === true;
     const scopeKey = modelParamsScopeForRouting({
       tier: resolved.tier,
       specificityCategory: resolved.specificity_category,
       headerTierId: resolved.header_tier_id,
     });
-    const paramMergeContext: ParamMergeContext = { agentId, scopeKey };
+    const paramMergeContext: ParamMergeContext | undefined = explicitModelOverride
+      ? undefined
+      : { agentId, scopeKey };
 
     // Snapshot of which known param keys are *effectively in play* for the
     // primary attempt. Stored on every `agent_messages` row recorded for
@@ -260,15 +269,25 @@ export class ProxyService {
     // Independent reads — the params row and the provider spec list don't
     // depend on each other, so fetch them concurrently to shave a round-trip
     // off the cold path before forwarding.
-    const [primaryModelParams, primarySpecs] = await Promise.all([
-      this.modelParamsService.get(agentId, scopeKey, route.provider, route.authType, primaryModel),
-      this.providerParamSpecs.getSpecs(route.provider, route.authType, primaryModel),
-    ]);
-    const primaryRequestParams = snapshotRequestParams({
-      body: routingBody as Record<string, unknown>,
-      modelParams: primaryModelParams,
-      specs: primarySpecs,
-    });
+    const [primaryModelParams, primarySpecs] = explicitModelOverride
+      ? ([null, []] as const)
+      : await Promise.all([
+          this.modelParamsService.get(
+            agentId,
+            scopeKey,
+            route.provider,
+            route.authType,
+            primaryModel,
+          ),
+          this.providerParamSpecs.getSpecs(route.provider, route.authType, primaryModel),
+        ]);
+    const primaryRequestParams = explicitModelOverride
+      ? null
+      : snapshotRequestParams({
+          body: routingBody as Record<string, unknown>,
+          modelParams: primaryModelParams,
+          specs: primarySpecs,
+        });
 
     const forward = await this.fallbackService.tryForwardToProvider({
       provider: route.provider,
@@ -293,7 +312,12 @@ export class ProxyService {
       paramMergeContext,
     });
 
-    if (!forward.response.ok && shouldTriggerFallback(forward.response.status)) {
+    if (
+      !explicitModelOverride &&
+      !forward.response.ok &&
+      shouldTriggerFallback(forward.response.status) &&
+      paramMergeContext
+    ) {
       const fallbackResult = await this.tryFallbackChain({
         agentId,
         tenantId,
@@ -359,25 +383,27 @@ export class ProxyService {
         isResponses: forward.isResponses,
         isCodeAssist: forward.isCodeAssist,
       };
-      const fallbackResult = await this.tryFallbackChain({
-        agentId,
-        tenantId,
-        resolved,
-        primaryModel,
-        forward: syntheticForward,
-        body,
-        chatBody,
-        stream,
-        sessionKey,
-        signal,
-        signatureLookup,
-        thinkingLookup,
-        reasoningContentLookup,
-        apiMode,
-        paramMergeContext,
-        primaryTenantProviderId: credentials.tenantProviderId,
-      });
-      if (fallbackResult) return fallbackResult;
+      if (!explicitModelOverride && paramMergeContext) {
+        const fallbackResult = await this.tryFallbackChain({
+          agentId,
+          tenantId,
+          resolved,
+          primaryModel,
+          forward: syntheticForward,
+          body,
+          chatBody,
+          stream,
+          sessionKey,
+          signal,
+          signatureLookup,
+          thinkingLookup,
+          reasoningContentLookup,
+          apiMode,
+          paramMergeContext,
+          primaryTenantProviderId: credentials.tenantProviderId,
+        });
+        if (fallbackResult) return fallbackResult;
+      }
 
       // Warmup failed and no fallbacks available: return the synthetic 502
       // instead of the original forward (whose body was consumed by peekStream).
@@ -429,7 +455,25 @@ export class ProxyService {
     sessionKey: string,
     specificityOverride: ProxyRequestOptions['specificityOverride'],
     headers: ProxyRequestOptions['headers'],
-  ) {
+    apiMode: ProxyApiMode,
+  ): Promise<ResolvedRouting> {
+    const requestedModel = typeof body.model === 'string' ? body.model : undefined;
+    // Anthropic Messages requests require a provider-native model field; only
+    // OpenAI-compatible surfaces use /v1/models IDs as route overrides.
+    if (apiMode !== 'messages' && requestedModel && requestedModel !== OPENAI_MODEL_ID_AUTO) {
+      const models = await this.modelDiscovery.getModelsForAgent(tenantId, agentId);
+      return {
+        tier: 'default' as const,
+        route: routeForOpenAiModelId(requestedModel, models),
+        fallback_routes: null,
+        response_mode: DEFAULT_RESPONSE_MODE,
+        confidence: 1,
+        score: 0,
+        reason: 'default' as const,
+        explicit_model_override: true,
+      };
+    }
+
     const messages = body.messages as ScorerMessage[];
     const scoringMessages = this.filterScoringMessages(messages);
     const scoringTools = Array.isArray(body.tools) ? body.tools : undefined;
@@ -437,7 +481,7 @@ export class ProxyService {
     const recentTiers = this.momentum.getRecentTiers(sessionKey);
     const recentCategories = this.momentum.getRecentCategories(sessionKey);
 
-    return isHeartbeat
+    const baseResolved = await (isHeartbeat
       ? this.resolveService.resolveForTier(agentId, tenantId, 'simple')
       : this.resolveService.resolve(
           agentId,
@@ -450,7 +494,9 @@ export class ProxyService {
           specificityOverride,
           recentCategories,
           headers,
-        );
+        ));
+
+    return baseResolved;
   }
 
   private async resolveCredentials(


### PR DESCRIPTION
### ✨ What changed
- Routed exact `/v1/models` IDs through the OpenAI-compatible proxy.
- Kept `auto` on the existing Manifest routing path.
- Made explicit model IDs a V1 full override: no normal model routing, no saved Manifest model params, and no Manifest fallback chain.
- Left `/v1/messages` on the Anthropic-native model path so its `model` field is not treated as an SDK override.

### 👤 For users
SDK calls can pass IDs returned by `/v1/models` plus normal SDK request parameters in the same body.

### 💭 Why
`/v1/models` now exposes real model IDs. SDK callers need those IDs to select a concrete provider route without inheriting Manifest routing defaults.