### PR TITLE
fix: reflect in-flight state on connection Disconnect button

### DIFF
--- a/packages/frontend/src/pages/providers/ConnectionDetail.tsx
+++ b/packages/frontend/src/pages/providers/ConnectionDetail.tsx
@@ -1006,10 +1006,18 @@ const ConnectionDetail: Component = () => {
 
                           {/* Actions */}
                           <div style="display: flex; justify-content: space-between; align-items: center; padding-top: 16px; border-top: 1px solid hsl(var(--border));">
-                            <button class="btn btn--danger btn--sm" onClick={handleDisconnect}>
-                              Disconnect
+                            <button
+                              class="btn btn--danger btn--sm"
+                              onClick={handleDisconnect}
+                              disabled={deletingConnection()}
+                            >
+                              {deletingConnection() ? 'Disconnecting...' : 'Disconnect'}
                             </button>
-                            <button class="btn btn--outline btn--sm" onClick={closeManageModal}>
+                            <button
+                              class="btn btn--outline btn--sm"
+                              onClick={closeManageModal}
+                              disabled={deletingConnection()}
+                            >
                               Done
                             </button>
                           </div>

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -1459,6 +1459,29 @@ describe('ConnectionDetail (analytics)', () => {
     expect(routerState.navigate).toHaveBeenCalledWith('/providers/usage-based');
   });
 
+  it('disables the Disconnect and Done buttons and shows progress while in flight', async () => {
+    let resolveDisconnect!: (value: unknown) => void;
+    apiMocks.disconnectProvider.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDisconnect = resolve;
+      }),
+    );
+    render(() => <ConnectionDetail />);
+    await openManageModal();
+
+    const disconnectBtn = screen.getByText('Disconnect') as HTMLButtonElement;
+    fireEvent.click(disconnectBtn);
+
+    const inFlightBtn = (await waitFor(() =>
+      screen.getByText('Disconnecting...'),
+    )) as HTMLButtonElement;
+    expect(inFlightBtn.disabled).toBe(true);
+    expect((screen.getByText('Done') as HTMLButtonElement).disabled).toBe(true);
+
+    resolveDisconnect({ notifications: [] });
+    await waitFor(() => expect(routerState.navigate).toHaveBeenCalledWith('/providers/usage-based'));
+  });
+
   it('shows an error toast when disconnecting fails', async () => {
     apiMocks.disconnectProvider.mockRejectedValueOnce(new Error('disconnect boom'));
     render(() => <ConnectionDetail />);


### PR DESCRIPTION
### ✨ What changed
- The active connection's **Disconnect** button now disables and shows "Disconnecting..." while the request is in flight.
- The adjacent **Done** button is disabled during the same window.

### 💭 Why
The button had no `deletingConnection()` binding, unlike the inactive-connection "Delete connection" button right beside it. Disconnecting a provider or subscription gave zero feedback and stayed clickable, so a second click fired a duplicate disconnect request.

### 👤 For users
Click Disconnect on a provider or subscription and the button greys out and reads "Disconnecting..." until it completes. No more double-fires.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the Disconnect button and show "Disconnecting..." while the request is in flight. Also disable the adjacent Done button to prevent duplicate disconnects, with tests covering the behavior.

<sup>Written for commit a70ba9b09bd509ef30dfefa3c3ac86c18effb887. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

