### PR TITLE
fix: show direct model overrides in messages

### DIFF
--- a/.changeset/direct-message-label.md
+++ b/.changeset/direct-message-label.md
@@ -1,0 +1,7 @@
+---
+'manifest-backend': patch
+'manifest-frontend': patch
+'manifest-shared': patch
+---
+
+Show explicit SDK model overrides as Direct in Messages.

--- a/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
@@ -83,8 +83,8 @@ describe('MessagesQueryDto', () => {
     expect(dto.include_filter_options).toBe(true);
   });
 
-  it('accepts each known routing_tier value including playground', async () => {
-    for (const tier of ['simple', 'standard', 'complex', 'reasoning', 'playground']) {
+  it('accepts each known routing_tier value including direct and playground', async () => {
+    for (const tier of ['simple', 'standard', 'complex', 'reasoning', 'direct', 'playground']) {
       const dto = plainToInstance(MessagesQueryDto, { routing_tier: tier });
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -443,7 +443,8 @@ describe('ProxyService — orchestration', () => {
       expect(modelParamsService.get).not.toHaveBeenCalled();
       expect(providerParamSpecs.getSpecs).not.toHaveBeenCalled();
       expect(result.meta).toMatchObject({
-        tier: 'default',
+        tier: 'direct',
+        reason: 'direct',
         provider: 'openai',
         auth_type: 'api_key',
         model: 'gpt-4o-mini',
@@ -611,6 +612,8 @@ describe('ProxyService — orchestration', () => {
       expect(fallbackService.tryFallbacks).not.toHaveBeenCalled();
       expect(result.forward.response.status).toBe(502);
       expect(result.meta).toMatchObject({
+        tier: 'direct',
+        reason: 'direct',
         provider: 'openai',
         model: 'gpt-4o-mini',
       });

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -76,7 +76,7 @@ const SCORING_EXCLUDED_ROLES = new Set(['system', 'developer']);
 const SCORING_RECENT_MESSAGES = 10;
 
 export interface RoutingMeta {
-  tier: TierSlot;
+  tier: TierSlot | 'direct';
   model: string;
   provider: string;
   confidence: number;
@@ -753,12 +753,13 @@ export class ProxyService {
     model: string,
     overrides: Partial<RoutingMeta> = {},
   ): RoutingMeta {
+    const directOverride = resolved.explicit_model_override === true;
     return {
-      tier: resolved.tier,
+      tier: directOverride ? 'direct' : resolved.tier,
       model,
       provider: overrides.provider ?? resolved.route?.provider ?? '',
       confidence: resolved.confidence,
-      reason: resolved.reason,
+      reason: directOverride ? 'direct' : resolved.reason,
       auth_type: resolved.route?.authType,
       specificity_category: resolved.specificity_category,
       provider_key_label: resolved.route?.keyLabel ?? undefined,

--- a/packages/backend/src/telemetry/payload-builder.service.spec.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.spec.ts
@@ -315,6 +315,19 @@ describe('PayloadBuilderService', () => {
     expect(payload.messages_by_tier).toEqual({ unknown: 5, simple: 10 });
   });
 
+  it('keeps message-only routing tiers in telemetry buckets', async () => {
+    const service = await makeService({
+      tiers: [
+        { bucket: 'direct', count: '3' },
+        { bucket: 'playground', count: '2' },
+      ],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.messages_by_tier).toEqual({ direct: 3, playground: 2 });
+  });
+
   it('collapses unknown routing_tier strings to "other" so a future write path cannot leak verbatim values', async () => {
     // Defense-in-depth: if some caller writes "warp-speed" into routing_tier,
     // the whitelist clamps it to "other" before it leaves the install.

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -1,14 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { AUTH_TYPES, TIER_SLOTS } from 'manifest-shared';
+import { ALL_TIERS, AUTH_TYPES, TIER_SLOTS } from 'manifest-shared';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 import { Agent } from '../entities/agent.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import type { TelemetryPayloadV1 } from './dto/telemetry-payload';
 import { TELEMETRY_SCHEMA_VERSION } from './telemetry.config';
 
-const TIER_WHITELIST: ReadonlySet<string> = new Set<string>(TIER_SLOTS);
+const TIER_WHITELIST: ReadonlySet<string> = new Set<string>([...TIER_SLOTS, ...ALL_TIERS]);
 const AUTH_TYPE_WHITELIST: ReadonlySet<string> = new Set<string>(AUTH_TYPES);
 
 interface ProviderAggregateRow {

--- a/packages/frontend/src/components/MessageDetails.tsx
+++ b/packages/frontend/src/components/MessageDetails.tsx
@@ -7,6 +7,7 @@ import {
 import { inferProviderName } from '../services/routing-utils.js';
 import { getModelDisplayName } from '../services/model-display.js';
 import { ModelParamsSection, RequestHeadersSection } from './MessageDetailsSections.jsx';
+import { routingTierLabel } from './message-table-types.js';
 
 export interface MessageDetailsProps {
   messageId: string;
@@ -124,7 +125,7 @@ export default function MessageDetails(props: MessageDetailsProps): JSX.Element 
                       m.header_tier_name ??
                       (m.specificity_category
                         ? m.specificity_category.replace(/_/g, ' ')
-                        : m.routing_tier)
+                        : routingTierLabel(m.routing_tier))
                     }
                   />
                   <Show when={m.specificity_category}>
@@ -133,7 +134,10 @@ export default function MessageDetails(props: MessageDetailsProps): JSX.Element 
                       initiallyFlagged={m.specificity_miscategorized}
                     />
                   </Show>
-                  <MetaField label="Reason" value={m.routing_reason} />
+                  <MetaField
+                    label="Reason"
+                    value={m.routing_reason === 'direct' ? 'DIRECT' : m.routing_reason}
+                  />
                   <MetaField label="Service" value={m.service_type} />
                   <MetaField label="Session" value={m.session_key} />
                   <MetaField label="Description" value={m.description} />

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -1,6 +1,6 @@
 import { Show, type JSX } from 'solid-js';
 import { A } from '@solidjs/router';
-import type { MessageRow, MessageColumnKey } from './message-table-types.js';
+import { routingTierLabel, type MessageRow, type MessageColumnKey } from './message-table-types.js';
 import InfoTooltip from './InfoTooltip.jsx';
 import {
   formatCost,
@@ -286,7 +286,9 @@ export function ModelCell(item: MessageRow): JSX.Element {
             {item.specificity_category.replace(/_/g, ' ')}
           </span>
         ) : item.routing_tier ? (
-          <span class={`tier-badge tier-badge--${item.routing_tier}`}>{item.routing_tier}</span>
+          <span class={`tier-badge tier-badge--${item.routing_tier}`}>
+            {routingTierLabel(item.routing_tier)}
+          </span>
         ) : null}
         {item.fallback_from_model && (
           <span

--- a/packages/frontend/src/components/message-table-types.ts
+++ b/packages/frontend/src/components/message-table-types.ts
@@ -27,6 +27,11 @@ export interface MessageRow {
   feedback_rating?: string | null;
 }
 
+export function routingTierLabel(tier: string | null | undefined): string | undefined {
+  if (!tier) return undefined;
+  return tier === 'direct' ? 'DIRECT' : tier;
+}
+
 export type MessageColumnKey =
   | 'date'
   | 'message'

--- a/packages/frontend/src/styles/data.css
+++ b/packages/frontend/src/styles/data.css
@@ -182,6 +182,10 @@
   background: hsl(var(--chart-1) / 0.15);
   color: hsl(var(--chart-1));
 }
+.tier-badge--direct {
+  background: hsl(188 80% 42% / 0.14);
+  color: hsl(188 82% 32%);
+}
 .tier-badge--specificity {
   background: hsl(270 60% 50% / 0.12);
   color: hsl(270 60% 45%);

--- a/packages/frontend/tests/components/MessageDetails.test.tsx
+++ b/packages/frontend/tests/components/MessageDetails.test.tsx
@@ -213,6 +213,23 @@ describe('MessageDetails', () => {
     });
   });
 
+  it('displays direct model overrides as DIRECT routing metadata', async () => {
+    mockGetMessageDetails.mockResolvedValue({
+      ...detailsResponse,
+      message: {
+        ...detailsResponse.message,
+        routing_tier: 'direct',
+        routing_reason: 'direct',
+      },
+    });
+    const { container } = render(() => <MessageDetails messageId="msg-1" />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Routing');
+      expect(container.textContent).toContain('DIRECT');
+      expect(container.textContent).not.toContain('default');
+    });
+  });
+
   it('renders App and SDK metadata when caller_attribution is present', async () => {
     const withAttribution = {
       ...detailsResponse,

--- a/packages/frontend/tests/components/MessageTable.test.tsx
+++ b/packages/frontend/tests/components/MessageTable.test.tsx
@@ -438,6 +438,19 @@ describe('MessageTable', () => {
       expect(badge!.textContent).toBe('fast');
     });
 
+    it('renders direct routing tier badge in uppercase', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ routing_tier: 'direct' })]}
+          columns={['model']}
+          agentName="agent-1"
+        />
+      ));
+      const badge = container.querySelector('.tier-badge--direct');
+      expect(badge).not.toBeNull();
+      expect(badge!.textContent).toBe('DIRECT');
+    });
+
     it('renders specificity category badge (with underscores replaced) over tier badge', () => {
       const { container } = render(() => (
         <MessageTable

--- a/packages/shared/src/tiers.ts
+++ b/packages/shared/src/tiers.ts
@@ -25,16 +25,18 @@ export const TIER_DESCRIPTIONS: Readonly<Record<TierSlot, string>> = {
 
 /**
  * Superset of the scoring-output `Tier` that includes non-scoring tier values
- * which can legally appear in `agent_messages.routing_tier` — currently just
- * `'playground'`, emitted by `/api/v1/playground/run`. Use this type (not `Tier`)
+ * which can legally appear in `agent_messages.routing_tier`: `'direct'` for
+ * explicit SDK model overrides and `'playground'` for `/api/v1/playground/run`.
+ * Use this type (not `Tier`)
  * for message badges, filters, and telemetry buckets. Do NOT use it in the
  * scoring, routing, or tier-assignment layers — those consume the narrower
  * `Tier` domain.
  */
-export const ALL_TIERS = [...TIERS, 'playground'] as const;
+export const ALL_TIERS = [...TIERS, 'direct', 'playground'] as const;
 export type MessageTier = (typeof ALL_TIERS)[number];
 
 export const TIER_LABELS_ALL: Readonly<Record<MessageTier, string>> = {
   ...TIER_LABELS,
+  direct: 'Direct',
   playground: 'Playground',
 };


### PR DESCRIPTION
### ✨ What changed
- Record explicit SDK model overrides as `direct`.
- Show `DIRECT` badges with a teal treatment in Messages.
- Allow direct message-tier filters and telemetry buckets.

### 💭 Why
Explicit model IDs bypass normal default routing, so Messages should not label them as Default.

### 👤 For users
Direct SDK model calls show as `DIRECT` in Messages instead of default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show explicit SDK model overrides as DIRECT in Messages instead of default. We now record these as the `direct` routing tier and update UI, filters, and telemetry.

- **Bug Fixes**
  - Backend/telemetry: set tier and reason to `direct` when an explicit model override is used; accept `direct` in query DTO; include `direct` in telemetry via `ALL_TIERS`.
  - Frontend: display a teal `DIRECT` badge and reason in Message table and details; enable tier filtering for `direct`.

<sup>Written for commit fef144ac17771c3f0a915cc8e7633ba62720a392. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

