### PR TITLE
feat: add Antigravity coding agent

### DIFF
--- a/.changeset/antigravity-coding-agent.md
+++ b/.changeset/antigravity-coding-agent.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add Antigravity as a supported Coding Assistant with setup guidance.

--- a/packages/frontend/public/icons/providers/antigravity.svg
+++ b/packages/frontend/public/icons/providers/antigravity.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 112 112" role="img" aria-label="Antigravity">
+  <rect x="4" y="4" width="104" height="104" rx="24" fill="#fff" />
+  <path
+    d="M89.6992 93.695C94.3659 97.195 101.366 94.8617 94.9492 88.445C75.6992 69.7783 79.7825 18.445 55.8659 18.445C31.9492 18.445 36.0325 69.7783 16.7825 88.445C9.78251 95.445 17.3658 97.195 22.0325 93.695C40.1159 81.445 38.9492 59.8617 55.8659 59.8617C72.7825 59.8617 71.6159 81.445 89.6992 93.695Z"
+    fill="url(#antigravity-gradient)"
+  />
+  <defs>
+    <linearGradient
+      id="antigravity-gradient"
+      x1="55.8659"
+      y1="18.445"
+      x2="55.8659"
+      y2="97.195"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop offset="0" stop-color="#ff5f2e" />
+      <stop offset=".22" stop-color="#fbbc04" />
+      <stop offset=".45" stop-color="#34a853" />
+      <stop offset=".68" stop-color="#35a7ff" />
+      <stop offset="1" stop-color="#3186ff" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/packages/frontend/src/components/AntigravitySetup.tsx
+++ b/packages/frontend/src/components/AntigravitySetup.tsx
@@ -1,0 +1,46 @@
+import type { Component } from 'solid-js';
+import CopyButton from './CopyButton.jsx';
+
+interface Props {
+  apiKey: string | null;
+  keyPrefix: string | null;
+  baseUrl: string;
+}
+
+const ConfigField: Component<{
+  label: string;
+  value: string;
+  copyValue?: string;
+}> = (props) => (
+  <div class="setup-onboard-fields__row" role="listitem">
+    <span class="setup-onboard-fields__label">{props.label}</span>
+    <span class="setup-onboard-fields__value">
+      <code>{props.value}</code>
+      <Show when={props.copyValue}>
+        <CopyButton text={props.copyValue!} />
+      </Show>
+    </span>
+  </div>
+);
+
+const AntigravitySetup: Component<Props> = (props) => (
+  <div class="setup-agents-card">
+    <p class="setup-method__hint">
+      Antigravity's current Models settings are for built-in model and quota selection. It does not
+      expose a custom OpenAI-compatible provider setting, so Manifest cannot be connected to
+      Antigravity directly yet.
+    </p>
+    <p class="setup-method__hint">
+      Use OpenCode, Claude Code, or a toolkit integration to route through Manifest today. These
+      endpoint values are here for reference if Antigravity adds custom model endpoints later.
+    </p>
+
+    <div class="setup-onboard-fields" role="list" aria-label="Reference endpoint values">
+      <ConfigField label="Base URL" value={props.baseUrl} copyValue={props.baseUrl} />
+      <ConfigField label="Model ID" value="auto" copyValue="auto" />
+      <ConfigField label="Model name" value="manifest/auto" copyValue="manifest/auto" />
+    </div>
+  </div>
+);
+
+export default AntigravitySetup;

--- a/packages/frontend/src/components/SetupStepAddProvider.tsx
+++ b/packages/frontend/src/components/SetupStepAddProvider.tsx
@@ -6,10 +6,18 @@ import NanobotSetup from './NanobotSetup.jsx';
 import CraftAgentSetup from './CraftAgentSetup.jsx';
 import ClaudeCodeSetup from './ClaudeCodeSetup.jsx';
 import OpenCodeSetup from './OpenCodeSetup.jsx';
+import AntigravitySetup from './AntigravitySetup.jsx';
 import type { ToolkitId } from '../services/framework-snippets.js';
 
 type SetupTab = 'toolkits' | 'agents';
-type AgentId = 'openclaw' | 'hermes' | 'nanobot' | 'craft' | 'claude-code' | 'opencode';
+type AgentId =
+  | 'openclaw'
+  | 'hermes'
+  | 'nanobot'
+  | 'craft'
+  | 'claude-code'
+  | 'opencode'
+  | 'antigravity';
 
 interface Props {
   apiKey: string | null;
@@ -55,7 +63,9 @@ const SetupStepAddProvider: Component<Props> = (props) => {
                   ? 'Connect Claude Code to Manifest'
                   : props.platform === 'opencode'
                     ? 'Connect OpenCode to Manifest'
-                    : 'Connect your harness to Manifest'}
+                    : props.platform === 'antigravity'
+                      ? 'Antigravity cannot connect to Manifest yet'
+                      : 'Connect your harness to Manifest'}
       </h3>
 
       {/* Platform-filtered mode: show only relevant content */}
@@ -78,6 +88,9 @@ const SetupStepAddProvider: Component<Props> = (props) => {
           </Match>
           <Match when={props.platform === 'opencode'}>
             <OpenCodeSetup {...snippetProps()} />
+          </Match>
+          <Match when={props.platform === 'antigravity'}>
+            <AntigravitySetup {...snippetProps()} />
           </Match>
           <Match when={toolkitId()}>
             <FrameworkSnippets
@@ -221,6 +234,22 @@ const SetupStepAddProvider: Component<Props> = (props) => {
                 />
                 OpenCode
               </button>
+              <button
+                class="panel__tab"
+                classList={{ 'panel__tab--active': activeAgent() === 'antigravity' }}
+                onClick={() => setActiveAgent('antigravity')}
+                role="tab"
+                aria-selected={activeAgent() === 'antigravity'}
+              >
+                <img
+                  src="/icons/providers/antigravity.svg"
+                  alt=""
+                  class="panel__tab-icon"
+                  width="16"
+                  height="16"
+                />
+                Antigravity
+              </button>
             </div>
           </div>
 
@@ -242,6 +271,9 @@ const SetupStepAddProvider: Component<Props> = (props) => {
             </Match>
             <Match when={activeAgent() === 'opencode'}>
               <OpenCodeSetup {...snippetProps()} />
+            </Match>
+            <Match when={activeAgent() === 'antigravity'}>
+              <AntigravitySetup {...snippetProps()} />
             </Match>
           </Switch>
         </Show>

--- a/packages/frontend/tests/components/AgentTypeGrid.test.tsx
+++ b/packages/frontend/tests/components/AgentTypeGrid.test.tsx
@@ -1,50 +1,52 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
 
-vi.mock("manifest-shared", () => ({
-  AGENT_CATEGORIES: ["personal", "app", "coding"],
+vi.mock('manifest-shared', () => ({
+  AGENT_CATEGORIES: ['personal', 'app', 'coding'],
   CATEGORY_LABELS: {
-    personal: "AI agents",
-    app: "App AI SDK",
-    coding: "Coding Assistant",
+    personal: 'AI agents',
+    app: 'App AI SDK',
+    coding: 'Coding Assistant',
   },
   PLATFORM_LABELS: {
-    openclaw: "OpenClaw",
-    hermes: "Hermes Agent",
-    nanobot: "Nanobot",
-    craft: "Craft Agent",
-    "openai-sdk": "OpenAI SDK",
-    "vercel-ai-sdk": "Vercel AI SDK",
-    langchain: "LangChain",
-    curl: "cURL",
-    "claude-code": "Claude Code",
-    opencode: "OpenCode",
-    other: "Other",
+    openclaw: 'OpenClaw',
+    hermes: 'Hermes Agent',
+    nanobot: 'Nanobot',
+    craft: 'Craft Agent',
+    'openai-sdk': 'OpenAI SDK',
+    'vercel-ai-sdk': 'Vercel AI SDK',
+    langchain: 'LangChain',
+    curl: 'cURL',
+    'claude-code': 'Claude Code',
+    opencode: 'OpenCode',
+    antigravity: 'Antigravity',
+    other: 'Other',
   },
   PLATFORMS_BY_CATEGORY: {
-    personal: ["openclaw", "hermes", "nanobot", "craft", "other"],
-    app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
-    coding: ["claude-code", "opencode", "other"],
+    personal: ['openclaw', 'hermes', 'nanobot', 'craft', 'other'],
+    app: ['openai-sdk', 'vercel-ai-sdk', 'langchain', 'other'],
+    coding: ['claude-code', 'opencode', 'antigravity', 'other'],
   },
   PLATFORM_ICONS: {
-    openclaw: "/icons/openclaw.png",
-    hermes: "/icons/hermes.png",
-    nanobot: "/icons/nanobot.png",
-    craft: "/icons/craft.png",
-    "openai-sdk": "/icons/providers/openai.svg",
-    "vercel-ai-sdk": "/icons/vercel.svg",
-    langchain: "/icons/langchain.svg",
-    "claude-code": "/icons/providers/claude-code.svg",
-    opencode: "/icons/providers/opencode.svg",
+    openclaw: '/icons/openclaw.png',
+    hermes: '/icons/hermes.png',
+    nanobot: '/icons/nanobot.png',
+    craft: '/icons/craft.png',
+    'openai-sdk': '/icons/providers/openai.svg',
+    'vercel-ai-sdk': '/icons/vercel.svg',
+    langchain: '/icons/langchain.svg',
+    'claude-code': '/icons/providers/claude-code.svg',
+    opencode: '/icons/providers/opencode.svg',
+    antigravity: '/icons/providers/antigravity.svg',
   },
 }));
 
-import AgentTypeGrid from "../../src/components/AgentTypeGrid";
+import AgentTypeGrid from '../../src/components/AgentTypeGrid';
 
-describe("AgentTypeGrid", () => {
+describe('AgentTypeGrid', () => {
   const defaultProps = {
-    category: "personal" as string | null,
-    platform: "openclaw" as string | null,
+    category: 'personal' as string | null,
+    platform: 'openclaw' as string | null,
     onCategoryChange: vi.fn(),
     onPlatformChange: vi.fn(),
   };
@@ -53,35 +55,35 @@ describe("AgentTypeGrid", () => {
     vi.clearAllMocks();
   });
 
-  it("renders inline grid with all three category groups in order", () => {
+  it('renders inline grid with all three category groups in order', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const labels = container.querySelectorAll(".agent-type-select__group-label");
+    const labels = container.querySelectorAll('.agent-type-select__group-label');
     expect(labels).toHaveLength(3);
-    expect(labels[0].textContent).toContain("AI agents");
-    expect(labels[1].textContent).toContain("App AI SDK");
-    expect(labels[2].textContent).toContain("Coding Assistant");
+    expect(labels[0].textContent).toContain('AI agents');
+    expect(labels[1].textContent).toContain('App AI SDK');
+    expect(labels[2].textContent).toContain('Coding Assistant');
   });
 
-  it("renders all platform options from all three categories", () => {
+  it('renders all platform options from all three categories', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const options = container.querySelectorAll(".agent-type-select__option");
-    expect(options).toHaveLength(12);
+    const options = container.querySelectorAll('.agent-type-select__option');
+    expect(options).toHaveLength(13);
   });
 
-  it("renders three columns", () => {
+  it('renders three columns', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const columns = container.querySelectorAll(".agent-type-select__column");
+    const columns = container.querySelectorAll('.agent-type-select__column');
     expect(columns).toHaveLength(3);
   });
 
-  it("marks selected option", () => {
+  it('marks selected option', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const selected = container.querySelectorAll(".agent-type-select__option--selected");
+    const selected = container.querySelectorAll('.agent-type-select__option--selected');
     expect(selected).toHaveLength(1);
-    expect(selected[0].textContent).toContain("OpenClaw");
+    expect(selected[0].textContent).toContain('OpenClaw');
   });
 
-  it("calls onCategoryChange and onPlatformChange on click", () => {
+  it('calls onCategoryChange and onPlatformChange on click', () => {
     const onCategoryChange = vi.fn();
     const onPlatformChange = vi.fn();
     const { container } = render(() => (
@@ -91,13 +93,13 @@ describe("AgentTypeGrid", () => {
         onPlatformChange={onPlatformChange}
       />
     ));
-    const options = container.querySelectorAll(".agent-type-select__option");
+    const options = container.querySelectorAll('.agent-type-select__option');
     fireEvent.click(options[5]); // OpenAI SDK (app category)
-    expect(onCategoryChange).toHaveBeenCalledWith("app");
-    expect(onPlatformChange).toHaveBeenCalledWith("openai-sdk");
+    expect(onCategoryChange).toHaveBeenCalledWith('app');
+    expect(onPlatformChange).toHaveBeenCalledWith('openai-sdk');
   });
 
-  it("selecting Claude Code routes to coding/claude-code", () => {
+  it('selecting Claude Code routes to coding/claude-code', () => {
     const onCategoryChange = vi.fn();
     const onPlatformChange = vi.fn();
     const { container } = render(() => (
@@ -107,13 +109,13 @@ describe("AgentTypeGrid", () => {
         onPlatformChange={onPlatformChange}
       />
     ));
-    const options = container.querySelectorAll(".agent-type-select__option");
+    const options = container.querySelectorAll('.agent-type-select__option');
     fireEvent.click(options[9]); // Claude Code (coding column, first item)
-    expect(onCategoryChange).toHaveBeenCalledWith("coding");
-    expect(onPlatformChange).toHaveBeenCalledWith("claude-code");
+    expect(onCategoryChange).toHaveBeenCalledWith('coding');
+    expect(onPlatformChange).toHaveBeenCalledWith('claude-code');
   });
 
-  it("selecting OpenCode routes to coding/opencode", () => {
+  it('selecting OpenCode routes to coding/opencode', () => {
     const onCategoryChange = vi.fn();
     const onPlatformChange = vi.fn();
     const { container } = render(() => (
@@ -123,103 +125,127 @@ describe("AgentTypeGrid", () => {
         onPlatformChange={onPlatformChange}
       />
     ));
-    const options = container.querySelectorAll(".agent-type-select__option");
+    const options = container.querySelectorAll('.agent-type-select__option');
     fireEvent.click(options[10]); // OpenCode (coding column, second item)
-    expect(onCategoryChange).toHaveBeenCalledWith("coding");
-    expect(onPlatformChange).toHaveBeenCalledWith("opencode");
+    expect(onCategoryChange).toHaveBeenCalledWith('coding');
+    expect(onPlatformChange).toHaveBeenCalledWith('opencode');
   });
 
-  it("shows platform icons", () => {
+  it('selecting Antigravity routes to coding/antigravity', () => {
+    const onCategoryChange = vi.fn();
+    const onPlatformChange = vi.fn();
+    const { container } = render(() => (
+      <AgentTypeGrid
+        {...defaultProps}
+        onCategoryChange={onCategoryChange}
+        onPlatformChange={onPlatformChange}
+      />
+    ));
+    const options = container.querySelectorAll('.agent-type-select__option');
+    fireEvent.click(options[11]); // Antigravity (coding column, third item)
+    expect(onCategoryChange).toHaveBeenCalledWith('coding');
+    expect(onPlatformChange).toHaveBeenCalledWith('antigravity');
+  });
+
+  it('shows platform icons', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const icons = container.querySelectorAll(".agent-type-select__option-icon");
+    const icons = container.querySelectorAll('.agent-type-select__option-icon');
     expect(icons.length).toBeGreaterThanOrEqual(5);
-    expect(icons[0].getAttribute("src")).toBe("/icons/openclaw.png");
+    expect(icons[0].getAttribute('src')).toBe('/icons/openclaw.png');
   });
 
-  it("uses other-agent.svg for personal Other", () => {
+  it('uses other-agent.svg for personal Other', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const options = container.querySelectorAll(".agent-type-select__option");
-    const icon = options[4].querySelector(".agent-type-select__option-icon");
-    expect(icon!.getAttribute("src")).toBe("/icons/other-agent.svg");
+    const options = container.querySelectorAll('.agent-type-select__option');
+    const icon = options[4].querySelector('.agent-type-select__option-icon');
+    expect(icon!.getAttribute('src')).toBe('/icons/other-agent.svg');
   });
 
-  it("uses other.svg for app Other", () => {
+  it('uses other.svg for app Other', () => {
     const { container } = render(() => (
       <AgentTypeGrid {...defaultProps} category="app" platform="other" />
     ));
-    const selected = container.querySelector(".agent-type-select__option--selected");
-    const icon = selected?.querySelector(".agent-type-select__option-icon");
-    expect(selected?.textContent).toContain("Other");
-    expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
+    const selected = container.querySelector('.agent-type-select__option--selected');
+    const icon = selected?.querySelector('.agent-type-select__option-icon');
+    expect(selected?.textContent).toContain('Other');
+    expect(icon!.getAttribute('src')).toBe('/icons/other.svg');
   });
 
-  it("uses other.svg for coding Other (not the personal-agent variant)", () => {
+  it('uses other.svg for coding Other (not the personal-agent variant)', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const options = container.querySelectorAll(".agent-type-select__option");
-    // coding/Other is at index 11 (5 personal + 4 app + 2 coding before it)
-    const icon = options[11].querySelector(".agent-type-select__option-icon");
-    expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
+    const options = container.querySelectorAll('.agent-type-select__option');
+    // coding/Other is at index 12 (5 personal + 4 app + 3 coding before it)
+    const icon = options[12].querySelector('.agent-type-select__option-icon');
+    expect(icon!.getAttribute('src')).toBe('/icons/other.svg');
   });
 
-  it("renders the official Claude Code icon in the coding column", () => {
+  it('renders the official Claude Code icon in the coding column', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const options = container.querySelectorAll(".agent-type-select__option");
-    const icon = options[9].querySelector(".agent-type-select__option-icon");
-    expect(icon!.getAttribute("src")).toBe("/icons/providers/claude-code.svg");
+    const options = container.querySelectorAll('.agent-type-select__option');
+    const icon = options[9].querySelector('.agent-type-select__option-icon');
+    expect(icon!.getAttribute('src')).toBe('/icons/providers/claude-code.svg');
   });
 
-  it("renders the OpenCode icon in the coding column", () => {
+  it('renders the OpenCode icon in the coding column', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const options = container.querySelectorAll(".agent-type-select__option");
-    const icon = options[10].querySelector(".agent-type-select__option-icon");
-    expect(icon!.getAttribute("src")).toBe("/icons/providers/opencode.svg");
+    const options = container.querySelectorAll('.agent-type-select__option');
+    const icon = options[10].querySelector('.agent-type-select__option-icon');
+    expect(icon!.getAttribute('src')).toBe('/icons/providers/opencode.svg');
   });
 
-  it("disables buttons when disabled prop is true", () => {
-    const { container } = render(() => (
-      <AgentTypeGrid {...defaultProps} disabled={true} />
-    ));
-    const options = container.querySelectorAll(".agent-type-select__option") as NodeListOf<HTMLButtonElement>;
+  it('renders the Antigravity icon in the coding column', () => {
+    const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
+    const options = container.querySelectorAll('.agent-type-select__option');
+    const icon = options[11].querySelector('.agent-type-select__option-icon');
+    expect(icon!.getAttribute('src')).toBe('/icons/providers/antigravity.svg');
+  });
+
+  it('disables buttons when disabled prop is true', () => {
+    const { container } = render(() => <AgentTypeGrid {...defaultProps} disabled={true} />);
+    const options = container.querySelectorAll(
+      '.agent-type-select__option',
+    ) as NodeListOf<HTMLButtonElement>;
     for (const opt of options) {
       expect(opt.disabled).toBe(true);
     }
   });
 
-  it("has inline modifier class", () => {
+  it('has inline modifier class', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    expect(container.querySelector(".agent-type-select__dropdown--inline")).not.toBeNull();
+    expect(container.querySelector('.agent-type-select__dropdown--inline')).not.toBeNull();
   });
 
-  it("sets aria-selected on selected option", () => {
+  it('sets aria-selected on selected option', () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const options = container.querySelectorAll('[role="option"]');
-    expect(options[0].getAttribute("aria-selected")).toBe("true");
-    expect(options[1].getAttribute("aria-selected")).toBe("false");
+    expect(options[0].getAttribute('aria-selected')).toBe('true');
+    expect(options[1].getAttribute('aria-selected')).toBe('false');
   });
 
-  it("selects app Other correctly", () => {
+  it('selects app Other correctly', () => {
     const { container } = render(() => (
-      <AgentTypeGrid
-        {...defaultProps}
-        category="app"
-        platform="other"
-      />
+      <AgentTypeGrid {...defaultProps} category="app" platform="other" />
     ));
-    const selected = container.querySelectorAll(".agent-type-select__option--selected");
+    const selected = container.querySelectorAll('.agent-type-select__option--selected');
     expect(selected).toHaveLength(1);
-    expect(selected[0].textContent).toContain("Other");
+    expect(selected[0].textContent).toContain('Other');
   });
 
-  it("selects coding Claude Code correctly", () => {
+  it('selects coding Claude Code correctly', () => {
     const { container } = render(() => (
-      <AgentTypeGrid
-        {...defaultProps}
-        category="coding"
-        platform="claude-code"
-      />
+      <AgentTypeGrid {...defaultProps} category="coding" platform="claude-code" />
     ));
-    const selected = container.querySelectorAll(".agent-type-select__option--selected");
+    const selected = container.querySelectorAll('.agent-type-select__option--selected');
     expect(selected).toHaveLength(1);
-    expect(selected[0].textContent).toContain("Claude Code");
+    expect(selected[0].textContent).toContain('Claude Code');
+  });
+
+  it('selects coding Antigravity correctly', () => {
+    const { container } = render(() => (
+      <AgentTypeGrid {...defaultProps} category="coding" platform="antigravity" />
+    ));
+    const selected = container.querySelectorAll('.agent-type-select__option--selected');
+    expect(selected).toHaveLength(1);
+    expect(selected[0].textContent).toContain('Antigravity');
   });
 });

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -1,425 +1,452 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
 
-vi.stubGlobal("navigator", {
+vi.stubGlobal('navigator', {
   clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
 });
 
-import SetupStepAddProvider from "../../src/components/SetupStepAddProvider";
+import SetupStepAddProvider from '../../src/components/SetupStepAddProvider';
 
-describe("SetupStepAddProvider", () => {
+describe('SetupStepAddProvider', () => {
   const defaultProps = {
     apiKey: null as string | null,
     keyPrefix: null as string | null,
-    baseUrl: "http://localhost:3001/v1",
+    baseUrl: 'http://localhost:3001/v1',
   };
 
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it("renders heading", () => {
+  it('renders heading', () => {
     render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(screen.getByText("Connect your harness to Manifest")).toBeDefined();
+    expect(screen.getByText('Connect your harness to Manifest')).toBeDefined();
   });
 
-  it("shows description with auto model", () => {
+  it('shows description with auto model', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain("auto");
-    expect(container.textContent).toContain("Point your harness");
+    expect(container.textContent).toContain('auto');
+    expect(container.textContent).toContain('Point your harness');
   });
 
-  it("renders Agents and Toolkits segmented tabs", () => {
+  it('renders Agents and Toolkits segmented tabs', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const segment = container.querySelector(".setup-segment");
+    const segment = container.querySelector('.setup-segment');
     expect(segment).not.toBeNull();
-    const buttons = segment!.querySelectorAll(".setup-segment__btn");
+    const buttons = segment!.querySelectorAll('.setup-segment__btn');
     expect(buttons).toHaveLength(2);
-    expect(buttons[0].textContent).toBe("Agents");
-    expect(buttons[1].textContent).toBe("Toolkits");
+    expect(buttons[0].textContent).toBe('Agents');
+    expect(buttons[1].textContent).toBe('Toolkits');
   });
 
-  it("defaults to Agents tab", () => {
+  it('defaults to Agents tab', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const activeBtn = container.querySelector(".setup-segment__btn--active");
+    const activeBtn = container.querySelector('.setup-segment__btn--active');
     expect(activeBtn).not.toBeNull();
-    expect(activeBtn!.textContent).toBe("Agents");
+    expect(activeBtn!.textContent).toBe('Agents');
   });
 
-  it("shows OpenClaw, Hermes, Nanobot, Craft, Claude Code, and OpenCode tabs inside Agents", () => {
+  it('shows OpenClaw, Hermes, Nanobot, Craft, Claude Code, OpenCode, and Antigravity tabs inside Agents', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const agentTabs = container.querySelectorAll(".panel__tab");
-    expect(agentTabs).toHaveLength(6);
-    expect(agentTabs[0].textContent).toContain("OpenClaw");
-    expect(agentTabs[1].textContent).toContain("Hermes Agent");
-    expect(agentTabs[2].textContent).toContain("Nanobot");
-    expect(agentTabs[3].textContent).toContain("Craft Agent");
-    expect(agentTabs[4].textContent).toContain("Claude Code");
-    expect(agentTabs[5].textContent).toContain("OpenCode");
+    const agentTabs = container.querySelectorAll('.panel__tab');
+    expect(agentTabs).toHaveLength(7);
+    expect(agentTabs[0].textContent).toContain('OpenClaw');
+    expect(agentTabs[1].textContent).toContain('Hermes Agent');
+    expect(agentTabs[2].textContent).toContain('Nanobot');
+    expect(agentTabs[3].textContent).toContain('Craft Agent');
+    expect(agentTabs[4].textContent).toContain('Claude Code');
+    expect(agentTabs[5].textContent).toContain('OpenCode');
+    expect(agentTabs[6].textContent).toContain('Antigravity');
   });
 
-  it("shows Nanobot setup when Nanobot tab clicked", () => {
+  it('shows Nanobot setup when Nanobot tab clicked', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const agentTabs = container.querySelectorAll(".panel__tab");
+    const agentTabs = container.querySelectorAll('.panel__tab');
     fireEvent.click(agentTabs[2]); // Nanobot
-    expect(container.textContent).toContain("~/.nanobot/config.json");
-    expect(container.textContent).toContain("apiBase");
+    expect(container.textContent).toContain('~/.nanobot/config.json');
+    expect(container.textContent).toContain('apiBase');
   });
 
-  it("shows Claude Code setup when Claude Code tab clicked", () => {
+  it('shows Claude Code setup when Claude Code tab clicked', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const agentTabs = container.querySelectorAll(".panel__tab");
+    const agentTabs = container.querySelectorAll('.panel__tab');
     fireEvent.click(agentTabs[4]); // Claude Code
-    expect(container.textContent).toContain("ANTHROPIC_BASE_URL");
-    expect(container.textContent).toContain("ANTHROPIC_AUTH_TOKEN");
+    expect(container.textContent).toContain('ANTHROPIC_BASE_URL');
+    expect(container.textContent).toContain('ANTHROPIC_AUTH_TOKEN');
   });
 
-  it("shows Craft setup when Craft Agent tab clicked", () => {
+  it('shows Craft setup when Craft Agent tab clicked', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const agentTabs = container.querySelectorAll(".panel__tab");
+    const agentTabs = container.querySelectorAll('.panel__tab');
     fireEvent.click(agentTabs[3]); // Craft Agent
-    expect(container.textContent).toContain("Manifest provider preset");
-    expect(container.textContent).toContain("mnfst_YOUR_KEY");
+    expect(container.textContent).toContain('Manifest provider preset');
+    expect(container.textContent).toContain('mnfst_YOUR_KEY');
   });
 
-  it("shows OpenCode setup when OpenCode tab clicked", () => {
+  it('shows OpenCode setup when OpenCode tab clicked', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const agentTabs = container.querySelectorAll(".panel__tab");
+    const agentTabs = container.querySelectorAll('.panel__tab');
     fireEvent.click(agentTabs[5]); // OpenCode
-    expect(container.textContent).toContain("~/.config/opencode/opencode.json");
+    expect(container.textContent).toContain('~/.config/opencode/opencode.json');
     expect(container.textContent).toContain('"model": "manifest/auto"');
   });
 
-  it("defaults to OpenClaw agent tab", () => {
+  it('shows Antigravity setup when Antigravity tab clicked', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const agentTabs = container.querySelectorAll(".panel__tab");
-    expect(agentTabs[0].classList.contains("panel__tab--active")).toBe(true);
+    const agentTabs = container.querySelectorAll('.panel__tab');
+    fireEvent.click(agentTabs[6]); // Antigravity
+    expect(container.textContent).toContain('Antigravity');
+    expect(container.textContent).toContain('cannot be connected to Antigravity directly yet');
+    expect(container.textContent).toContain('manifest/auto');
   });
 
-  it("shows OpenClaw logo in agent tab", () => {
+  it('does not expose Antigravity API key controls while direct setup is unavailable', () => {
+    const { container } = render(() => (
+      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_secret" keyPrefix="mnfst_abc" />
+    ));
+    const agentTabs = container.querySelectorAll('.panel__tab');
+    fireEvent.click(agentTabs[6]); // Antigravity
+    expect(container.textContent).toContain('custom model endpoints later');
+    expect(container.textContent).not.toContain('mnfst_secret');
+    expect(container.textContent).not.toContain('mnfst_abc');
+    expect(container.querySelector('[aria-label="Reveal API key"]')).toBeNull();
+  });
+
+  it('defaults to OpenClaw agent tab', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const icon = container.querySelector(".panel__tab-icon");
+    const agentTabs = container.querySelectorAll('.panel__tab');
+    expect(agentTabs[0].classList.contains('panel__tab--active')).toBe(true);
+  });
+
+  it('shows OpenClaw logo in agent tab', () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const icon = container.querySelector('.panel__tab-icon');
     expect(icon).not.toBeNull();
-    expect(icon!.getAttribute("src")).toBe("/icons/openclaw.svg");
+    expect(icon!.getAttribute('src')).toBe('/icons/openclaw.svg');
   });
 
-  it("shows Agents card when OpenClaw selected", () => {
+  it('shows Agents card when OpenClaw selected', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.querySelector(".setup-agents-card")).not.toBeNull();
-    expect(container.textContent).toContain("manifest/auto");
+    expect(container.querySelector('.setup-agents-card')).not.toBeNull();
+    expect(container.textContent).toContain('manifest/auto');
   });
 
-  it("shows Hermes setup when Hermes Agent selected", () => {
+  it('shows Hermes setup when Hermes Agent selected', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const agentTabs = container.querySelectorAll(".panel__tab");
+    const agentTabs = container.querySelectorAll('.panel__tab');
     fireEvent.click(agentTabs[1]); // Hermes Agent
-    expect(container.textContent).toContain("Point Hermes at the Manifest endpoint");
+    expect(container.textContent).toContain('Point Hermes at the Manifest endpoint');
   });
 
-  it("switches back to OpenClaw from Hermes Agent", () => {
+  it('switches back to OpenClaw from Hermes Agent', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const agentTabs = container.querySelectorAll(".panel__tab");
+    const agentTabs = container.querySelectorAll('.panel__tab');
     fireEvent.click(agentTabs[1]); // Hermes
     fireEvent.click(agentTabs[0]); // OpenClaw
-    expect(container.textContent).toContain("manifest/auto");
-    expect(container.textContent).not.toContain("Point Hermes at the Manifest endpoint");
+    expect(container.textContent).toContain('manifest/auto');
+    expect(container.textContent).not.toContain('Point Hermes at the Manifest endpoint');
   });
 
-  it("shows CLI and openclaw onboard sub-tabs", () => {
+  it('shows CLI and openclaw onboard sub-tabs', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const fullSegment = container.querySelector(".setup-segment--full");
+    const fullSegment = container.querySelector('.setup-segment--full');
     expect(fullSegment).not.toBeNull();
-    const btns = fullSegment!.querySelectorAll(".setup-segment__btn");
+    const btns = fullSegment!.querySelectorAll('.setup-segment__btn');
     expect(btns).toHaveLength(2);
-    expect(btns[0].textContent).toBe("CLI configuration");
-    expect(btns[1].textContent).toBe("openclaw onboard");
+    expect(btns[0].textContent).toBe('CLI configuration');
+    expect(btns[1].textContent).toBe('openclaw onboard');
   });
 
-  it("defaults to CLI configuration sub-tab", () => {
+  it('defaults to CLI configuration sub-tab', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const fullSegment = container.querySelector(".setup-segment--full");
-    const btns = fullSegment!.querySelectorAll(".setup-segment__btn");
-    expect(btns[0].classList.contains("setup-segment__btn--active")).toBe(true);
+    const fullSegment = container.querySelector('.setup-segment--full');
+    const btns = fullSegment!.querySelectorAll('.setup-segment__btn');
+    expect(btns[0].classList.contains('setup-segment__btn--active')).toBe(true);
   });
 
-  it("shows CLI commands on CLI sub-tab", () => {
+  it('shows CLI commands on CLI sub-tab', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain("openclaw config set");
-    expect(container.textContent).toContain("openclaw gateway restart");
+    expect(container.textContent).toContain('openclaw config set');
+    expect(container.textContent).toContain('openclaw gateway restart');
   });
 
-  it("shows CLI description", () => {
+  it('shows CLI description', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain("Set the provider config and default model directly via CLI commands");
+    expect(container.textContent).toContain(
+      'Set the provider config and default model directly via CLI commands',
+    );
   });
 
-  it("switches to openclaw onboard sub-tab", () => {
+  it('switches to openclaw onboard sub-tab', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const fullSegment = container.querySelector(".setup-segment--full");
-    const btns = fullSegment!.querySelectorAll(".setup-segment__btn");
+    const fullSegment = container.querySelector('.setup-segment--full');
+    const btns = fullSegment!.querySelectorAll('.setup-segment__btn');
     fireEvent.click(btns[1]); // openclaw onboard
-    expect(container.textContent).toContain("openclaw onboard");
-    expect(container.textContent).toContain("Custom Provider");
+    expect(container.textContent).toContain('openclaw onboard');
+    expect(container.textContent).toContain('Custom Provider');
   });
 
-  it("shows onboard fields on wizard sub-tab", () => {
+  it('shows onboard fields on wizard sub-tab', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const fullSegment = container.querySelector(".setup-segment--full");
-    fireEvent.click(fullSegment!.querySelectorAll(".setup-segment__btn")[1]);
-    const fields = container.querySelectorAll(".setup-onboard-fields__row");
+    const fullSegment = container.querySelector('.setup-segment--full');
+    fireEvent.click(fullSegment!.querySelectorAll('.setup-segment__btn')[1]);
+    const fields = container.querySelectorAll('.setup-onboard-fields__row');
     expect(fields).toHaveLength(5);
-    expect(fields[0].textContent).toContain("API Base URL");
-    expect(fields[0].textContent).toContain("http://localhost:3001/v1");
-    expect(fields[1].textContent).toContain("API Key");
-    expect(fields[2].textContent).toContain("Endpoint compatibility");
-    expect(fields[2].textContent).toContain("OpenAI Chat Completions-compatible");
-    expect(fields[3].textContent).toContain("Model ID");
-    expect(fields[3].textContent).toContain("auto");
-    expect(fields[4].textContent).toContain("Endpoint ID");
-    expect(fields[4].textContent).toContain("manifest");
+    expect(fields[0].textContent).toContain('API Base URL');
+    expect(fields[0].textContent).toContain('http://localhost:3001/v1');
+    expect(fields[1].textContent).toContain('API Key');
+    expect(fields[2].textContent).toContain('Endpoint compatibility');
+    expect(fields[2].textContent).toContain('OpenAI Chat Completions-compatible');
+    expect(fields[3].textContent).toContain('Model ID');
+    expect(fields[3].textContent).toContain('auto');
+    expect(fields[4].textContent).toContain('Endpoint ID');
+    expect(fields[4].textContent).toContain('manifest');
   });
 
-  it("shows eye toggle on CLI sub-tab when apiKey provided", () => {
+  it('shows eye toggle on CLI sub-tab when apiKey provided', () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} apiKey="mnfst_secret" keyPrefix="mnfst_abc" />
     ));
     expect(container.querySelector('[aria-label="Reveal API key"]')).not.toBeNull();
   });
 
-  it("reveals key in CLI commands when eye toggle clicked", () => {
+  it('reveals key in CLI commands when eye toggle clicked', () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} apiKey="mnfst_secret" keyPrefix="mnfst_abc" />
     ));
-    expect(container.textContent).toContain("mnfst_abc...");
-    expect(container.textContent).not.toContain("mnfst_secret");
+    expect(container.textContent).toContain('mnfst_abc...');
+    expect(container.textContent).not.toContain('mnfst_secret');
     fireEvent.click(container.querySelector('[aria-label="Reveal API key"]')!);
-    expect(container.textContent).toContain("mnfst_secret");
+    expect(container.textContent).toContain('mnfst_secret');
   });
 
-  it("hides key again on second CLI eye toggle click", () => {
+  it('hides key again on second CLI eye toggle click', () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} apiKey="mnfst_secret" keyPrefix="mnfst_abc" />
     ));
     fireEvent.click(container.querySelector('[aria-label="Reveal API key"]')!);
     fireEvent.click(container.querySelector('[aria-label="Hide API key"]')!);
-    expect(container.textContent).not.toContain("mnfst_secret");
+    expect(container.textContent).not.toContain('mnfst_secret');
   });
 
-  it("does not show eye toggle on CLI when no apiKey", () => {
+  it('does not show eye toggle on CLI when no apiKey', () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} keyPrefix="mnfst_abc" />
     ));
     expect(container.querySelector('[aria-label="Reveal API key"]')).toBeNull();
   });
 
-  it("switches to Toolkits tab on click", () => {
+  it('switches to Toolkits tab on click', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const segmentBtns = container.querySelectorAll(".setup-segment__btn");
+    const segmentBtns = container.querySelectorAll('.setup-segment__btn');
     fireEvent.click(segmentBtns[1]); // Toolkits
-    expect(container.querySelector(".framework-snippets")).not.toBeNull();
-    expect(container.querySelector(".setup-agents-card")).toBeNull();
+    expect(container.querySelector('.framework-snippets')).not.toBeNull();
+    expect(container.querySelector('.setup-agents-card')).toBeNull();
   });
 
-  it("shows toolkit tabs on Toolkits tab", () => {
+  it('shows toolkit tabs on Toolkits tab', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    fireEvent.click(container.querySelectorAll(".setup-segment__btn")[1]);
-    const tabs = container.querySelectorAll(".panel__tab");
+    fireEvent.click(container.querySelectorAll('.setup-segment__btn')[1]);
+    const tabs = container.querySelectorAll('.panel__tab');
     expect(tabs).toHaveLength(5);
-    expect(tabs[0].textContent).toContain("OpenAI SDK");
-    expect(tabs[1].textContent).toContain("Anthropic SDK");
+    expect(tabs[0].textContent).toContain('OpenAI SDK');
+    expect(tabs[1].textContent).toContain('Anthropic SDK');
   });
 
-  it("shows full API key on Toolkits tab when provided", () => {
+  it('shows full API key on Toolkits tab when provided', () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} apiKey="mnfst_test_key" />
     ));
-    fireEvent.click(container.querySelectorAll(".setup-segment__btn")[1]);
-    expect(container.textContent).toContain("mnfst_test_key");
+    fireEvent.click(container.querySelectorAll('.setup-segment__btn')[1]);
+    expect(container.textContent).toContain('mnfst_test_key');
   });
 
-  it("shows placeholder when no apiKey or keyPrefix", () => {
+  it('shows placeholder when no apiKey or keyPrefix', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain("mnfst_YOUR_KEY");
+    expect(container.textContent).toContain('mnfst_YOUR_KEY');
   });
 
-  it("has copy buttons", () => {
+  it('has copy buttons', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const copyButtons = container.querySelectorAll(".modal-terminal__copy");
+    const copyButtons = container.querySelectorAll('.modal-terminal__copy');
     expect(copyButtons.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("switches between tabs correctly", () => {
+  it('switches between tabs correctly', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const segmentBtns = container.querySelectorAll(".setup-segment__btn");
-    expect(container.querySelector(".setup-agents-card")).not.toBeNull();
+    const segmentBtns = container.querySelectorAll('.setup-segment__btn');
+    expect(container.querySelector('.setup-agents-card')).not.toBeNull();
     fireEvent.click(segmentBtns[1]); // Toolkits
-    expect(container.querySelector(".framework-snippets")).not.toBeNull();
-    expect(container.querySelector(".setup-agents-card")).toBeNull();
+    expect(container.querySelector('.framework-snippets')).not.toBeNull();
+    expect(container.querySelector('.setup-agents-card')).toBeNull();
     fireEvent.click(segmentBtns[0]); // Agents
-    expect(container.querySelector(".setup-agents-card")).not.toBeNull();
-    expect(container.querySelector(".framework-snippets")).toBeNull();
+    expect(container.querySelector('.setup-agents-card')).not.toBeNull();
+    expect(container.querySelector('.framework-snippets')).toBeNull();
   });
 
-  it("uses setup-step__heading class", () => {
+  it('uses setup-step__heading class', () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.querySelector(".setup-step__heading")).not.toBeNull();
+    expect(container.querySelector('.setup-step__heading')).not.toBeNull();
   });
 
-  it("includes api key in CLI snippet", () => {
+  it('includes api key in CLI snippet', () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} apiKey="mnfst_test" keyPrefix="mnfst_tes" />
     ));
     fireEvent.click(container.querySelector('[aria-label="Reveal API key"]')!);
-    expect(container.textContent).toContain("mnfst_test");
+    expect(container.textContent).toContain('mnfst_test');
   });
 
-  describe("platform-filtered mode", () => {
-    it("shows OpenClawSetup directly when platform is openclaw", () => {
+  describe('platform-filtered mode', () => {
+    it('shows OpenClawSetup directly when platform is openclaw', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="openclaw" />
       ));
-      expect(container.textContent).toContain("Register Manifest in your OpenClaw config");
+      expect(container.textContent).toContain('Register Manifest in your OpenClaw config');
       expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
     });
 
-    it("shows correct heading for openclaw", () => {
-      render(() => (
-        <SetupStepAddProvider {...defaultProps} platform="openclaw" />
-      ));
-      expect(screen.getByText("Connect your OpenClaw harness to Manifest")).toBeDefined();
+    it('shows correct heading for openclaw', () => {
+      render(() => <SetupStepAddProvider {...defaultProps} platform="openclaw" />);
+      expect(screen.getByText('Connect your OpenClaw harness to Manifest')).toBeDefined();
     });
 
-    it("shows HermesSetup directly when platform is hermes", () => {
+    it('shows HermesSetup directly when platform is hermes', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="hermes" />
       ));
-      expect(container.textContent).toContain("Point Hermes at the Manifest endpoint");
+      expect(container.textContent).toContain('Point Hermes at the Manifest endpoint');
       expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
     });
 
-    it("shows correct heading for hermes", () => {
-      render(() => (
-        <SetupStepAddProvider {...defaultProps} platform="hermes" />
-      ));
-      expect(screen.getByText("Connect your Hermes harness to Manifest")).toBeDefined();
+    it('shows correct heading for hermes', () => {
+      render(() => <SetupStepAddProvider {...defaultProps} platform="hermes" />);
+      expect(screen.getByText('Connect your Hermes harness to Manifest')).toBeDefined();
     });
 
-    it("shows NanobotSetup directly when platform is nanobot", () => {
+    it('shows NanobotSetup directly when platform is nanobot', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="nanobot" />
       ));
-      expect(container.textContent).toContain("~/.nanobot/config.json");
-      expect(container.textContent).toContain("apiBase");
+      expect(container.textContent).toContain('~/.nanobot/config.json');
+      expect(container.textContent).toContain('apiBase');
       // No top-level Agents/Toolkits tabs in filtered mode.
       expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
     });
 
-    it("shows correct heading for nanobot", () => {
-      render(() => (
-        <SetupStepAddProvider {...defaultProps} platform="nanobot" />
-      ));
-      expect(screen.getByText("Connect your Nanobot harness to Manifest")).toBeDefined();
+    it('shows correct heading for nanobot', () => {
+      render(() => <SetupStepAddProvider {...defaultProps} platform="nanobot" />);
+      expect(screen.getByText('Connect your Nanobot harness to Manifest')).toBeDefined();
     });
 
-    it("shows CraftAgentSetup directly when platform is craft", () => {
+    it('shows CraftAgentSetup directly when platform is craft', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="craft" />
       ));
-      expect(container.textContent).toContain("Manifest provider preset");
-      expect(container.textContent).toContain("mnfst_YOUR_KEY");
+      expect(container.textContent).toContain('Manifest provider preset');
+      expect(container.textContent).toContain('mnfst_YOUR_KEY');
       // No top-level Agents/Toolkits tabs in filtered mode.
       expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
     });
 
-    it("shows correct heading for craft", () => {
-      render(() => (
-        <SetupStepAddProvider {...defaultProps} platform="craft" />
-      ));
-      expect(screen.getByText("Connect your Craft harness to Manifest")).toBeDefined();
+    it('shows correct heading for craft', () => {
+      render(() => <SetupStepAddProvider {...defaultProps} platform="craft" />);
+      expect(screen.getByText('Connect your Craft harness to Manifest')).toBeDefined();
     });
 
-    it("shows ClaudeCodeSetup directly when platform is claude-code", () => {
+    it('shows ClaudeCodeSetup directly when platform is claude-code', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="claude-code" />
       ));
-      expect(container.textContent).toContain("~/.claude/settings.json");
-      expect(container.textContent).toContain("ANTHROPIC_BASE_URL");
+      expect(container.textContent).toContain('~/.claude/settings.json');
+      expect(container.textContent).toContain('ANTHROPIC_BASE_URL');
       // No top-level Agents/Toolkits tabs in filtered mode.
       expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
     });
 
-    it("shows correct heading for claude-code", () => {
-      render(() => (
-        <SetupStepAddProvider {...defaultProps} platform="claude-code" />
-      ));
-      expect(screen.getByText("Connect Claude Code to Manifest")).toBeDefined();
+    it('shows correct heading for claude-code', () => {
+      render(() => <SetupStepAddProvider {...defaultProps} platform="claude-code" />);
+      expect(screen.getByText('Connect Claude Code to Manifest')).toBeDefined();
     });
 
-    it("shows OpenCodeSetup directly when platform is opencode", () => {
+    it('shows OpenCodeSetup directly when platform is opencode', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="opencode" />
       ));
-      expect(container.textContent).toContain("~/.config/opencode/opencode.json");
+      expect(container.textContent).toContain('~/.config/opencode/opencode.json');
       expect(container.textContent).toContain('"model": "manifest/auto"');
       expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
     });
 
-    it("shows correct heading for opencode", () => {
-      render(() => (
-        <SetupStepAddProvider {...defaultProps} platform="opencode" />
-      ));
-      expect(screen.getByText("Connect OpenCode to Manifest")).toBeDefined();
+    it('shows correct heading for opencode', () => {
+      render(() => <SetupStepAddProvider {...defaultProps} platform="opencode" />);
+      expect(screen.getByText('Connect OpenCode to Manifest')).toBeDefined();
     });
 
-    it("shows OpenAI SDK snippet when platform is openai-sdk", () => {
+    it('shows AntigravitySetup directly when platform is antigravity', () => {
+      const { container } = render(() => (
+        <SetupStepAddProvider {...defaultProps} platform="antigravity" />
+      ));
+      expect(container.textContent).toContain('cannot be connected to Antigravity directly yet');
+      expect(container.querySelector('[aria-label="Reference endpoint values"]')).not.toBeNull();
+      expect(container.textContent).toContain('manifest/auto');
+      expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
+    });
+
+    it('shows correct heading for antigravity', () => {
+      render(() => <SetupStepAddProvider {...defaultProps} platform="antigravity" />);
+      expect(screen.getByText('Antigravity cannot connect to Manifest yet')).toBeDefined();
+    });
+
+    it('shows OpenAI SDK snippet when platform is openai-sdk', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="openai-sdk" />
       ));
-      expect(container.querySelector(".framework-snippets")).not.toBeNull();
+      expect(container.querySelector('.framework-snippets')).not.toBeNull();
       expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
       // Should show OpenAI-specific code
-      expect(container.textContent).toContain("OpenAI");
-      expect(container.textContent).toContain("client.responses.create");
-      expect(container.textContent).not.toContain("chat.completions.create");
+      expect(container.textContent).toContain('OpenAI');
+      expect(container.textContent).toContain('client.responses.create');
+      expect(container.textContent).not.toContain('chat.completions.create');
     });
 
-    it("shows Vercel AI SDK snippet when platform is vercel-ai-sdk", () => {
+    it('shows Vercel AI SDK snippet when platform is vercel-ai-sdk', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="vercel-ai-sdk" />
       ));
-      expect(container.querySelector(".framework-snippets")).not.toBeNull();
+      expect(container.querySelector('.framework-snippets')).not.toBeNull();
       // Should show Vercel-specific code
-      expect(container.textContent).toContain("ai");
+      expect(container.textContent).toContain('ai');
     });
 
-    it("shows LangChain snippet when platform is langchain", () => {
+    it('shows LangChain snippet when platform is langchain', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="langchain" />
       ));
-      expect(container.querySelector(".framework-snippets")).not.toBeNull();
+      expect(container.querySelector('.framework-snippets')).not.toBeNull();
       // Should show LangChain-specific code
-      expect(container.textContent).toContain("ChatOpenAI");
+      expect(container.textContent).toContain('ChatOpenAI');
     });
 
-    it("shows cURL snippet when platform is curl", () => {
+    it('shows cURL snippet when platform is curl', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="curl" />
       ));
-      expect(container.querySelector(".framework-snippets")).not.toBeNull();
-      expect(container.textContent).toContain("curl");
+      expect(container.querySelector('.framework-snippets')).not.toBeNull();
+      expect(container.textContent).toContain('curl');
     });
 
-    it("shows cURL snippet when platform is other", () => {
+    it('shows cURL snippet when platform is other', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="other" />
       ));
-      expect(container.querySelector(".framework-snippets")).not.toBeNull();
-      expect(container.textContent).toContain("curl");
+      expect(container.querySelector('.framework-snippets')).not.toBeNull();
+      expect(container.textContent).toContain('curl');
       // No top-level Agents/Toolkits tabs
       expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
     });
 
-    it("hides SDK tabs when platform is a specific toolkit", () => {
+    it('hides SDK tabs when platform is a specific toolkit', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="openai-sdk" />
       ));
@@ -428,25 +455,25 @@ describe("SetupStepAddProvider", () => {
       expect(panelTabs).toHaveLength(0);
     });
 
-    it("shows full tabbed UI when platform is null", () => {
+    it('shows full tabbed UI when platform is null', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform={null} />
       ));
-      expect(container.querySelector(".setup-segment")).not.toBeNull();
+      expect(container.querySelector('.setup-segment')).not.toBeNull();
     });
 
-    it("still shows heading in platform-filtered mode", () => {
+    it('still shows heading in platform-filtered mode', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="openclaw" />
       ));
-      expect(container.textContent).toContain("Connect your OpenClaw harness to Manifest");
+      expect(container.textContent).toContain('Connect your OpenClaw harness to Manifest');
     });
 
-    it("does not show description text in filtered mode", () => {
+    it('does not show description text in filtered mode', () => {
       const { container } = render(() => (
         <SetupStepAddProvider {...defaultProps} platform="openclaw" />
       ));
-      expect(container.textContent).not.toContain("Point your harness at the Manifest endpoint");
+      expect(container.textContent).not.toContain('Point your harness at the Manifest endpoint');
     });
   });
 });

--- a/packages/shared/__tests__/agent-type.spec.ts
+++ b/packages/shared/__tests__/agent-type.spec.ts
@@ -18,6 +18,7 @@ describe('agent-type', () => {
       'craft',
       'claude-code',
       'opencode',
+      'antigravity',
       'openai-sdk',
       'anthropic-sdk',
       'vercel-ai-sdk',
@@ -59,10 +60,13 @@ describe('agent-type', () => {
   it('places coding assistants under coding only, not personal or app', () => {
     expect(PLATFORMS_BY_CATEGORY.coding).toContain('claude-code');
     expect(PLATFORMS_BY_CATEGORY.coding).toContain('opencode');
+    expect(PLATFORMS_BY_CATEGORY.coding).toContain('antigravity');
     expect(PLATFORMS_BY_CATEGORY.personal).not.toContain('claude-code');
     expect(PLATFORMS_BY_CATEGORY.personal).not.toContain('opencode');
+    expect(PLATFORMS_BY_CATEGORY.personal).not.toContain('antigravity');
     expect(PLATFORMS_BY_CATEGORY.app).not.toContain('claude-code');
     expect(PLATFORMS_BY_CATEGORY.app).not.toContain('opencode');
+    expect(PLATFORMS_BY_CATEGORY.app).not.toContain('antigravity');
   });
 
   it('keeps "other" available in every category for the unknown-platform fallback', () => {
@@ -119,6 +123,7 @@ describe('agent-type', () => {
       expect(platformIcon('nanobot', 'personal')).toBe(PLATFORM_ICONS.nanobot);
       expect(platformIcon('claude-code', 'coding')).toBe(PLATFORM_ICONS['claude-code']);
       expect(platformIcon('opencode', 'coding')).toBe(PLATFORM_ICONS.opencode);
+      expect(platformIcon('antigravity', 'coding')).toBe(PLATFORM_ICONS.antigravity);
       expect(platformIcon('openai-sdk', 'app')).toBe(PLATFORM_ICONS['openai-sdk']);
       expect(platformIcon('anthropic-sdk', 'app')).toBe(PLATFORM_ICONS['anthropic-sdk']);
       expect(platformIcon('vercel-ai-sdk', 'app')).toBe(PLATFORM_ICONS['vercel-ai-sdk']);
@@ -135,6 +140,10 @@ describe('agent-type', () => {
       expect(platformIcon('opencode', 'coding')).toBe('/icons/providers/opencode.svg');
     });
 
+    it('antigravity resolves to the providers/antigravity.svg mark', () => {
+      expect(platformIcon('antigravity', 'coding')).toBe('/icons/providers/antigravity.svg');
+    });
+
     it('returns the platform icon regardless of the category passed (icon is keyed by platform)', () => {
       // Even if the caller passes an inconsistent (platform, category) pair —
       // e.g. a stale row in the DB — we still resolve to the registered icon
@@ -142,6 +151,7 @@ describe('agent-type', () => {
       expect(platformIcon('claude-code', 'personal')).toBe(PLATFORM_ICONS['claude-code']);
       expect(platformIcon('claude-code', null)).toBe(PLATFORM_ICONS['claude-code']);
       expect(platformIcon('opencode', 'personal')).toBe(PLATFORM_ICONS.opencode);
+      expect(platformIcon('antigravity', 'personal')).toBe(PLATFORM_ICONS.antigravity);
       expect(platformIcon('openclaw', 'coding')).toBe(PLATFORM_ICONS.openclaw);
     });
 

--- a/packages/shared/src/agent-type.ts
+++ b/packages/shared/src/agent-type.ts
@@ -8,6 +8,7 @@ export const AGENT_PLATFORMS = [
   'craft',
   'claude-code',
   'opencode',
+  'antigravity',
   'openai-sdk',
   'anthropic-sdk',
   'vercel-ai-sdk',
@@ -30,6 +31,7 @@ export const PLATFORM_LABELS: Readonly<Record<AgentPlatform, string>> = {
   craft: 'Craft Agent',
   'claude-code': 'Claude Code',
   opencode: 'OpenCode',
+  antigravity: 'Antigravity',
   'openai-sdk': 'OpenAI SDK',
   'anthropic-sdk': 'Anthropic SDK',
   'vercel-ai-sdk': 'Vercel AI SDK',
@@ -41,7 +43,7 @@ export const PLATFORM_LABELS: Readonly<Record<AgentPlatform, string>> = {
 export const PLATFORMS_BY_CATEGORY: Readonly<Record<AgentCategory, readonly AgentPlatform[]>> = {
   personal: ['openclaw', 'hermes', 'nanobot', 'craft', 'other'],
   app: ['openai-sdk', 'anthropic-sdk', 'vercel-ai-sdk', 'langchain', 'other'],
-  coding: ['claude-code', 'opencode', 'other'],
+  coding: ['claude-code', 'opencode', 'antigravity', 'other'],
 };
 
 export const PLATFORM_ICONS: Readonly<Partial<Record<AgentPlatform, string>>> = {
@@ -51,6 +53,7 @@ export const PLATFORM_ICONS: Readonly<Partial<Record<AgentPlatform, string>>> = 
   craft: '/icons/craft.png',
   'claude-code': '/icons/providers/claude-code.svg',
   opencode: '/icons/providers/opencode.svg',
+  antigravity: '/icons/providers/antigravity.svg',
   'openai-sdk': '/icons/providers/openai.svg',
   'anthropic-sdk': '/icons/providers/anthropic.svg',
   'vercel-ai-sdk': '/icons/vercel.svg',


### PR DESCRIPTION
### ✨ What changed
- Added Antigravity to Coding Assistant platform options.
- Added Antigravity setup guidance for Manifest provider values.
- Covered Antigravity selection and icon behavior in focused tests.

### 💭 Why
Antigravity can use OpenAI-compatible model providers, so Manifest should be selectable from setup.

### 👤 For users
Users can pick Antigravity and copy the values needed for `manifest/auto`.

### 📝 Notes
Antigravity site: https://antigravity.google

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Antigravity to Coding Assistant options with a read‑only setup that explains direct Manifest integration isn’t supported yet and shows reference endpoint values.

- **New Features**
  - Added `AntigravitySetup` with a notice and reference fields: Base URL, Model ID `auto`, and Model name `manifest/auto` (with copy buttons; no API key controls).
  - Added an Antigravity tab in Agents and a platform-filtered view with the heading “Antigravity cannot connect to Manifest yet.”
  - Registered `antigravity` in shared config (label, coding category mapping, icon at `/icons/providers/antigravity.svg`) and updated tests for option counts, routing, icons, headings, platform-filtered flows, and hidden API key controls.

<sup>Written for commit 9a7975f7263d4067d327d59593be5cc196c1952f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

