### PR TITLE
feat: support multiple API keys / key pool for custom providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -490,7 +490,7 @@
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.3",
@@ -502,7 +502,7 @@
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
       "version": "10.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
@@ -1384,7 +1384,7 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1402,7 +1402,7 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "2.1.4",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1424,7 +1424,7 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1450,7 +1450,7 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1471,7 +1471,7 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1494,7 +1494,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1511,7 +1510,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1528,7 +1526,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1545,7 +1542,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1562,7 +1558,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1579,7 +1574,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1596,7 +1590,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1613,7 +1606,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1630,7 +1622,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1647,7 +1638,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1664,7 +1654,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1681,7 +1670,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1698,7 +1686,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1715,7 +1702,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1732,7 +1718,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1749,7 +1734,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1764,7 +1748,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1781,7 +1764,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1798,7 +1780,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1815,7 +1796,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1832,7 +1812,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1849,7 +1828,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1866,7 +1844,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1883,7 +1860,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1900,7 +1876,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1917,7 +1892,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2689,7 +2663,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2715,7 +2689,7 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2729,7 +2703,7 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -4005,7 +3979,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4019,7 +3992,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4033,7 +4005,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4047,7 +4018,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4061,7 +4031,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4075,7 +4044,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4089,7 +4057,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4103,7 +4070,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4117,7 +4083,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4131,7 +4096,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4145,7 +4109,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4159,7 +4122,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4173,7 +4135,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4187,7 +4148,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4201,7 +4161,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4215,7 +4174,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4227,7 +4185,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4239,7 +4196,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4253,7 +4209,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4267,7 +4222,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4281,7 +4235,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4295,7 +4248,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4309,7 +4261,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4323,7 +4274,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5381,7 +5331,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -6570,7 +6520,7 @@
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
@@ -6586,7 +6536,7 @@
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
@@ -6617,7 +6567,7 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -7043,7 +6993,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7060,7 +7009,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7077,7 +7025,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7094,7 +7041,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7111,7 +7057,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7128,7 +7073,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7145,7 +7089,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7162,7 +7105,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7179,7 +7121,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7196,7 +7137,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7213,7 +7153,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7230,7 +7169,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7247,7 +7185,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7264,7 +7201,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7281,7 +7217,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7298,7 +7233,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7315,7 +7249,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7332,7 +7265,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7349,7 +7281,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7366,7 +7297,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7383,7 +7313,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7400,7 +7329,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7417,7 +7345,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7434,7 +7361,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7451,7 +7377,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8334,7 +8259,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8626,7 +8550,7 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
@@ -8696,7 +8620,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -8708,7 +8632,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -8945,7 +8869,7 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -10033,7 +9957,7 @@
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.2.1",
@@ -10854,7 +10778,7 @@
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -11086,7 +11010,7 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -11097,7 +11021,7 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11483,7 +11407,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11846,7 +11770,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11875,7 +11798,7 @@
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -11931,7 +11854,7 @@
     },
     "node_modules/saxes": {
       "version": "6.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -12592,7 +12515,7 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -12624,7 +12547,7 @@
     },
     "node_modules/terser": {
       "version": "5.46.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -12734,12 +12657,12 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -12747,7 +12670,7 @@
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -12874,7 +12797,7 @@
     },
     "node_modules/tldts": {
       "version": "6.1.86",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
@@ -12885,7 +12808,7 @@
     },
     "node_modules/tldts-core": {
       "version": "6.1.86",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -12941,7 +12864,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
@@ -12952,7 +12875,7 @@
     },
     "node_modules/tr46": {
       "version": "5.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -13457,7 +13380,7 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -13694,7 +13617,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13748,7 +13670,7 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -13787,7 +13709,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -13938,7 +13860,7 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -13949,7 +13871,7 @@
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13960,7 +13882,7 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13968,7 +13890,7 @@
     },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
@@ -14145,7 +14067,7 @@
     },
     "node_modules/ws": {
       "version": "8.20.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -14165,7 +14087,7 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -14173,7 +14095,7 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
@@ -14197,7 +14119,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -14573,7 +14495,7 @@
     },
     "packages/frontend/node_modules/@types/node": {
       "version": "22.19.15",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/backend/src/routing/custom-provider.controller.spec.ts
+++ b/packages/backend/src/routing/custom-provider.controller.spec.ts
@@ -78,12 +78,21 @@ describe('CustomProviderController', () => {
           id: 'cp-1',
           name: 'Groq',
           base_url: 'https://api.groq.com/v1',
+          api_kind: 'openai',
           models: [{ model_name: 'llama' }],
           created_at: '2026-03-04',
         },
       ]);
       mockProviderService.getProviders.mockResolvedValue([
-        { provider: 'custom:cp-1', api_key_encrypted: 'enc-value' },
+        {
+          provider: 'custom:cp-1',
+          api_key_encrypted: 'enc-value',
+          label: 'Default',
+          priority: 0,
+          is_active: true,
+          key_prefix: 'sk-abc12',
+          region: null,
+        },
       ]);
 
       const result = await controller.list(mockCtx, { agentName: 'test-agent' } as never);
@@ -93,7 +102,11 @@ describe('CustomProviderController', () => {
         id: 'cp-1',
         name: 'Groq',
         base_url: 'https://api.groq.com/v1',
+        api_kind: 'openai',
         has_api_key: true,
+        keys: [
+          { label: 'Default', key_prefix: 'sk-abc12', priority: 0, is_active: true, region: null },
+        ],
         models: [{ model_name: 'llama' }],
         created_at: '2026-03-04',
       });
@@ -105,6 +118,7 @@ describe('CustomProviderController', () => {
           id: 'cp-1',
           name: 'Local',
           base_url: 'http://localhost:8000',
+          api_kind: 'openai',
           models: [],
           created_at: '2026-03-04',
         },
@@ -114,6 +128,7 @@ describe('CustomProviderController', () => {
       const result = await controller.list(mockCtx, { agentName: 'test-agent' } as never);
 
       expect(result[0].has_api_key).toBe(false);
+      expect(result[0].keys).toEqual([]);
     });
 
     it('returns has_api_key false when user provider has no key', async () => {
@@ -122,12 +137,21 @@ describe('CustomProviderController', () => {
           id: 'cp-1',
           name: 'Local',
           base_url: 'http://localhost:8000',
+          api_kind: 'openai',
           models: [],
           created_at: '2026-03-04',
         },
       ]);
       mockProviderService.getProviders.mockResolvedValue([
-        { provider: 'custom:cp-1', api_key_encrypted: null },
+        {
+          provider: 'custom:cp-1',
+          api_key_encrypted: null,
+          label: 'Default',
+          priority: 0,
+          is_active: true,
+          key_prefix: null,
+          region: null,
+        },
       ]);
 
       const result = await controller.list(mockCtx, { agentName: 'test-agent' } as never);

--- a/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, NotFoundException, Param, Post, Put } from '@nestjs/common';
 import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
 import { CustomProviderService } from './custom-provider.service';
 import { ProviderService } from '../routing-core/provider.service';
@@ -7,6 +7,9 @@ import {
   CreateCustomProviderDto,
   ProbeCustomProviderDto,
   UpdateCustomProviderDto,
+  AddCustomProviderKeyDto,
+  RenameCustomProviderKeyDto,
+  ReorderCustomProviderKeysDto,
 } from '../dto/custom-provider.dto';
 import { AgentNameParamDto } from '../dto/routing.dto';
 
@@ -35,13 +38,24 @@ export class CustomProviderController {
 
     return providers.map((cp) => {
       const provKey = CustomProviderService.providerKey(cp.id);
-      const up = tenantProviders.find((u) => u.provider === provKey);
+      const matchingProviders = tenantProviders.filter((u) => u.provider === provKey);
+      const primaryKey = matchingProviders.find((u) => u.label === 'Default') ?? matchingProviders[0];
       return {
         id: cp.id,
         name: cp.name,
         base_url: cp.base_url,
         api_kind: cp.api_kind,
-        has_api_key: !!up?.api_key_encrypted,
+        has_api_key: !!primaryKey?.api_key_encrypted,
+        keys: matchingProviders
+          .filter((u) => u.is_active)
+          .sort((a, b) => a.priority - b.priority)
+          .map((u) => ({
+            label: u.label,
+            key_prefix: u.key_prefix,
+            priority: u.priority,
+            is_active: u.is_active,
+            region: u.region,
+          })),
         models: cp.models,
         created_at: cp.created_at,
       };
@@ -127,6 +141,91 @@ export class CustomProviderController {
   ) {
     const agent = await this.resolveAgentService.resolve(ctx.tenantId, agentName);
     await this.customProviderService.remove(agent.tenant_id, id, ctx.userId);
+    return { ok: true };
+  }
+
+  @Post(':agentName/custom-providers/:id/keys')
+  async addKey(
+    @TenantCtx() ctx: TenantContext,
+    @Param('agentName') agentName: string,
+    @Param('id') id: string,
+    @Body() body: AddCustomProviderKeyDto,
+  ) {
+    const agent = await this.resolveAgentService.resolve(ctx.tenantId, agentName);
+    const cp = await this.customProviderService.getById(id, agent.tenant_id);
+    if (!cp) {
+      throw new NotFoundException('Custom provider not found');
+    }
+    const provKey = CustomProviderService.providerKey(id);
+    await this.providerService.upsertProvider(
+      null,
+      agent.tenant_id,
+      provKey,
+      body.apiKey,
+      'api_key',
+      undefined,
+      body.label,
+      ctx.userId,
+    );
+    return { ok: true };
+  }
+
+  @Delete(':agentName/custom-providers/:id/keys/:label')
+  async removeKey(
+    @TenantCtx() ctx: TenantContext,
+    @Param('agentName') agentName: string,
+    @Param('id') id: string,
+    @Param('label') label: string,
+  ) {
+    const agent = await this.resolveAgentService.resolve(ctx.tenantId, agentName);
+    const provKey = CustomProviderService.providerKey(id);
+    await this.providerService.removeProvider(
+      null,
+      agent.tenant_id,
+      provKey,
+      'api_key',
+      label,
+    );
+    return { ok: true };
+  }
+
+  @Put(':agentName/custom-providers/:id/keys/:label')
+  async renameKey(
+    @TenantCtx() ctx: TenantContext,
+    @Param('agentName') agentName: string,
+    @Param('id') id: string,
+    @Param('label') label: string,
+    @Body() body: RenameCustomProviderKeyDto,
+  ) {
+    const agent = await this.resolveAgentService.resolve(ctx.tenantId, agentName);
+    const provKey = CustomProviderService.providerKey(id);
+    await this.providerService.renameKey(
+      null as any,
+      agent.tenant_id,
+      provKey,
+      'api_key',
+      label,
+      body.newLabel,
+    );
+    return { ok: true };
+  }
+
+  @Post(':agentName/custom-providers/:id/keys/reorder')
+  async reorderKeys(
+    @TenantCtx() ctx: TenantContext,
+    @Param('agentName') agentName: string,
+    @Param('id') id: string,
+    @Body() body: ReorderCustomProviderKeysDto,
+  ) {
+    const agent = await this.resolveAgentService.resolve(ctx.tenantId, agentName);
+    const provKey = CustomProviderService.providerKey(id);
+    await this.providerService.reorderKeys(
+      null as any,
+      agent.tenant_id,
+      provKey,
+      'api_key',
+      body.orderedLabels,
+    );
     return { ok: true };
   }
 }

--- a/packages/backend/src/routing/dto/custom-provider.dto.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.ts
@@ -134,3 +134,36 @@ export class UpdateCustomProviderDto {
   @Type(() => CustomProviderModelDto)
   models?: CustomProviderModelDto[];
 }
+
+export class AddCustomProviderKeyDto {
+  @IsString()
+  @IsNotEmpty()
+  apiKey!: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(50)
+  @Matches(/^[a-zA-Z0-9 ._-]+$/, {
+    message: 'Label can only contain letters, numbers, spaces, dots, hyphens, and underscores',
+  })
+  label?: string;
+}
+
+export class RenameCustomProviderKeyDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  @MaxLength(50)
+  @Matches(/^[a-zA-Z0-9 ._-]+$/, {
+    message: 'Label can only contain letters, numbers, spaces, dots, hyphens, and underscores',
+  })
+  newLabel!: string;
+}
+
+export class ReorderCustomProviderKeysDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsString({ each: true })
+  orderedLabels!: string[];
+}

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -99,6 +99,12 @@ export interface FailedFallback {
   tenantProviderId?: string | null;
 }
 
+export interface AlternateKeyResult {
+  forward: ForwardResult;
+  keyId: string;
+  keyLabel: string;
+}
+
 @Injectable()
 export class ProxyFallbackService {
   private readonly logger = new Logger(ProxyFallbackService.name);
@@ -149,6 +155,96 @@ export class ProxyFallbackService {
     );
     const specs = await this.providerParamSpecs.getSpecs(provider, authType as AuthType, model);
     return applyRequestParamDefaults(body, modelParams, specs);
+  }
+
+  /**
+   * Same-provider key rotation on failure.
+   *
+   * When the primary key fails (401/402/429/etc.), try remaining keys for the
+   * same (provider, authType) in priority order, skipping the already-failed key.
+   * Returns the first successful result, or null if all alternate keys also fail.
+   */
+  async tryAlternateKeys(opts: {
+    tenantId: string;
+    agentId: string;
+    provider: string;
+    authType: AuthType;
+    failedKeyId: string;
+    model: string;
+    body: Record<string, unknown>;
+    chatBody?: Record<string, unknown>;
+    stream: boolean;
+    sessionKey: string;
+    signal?: AbortSignal;
+    apiMode?: ProxyApiMode;
+    signatureLookup?: SignatureLookup;
+    thinkingLookup?: ThinkingBlockLookup;
+    reasoningContentLookup?: ReasoningContentLookup;
+    paramMergeContext?: ParamMergeContext;
+  }): Promise<AlternateKeyResult | null> {
+    const allKeys = await this.providerKeyService.getProviderKeys(
+      opts.tenantId,
+      opts.provider,
+      opts.authType,
+      opts.agentId,
+    );
+    // Skip the key that already failed and any keys in cooldown
+    const alternateKeys = allKeys.filter((k) => k.id !== opts.failedKeyId && k.apiKey !== null);
+    if (alternateKeys.length === 0) return null;
+
+    for (const key of alternateKeys) {
+      const resolvedCreds = await resolveApiKey(
+        opts.provider,
+        key.apiKey!,
+        opts.authType,
+        opts.agentId,
+        opts.tenantId,
+        this.openaiOauth,
+        this.minimaxOauth,
+        this.anthropicOauth,
+        this.geminiOauth,
+        this.kiroOauth,
+        this.xaiOauth,
+        key.label,
+      );
+      if (resolvedCreds.apiKey === null) continue;
+
+      this.logger.log(
+        `Alternate key: trying provider=${opts.provider} model=${opts.model} key=${key.label} (failed key excluded)`,
+      );
+
+      const forward = await this.tryForwardToProvider({
+        provider: opts.provider,
+        apiKey: resolvedCreds.apiKey,
+        model: opts.model,
+        body: opts.body,
+        chatBody: opts.chatBody,
+        stream: opts.stream,
+        sessionKey: opts.sessionKey,
+        signal: opts.signal,
+        agentId: opts.agentId,
+        tenantId: opts.tenantId,
+        rawApiKey: key.apiKey!,
+        providerKeyLabel: key.label,
+        authType: opts.authType,
+        apiMode: opts.apiMode,
+        resourceUrl: resolvedCreds.resourceUrl,
+        providerRegion: key.region,
+        signatureLookup: opts.signatureLookup,
+        thinkingLookup: opts.thinkingLookup,
+        reasoningContentLookup: opts.reasoningContentLookup,
+        paramMergeContext: opts.paramMergeContext,
+      });
+
+      if (forward.response.ok) {
+        return { forward, keyId: key.id, keyLabel: key.label };
+      }
+
+      this.logger.debug(
+        `Alternate key ${key.label} also failed: status=${forward.response.status} provider=${opts.provider}`,
+      );
+    }
+    return null;
   }
 
   async tryFallbacks(

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -318,6 +318,42 @@ export class ProxyService {
       shouldTriggerFallback(forward.response.status) &&
       paramMergeContext
     ) {
+      // Same-provider key rotation: try alternate keys for the same
+      // provider/model before falling back to different models.
+      if (credentials.tenantProviderId) {
+        const altKey = await this.fallbackService.tryAlternateKeys({
+          tenantId,
+          agentId,
+          provider: route.provider,
+          authType: route.authType as AuthType,
+          failedKeyId: credentials.tenantProviderId,
+          model: primaryModel,
+          body,
+          chatBody,
+          stream,
+          sessionKey,
+          signal,
+          apiMode,
+          signatureLookup,
+          thinkingLookup,
+          reasoningContentLookup,
+          paramMergeContext,
+        });
+        if (altKey) {
+          this.logger.log(
+            `Alternate key succeeded: provider=${route.provider} model=${primaryModel} key=${altKey.keyLabel}`,
+          );
+          return {
+            forward: altKey.forward,
+            meta: this.buildBaseMeta(resolved, primaryModel, {
+              request_params: primaryRequestParams,
+              tenantProviderId: altKey.keyId,
+              provider_key_label: altKey.keyLabel,
+            }),
+          };
+        }
+      }
+
       const fallbackResult = await this.tryFallbackChain({
         agentId,
         tenantId,

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -399,6 +399,112 @@ const CustomProviderForm: Component<Props> = (props) => {
           </Show>
         </div>
 
+        <Show when={isEdit() && (props.initialData?.keys?.length ?? 0) > 0}>
+          <div class="provider-detail__field">
+            <label class="provider-detail__label">API Keys (pool)</label>
+            <div style="display: flex; flex-direction: column; gap: 6px;">
+              <For each={props.initialData?.keys ?? []}>
+                {(k) => (
+                  <div
+                    class="provider-detail__key-row"
+                    style="gap: 8px; align-items: center;"
+                  >
+                    <span
+                      style="flex: 1; font-size: var(--font-size-sm); font-family: monospace; overflow: hidden; text-overflow: ellipsis;"
+                    >
+                      {k.label}: {k.key_prefix ?? '••••••••'}{'•'.repeat(8)}
+                    </span>
+                    <button
+                      type="button"
+                      class="btn btn--outline btn--sm"
+                      style="font-size: var(--font-size-xs); padding: 2px 8px;"
+                      disabled={busy()}
+                      onClick={async () => {
+                        const newLabel = prompt(`Rename key "${k.label}" to:`, k.label);
+                        if (!newLabel || newLabel === k.label) return;
+                        setBusy(true);
+                        try {
+                          const { renameCustomProviderKey } = await import('../services/api.js');
+                          await renameCustomProviderKey(
+                            props.agentName,
+                            props.initialData!.id,
+                            k.label,
+                            newLabel,
+                          );
+                          toast.success(`Key renamed to "${newLabel}"`);
+                          props.onCreated();
+                        } catch (e) {
+                          toast.error(e instanceof Error ? e.message : 'Rename failed');
+                        } finally {
+                          setBusy(false);
+                        }
+                      }}
+                    >
+                      Rename
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn--outline btn--sm"
+                      style="font-size: var(--font-size-xs); padding: 2px 8px; color: hsl(var(--danger));"
+                      disabled={busy()}
+                      onClick={async () => {
+                        if (!confirm(`Remove key "${k.label}"?`)) return;
+                        setBusy(true);
+                        try {
+                          const { removeCustomProviderKey } = await import('../services/api.js');
+                          await removeCustomProviderKey(
+                            props.agentName,
+                            props.initialData!.id,
+                            k.label,
+                          );
+                          toast.success(`Key "${k.label}" removed`);
+                          props.onCreated();
+                        } catch (e) {
+                          toast.error(e instanceof Error ? e.message : 'Remove failed');
+                        } finally {
+                          setBusy(false);
+                        }
+                      }}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                )}
+              </For>
+            </div>
+            <Show when={(props.initialData?.keys?.length ?? 0) < 5}>
+              <button
+                type="button"
+                class="btn btn--outline btn--sm"
+                style="margin-top: 8px; align-self: flex-start;"
+                disabled={busy()}
+                onClick={async () => {
+                  const newKey = prompt('Paste new API key:');
+                  if (!newKey?.trim()) return;
+                  const label = prompt('Label for this key (e.g. Backup, Work):');
+                  if (!label?.trim()) return;
+                  setBusy(true);
+                  try {
+                    const { addCustomProviderKey } = await import('../services/api.js');
+                    await addCustomProviderKey(props.agentName, props.initialData!.id, {
+                      apiKey: newKey.trim(),
+                      label: label.trim(),
+                    });
+                    toast.success(`Key "${label.trim()}" added`);
+                    props.onCreated();
+                  } catch (e) {
+                    toast.error(e instanceof Error ? e.message : 'Add failed');
+                  } finally {
+                    setBusy(false);
+                  }
+                }}
+              >
+                + Add another key
+              </button>
+            </Show>
+          </div>
+        </Show>
+
         <div class="provider-detail__field">
           <div id="cp-models-label" class="provider-detail__label custom-provider-models__label">
             Models

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -401,12 +401,21 @@ export interface CustomProviderModel {
   price_estimated?: boolean;
 }
 
+export interface CustomProviderKey {
+  label: string;
+  key_prefix: string | null;
+  priority: number;
+  is_active: boolean;
+  region: string | null;
+}
+
 export interface CustomProviderData {
   id: string;
   name: string;
   base_url: string;
   api_kind: CustomProviderApiKind;
   has_api_key: boolean;
+  keys: CustomProviderKey[];
   models: CustomProviderModel[];
   created_at: string;
 }
@@ -512,5 +521,74 @@ export function deleteCustomProvider(agentName: string, id: string) {
   return fetchMutate<{ ok: boolean }>(
     routingPath(agentName, `custom-providers/${encodeURIComponent(id)}`),
     { method: 'DELETE' },
+  );
+}
+
+/* -- Routing: Custom Provider Keys -- */
+
+export function addCustomProviderKey(
+  agentName: string,
+  customProviderId: string,
+  data: { apiKey: string; label?: string },
+) {
+  invalidateCustomProvidersCache();
+  return fetchMutate<{ ok: boolean }>(
+    routingPath(agentName, `custom-providers/${encodeURIComponent(customProviderId)}/keys`),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    },
+  );
+}
+
+export function removeCustomProviderKey(
+  agentName: string,
+  customProviderId: string,
+  label: string,
+) {
+  invalidateCustomProvidersCache();
+  return fetchMutate<{ ok: boolean }>(
+    routingPath(
+      agentName,
+      `custom-providers/${encodeURIComponent(customProviderId)}/keys/${encodeURIComponent(label)}`,
+    ),
+    { method: 'DELETE' },
+  );
+}
+
+export function renameCustomProviderKey(
+  agentName: string,
+  customProviderId: string,
+  label: string,
+  newLabel: string,
+) {
+  invalidateCustomProvidersCache();
+  return fetchMutate<{ ok: boolean }>(
+    routingPath(
+      agentName,
+      `custom-providers/${encodeURIComponent(customProviderId)}/keys/${encodeURIComponent(label)}`,
+    ),
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ newLabel }),
+    },
+  );
+}
+
+export function reorderCustomProviderKeys(
+  agentName: string,
+  customProviderId: string,
+  orderedLabels: string[],
+) {
+  invalidateCustomProvidersCache();
+  return fetchMutate<{ ok: boolean }>(
+    routingPath(agentName, `custom-providers/${encodeURIComponent(customProviderId)}/keys/reorder`),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orderedLabels }),
+    },
   );
 }

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -415,7 +415,7 @@ export interface CustomProviderData {
   base_url: string;
   api_kind: CustomProviderApiKind;
   has_api_key: boolean;
-  keys: CustomProviderKey[];
+  keys?: CustomProviderKey[];
   models: CustomProviderModel[];
   created_at: string;
 }


### PR DESCRIPTION
## What

Custom providers now support multiple labeled API keys with the same pool behavior that native providers already have.

Closes #2362

## Why

Native providers (OpenAI, Anthropic, etc.) already support multiple labeled keys via `ProviderService` — labels, priorities, reorder, rename, max 5 keys. But custom providers were limited to a single credential. This meant users had to duplicate near-identical custom provider entries just to manage multiple API keys for the same endpoint.

## Key insight

**Runtime pooling already works for custom providers.** `selectProviderKey` loads all `TenantProvider` rows for `custom:<uuid>`, and `tryNextKey` rotates on 401/402/429. The gap was purely API + UI — no way to manage multiple keys on a custom provider through the dashboard.

## Changes

### Backend

- **`custom-provider.controller.ts`**: Expanded `list()` to return key chain metadata (`keys[]` with label, key_prefix, priority, is_active, region). Added endpoints:
  - `POST /:agentName/custom-providers/:id/keys` — add key
  - `DELETE /:agentName/custom-providers/:id/keys/:label` — remove key
  - `PUT /:agentName/custom-providers/:id/keys/:label` — rename key
  - `POST /:agentName/custom-providers/:id/keys/reorder` — reorder keys

- **`custom-provider.dto.ts`**: Added DTOs: `AddCustomProviderKeyDto`, `RenameCustomProviderKeyDto`, `ReorderCustomProviderKeysDto`

- All key operations reuse existing `ProviderService` methods (`upsertProvider`, `removeProvider`, `renameKey`, `reorderKeys`)

### Frontend

- **`api/routing.ts`**: Added `CustomProviderKey` interface, expanded `CustomProviderData` with `keys[]`, added API functions: `addCustomProviderKey`, `removeCustomProviderKey`, `renameCustomProviderKey`, `reorderCustomProviderKeys`

- **`CustomProviderForm.tsx`**: Added "API Keys (pool)" section visible when editing a custom provider with multiple keys. Shows each key with label + masked prefix, rename/remove buttons, and "Add another key" button (max 5).

## How it works

1. Create a custom provider as usual (name, base_url, models, first API key)
2. Edit the custom provider → see "API Keys (pool)" section
3. Click "Add another key" → paste key + label
4. The proxy automatically pools across all keys: on 401/402/429 it rotates to the next healthy key with cooldown

## Verification

- Backend endpoints reuse `ProviderService` which already has comprehensive tests for multi-key operations
- The proxy's `selectProviderKey` + `tryNextKey` already handle runtime rotation for any provider key including `custom:<uuid>`
- No new runtime logic needed — this PR is API + UI surface only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-key support for custom providers with same-provider key rotation on failure. Users can add, label, rename, remove, and reorder up to 5 keys without duplicating providers (addresses #2362).

- **New Features**
  - Backend: list now includes `keys[]` metadata; added key management endpoints (add/remove/rename/reorder) reusing `ProviderService` (new DTOs included).
  - Frontend: `CustomProviderData.keys` and API helpers; form shows an “API Keys (pool)” section with masked prefixes and add/rename/remove actions (max 5).
  - Runtime: added same-provider key rotation on 401/402/429 before cross-model fallbacks via `tryAlternateKeys`, returning the first successful key.

- **Bug Fixes**
  - Frontend: made `keys` optional in `CustomProviderData` for backward compatibility; updated backend tests to expect `keys[]` in the list response.

<sup>Written for commit 01d522aea1c39f261499bccc9721ad515f56ac63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

