### PR TITLE
feat: update OpenAI SDK shipped modal

### DIFF
--- a/.changeset/openai-sdk-shipped-modal.md
+++ b/.changeset/openai-sdk-shipped-modal.md
@@ -1,0 +1,5 @@
+---
+'manifest-frontend': patch
+---
+
+Update the shipped modal for OpenAI-compatible model discovery and direct model calls.

--- a/packages/frontend/src/components/WhatsNewModal.tsx
+++ b/packages/frontend/src/components/WhatsNewModal.tsx
@@ -3,14 +3,14 @@ import { createSignal, For, Show, onMount, onCleanup, type JSX } from 'solid-js'
 // Bump this id when there's a new announcement worth re-surfacing to everyone.
 // Keyed on a fixed announcement id (not the app version) so routine patch
 // bumps don't re-trigger the same popup.
-const ANNOUNCEMENT_ID = 'global-providers-v1';
+const ANNOUNCEMENT_ID = 'openai-sdk-models-v1';
 const STORAGE_KEY = `manifest:whatsnew:${ANNOUNCEMENT_ID}`;
 
 const HIGHLIGHTS = [
-  'One unified place to connect and manage every provider across all your harnesses.',
-  'Connect a provider once — it now works across every harness.',
-  'Need isolation? Scope it — disconnect a provider from specific harnesses.',
-  'Track consumption — subscription vs usage-based, per provider and harness.',
+  'List OpenAI-compatible models with GET /v1/models.',
+  'Use any returned model ID in the SDK model field to call that model directly.',
+  'Keep model: auto when you want Manifest routing, params, and fallbacks.',
+  'Direct SDK calls still appear in Messages and provider usage.',
 ] as const;
 
 function hasSeen(): boolean {
@@ -95,9 +95,8 @@ export default function WhatsNewModal(): JSX.Element {
           <div class="whatsnew-modal__body">
             <h2 class="whatsnew-modal__headline">What we just shipped</h2>
             <p class="whatsnew-modal__lead">
-              There&rsquo;s now a single, unified UI to connect and manage your providers across all
-              your harnesses. Your existing connected providers have been migrated to global
-              automatically.
+              OpenAI-compatible clients can now discover the models available through Manifest and
+              opt into an exact provider/model pair when you want to skip routing.
             </p>
             <ul class="whatsnew-modal__list">
               <For each={HIGHLIGHTS as unknown as string[]}>

--- a/packages/frontend/tests/components/WhatsNewModal.test.tsx
+++ b/packages/frontend/tests/components/WhatsNewModal.test.tsx
@@ -3,7 +3,8 @@ import { render, screen, fireEvent, cleanup } from '@solidjs/testing-library';
 
 import WhatsNewModal from '../../src/components/WhatsNewModal';
 
-const STORAGE_KEY = 'manifest:whatsnew:global-providers-v1';
+const STORAGE_KEY = 'manifest:whatsnew:openai-sdk-models-v1';
+const PREVIOUS_STORAGE_KEY = 'manifest:whatsnew:global-providers-v1';
 const HEADLINE = 'What we just shipped';
 
 describe('WhatsNewModal', () => {
@@ -28,12 +29,18 @@ describe('WhatsNewModal', () => {
     expect(screen.queryByText(HEADLINE)).toBeNull();
   });
 
+  it('opens when only the previous announcement was dismissed', () => {
+    localStorage.setItem(PREVIOUS_STORAGE_KEY, new Date().toISOString());
+    render(() => <WhatsNewModal />);
+    expect(screen.getByText(HEADLINE)).toBeDefined();
+  });
+
   it('renders every highlight bullet', () => {
     render(() => <WhatsNewModal />);
-    expect(screen.getByText(/One unified place to connect and manage/)).toBeDefined();
-    expect(screen.getByText(/Connect a provider once/)).toBeDefined();
-    expect(screen.getByText(/Need isolation\?/)).toBeDefined();
-    expect(screen.getByText(/Track consumption/)).toBeDefined();
+    expect(screen.getByText(/GET \/v1\/models/)).toBeDefined();
+    expect(screen.getByText(/returned model ID/)).toBeDefined();
+    expect(screen.getByText(/model: auto/)).toBeDefined();
+    expect(screen.getByText(/Messages and provider usage/)).toBeDefined();
   });
 
   it('links out to GitHub issues and Discord in a new tab', () => {


### PR DESCRIPTION
### ✨ What changed
- Update the shipped modal for `/v1/models` and direct SDK model calls.
- Bump the announcement id so users see this modal once.

### 💭 Why
The latest OpenAI-compatible SDK changes need a visible product announcement without changing docs in this PR.

### 👤 For users
Users who dismissed the previous announcement see this new one once.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the “What’s New” modal to announce OpenAI-compatible model discovery and direct SDK model calls, and bump the announcement ID so users see it once even if they dismissed the previous one.

- **New Features**
  - New highlights: list models via GET `/v1/models`, use returned model IDs for direct SDK calls, keep `model: auto` for routing, and see direct calls in Messages and provider usage.
  - Announcement ID bumped to `openai-sdk-models-v1`; users who dismissed the previous announcement will see this one once.
  - Tests updated for the new storage key, previous key fallback, and new bullet copy.

<sup>Written for commit 5572692e38617f614569a4722feefa59c229abf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

