### PR TITLE
feat: add Mistral Vibe subscription

### DIFF
--- a/.changeset/mistral-vibe-subscription.md
+++ b/.changeset/mistral-vibe-subscription.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add Mistral Vibe as a subscription provider with token setup, Vibe key guidance, and subscription-scoped discovery for the Vibe CLI model.

--- a/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
+++ b/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
@@ -277,6 +277,12 @@ describe('filterNonChatModels', () => {
       expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
     });
 
+    it('keeps mistral-vibe-cli models for subscription discovery', () => {
+      const models = [makeModel('mistral-vibe-cli-latest'), makeModel('mistral-large-latest')];
+      const result = filterNonChatModels(models, 'mistral-subscription');
+      expect(result.map((m) => m.id)).toEqual(['mistral-vibe-cli-latest', 'mistral-large-latest']);
+    });
+
     it('filters labs-prefixed models', () => {
       const models = [makeModel('labs-leanstral-2603'), makeModel('mistral-large-latest')];
       const result = filterNonChatModels(models, 'mistral');

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -685,6 +685,30 @@ describe('ModelDiscoveryService', () => {
       expect(result.map((m) => m.id)).toEqual(['gpt-5.5', 'gpt-5.3-codex-spark']);
     });
 
+    it('should keep Mistral Vibe subscription cached models that API-key Mistral hides', async () => {
+      const providers = [
+        makeProvider({
+          provider: 'mistral',
+          auth_type: 'subscription',
+          cached_models: [
+            makeModel({
+              id: 'mistral-vibe-cli-latest',
+              provider: 'mistral',
+              authType: 'subscription',
+            }),
+          ],
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(result.map((m) => `${m.provider}:${m.authType}:${m.id}`)).toEqual([
+        'mistral:subscription:mistral-vibe-cli-latest',
+      ]);
+    });
+
     it('should inherit auth_type from tenant_providers row for custom provider models', async () => {
       const providers = [
         makeProvider({

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -5,7 +5,12 @@ import { resolveProviderMetadataIdentity, type AuthType } from 'manifest-shared'
 import { TenantProvider } from '../entities/tenant-provider.entity';
 import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
-import { ProviderModelFetcherService, filterNonChatModels } from './provider-model-fetcher.service';
+import {
+  ProviderModelFetcherService,
+  PROVIDER_BLOCKLIST,
+  PROVIDER_NON_CHAT,
+  filterNonChatModels,
+} from './provider-model-fetcher.service';
 import { ProviderModelRegistryService } from './provider-model-registry.service';
 import { DiscoveredModel, DEFAULT_CONTEXT_WINDOW } from './model-fetcher';
 import { decrypt, getEncryptionSecret } from '../common/utils/crypto.util';
@@ -54,6 +59,17 @@ function modelsDevModelIdPrefix(providerId: string): string | undefined {
 function prefersModelsDevCatalog(providerId: string): boolean {
   const lower = providerId.toLowerCase();
   return lower === 'opencode-zen';
+}
+
+function nonChatFilterKey(providerId: string, authType: AuthType): string {
+  const normalizedProvider = providerId.toLowerCase();
+  if (authType !== 'subscription') return normalizedProvider;
+
+  const subscriptionKey = `${normalizedProvider}-subscription`;
+  if (PROVIDER_NON_CHAT[subscriptionKey] || PROVIDER_BLOCKLIST[subscriptionKey]) {
+    return subscriptionKey;
+  }
+  return normalizedProvider;
 }
 
 /** 2-minute TTL for the per-agent discovered-model list, matching RoutingCacheService. */
@@ -473,10 +489,7 @@ export class ModelDiscoveryService {
       if (!Array.isArray(rawCached)) continue;
       const providerAuthType: AuthType = p.auth_type;
       const providerId = p.provider.toLowerCase();
-      const filterKey =
-        providerId === 'openai' && providerAuthType === 'subscription'
-          ? 'openai-subscription'
-          : providerId;
+      const filterKey = nonChatFilterKey(providerId, providerAuthType);
       const cached = filterNonChatModels(rawCached, filterKey);
       for (const m of cached) {
         const effectiveAuthType = m.authType ?? providerAuthType;

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -325,6 +325,31 @@ describe('buildSubscriptionFallbackModels', () => {
     expect(result).toEqual([]);
   });
 
+  it('surfaces the fixed Mistral Vibe model even when the pricing cache lacks it', () => {
+    const ids = buildSubscriptionFallbackModels(makePricingSync(new Map()), 'mistral').map(
+      (m) => m.id,
+    );
+
+    expect(ids).toEqual(['mistral-vibe-cli-latest']);
+  });
+
+  it('keeps Mistral Vibe fallback matching exact', () => {
+    const cache = new Map([
+      [
+        'mistralai/mistral-vibe-cli-latest',
+        { input: 0.000001, output: 0.000003, displayName: 'Mistral Vibe CLI' },
+      ],
+      [
+        'mistralai/mistral-vibe-cli-fast',
+        { input: 0.000001, output: 0.000003, displayName: 'Mistral Vibe CLI Fast' },
+      ],
+    ]);
+
+    const result = buildSubscriptionFallbackModels(makePricingSync(cache), 'mistral');
+    expect(result.map((m) => m.id)).toEqual(['mistral-vibe-cli-latest']);
+    expect(result[0].displayName).toBe('Mistral Vibe CLI');
+  });
+
   describe('knownModelsMatch exact mode (gemini)', () => {
     it('includes only verbatim knownModel entries from the OpenRouter cache', () => {
       const cache = new Map([

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -28,6 +28,7 @@ describe('ProviderModelFetcherService', () => {
       'groq',
       'kilo',
       'mistral',
+      'mistral-subscription',
       'moonshot',
       'nous',
       'nvidia',
@@ -2575,6 +2576,31 @@ describe('ProviderModelFetcherService', () => {
       const result = await service.fetch('mistral', 'key');
       // Both pass: pixtral has no "mistral-ocr" prefix, "some-ocr-model" has "ocr" mid-name not prefix
       expect(result).toHaveLength(2);
+    });
+
+    it('filters the Vibe CLI model from API-key discovery and restricts subscription discovery to it', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'mistral-vibe-cli-latest' }, { id: 'mistral-large-latest' }],
+        }),
+      });
+
+      const apiKeyResult = await service.fetch('mistral', 'mistral-api-key', 'api_key');
+      const subscriptionResult = await service.fetch('mistral', 'mistral-vibe-key', 'subscription');
+
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        1,
+        'https://api.mistral.ai/v1/models',
+        expect.objectContaining({ headers: { Authorization: 'Bearer mistral-api-key' } }),
+      );
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        2,
+        'https://api.mistral.ai/v1/models',
+        expect.objectContaining({ headers: { Authorization: 'Bearer mistral-vibe-key' } }),
+      );
+      expect(apiKeyResult.map((m) => m.id)).toEqual(['mistral-large-latest']);
+      expect(subscriptionResult.map((m) => m.id)).toEqual(['mistral-vibe-cli-latest']);
     });
   });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -213,6 +213,7 @@ export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
     /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview-\d{2}-\d{4}$|robotics)/i,
   mistral:
     /(?:^mistral-ocr|moderation|voxtral-.*-(?:transcribe|realtime)|^labs-|^mistral-vibe-cli)/i,
+  'mistral-subscription': /(?:^mistral-ocr|moderation|voxtral-.*-(?:transcribe|realtime)|^labs-)/i,
   // Groq filters:
   //  - compound family: server-side router/agent product (compound,
   //    compound-mini, compound-beta). Not a model the user picks directly,
@@ -249,6 +250,9 @@ export const PROVIDER_BLOCKLIST: Record<string, ReadonlySet<string>> = {
     'gpt-5.1-codex', // ChatGPT Codex returns 400: not supported with a ChatGPT account
   ]),
   mistral: new Set([
+    'voxtral-mini-2602', // Invalid model returned by API; not a real chat endpoint
+  ]),
+  'mistral-subscription': new Set([
     'voxtral-mini-2602', // Invalid model returned by API; not a real chat endpoint
   ]),
 };
@@ -295,6 +299,11 @@ const parseMistral = createModelParser<MistralModelEntry>({
   getId: (entry) => entry.id,
   getDisplayName: (_entry, id) => id,
 });
+
+const parseMistralVibeSubscription = (body: unknown, provider: string): DiscoveredModel[] => {
+  const known = new Set(getSubscriptionKnownModels('mistral') ?? []);
+  return parseMistral(body, provider).filter((model) => known.has(model.id));
+};
 
 interface AnthropicModelEntry {
   id: string;
@@ -581,6 +590,11 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     buildHeaders: bearerHeaders,
     parse: parseMistral,
   },
+  'mistral-subscription': {
+    endpoint: 'https://api.mistral.ai/v1/models',
+    buildHeaders: bearerHeaders,
+    parse: parseMistralVibeSubscription,
+  },
   moonshot: {
     endpoint: 'https://api.moonshot.ai/v1/models',
     buildHeaders: bearerHeaders,
@@ -732,6 +746,8 @@ export class ProviderModelFetcherService {
       configKey = 'openai-subscription';
     } else if (configKey === 'minimax' && authType === 'subscription') {
       configKey = 'minimax-subscription';
+    } else if (configKey === 'mistral' && authType === 'subscription') {
+      configKey = 'mistral-subscription';
     } else if (configKey === 'xiaomi' && authType === 'subscription') {
       configKey = 'xiaomi-subscription';
     } else if (configKey === 'moonshot' && authType === 'subscription') {

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -40,6 +40,7 @@ export const SUBSCRIPTION_PROVIDER_KEY_URLS: Record<string, string> = {
   moonshot: 'https://www.kimi.com/code/console',
   'ollama-cloud': 'https://ollama.com/settings/keys',
   kiro: 'https://app.kiro.dev',
+  mistral: 'https://chat.mistral.ai/code/extensions',
   xiaomi: 'https://platform.xiaomimimo.com/token-plan',
   zai: 'https://z.ai/manage-apikey/apikey-list',
 };

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -313,6 +313,12 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   mistral: {
     initial: 'M',
     subtitle: 'Mistral Large, Codestral, Pixtral',
+    supportsSubscription: true,
+    subscriptionLabel: 'Mistral Vibe subscription',
+    subscriptionAuthMode: 'token',
+    subscriptionCredentialKind: 'api-key',
+    subscriptionCredentialName: 'Mistral Vibe',
+    subscriptionKeyPlaceholder: 'Paste your Mistral Vibe API key',
     models: [],
   },
   moonshot: {

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -537,6 +537,17 @@ describe('PROVIDERS', () => {
     expect(minimax.subscriptionAuthMode).toBe('device_code');
   });
 
+  it('Mistral supports Vibe subscription with token flow', () => {
+    const mistral = PROVIDERS.find((p) => p.id === 'mistral')!;
+    expect(mistral.supportsSubscription).toBe(true);
+    expect(mistral.subscriptionLabel).toBe('Mistral Vibe subscription');
+    expect(mistral.subscriptionAuthMode).toBe('token');
+    expect(mistral.subscriptionCredentialKind).toBe('api-key');
+    expect(mistral.subscriptionCredentialName).toBe('Mistral Vibe');
+    expect(mistral.subscriptionKeyPlaceholder).toBe('Paste your Mistral Vibe API key');
+    expect(mistral.subscriptionOnly).toBeUndefined();
+  });
+
   it('Qwen supports Token Plan subscription with token flow', () => {
     const qwen = PROVIDERS.find((p) => p.id === 'qwen')!;
     expect(qwen.apiKeyEndpointRegions?.[0]).toEqual({
@@ -647,6 +658,13 @@ describe('PROVIDERS', () => {
 
   it('provides a subscription-key URL for Moonshot/Kimi pointing at the Kimi Code console', () => {
     expect(getSubscriptionProviderKeyUrl('moonshot')).toBe('https://www.kimi.com/code/console');
+  });
+
+  it('provides distinct API-key and subscription-key URLs for Mistral', () => {
+    expect(getRoutingProviderApiKeyUrl('mistral')).toBe('https://console.mistral.ai/api-keys/');
+    expect(getSubscriptionProviderKeyUrl('mistral')).toBe(
+      'https://chat.mistral.ai/code/extensions',
+    );
   });
 
   it('provides only the subscription-key URL for Command Code', () => {
@@ -846,6 +864,21 @@ describe('PROVIDERS', () => {
       error: 'Token is too short (minimum 10 characters)',
     });
     expect(validateSubscriptionKey(nous, 'nous-valid-token-1234')).toEqual({
+      valid: true,
+    });
+  });
+
+  it('Mistral Vibe subscription key is validated with generic token length', () => {
+    const mistral = PROVIDERS.find((p) => p.id === 'mistral')!;
+    expect(validateSubscriptionKey(mistral, '')).toEqual({
+      valid: false,
+      error: 'Token is required',
+    });
+    expect(validateSubscriptionKey(mistral, 'short')).toEqual({
+      valid: false,
+      error: 'Token is too short (minimum 10 characters)',
+    });
+    expect(validateSubscriptionKey(mistral, 'mistral-vibe-token-1234')).toEqual({
       valid: true,
     });
   });

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -17,6 +17,7 @@ describe('SUBSCRIPTION_PROVIDER_CONFIGS', () => {
         'byteplus',
         'openai',
         'minimax',
+        'mistral',
         'xiaomi',
         'qwen',
         'moonshot',
@@ -94,6 +95,18 @@ describe('getSubscriptionProviderConfig', () => {
     expect(config).toMatchObject({
       subscriptionAuthMode: 'device_code',
     });
+  });
+
+  it('returns config for Mistral Vibe subscription', () => {
+    const config = getSubscriptionProviderConfig('mistral');
+    expect(config).toMatchObject({
+      supportsSubscription: true,
+      subscriptionLabel: 'Mistral Vibe subscription',
+      subscriptionAuthMode: 'token',
+      subscriptionKeyPlaceholder: 'Paste your Mistral Vibe API key',
+      knownModelsMatch: 'exact',
+    });
+    expect(config?.knownModels).toEqual(['mistral-vibe-cli-latest']);
   });
 
   it('returns config for Xiaomi MiMo Token Plan', () => {
@@ -274,6 +287,7 @@ describe('supportsSubscriptionProvider', () => {
     expect(supportsSubscriptionProvider('byteplus')).toBe(true);
     expect(supportsSubscriptionProvider('openai')).toBe(true);
     expect(supportsSubscriptionProvider('minimax')).toBe(true);
+    expect(supportsSubscriptionProvider('mistral')).toBe(true);
     expect(supportsSubscriptionProvider('xiaomi')).toBe(true);
     expect(supportsSubscriptionProvider('qwen')).toBe(true);
     expect(supportsSubscriptionProvider('moonshot')).toBe(true);
@@ -295,7 +309,6 @@ describe('supportsSubscriptionProvider', () => {
   it('returns false for unsupported providers', () => {
     expect(supportsSubscriptionProvider('deepseek')).toBe(false);
     expect(supportsSubscriptionProvider('kilo')).toBe(false);
-    expect(supportsSubscriptionProvider('mistral')).toBe(false);
   });
 });
 
@@ -333,6 +346,10 @@ describe('getSubscriptionKnownModels', () => {
     expect(models).toContain('MiniMax-M2.7');
     expect(models).toContain('MiniMax-M2.7-highspeed');
     expect(models).toContain('MiniMax-M2.5');
+  });
+
+  it('returns the fixed model id for Mistral Vibe', () => {
+    expect(getSubscriptionKnownModels('mistral')).toEqual(['mistral-vibe-cli-latest']);
   });
 
   it('returns known models for Xiaomi MiMo Token Plan', () => {
@@ -412,6 +429,10 @@ describe('getSubscriptionKnownModelsMatch', () => {
 
   it('returns exact for moonshot Kimi Coding Plan', () => {
     expect(getSubscriptionKnownModelsMatch('moonshot')).toBe('exact');
+  });
+
+  it('returns exact for Mistral Vibe', () => {
+    expect(getSubscriptionKnownModelsMatch('mistral')).toBe('exact');
   });
 
   it('returns exact for Xiaomi MiMo Token Plan', () => {
@@ -506,6 +527,15 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('qwen');
     expect(caps).toMatchObject({
       maxContextWindow: 991000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    });
+  });
+
+  it('returns capabilities for Mistral Vibe subscription', () => {
+    const caps = getSubscriptionCapabilities('mistral');
+    expect(caps).toMatchObject({
+      maxContextWindow: 200000,
       supportsPromptCaching: false,
       supportsBatching: false,
     });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -83,6 +83,19 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       supportsBatching: false,
     }),
   }),
+  mistral: Object.freeze({
+    supportsSubscription: true as const,
+    subscriptionLabel: 'Mistral Vibe subscription',
+    subscriptionAuthMode: 'token' as const,
+    subscriptionKeyPlaceholder: 'Paste your Mistral Vibe API key',
+    knownModels: Object.freeze(['mistral-vibe-cli-latest']),
+    knownModelsMatch: 'exact' as const,
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 200000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
   xiaomi: Object.freeze({
     supportsSubscription: true as const,
     subscriptionLabel: 'Xiaomi MiMo Token Plan',


### PR DESCRIPTION
### ✨ What changed
- Add Mistral Vibe as a subscription provider.
- Discover only mistral-vibe-cli-latest for Vibe credentials.
- Keep regular Mistral API-key discovery excluding Vibe CLI models.
- Fix Routing cached-model filtering for subscription-specific catalogs.

### 💭 Why
Mistral Vibe exposes a subscription token flow for the CLI model. Manifest needs to treat it separately from regular Mistral API keys.

### 👤 For users
Users can connect a Mistral Vibe key and route agents to mistral-vibe-cli-latest.

### 📝 Notes
Live local smoke returned HTTP 200 from mistral-vibe-cli-latest with response pong.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Mistral Vibe as a subscription provider with token auth and subscription-scoped discovery. Subscribers route to `mistral-vibe-cli-latest`, while regular Mistral API keys keep the standard catalog.

- New Features
  - Added Mistral Vibe subscription config (`subscriptionAuthMode: token`) with UI copy, key URL, and validation.
  - Introduced `mistral-subscription` fetcher that returns only `mistral-vibe-cli-latest`; set exact known-models and capabilities.
  - Ensured Vibe shows in subscription cached models and as a fallback even when pricing is missing.

- Bug Fixes
  - Corrected cached-model filtering to honor subscription-specific non-chat/blocklists (e.g., `mistral-subscription`), keeping Vibe CLI out of API-key discovery.

<sup>Written for commit 71d4acc98e08110d232f2a88f887d5d56c2b7986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

