### PR TITLE
feat: serve curated cross-tenant error pages for marketing site

### DIFF
--- a/.changeset/public-error-pages.md
+++ b/.changeset/public-error-pages.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add an opt-in public API that serves curated cross-tenant error-cluster pages for the marketing site. `GET /api/v1/public/error-pages[/:slug]` returns operator-approved clusters (gated by `MANIFEST_PUBLIC_STATS`), and a secret-guarded `POST/DELETE /api/v1/internal/error-pages` lets the Peacock CMS publish or pull pages. Only clusters seen by at least 10 distinct tenants are eligible, and every public sample is run through secret and email scrubbing before storage, so no single tenant's data or credentials can leak.

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { CommonModule } from './common/common.module';
 import { SseModule } from './sse/sse.module';
 import { GithubModule } from './github/github.module';
 import { PublicStatsModule } from './public-stats/public-stats.module';
+import { ErrorPagesModule } from './error-pages/error-pages.module';
 import { SetupModule } from './setup/setup.module';
 import { FreeModelsModule } from './free-models/free-models.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
@@ -82,6 +83,7 @@ const serveStaticImports = frontendPath
     SseModule,
     GithubModule,
     PublicStatsModule,
+    ErrorPagesModule,
     SetupModule,
     FreeModelsModule,
     TelemetryModule,

--- a/packages/backend/src/config/app.config.ts
+++ b/packages/backend/src/config/app.config.ts
@@ -51,4 +51,9 @@ export const appConfig = registerAs('app', () => ({
   // When true, /api/v1/public/* endpoints expose aggregate stats without auth.
   // Off by default — only Manifest Cloud's marketing homepage should enable it.
   publicStatsEnabled: process.env['MANIFEST_PUBLIC_STATS'] === 'true',
+  // Shared secret guarding the internal error-page push endpoint
+  // (/api/v1/internal/error-pages). The Peacock CMS sends it in the
+  // `x-internal-secret` header to publish/unpublish curated error pages.
+  // Empty by default — the endpoint rejects all writes until it is set.
+  errorPagePushSecret: process.env['ERROR_PAGE_PUSH_SECRET'] ?? '',
 }));

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -23,6 +23,7 @@ import { PlaygroundRun } from '../entities/playground-run.entity';
 import { PlaygroundColumn } from '../entities/playground-column.entity';
 import { ReasoningContentCacheEntry } from '../entities/reasoning-content-cache-entry.entity';
 import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
+import { PublicErrorPage } from '../entities/public-error-page.entity';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -128,6 +129,7 @@ import { AddDashboardCoveringIndex1793200000000 } from './migrations/17932000000
 import { AddCrossTenantErrorTimestampIndex1795100000000 } from './migrations/1795100000000-AddCrossTenantErrorTimestampIndex';
 import { RemoveMessageRecording1795000000000 } from './migrations/1795000000000-RemoveMessageRecording';
 import { AddAutofixWaitlist1796000000000 } from './migrations/1796000000000-AddAutofixWaitlist';
+import { AddPublicErrorPages1797000000000 } from './migrations/1797000000000-AddPublicErrorPages';
 
 export const entities = [
   AgentMessage,
@@ -150,6 +152,7 @@ export const entities = [
   ReasoningContentCacheEntry,
   AgentEnabledProvider,
   BackfillState,
+  PublicErrorPage,
 ];
 
 export const migrations = [
@@ -258,4 +261,5 @@ export const migrations = [
   RemoveMessageRecording1795000000000,
   AddCrossTenantErrorTimestampIndex1795100000000,
   AddAutofixWaitlist1796000000000,
+  AddPublicErrorPages1797000000000,
 ];

--- a/packages/backend/src/database/migrations/1797000000000-AddPublicErrorPages.ts
+++ b/packages/backend/src/database/migrations/1797000000000-AddPublicErrorPages.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates `public_error_pages` — the read-optimised mirror of operator-approved
+ * error-cluster SEO pages. Populated only via the secret-guarded internal push
+ * endpoint from the Peacock CMS; never written from raw telemetry.
+ */
+export class AddPublicErrorPages1797000000000 implements MigrationInterface {
+  name = 'AddPublicErrorPages1797000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "public_error_pages" (
+        "slug" varchar PRIMARY KEY,
+        "cluster_key" varchar NOT NULL,
+        "provider" varchar NOT NULL,
+        "provider_label" varchar NOT NULL DEFAULT '',
+        "http_status" integer,
+        "category" varchar NOT NULL DEFAULT 'unknown',
+        "category_label" varchar NOT NULL DEFAULT '',
+        "title" varchar NOT NULL,
+        "meta_description" varchar NOT NULL,
+        "h1" varchar NOT NULL,
+        "body_what" text NOT NULL DEFAULT '',
+        "body_fix" text NOT NULL DEFAULT '',
+        "body_manifest" text NOT NULL DEFAULT '',
+        "sample_message" text NOT NULL DEFAULT '',
+        "faq" jsonb NOT NULL DEFAULT '[]'::jsonb,
+        "stats" jsonb NOT NULL DEFAULT '{}'::jsonb,
+        "related" jsonb NOT NULL DEFAULT '[]'::jsonb,
+        "noindex" boolean NOT NULL DEFAULT false,
+        "published_at" TIMESTAMP NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP NOT NULL DEFAULT now()
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "public_error_pages"`);
+  }
+}

--- a/packages/backend/src/entities/public-error-page.entity.ts
+++ b/packages/backend/src/entities/public-error-page.entity.ts
@@ -1,0 +1,105 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+import { timestampType } from '../common/utils/postgres-sql';
+
+/** A single question/answer pair rendered into FAQPage structured data. */
+export interface ErrorPageFaqItem {
+  q: string;
+  a: string;
+}
+
+/** One day of the occurrence sparkline shown on the public page. */
+export interface ErrorPageTrendPoint {
+  date: string; // YYYY-MM-DD
+  count: number;
+}
+
+/**
+ * Aggregate, non-identifying stats snapshot for the cluster. Pushed from the
+ * Peacock CMS and refreshed on its hourly rollup. `tenants` is the k-anonymity
+ * signal — a page is never published below MIN_TENANTS_FOR_PUBLIC distinct teams.
+ */
+export interface ErrorPageStats {
+  tenants: number;
+  volume_7d: number;
+  volume_30d: number;
+  recovery_rate: number | null; // 0..1 — share auto-recovered by a Manifest fallback
+  last_seen: string | null; // ISO timestamp
+  trend: ErrorPageTrendPoint[];
+  variants?: string[]; // distinct message wordings for the same cluster ("Also seen as")
+}
+
+export interface ErrorPageRelatedLink {
+  slug: string;
+  title: string;
+}
+
+/**
+ * A published, operator-approved error-cluster page served to the public
+ * marketing site. This table is a READ-OPTIMISED MIRROR: it only ever holds
+ * rows that an operator explicitly published from the Peacock CMS (pushed via
+ * the secret-guarded internal endpoint). There is no code path from raw
+ * `agent_messages` to this table — that is the trust boundary that keeps
+ * un-curated error data private.
+ */
+@Entity('public_error_pages')
+export class PublicErrorPage {
+  @PrimaryColumn('varchar')
+  slug!: string;
+
+  @Column('varchar')
+  cluster_key!: string;
+
+  @Column('varchar')
+  provider!: string;
+
+  @Column('varchar', { default: '' })
+  provider_label!: string;
+
+  @Column('integer', { nullable: true })
+  http_status!: number | null;
+
+  @Column('varchar', { default: 'unknown' })
+  category!: string;
+
+  @Column('varchar', { default: '' })
+  category_label!: string;
+
+  @Column('varchar')
+  title!: string;
+
+  @Column('varchar')
+  meta_description!: string;
+
+  @Column('varchar')
+  h1!: string;
+
+  @Column('text', { default: '' })
+  body_what!: string;
+
+  @Column('text', { default: '' })
+  body_fix!: string;
+
+  @Column('text', { default: '' })
+  body_manifest!: string;
+
+  @Column('text', { default: '' })
+  sample_message!: string;
+
+  @Column('jsonb')
+  faq!: ErrorPageFaqItem[];
+
+  @Column('jsonb')
+  stats!: ErrorPageStats;
+
+  @Column('jsonb')
+  related!: ErrorPageRelatedLink[];
+
+  @Column('boolean', { default: false })
+  noindex!: boolean;
+
+  @Column(timestampType())
+  published_at!: string;
+
+  @Column(timestampType())
+  updated_at!: string;
+}

--- a/packages/backend/src/error-pages/dto/upsert-error-page.dto.ts
+++ b/packages/backend/src/error-pages/dto/upsert-error-page.dto.ts
@@ -1,0 +1,34 @@
+import { IsArray, IsBoolean, IsInt, IsObject, IsOptional, IsString } from 'class-validator';
+import type {
+  ErrorPageFaqItem,
+  ErrorPageRelatedLink,
+  ErrorPageStats,
+} from '../../entities/public-error-page.entity';
+
+/**
+ * Payload the Peacock CMS pushes to publish (or re-publish/refresh) a page.
+ * The global ValidationPipe runs with whitelist + forbidNonWhitelisted, so every
+ * accepted field must be declared here; nested objects are validated loosely
+ * (the push is a trusted, secret-guarded internal call, and the service
+ * re-scrubs + re-validates the k-anonymity floor defensively).
+ */
+export class UpsertErrorPageDto {
+  @IsString() slug!: string;
+  @IsString() cluster_key!: string;
+  @IsString() provider!: string;
+  @IsOptional() @IsString() provider_label?: string;
+  @IsOptional() @IsInt() http_status?: number | null;
+  @IsOptional() @IsString() category?: string;
+  @IsOptional() @IsString() category_label?: string;
+  @IsString() title!: string;
+  @IsString() meta_description!: string;
+  @IsString() h1!: string;
+  @IsOptional() @IsString() body_what?: string;
+  @IsOptional() @IsString() body_fix?: string;
+  @IsOptional() @IsString() body_manifest?: string;
+  @IsOptional() @IsString() sample_message?: string;
+  @IsOptional() @IsArray() faq?: ErrorPageFaqItem[];
+  @IsObject() stats!: ErrorPageStats;
+  @IsOptional() @IsArray() related?: ErrorPageRelatedLink[];
+  @IsOptional() @IsBoolean() noindex?: boolean;
+}

--- a/packages/backend/src/error-pages/error-cluster-seeder.service.spec.ts
+++ b/packages/backend/src/error-pages/error-cluster-seeder.service.spec.ts
@@ -1,0 +1,122 @@
+import { ErrorClusterSeederService } from './error-cluster-seeder.service';
+
+/**
+ * Build a fake repo whose query-builder chain resolves `getCount()` to the
+ * supplied value, and whose `insert` records every batch it receives.
+ */
+function makeRepo(existingCount: number) {
+  const qb = {
+    where: jest.fn().mockReturnThis(),
+    getCount: jest.fn().mockResolvedValue(existingCount),
+  };
+  const insert = jest.fn().mockResolvedValue(undefined);
+  const repo = {
+    createQueryBuilder: jest.fn().mockReturnValue(qb),
+    insert,
+  };
+  return { repo, qb, insert };
+}
+
+describe('ErrorClusterSeederService', () => {
+  const original = process.env['SEED_DATA'];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env['SEED_DATA'];
+    else process.env['SEED_DATA'] = original;
+    jest.restoreAllMocks();
+  });
+
+  it('returns early without querying when SEED_DATA is unset', async () => {
+    delete process.env['SEED_DATA'];
+    const { repo, insert } = makeRepo(0);
+    const service = new ErrorClusterSeederService(repo as never);
+
+    await service.onModuleInit();
+
+    expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('returns early when SEED_DATA is set to a non-"true" value', async () => {
+    process.env['SEED_DATA'] = 'false';
+    const { repo, insert } = makeRepo(0);
+    const service = new ErrorClusterSeederService(repo as never);
+
+    await service.onModuleInit();
+
+    expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('skips inserting when seed rows already exist', async () => {
+    process.env['SEED_DATA'] = 'true';
+    const { repo, qb, insert } = makeRepo(5);
+    const service = new ErrorClusterSeederService(repo as never);
+
+    await service.onModuleInit();
+
+    expect(qb.where).toHaveBeenCalledWith('m.id LIKE :p', { p: 'seed-err-%' });
+    expect(qb.getCount).toHaveBeenCalledTimes(1);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  describe('full seed run', () => {
+    it('inserts error rows (plus recovered siblings) in batches of 500', async () => {
+      process.env['SEED_DATA'] = 'true';
+      // Make randomness deterministic so both the recentOnly branch and the
+      // recovery-sibling branch are exercised on every spec.
+      jest.spyOn(Math, 'random').mockReturnValue(0.1);
+      const { repo, insert } = makeRepo(0);
+      const service = new ErrorClusterSeederService(repo as never);
+
+      await service.onModuleInit();
+
+      expect(insert).toHaveBeenCalled();
+
+      // Every batch must be <= 500 rows.
+      const batches = insert.mock.calls.map((c) => c[0] as unknown[]);
+      for (const batch of batches) {
+        expect(batch.length).toBeGreaterThan(0);
+        expect(batch.length).toBeLessThanOrEqual(500);
+      }
+
+      const allRows = batches.flat() as Array<Record<string, unknown>>;
+
+      // Error rows carry the seed id prefix and an http status field.
+      const errorRows = allRows.filter((r) => !String(r['id']).endsWith('-ok'));
+      expect(errorRows.length).toBeGreaterThan(0);
+      errorRows.forEach((r) => {
+        expect(String(r['id']).startsWith('seed-err-')).toBe(true);
+        expect(r['agent_id']).toBe('seed-err-agent');
+      });
+
+      // With random=0.1 (< every spec's recovery fraction at made/total≈0), at
+      // least some recovered `ok` siblings are produced sharing the trace.
+      const okRows = allRows.filter((r) => String(r['id']).endsWith('-ok'));
+      expect(okRows.length).toBeGreaterThan(0);
+      okRows.forEach((r) => {
+        expect(r['status']).toBe('ok');
+        expect(r['input_tokens']).toBe(50);
+        expect(r['output_tokens']).toBe(80);
+      });
+    });
+
+    it('omits recovered siblings when randomness exceeds every recovery fraction', async () => {
+      process.env['SEED_DATA'] = 'true';
+      // random=0.99 keeps made/total < recovery false for the very first row of
+      // each spec (recovery max is 0.88), so the recovery branch is skipped.
+      jest.spyOn(Math, 'random').mockReturnValue(0.99);
+      const { repo, insert } = makeRepo(0);
+      const service = new ErrorClusterSeederService(repo as never);
+
+      await service.onModuleInit();
+
+      const allRows = insert.mock.calls.flatMap((c) => c[0] as Array<Record<string, unknown>>);
+      // Some `ok` rows may still appear once made/total climbs, but the first
+      // row of the first spec must be an error with no immediate sibling — the
+      // branch coverage we care about (the `if` evaluating false) is hit.
+      expect(allRows.length).toBeGreaterThan(0);
+      expect(allRows.some((r) => !String(r['id']).endsWith('-ok'))).toBe(true);
+    });
+  });
+});

--- a/packages/backend/src/error-pages/error-cluster-seeder.service.ts
+++ b/packages/backend/src/error-pages/error-cluster-seeder.service.ts
@@ -1,0 +1,226 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AgentMessage } from '../entities/agent-message.entity';
+
+/**
+ * Seeds realistic error `agent_messages` (dev/test only) so the live discovery
+ * endpoint produces real GROUP BY clusters instead of a hardcoded list. Each
+ * spec fans out across `tenants` distinct synthetic tenants with a recovered
+ * fraction (an `ok` sibling sharing the trace) and rotates through several
+ * message `samples` so discovery can surface real "Also seen as" variants.
+ * Idempotent: skips if seed rows already exist (id LIKE 'seed-err-%').
+ */
+interface Spec {
+  key: string;
+  provider: string;
+  http: number | null;
+  status: string;
+  model: string;
+  samples: string[];
+  tenants: number;
+  rowsPerTenant: number;
+  recovery: number;
+  recentOnly?: boolean;
+}
+
+const SPECS: Spec[] = [
+  {
+    key: 'g429',
+    provider: 'gemini',
+    http: 429,
+    status: 'rate_limited',
+    model: 'gemini-2.5-pro',
+    tenants: 120,
+    rowsPerTenant: 6,
+    recovery: 0.74,
+    samples: [
+      '{ "error": { "code": 429, "message": "You exceeded your current quota, please check your plan and billing details.", "status": "RESOURCE_EXHAUSTED" } }',
+      '{ "error": { "code": 429, "message": "Resource has been exhausted (e.g. check quota).", "status": "RESOURCE_EXHAUSTED" } }',
+      'Quota exceeded for quota metric "Generate Content API requests per minute".',
+    ],
+  },
+  {
+    key: 'or404',
+    provider: 'openrouter',
+    http: 404,
+    status: 'error',
+    model: 'anthropic/claude-3.5-sonnet',
+    tenants: 80,
+    rowsPerTenant: 5,
+    recovery: 0.81,
+    samples: [
+      '{"error":{"message":"No endpoints found for the requested model.","code":404}}',
+      '{"error":{"message":"No allowed providers are available for the selected model.","code":404}}',
+    ],
+  },
+  {
+    key: 'or402',
+    provider: 'openrouter',
+    http: 402,
+    status: 'error',
+    model: 'qwen/qwen3-coder:free',
+    tenants: 70,
+    rowsPerTenant: 6,
+    recovery: 0.88,
+    samples: [
+      '{"error":{"message":"Rate limit exceeded: free-models-per-day. Add 10 credits to unlock 1000 free model requests per day.","code":402}}',
+      '{"error":{"message":"Insufficient credits. Add more credits to continue.","code":402}}',
+    ],
+  },
+  {
+    key: 'oa401',
+    provider: 'openai',
+    http: 401,
+    status: 'error',
+    model: 'gpt-4o',
+    tenants: 55,
+    rowsPerTenant: 7,
+    recovery: 0.42,
+    samples: [
+      '{ "error": { "message": "Your authentication token has been invalidated. Please try signing in again.", "type": "invalid_request_error", "code": "invalid_authentication" } }',
+      '{ "error": { "message": "Incorrect API key provided.", "type": "invalid_request_error", "code": "invalid_api_key" } }',
+    ],
+  },
+  {
+    key: 'ds400',
+    provider: 'deepseek',
+    http: 400,
+    status: 'error',
+    model: 'deepseek-reasoner',
+    tenants: 48,
+    rowsPerTenant: 5,
+    recovery: 0.6,
+    samples: [
+      '{"error":{"message":"The reasoning_content in the thinking mode must be passed.","code":400}}',
+      '{"error":{"message":"deepseek-reasoner does not support successive user or assistant messages.","code":400}}',
+    ],
+  },
+  {
+    key: 'zai429',
+    provider: 'zai',
+    http: 429,
+    status: 'rate_limited',
+    model: 'glm-4.6',
+    tenants: 46,
+    rowsPerTenant: 4,
+    recovery: 0.5,
+    samples: [
+      '{"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}',
+    ],
+  },
+  {
+    key: 'g400',
+    provider: 'gemini',
+    http: 400,
+    status: 'error',
+    model: 'gemini-2.5-flash',
+    tenants: 42,
+    rowsPerTenant: 4,
+    recovery: 0.66,
+    samples: [
+      '{ "error": { "code": 400, "message": "Function call is missing a thought_signature in functionCall parts.", "status": "INVALID_ARGUMENT" } }',
+      '{ "error": { "code": 400, "message": "Please ensure that function call turns come immediately after a user turn or after a function response turn.", "status": "INVALID_ARGUMENT" } }',
+    ],
+  },
+  {
+    key: 'g503',
+    provider: 'gemini',
+    http: 503,
+    status: 'error',
+    model: 'gemini-2.5-pro',
+    tenants: 40,
+    rowsPerTenant: 5,
+    recovery: 0.79,
+    recentOnly: true,
+    samples: [
+      '{ "error": { "code": 503, "message": "This model is currently experiencing high demand. Spikes in demand are usually temporary.", "status": "UNAVAILABLE" } }',
+      '{ "error": { "code": 503, "message": "The service is currently unavailable.", "status": "UNAVAILABLE" } }',
+    ],
+  },
+  {
+    key: 'an400',
+    provider: 'anthropic',
+    http: 400,
+    status: 'error',
+    model: 'claude-sonnet-4',
+    tenants: 30,
+    rowsPerTenant: 5,
+    recovery: 0.7,
+    samples: [
+      '{"type":"error","error":{"type":"invalid_request_error","message":"You are out of extra usage. Add more at claude.ai to keep going."}}',
+    ],
+  },
+];
+
+const DAY_MS = 86400000;
+
+@Injectable()
+export class ErrorClusterSeederService implements OnModuleInit {
+  private readonly logger = new Logger(ErrorClusterSeederService.name);
+
+  constructor(
+    @InjectRepository(AgentMessage)
+    private readonly repo: Repository<AgentMessage>,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env['SEED_DATA'] !== 'true') return;
+    const existing = await this.repo
+      .createQueryBuilder('m')
+      .where('m.id LIKE :p', { p: 'seed-err-%' })
+      .getCount();
+    if (existing > 0) return;
+
+    const rows: Partial<AgentMessage>[] = [];
+    const now = Date.now();
+    for (const s of SPECS) {
+      let made = 0;
+      const total = s.tenants * s.rowsPerTenant;
+      for (let t = 0; t < s.tenants; t++) {
+        for (let r = 0; r < s.rowsPerTenant; r++) {
+          const dayOffset = s.recentOnly ? Math.random() * 2 : Math.pow(Math.random(), 1.6) * 30;
+          const tsMs = now - dayOffset * DAY_MS - Math.random() * DAY_MS;
+          const ts = new Date(tsMs).toISOString();
+          const trace = `seed-err-${s.key}-${t}-${r}`;
+          rows.push({
+            id: trace,
+            tenant_id: `seed-err-${s.key}-t${t}`,
+            agent_id: 'seed-err-agent',
+            trace_id: trace,
+            timestamp: ts,
+            status: s.status,
+            error_message: s.samples[(t + r) % s.samples.length],
+            error_http_status: s.http,
+            provider: s.provider,
+            model: s.model,
+            input_tokens: 0,
+            output_tokens: 0,
+          });
+          if (made / total < s.recovery) {
+            rows.push({
+              id: `${trace}-ok`,
+              tenant_id: `seed-err-${s.key}-t${t}`,
+              agent_id: 'seed-err-agent',
+              trace_id: trace,
+              timestamp: new Date(tsMs + 1500).toISOString(),
+              status: 'ok',
+              provider: s.provider,
+              model: s.model,
+              input_tokens: 50,
+              output_tokens: 80,
+            });
+          }
+          made++;
+        }
+      }
+    }
+
+    for (let i = 0; i < rows.length; i += 500) {
+      await this.repo.insert(rows.slice(i, i + 500));
+    }
+    this.logger.log(
+      `Seeded ${rows.length} error/recovery agent_messages across ${SPECS.length} clusters (with message variants)`,
+    );
+  }
+}

--- a/packages/backend/src/error-pages/error-discovery.service.spec.ts
+++ b/packages/backend/src/error-pages/error-discovery.service.spec.ts
@@ -1,0 +1,305 @@
+import { ErrorDiscoveryService } from './error-discovery.service';
+
+type AggRow = {
+  provider: string;
+  http: number | null;
+  volume_30d: number;
+  volume_7d: number;
+  tenants: number;
+  first_seen: string | null;
+  last_seen: string | null;
+  recovery: number | null;
+  sample: string | null;
+};
+
+type TrendRow = { provider: string; http: number | null; day: string; cnt: number };
+
+type VariantRow = { provider: string; http: number | null; msg: string | null; cnt: number };
+
+function makeAgg(overrides: Partial<AggRow> = {}): AggRow {
+  return {
+    provider: 'gemini',
+    http: 429,
+    volume_30d: 400,
+    volume_7d: 100,
+    tenants: 42,
+    first_seen: '2026-05-01T00:00:00.000Z',
+    last_seen: '2026-06-01T00:00:00.000Z',
+    recovery: 0.74,
+    sample: 'quota exceeded',
+    ...overrides,
+  };
+}
+
+describe('ErrorDiscoveryService', () => {
+  let service: ErrorDiscoveryService;
+  let query: jest.Mock;
+
+  beforeEach(() => {
+    query = jest.fn();
+    service = new ErrorDiscoveryService({ query } as never);
+  });
+
+  /** Wire the three sequential `this.repo.query` calls: agg, trend, variants. */
+  function setup(aggRows: AggRow[], trendRows: TrendRow[] = [], variantRows: VariantRow[] = []) {
+    query
+      .mockResolvedValueOnce(aggRows)
+      .mockResolvedValueOnce(trendRows)
+      .mockResolvedValueOnce(variantRows);
+  }
+
+  it('issues exactly three queries (aggregate, trend, variants)', async () => {
+    setup([], []);
+
+    await service.discover();
+
+    expect(query).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns an empty list when there are no clusters', async () => {
+    setup([], []);
+
+    expect(await service.discover()).toEqual([]);
+  });
+
+  describe('categoryFor mapping', () => {
+    const cases: Array<[number | null, string, string]> = [
+      [429, 'rate_limit', 'Rate limit'],
+      [401, 'auth', 'Authentication'],
+      [403, 'auth', 'Authentication'],
+      [402, 'billing', 'Billing / quota'],
+      [404, 'model_unavailable', 'Model unavailable'],
+      [500, 'server', 'Server error'],
+      [503, 'server', 'Server error'],
+      [400, 'bad_request', 'Bad request'],
+      [422, 'bad_request', 'Bad request'],
+      [null, 'unknown', 'Unknown'],
+    ];
+
+    it.each(cases)('maps http %p to category %s', async (http, id, label) => {
+      setup([makeAgg({ http })], []);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.category).toBe(id);
+      expect(cluster.category_label).toBe(label);
+    });
+  });
+
+  describe('cluster_key and suggested_slug', () => {
+    it('builds key as provider|http and a hyphenated slug', async () => {
+      setup([makeAgg({ provider: 'gemini', http: 429 })], []);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.cluster_key).toBe('gemini|429');
+      expect(cluster.suggested_slug).toBe('gemini-429-rate-limit');
+    });
+
+    it('uses |none and -error- in the slug when http is null', async () => {
+      setup([makeAgg({ provider: 'openrouter', http: null })], []);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.cluster_key).toBe('openrouter|none');
+      expect(cluster.suggested_slug).toBe('openrouter-error-unknown');
+    });
+
+    it('replaces all underscores in the category id with hyphens', async () => {
+      setup([makeAgg({ provider: 'openrouter', http: 404 })], []);
+
+      const [cluster] = await service.discover();
+
+      // model_unavailable → model-unavailable
+      expect(cluster.suggested_slug).toBe('openrouter-404-model-unavailable');
+    });
+  });
+
+  describe('numeric coercion and passthrough', () => {
+    it('coerces string-y numbers and passes recovery through', async () => {
+      setup(
+        [
+          makeAgg({
+            http: '429' as unknown as number,
+            tenants: '42' as unknown as number,
+            volume_7d: '100' as unknown as number,
+            volume_30d: '400' as unknown as number,
+            recovery: 0.74,
+          }),
+        ],
+        [],
+      );
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.http_status).toBe(429);
+      expect(cluster.tenants).toBe(42);
+      expect(cluster.volume_7d).toBe(100);
+      expect(cluster.volume_30d).toBe(400);
+      expect(cluster.recovery_rate).toBe(0.74);
+      expect(cluster.first_seen).toBe('2026-05-01T00:00:00.000Z');
+      expect(cluster.last_seen).toBe('2026-06-01T00:00:00.000Z');
+    });
+
+    it('passes a null recovery rate through as null', async () => {
+      setup([makeAgg({ recovery: null })], []);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.recovery_rate).toBeNull();
+    });
+
+    it('preserves null first_seen / last_seen', async () => {
+      setup([makeAgg({ first_seen: null, last_seen: null })], []);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.first_seen).toBeNull();
+      expect(cluster.last_seen).toBeNull();
+    });
+  });
+
+  describe('sample scrubbing', () => {
+    it('scrubs secrets in the sample message', async () => {
+      setup([makeAgg({ sample: 'key=sk-ant-ABCDEF1234567890 boom' })], []);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.sample_message).toContain('[REDACTED]');
+      expect(cluster.sample_message).not.toContain('sk-ant-ABCDEF1234567890');
+    });
+
+    it('treats a null sample as an empty string', async () => {
+      setup([makeAgg({ sample: null })], []);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.sample_message).toBe('');
+    });
+  });
+
+  describe('trend assembly', () => {
+    it('attaches the trend rows matching a cluster key', async () => {
+      setup(
+        [makeAgg({ provider: 'gemini', http: 429 })],
+        [
+          { provider: 'gemini', http: 429, day: '2026-05-30', cnt: 5 },
+          { provider: 'gemini', http: 429, day: '2026-05-31', cnt: 8 },
+          // Different key — must NOT leak into the gemini|429 trend.
+          { provider: 'openai', http: 401, day: '2026-05-31', cnt: 3 },
+        ],
+      );
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.trend).toEqual([
+        { date: '2026-05-30', count: 5 },
+        { date: '2026-05-31', count: 8 },
+      ]);
+    });
+
+    it('assembles a trend keyed by provider|none for null http', async () => {
+      setup(
+        [makeAgg({ provider: 'openrouter', http: null })],
+        [{ provider: 'openrouter', http: null, day: '2026-05-31', cnt: 9 }],
+      );
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.trend).toEqual([{ date: '2026-05-31', count: 9 }]);
+    });
+
+    it('coerces string trend counts to numbers', async () => {
+      setup(
+        [makeAgg({ provider: 'gemini', http: 429 })],
+        [{ provider: 'gemini', http: 429, day: '2026-05-31', cnt: '7' as unknown as number }],
+      );
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.trend).toEqual([{ date: '2026-05-31', count: 7 }]);
+    });
+
+    it('defaults to an empty trend when no trend rows match the key', async () => {
+      setup([makeAgg({ provider: 'gemini', http: 429 })], []);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.trend).toEqual([]);
+    });
+  });
+
+  describe('variants assembly', () => {
+    it('attaches up to 5 distinct scrubbed variants by key, isolating other keys', async () => {
+      const vrows: VariantRow[] = [
+        { provider: 'gemini', http: 429, msg: 'You exceeded your current quota', cnt: 10 },
+        { provider: 'gemini', http: 429, msg: 'Resource has been exhausted', cnt: 8 },
+        { provider: 'gemini', http: 429, msg: 'v3', cnt: 7 },
+        { provider: 'gemini', http: 429, msg: 'v4', cnt: 6 },
+        { provider: 'gemini', http: 429, msg: 'v5', cnt: 5 },
+        { provider: 'gemini', http: 429, msg: 'v6-overflow', cnt: 4 },
+        { provider: 'openai', http: 401, msg: 'other-key', cnt: 9 },
+      ];
+      setup([makeAgg({ provider: 'gemini', http: 429 })], [], vrows);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.variants).toHaveLength(5);
+      expect(cluster.variants).toContain('You exceeded your current quota');
+      expect(cluster.variants).not.toContain('v6-overflow');
+      expect(cluster.variants).not.toContain('other-key');
+    });
+
+    it('scrubs secrets and truncates each variant to 160 chars', async () => {
+      const long = 'x'.repeat(200);
+      setup(
+        [makeAgg({ provider: 'gemini', http: 429 })],
+        [],
+        [{ provider: 'gemini', http: 429, msg: `key=sk-ant-ABCDEF1234567890 ${long}`, cnt: 1 }],
+      );
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.variants[0]).toContain('[REDACTED]');
+      expect(cluster.variants[0].length).toBeLessThanOrEqual(160);
+    });
+
+    it('treats a null variant message as empty and keys by provider|none', async () => {
+      setup(
+        [makeAgg({ provider: 'openrouter', http: null })],
+        [],
+        [{ provider: 'openrouter', http: null, msg: null, cnt: 2 }],
+      );
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.variants).toEqual(['']);
+    });
+
+    it('defaults to empty variants when none match', async () => {
+      setup([makeAgg({ provider: 'gemini', http: 429 })], [], []);
+
+      const [cluster] = await service.discover();
+
+      expect(cluster.variants).toEqual([]);
+    });
+  });
+
+  it('maps multiple clusters preserving aggregate row order', async () => {
+    setup(
+      [
+        makeAgg({ provider: 'gemini', http: 429, tenants: 120 }),
+        makeAgg({ provider: 'openai', http: 401, tenants: 55 }),
+      ],
+      [],
+    );
+
+    const result = await service.discover();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].provider).toBe('gemini');
+    expect(result[0].category).toBe('rate_limit');
+    expect(result[1].provider).toBe('openai');
+    expect(result[1].category).toBe('auth');
+  });
+});

--- a/packages/backend/src/error-pages/error-discovery.service.ts
+++ b/packages/backend/src/error-pages/error-discovery.service.ts
@@ -1,0 +1,169 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AgentMessage } from '../entities/agent-message.entity';
+import { scrubSecrets } from '../common/utils/secret-scrub';
+import { MIN_TENANTS_FOR_PUBLIC } from './error-pages.service';
+
+// A message variant must appear across at least this many distinct tenants
+// before it's surfaced publicly — k-anonymity at the variant level so one
+// customer's exact (possibly identifying) error string is never exposed.
+const MIN_TENANTS_PER_VARIANT = 3;
+
+// Public-facing scrub: provider-credential redaction (shared util) PLUS email
+// redaction. Error bodies sometimes echo a user's email; strip it before any
+// sample/variant leaves the building.
+const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+function scrubForPublic(text: string | null | undefined): string {
+  return scrubSecrets(text ?? '').replace(EMAIL_RE, '[email]');
+}
+
+export interface DiscoveredCluster {
+  cluster_key: string;
+  provider: string;
+  http_status: number | null;
+  category: string;
+  category_label: string;
+  suggested_slug: string;
+  tenants: number;
+  volume_7d: number;
+  volume_30d: number;
+  recovery_rate: number | null;
+  first_seen: string | null;
+  last_seen: string | null;
+  sample_message: string;
+  variants: string[];
+  trend: { date: string; count: number }[];
+}
+
+function categoryFor(http: number | null): { id: string; label: string } {
+  if (http === 429) return { id: 'rate_limit', label: 'Rate limit' };
+  if (http === 401 || http === 403) return { id: 'auth', label: 'Authentication' };
+  if (http === 402) return { id: 'billing', label: 'Billing / quota' };
+  if (http === 404) return { id: 'model_unavailable', label: 'Model unavailable' };
+  if (http != null && http >= 500) return { id: 'server', label: 'Server error' };
+  if (http != null && http >= 400) return { id: 'bad_request', label: 'Bad request' };
+  return { id: 'unknown', label: 'Unknown' };
+}
+
+/**
+ * Computes error-cluster aggregates live from `agent_messages` (cross-tenant).
+ * This is the rollup the Peacock CMS pulls from to discover and refresh clusters.
+ * Aggregates only — never returns tenant identities — and applies the same
+ * k-anonymity floor as publishing, so a cluster below the floor is never
+ * surfaced for curation in the first place.
+ */
+@Injectable()
+export class ErrorDiscoveryService {
+  constructor(
+    @InjectRepository(AgentMessage)
+    private readonly repo: Repository<AgentMessage>,
+  ) {}
+
+  async discover(): Promise<DiscoveredCluster[]> {
+    const aggRows: Array<{
+      provider: string;
+      http: number | null;
+      volume_30d: number;
+      volume_7d: number;
+      tenants: number;
+      first_seen: string | null;
+      last_seen: string | null;
+      recovery: number | null;
+      sample: string | null;
+    }> = await this.repo.query(`
+      SELECT e.provider AS provider,
+             e.error_http_status AS http,
+             COUNT(*)::int AS volume_30d,
+             COUNT(*) FILTER (WHERE e.timestamp >= NOW() - INTERVAL '7 days')::int AS volume_7d,
+             COUNT(DISTINCT e.tenant_id)::int AS tenants,
+             MIN(e.timestamp) AS first_seen,
+             MAX(e.timestamp) AS last_seen,
+             AVG(CASE WHEN ok.trace_id IS NOT NULL THEN 1.0 ELSE 0.0 END)::float AS recovery,
+             (array_agg(e.error_message ORDER BY e.timestamp DESC))[1] AS sample
+      FROM agent_messages e
+      LEFT JOIN (
+        SELECT DISTINCT trace_id FROM agent_messages WHERE status = 'ok' AND trace_id IS NOT NULL
+      ) ok ON ok.trace_id = e.trace_id
+      WHERE e.status IN ('error','fallback_error','rate_limited')
+        AND e.tenant_id IS NOT NULL
+        AND e.provider IS NOT NULL
+        AND e.provider NOT LIKE 'custom:%'
+      GROUP BY e.provider, e.error_http_status
+      HAVING COUNT(DISTINCT e.tenant_id) >= ${MIN_TENANTS_FOR_PUBLIC}
+      ORDER BY COUNT(DISTINCT e.tenant_id) DESC
+    `);
+
+    const trendRows: Array<{ provider: string; http: number | null; day: string; cnt: number }> =
+      await this.repo.query(`
+        SELECT e.provider AS provider,
+               e.error_http_status AS http,
+               to_char(date_trunc('day', e.timestamp), 'YYYY-MM-DD') AS day,
+               COUNT(*)::int AS cnt
+        FROM agent_messages e
+        WHERE e.status IN ('error','fallback_error','rate_limited')
+          AND e.timestamp >= NOW() - INTERVAL '14 days'
+          AND e.provider IS NOT NULL
+          AND e.provider NOT LIKE 'custom:%'
+        GROUP BY e.provider, e.error_http_status, day
+        ORDER BY day ASC
+      `);
+
+    const trendByKey = new Map<string, { date: string; count: number }[]>();
+    for (const r of trendRows) {
+      const key = `${r.provider}|${r.http ?? 'none'}`;
+      if (!trendByKey.has(key)) trendByKey.set(key, []);
+      trendByKey.get(key)!.push({ date: r.day, count: Number(r.cnt) });
+    }
+
+    // Top distinct message strings per cluster — powers the "Also seen as"
+    // block, widening lexical coverage to the variant wordings users search.
+    const variantRows: Array<{ provider: string; http: number | null; msg: string; cnt: number }> =
+      await this.repo.query(`
+        SELECT e.provider AS provider,
+               e.error_http_status AS http,
+               e.error_message AS msg,
+               COUNT(*)::int AS cnt
+        FROM agent_messages e
+        WHERE e.status IN ('error','fallback_error','rate_limited')
+          AND e.error_message IS NOT NULL
+          AND e.tenant_id IS NOT NULL
+          AND e.provider IS NOT NULL
+          AND e.provider NOT LIKE 'custom:%'
+        GROUP BY e.provider, e.error_http_status, e.error_message
+        HAVING COUNT(DISTINCT e.tenant_id) >= ${MIN_TENANTS_PER_VARIANT}
+        ORDER BY cnt DESC
+      `);
+
+    const variantsByKey = new Map<string, string[]>();
+    for (const r of variantRows) {
+      const key = `${r.provider}|${r.http ?? 'none'}`;
+      if (!variantsByKey.has(key)) variantsByKey.set(key, []);
+      const list = variantsByKey.get(key)!;
+      if (list.length < 5) list.push(scrubForPublic(r.msg).slice(0, 160));
+    }
+
+    return aggRows.map((r) => {
+      const http = r.http != null ? Number(r.http) : null;
+      const cat = categoryFor(http);
+      const key = `${r.provider}|${http ?? 'none'}`;
+      return {
+        cluster_key: key,
+        provider: r.provider,
+        http_status: http,
+        category: cat.id,
+        category_label: cat.label,
+        suggested_slug: `${r.provider}-${http ?? 'error'}-${cat.id.replace(/_/g, '-')}`,
+        tenants: Number(r.tenants),
+        volume_7d: Number(r.volume_7d),
+        volume_30d: Number(r.volume_30d),
+        recovery_rate: r.recovery != null ? Number(r.recovery) : null,
+        first_seen: r.first_seen,
+        last_seen: r.last_seen,
+        sample_message: scrubForPublic(r.sample),
+        variants: variantsByKey.get(key) ?? [],
+        trend: trendByKey.get(key) ?? [],
+      };
+    });
+  }
+}

--- a/packages/backend/src/error-pages/error-page-seed-data.spec.ts
+++ b/packages/backend/src/error-pages/error-page-seed-data.spec.ts
@@ -1,0 +1,48 @@
+import { ERROR_PAGE_SEEDS, seedTrend } from './error-page-seed-data';
+import { MIN_TENANTS_FOR_PUBLIC } from './error-pages.service';
+
+describe('seedTrend', () => {
+  const END = Date.UTC(2026, 6, 1); // 2026-07-01
+
+  it('returns 14 ascending daily points ending on the end date, never zero', () => {
+    const trend = seedTrend(720, 0, END);
+    expect(trend).toHaveLength(14);
+    expect(trend[0].date).toBe('2026-06-18');
+    expect(trend[13].date).toBe('2026-07-01');
+    for (const p of trend) expect(p.count).toBeGreaterThanOrEqual(1);
+    const dates = trend.map((p) => p.date);
+    expect([...dates].sort()).toEqual(dates); // already ascending
+  });
+
+  it('is deterministic and scales with volume + salt', () => {
+    expect(seedTrend(720, 0, END)).toEqual(seedTrend(720, 0, END));
+    const big = seedTrend(3000, 1, END).reduce((a, p) => a + p.count, 0);
+    const small = seedTrend(300, 1, END).reduce((a, p) => a + p.count, 0);
+    expect(big).toBeGreaterThan(small);
+  });
+
+  it('still emits a non-zero line for a tiny volume', () => {
+    const trend = seedTrend(1, 3, END);
+    expect(trend).toHaveLength(14);
+    for (const p of trend) expect(p.count).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('ERROR_PAGE_SEEDS', () => {
+  it('has unique slugs, each prefixed with its provider, above the k-anon floor', () => {
+    const slugs = ERROR_PAGE_SEEDS.map((s) => s.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+    for (const s of ERROR_PAGE_SEEDS) {
+      expect(s.slug.startsWith(`${s.provider}-`)).toBe(true);
+      expect(s.tenants).toBeGreaterThanOrEqual(MIN_TENANTS_FOR_PUBLIC);
+      expect(s.http_status).toBeGreaterThan(0);
+      expect(s.category).toBeTruthy();
+      expect(s.title).toBeTruthy();
+    }
+  });
+
+  it('covers several providers and categories for rich hubs', () => {
+    expect(new Set(ERROR_PAGE_SEEDS.map((s) => s.provider)).size).toBeGreaterThanOrEqual(4);
+    expect(new Set(ERROR_PAGE_SEEDS.map((s) => s.category)).size).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/backend/src/error-pages/error-page-seed-data.ts
+++ b/packages/backend/src/error-pages/error-page-seed-data.ts
@@ -1,0 +1,410 @@
+import type { ErrorPageTrendPoint } from '../entities/public-error-page.entity';
+
+/**
+ * Curated demo error pages published on boot (dev/test only) so the public
+ * `/errors/` catalog on the marketing site has a full, chart-rich set to render
+ * without a live Peacock CMS. Each entry is published through the same
+ * `ErrorPagesService.upsert` valve as a real CMS push, so the k-anonymity floor
+ * and secret/email scrub still apply. Content is illustrative, not real tenant
+ * data — `tenants`/`volume_*` are plausible aggregates and every `sample_message`
+ * is a public, provider-documented error shape.
+ */
+export interface ErrorPageSeed {
+  slug: string;
+  cluster_key: string;
+  provider: string;
+  provider_label: string;
+  http_status: number;
+  category: string;
+  category_label: string;
+  title: string;
+  meta_description: string;
+  h1: string;
+  body_what: string;
+  body_fix: string;
+  sample_message: string;
+  faq: { q: string; a: string }[];
+  tenants: number;
+  volume_7d: number;
+  volume_30d: number;
+  recovery_rate: number;
+  variants?: string[];
+}
+
+const DAY_MS = 86400000;
+const TREND_DAYS = 14;
+
+/**
+ * Build a 14-day occurrence sparkline that sums to roughly the 30-day volume,
+ * with a gentle upward ramp and a deterministic wave (so the demo chart looks
+ * alive without random noise, and tests stay stable). Never emits a zero day,
+ * so the line always renders.
+ */
+export function seedTrend(volume30d: number, salt: number, endMs: number): ErrorPageTrendPoint[] {
+  const perDay = Math.max(1, Math.round(volume30d / 30));
+  const start = endMs - (TREND_DAYS - 1) * DAY_MS;
+  const points: ErrorPageTrendPoint[] = [];
+  for (let d = 0; d < TREND_DAYS; d++) {
+    const wave = 0.7 + 0.6 * Math.abs(Math.sin((d + salt) * 0.6));
+    const ramp = 0.6 + (0.8 * d) / (TREND_DAYS - 1);
+    const count = Math.max(1, Math.round(perDay * wave * ramp));
+    points.push({ date: new Date(start + d * DAY_MS).toISOString().slice(0, 10), count });
+  }
+  return points;
+}
+
+export const ERROR_PAGE_SEEDS: ErrorPageSeed[] = [
+  {
+    slug: 'gemini-429-quota-exceeded',
+    cluster_key: 'gemini|rate_limited|429|RESOURCE_EXHAUSTED',
+    provider: 'gemini',
+    provider_label: 'Google Gemini',
+    http_status: 429,
+    category: 'rate_limit',
+    category_label: 'Rate limit',
+    title: 'Fix Gemini 429 "You exceeded your current quota"',
+    meta_description:
+      'Why Google Gemini returns 429 RESOURCE_EXHAUSTED across AI agents and how to stop it breaking runs.',
+    h1: 'Gemini 429 — You exceeded your current quota',
+    body_what:
+      'Gemini returns HTTP 429 with RESOURCE_EXHAUSTED when a project crosses its per-minute or per-day quota. Bursty agent loops hit it first.',
+    body_fix:
+      '- Back off and retry with exponential jitter\n- Request a quota increase in Google AI Studio\n- Spread load across keys or fall back to another model',
+    sample_message:
+      '{ "error": { "code": 429, "message": "You exceeded your current quota, please check your plan and billing details.", "status": "RESOURCE_EXHAUSTED" } }',
+    faq: [
+      {
+        q: 'Is a Gemini 429 the same as being rate limited?',
+        a: 'Yes. RESOURCE_EXHAUSTED means you hit a per-minute or per-day quota; it clears once the window resets.',
+      },
+    ],
+    tenants: 120,
+    volume_7d: 297,
+    volume_30d: 720,
+    recovery_rate: 0.74,
+    variants: [
+      'Resource has been exhausted (e.g. check quota).',
+      'Quota exceeded for quota metric "Generate Content API requests per minute".',
+    ],
+  },
+  {
+    slug: 'gemini-400-missing-thought-signature',
+    cluster_key: 'gemini|error|400|INVALID_ARGUMENT',
+    provider: 'gemini',
+    provider_label: 'Google Gemini',
+    http_status: 400,
+    category: 'bad_request',
+    category_label: 'Bad request',
+    title: 'Fix Gemini 400 "missing thought_signature" in function calls',
+    meta_description:
+      'Gemini 2.5 rejects tool calls that drop the thought_signature. Here is why and how to keep function calling working.',
+    h1: 'Gemini 400 — Function call missing a thought_signature',
+    body_what:
+      'Gemini 2.5 returns 400 INVALID_ARGUMENT when a functionCall part is replayed without the thought_signature it originally issued.',
+    body_fix:
+      '- Preserve thought_signature on every functionCall part you send back\n- Keep function turns immediately after the matching user or tool turn\n- Do not hand-edit or truncate prior tool messages',
+    sample_message:
+      '{ "error": { "code": 400, "message": "Function call is missing a thought_signature in functionCall parts.", "status": "INVALID_ARGUMENT" } }',
+    faq: [
+      {
+        q: 'Why did this start after upgrading to Gemini 2.5?',
+        a: 'Thought signatures are new to 2.5 thinking models; older clients that strip unknown fields drop them and trigger the 400.',
+      },
+    ],
+    tenants: 42,
+    volume_7d: 61,
+    volume_30d: 168,
+    recovery_rate: 0.66,
+  },
+  {
+    slug: 'gemini-503-overloaded',
+    cluster_key: 'gemini|error|503|UNAVAILABLE',
+    provider: 'gemini',
+    provider_label: 'Google Gemini',
+    http_status: 503,
+    category: 'server',
+    category_label: 'Server error',
+    title: 'Fix Gemini 503 "model is overloaded / UNAVAILABLE"',
+    meta_description:
+      'Gemini 503 UNAVAILABLE spikes when demand surges. How to ride it out without failing agent runs.',
+    h1: 'Gemini 503 — The model is currently overloaded',
+    body_what:
+      'A 503 UNAVAILABLE is server-side: Gemini is briefly saturated. It is transient but clusters during peak hours.',
+    body_fix:
+      '- Retry after a short delay with backoff\n- Fail over to a second model on repeated 503s\n- Avoid hammering the same region during a spike',
+    sample_message:
+      '{ "error": { "code": 503, "message": "The model is currently experiencing high demand. Spikes in demand are usually temporary.", "status": "UNAVAILABLE" } }',
+    faq: [
+      {
+        q: 'Is a 503 my fault?',
+        a: 'No. It is a temporary capacity issue on the provider; a retry or fallback usually succeeds within seconds.',
+      },
+    ],
+    tenants: 40,
+    volume_7d: 96,
+    volume_30d: 150,
+    recovery_rate: 0.79,
+  },
+  {
+    slug: 'openai-401-invalid-authentication',
+    cluster_key: 'openai|error|401|invalid_authentication',
+    provider: 'openai',
+    provider_label: 'OpenAI',
+    http_status: 401,
+    category: 'auth',
+    category_label: 'Authentication',
+    title: 'Fix OpenAI 401 "invalid authentication" / bad API key',
+    meta_description:
+      'OpenAI 401 invalid_authentication means the key is missing, wrong, or revoked. How to find and fix it fast.',
+    h1: 'OpenAI 401 — Invalid authentication',
+    body_what:
+      'OpenAI returns 401 when the API key is missing, malformed, revoked, or scoped to the wrong org or project.',
+    body_fix:
+      '- Confirm the Authorization: Bearer header carries a current key\n- Rotate the key if it may be leaked or revoked\n- Check the org and project the key is scoped to',
+    sample_message:
+      '{ "error": { "message": "Your authentication token has been invalidated. Please try signing in again.", "type": "invalid_request_error", "code": "invalid_authentication" } }',
+    faq: [
+      {
+        q: 'Why did a working key suddenly 401?',
+        a: 'Keys 401 the moment they are rotated or revoked, or if the project they belong to is deleted.',
+      },
+    ],
+    tenants: 55,
+    volume_7d: 120,
+    volume_30d: 385,
+    recovery_rate: 0.42,
+    variants: ['Incorrect API key provided.'],
+  },
+  {
+    slug: 'openai-429-rate-limit',
+    cluster_key: 'openai|rate_limited|429|rate_limit_exceeded',
+    provider: 'openai',
+    provider_label: 'OpenAI',
+    http_status: 429,
+    category: 'rate_limit',
+    category_label: 'Rate limit',
+    title: 'Fix OpenAI 429 "rate limit exceeded"',
+    meta_description:
+      'OpenAI 429s cap requests-per-minute and tokens-per-minute. How to smooth bursts so agents keep running.',
+    h1: 'OpenAI 429 — Rate limit exceeded',
+    body_what:
+      'OpenAI throttles by requests-per-minute and tokens-per-minute per model. Parallel agent calls trip it in bursts.',
+    body_fix:
+      '- Honor the Retry-After header before retrying\n- Add client-side concurrency limits\n- Request a higher tier or split traffic across models',
+    sample_message:
+      '{ "error": { "message": "Rate limit reached for requests. Limit 3500 per min.", "type": "requests", "code": "rate_limit_exceeded" } }',
+    faq: [
+      {
+        q: 'RPM or TPM — which limit am I hitting?',
+        a: 'The error names it: "requests" is per-minute request cap, "tokens" is per-minute token cap.',
+      },
+    ],
+    tenants: 68,
+    volume_7d: 210,
+    volume_30d: 540,
+    recovery_rate: 0.7,
+  },
+  {
+    slug: 'openai-400-context-length-exceeded',
+    cluster_key: 'openai|error|400|context_length_exceeded',
+    provider: 'openai',
+    provider_label: 'OpenAI',
+    http_status: 400,
+    category: 'bad_request',
+    category_label: 'Bad request',
+    title: 'Fix OpenAI 400 "context length exceeded"',
+    meta_description:
+      "OpenAI 400 context_length_exceeded means the prompt plus completion is over the model's window. How to trim it.",
+    h1: 'OpenAI 400 — Context length exceeded',
+    body_what:
+      "A 400 context_length_exceeded fires when input tokens plus max_tokens exceed the model's context window.",
+    body_fix:
+      '- Trim or summarize history before sending\n- Lower max_tokens to leave room for the prompt\n- Move to a longer-context model for big inputs',
+    sample_message:
+      '{ "error": { "message": "This model\'s maximum context length is 128000 tokens.", "type": "invalid_request_error", "code": "context_length_exceeded" } }',
+    faq: [
+      {
+        q: 'Does max_tokens count toward the limit?',
+        a: 'Yes. The window must fit prompt tokens plus the completion you reserve with max_tokens.',
+      },
+    ],
+    tenants: 34,
+    volume_7d: 70,
+    volume_30d: 210,
+    recovery_rate: 0.88,
+  },
+  {
+    slug: 'anthropic-400-out-of-extra-usage',
+    cluster_key: 'anthropic|error|400|invalid_request_error',
+    provider: 'anthropic',
+    provider_label: 'Anthropic',
+    http_status: 400,
+    category: 'bad_request',
+    category_label: 'Bad request',
+    title: 'Fix Anthropic "you are out of extra usage"',
+    meta_description:
+      'Claude returns a 400 invalid_request_error when a plan runs out of extra usage. What it means and how to keep going.',
+    h1: 'Anthropic 400 — You are out of extra usage',
+    body_what:
+      'Claude rejects the request when the account has spent its included plus extra usage allowance for the period.',
+    body_fix:
+      '- Add or raise the extra usage limit at claude.ai\n- Switch that agent to an API-key provider with credit\n- Fall back to a cheaper model for low-stakes calls',
+    sample_message:
+      '{ "type": "error", "error": { "type": "invalid_request_error", "message": "You are out of extra usage. Add more at claude.ai to keep going." } }',
+    faq: [
+      {
+        q: 'Is this a billing or a rate error?',
+        a: 'Billing. It clears when you raise the usage cap or the billing period resets, not by retrying.',
+      },
+    ],
+    tenants: 30,
+    volume_7d: 66,
+    volume_30d: 150,
+    recovery_rate: 0.7,
+  },
+  {
+    slug: 'anthropic-529-overloaded',
+    cluster_key: 'anthropic|error|529|overloaded_error',
+    provider: 'anthropic',
+    provider_label: 'Anthropic',
+    http_status: 529,
+    category: 'server',
+    category_label: 'Server error',
+    title: 'Fix Anthropic 529 "overloaded_error"',
+    meta_description:
+      'Claude 529 overloaded_error means the API is briefly saturated. How to retry and fail over cleanly.',
+    h1: 'Anthropic 529 — Overloaded',
+    body_what:
+      'A 529 overloaded_error is server-side back-pressure from Anthropic during demand spikes. It is transient.',
+    body_fix:
+      '- Retry with exponential backoff and jitter\n- Fail over to another provider on repeated 529s\n- Cap concurrency during known peak windows',
+    sample_message:
+      '{ "type": "error", "error": { "type": "overloaded_error", "message": "Overloaded" } }',
+    faq: [
+      {
+        q: 'Why 529 and not 503?',
+        a: 'Anthropic uses 529 specifically for capacity overload; treat it like a retryable 503.',
+      },
+    ],
+    tenants: 26,
+    volume_7d: 72,
+    volume_30d: 96,
+    recovery_rate: 0.83,
+  },
+  {
+    slug: 'openrouter-402-insufficient-credits',
+    cluster_key: 'openrouter|error|402|insufficient_credits',
+    provider: 'openrouter',
+    provider_label: 'OpenRouter',
+    http_status: 402,
+    category: 'billing',
+    category_label: 'Billing / quota',
+    title: 'Fix OpenRouter 402 "insufficient credits"',
+    meta_description:
+      'OpenRouter 402 means the account or free tier is out of credits. How to top up or route around it.',
+    h1: 'OpenRouter 402 — Insufficient credits',
+    body_what:
+      'OpenRouter returns 402 when paid credits run out, or when a free model exhausts its daily allowance.',
+    body_fix:
+      '- Top up credits on the OpenRouter dashboard\n- Route free-tier traffic to a key-backed provider\n- Watch the free-models-per-day cap in agent loops',
+    sample_message:
+      '{ "error": { "message": "Rate limit exceeded: free-models-per-day. Add 10 credits to unlock 1000 free model requests per day.", "code": 402 } }',
+    faq: [
+      {
+        q: 'Why a 402 on a free model?',
+        a: 'Free models share a daily request cap; once spent, OpenRouter returns 402 until you add credits or the day resets.',
+      },
+    ],
+    tenants: 70,
+    volume_7d: 150,
+    volume_30d: 420,
+    recovery_rate: 0.88,
+  },
+  {
+    slug: 'openrouter-404-model-not-found',
+    cluster_key: 'openrouter|error|404|no_endpoints',
+    provider: 'openrouter',
+    provider_label: 'OpenRouter',
+    http_status: 404,
+    category: 'model_unavailable',
+    category_label: 'Model unavailable',
+    title: 'Fix OpenRouter 404 "no endpoints found for model"',
+    meta_description:
+      'OpenRouter 404 means the requested model id has no available provider right now. How to pick a live one.',
+    h1: 'OpenRouter 404 — No endpoints found for model',
+    body_what:
+      'A 404 means the model slug is wrong, deprecated, or every provider behind it is temporarily unavailable.',
+    body_fix:
+      '- Verify the exact model id against the OpenRouter models list\n- Drop provider filters that exclude every endpoint\n- Fall back to an equivalent model that is live',
+    sample_message:
+      '{ "error": { "message": "No endpoints found for the requested model.", "code": 404 } }',
+    faq: [
+      {
+        q: 'The model existed yesterday — why 404 now?',
+        a: 'Models get deprecated or briefly lose all providers; pin to a current id or add a fallback.',
+      },
+    ],
+    tenants: 80,
+    volume_7d: 130,
+    volume_30d: 400,
+    recovery_rate: 0.81,
+  },
+  {
+    slug: 'deepseek-400-reasoning-content-required',
+    cluster_key: 'deepseek|error|400|reasoning_content',
+    provider: 'deepseek',
+    provider_label: 'DeepSeek',
+    http_status: 400,
+    category: 'bad_request',
+    category_label: 'Bad request',
+    title: 'Fix DeepSeek 400 "reasoning_content must be passed"',
+    meta_description:
+      'DeepSeek reasoner rejects turns that drop reasoning_content or stack same-role messages. How to shape the request.',
+    h1: 'DeepSeek 400 — reasoning_content must be passed',
+    body_what:
+      'deepseek-reasoner requires the prior reasoning_content on follow-up turns and rejects successive same-role messages.',
+    body_fix:
+      '- Echo the assistant reasoning_content back on the next turn\n- Never send two user or two assistant messages in a row\n- Strip reasoning_content only for non-reasoner models',
+    sample_message:
+      '{ "error": { "message": "The reasoning_content in the thinking mode must be passed.", "code": 400 } }',
+    faq: [
+      {
+        q: 'Do normal chat models need reasoning_content?',
+        a: 'No. Only the reasoner enforces it; sending it to a plain chat model can itself error.',
+      },
+    ],
+    tenants: 48,
+    volume_7d: 96,
+    volume_30d: 240,
+    recovery_rate: 0.6,
+  },
+  {
+    slug: 'groq-429-rate-limit',
+    cluster_key: 'groq|rate_limited|429|rate_limit_exceeded',
+    provider: 'groq',
+    provider_label: 'Groq',
+    http_status: 429,
+    category: 'rate_limit',
+    category_label: 'Rate limit',
+    title: 'Fix Groq 429 "rate limit exceeded"',
+    meta_description:
+      'Groq 429s cap requests and tokens per minute per model. How to pace bursts so agents keep flowing.',
+    h1: 'Groq 429 — Rate limit exceeded',
+    body_what:
+      'Groq enforces tight per-minute request and token limits per model; fast agent loops hit them in bursts.',
+    body_fix:
+      '- Wait for the window in the Retry-After header\n- Throttle concurrency on the client\n- Spread load across models or request a limit bump',
+    sample_message:
+      '{ "error": { "message": "Rate limit reached for model llama-3.3-70b in organization on tokens per minute (TPM).", "code": "rate_limit_exceeded", "type": "tokens" } }',
+    faq: [
+      {
+        q: 'Why does Groq rate limit so aggressively?',
+        a: 'Its very high throughput comes with tight per-minute caps; pacing and fallbacks keep runs alive.',
+      },
+    ],
+    tenants: 38,
+    volume_7d: 140,
+    volume_30d: 300,
+    recovery_rate: 0.76,
+  },
+];

--- a/packages/backend/src/error-pages/error-page-seeder.service.spec.ts
+++ b/packages/backend/src/error-pages/error-page-seeder.service.spec.ts
@@ -1,0 +1,53 @@
+import { ErrorPageSeederService } from './error-page-seeder.service';
+import { ErrorPagesService } from './error-pages.service';
+import { ERROR_PAGE_SEEDS } from './error-page-seed-data';
+
+describe('ErrorPageSeederService', () => {
+  let pages: { getBySlug: jest.Mock; upsert: jest.Mock };
+  let service: ErrorPageSeederService;
+  const prev = process.env['SEED_DATA'];
+
+  beforeEach(() => {
+    pages = {
+      getBySlug: jest.fn().mockResolvedValue(null),
+      upsert: jest.fn().mockResolvedValue({ ok: true }),
+    };
+    service = new ErrorPageSeederService(pages as unknown as ErrorPagesService);
+  });
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env['SEED_DATA'];
+    else process.env['SEED_DATA'] = prev;
+  });
+
+  it('does nothing unless SEED_DATA=true', async () => {
+    delete process.env['SEED_DATA'];
+    await service.onModuleInit();
+    expect(pages.getBySlug).not.toHaveBeenCalled();
+    expect(pages.upsert).not.toHaveBeenCalled();
+  });
+
+  it('skips when the demo pages are already published', async () => {
+    process.env['SEED_DATA'] = 'true';
+    pages.getBySlug.mockResolvedValue({ slug: ERROR_PAGE_SEEDS[0].slug });
+    await service.onModuleInit();
+    expect(pages.upsert).not.toHaveBeenCalled();
+  });
+
+  it('publishes every demo page with a populated 14-day trend when not yet seeded', async () => {
+    process.env['SEED_DATA'] = 'true';
+    await service.onModuleInit();
+    expect(pages.upsert).toHaveBeenCalledTimes(ERROR_PAGE_SEEDS.length);
+    const first = pages.upsert.mock.calls[0][0];
+    expect(first.slug).toBe(ERROR_PAGE_SEEDS[0].slug);
+    expect(first.stats.tenants).toBe(ERROR_PAGE_SEEDS[0].tenants);
+    expect(first.stats.trend).toHaveLength(14);
+    expect(first.stats.variants).toEqual(ERROR_PAGE_SEEDS[0].variants ?? []);
+    expect(first.stats.last_seen).toBeTruthy();
+    // an entry without explicit variants still publishes a [] variants array
+    const noVariant = pages.upsert.mock.calls
+      .map((c) => c[0])
+      .find((d) => d.slug === 'gemini-400-missing-thought-signature');
+    expect(noVariant.stats.variants).toEqual([]);
+  });
+});

--- a/packages/backend/src/error-pages/error-page-seeder.service.ts
+++ b/packages/backend/src/error-pages/error-page-seeder.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ErrorPagesService } from './error-pages.service';
+import { ERROR_PAGE_SEEDS, seedTrend } from './error-page-seed-data';
+import type { ErrorPageStats } from '../entities/public-error-page.entity';
+
+/**
+ * Publishes the curated demo error pages (dev/test only) through the same
+ * `ErrorPagesService.upsert` valve a real Peacock CMS push uses — so the
+ * marketing `/errors/` catalog renders a full, chart-rich set (sparkline trends
+ * included) without a live CMS. Gated by `SEED_DATA=true`; idempotent (skips if
+ * the first demo page is already published, so an operator can unpublish freely).
+ */
+@Injectable()
+export class ErrorPageSeederService implements OnModuleInit {
+  private readonly logger = new Logger(ErrorPageSeederService.name);
+
+  constructor(private readonly pages: ErrorPagesService) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env['SEED_DATA'] !== 'true') return;
+    if (await this.pages.getBySlug(ERROR_PAGE_SEEDS[0].slug)) return;
+
+    const now = Date.now();
+    const nowIso = new Date(now).toISOString();
+    for (let i = 0; i < ERROR_PAGE_SEEDS.length; i++) {
+      const s = ERROR_PAGE_SEEDS[i];
+      const stats: ErrorPageStats = {
+        tenants: s.tenants,
+        volume_7d: s.volume_7d,
+        volume_30d: s.volume_30d,
+        recovery_rate: s.recovery_rate,
+        last_seen: nowIso,
+        trend: seedTrend(s.volume_30d, i, now),
+        variants: s.variants ?? [],
+      };
+      await this.pages.upsert({
+        slug: s.slug,
+        cluster_key: s.cluster_key,
+        provider: s.provider,
+        provider_label: s.provider_label,
+        http_status: s.http_status,
+        category: s.category,
+        category_label: s.category_label,
+        title: s.title,
+        meta_description: s.meta_description,
+        h1: s.h1,
+        body_what: s.body_what,
+        body_fix: s.body_fix,
+        sample_message: s.sample_message,
+        faq: s.faq,
+        stats,
+      });
+    }
+    this.logger.log(`Seeded ${ERROR_PAGE_SEEDS.length} public error pages (dev demo, with trends)`);
+  }
+}

--- a/packages/backend/src/error-pages/error-pages.module.ts
+++ b/packages/backend/src/error-pages/error-pages.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PublicErrorPage } from '../entities/public-error-page.entity';
+import { AgentMessage } from '../entities/agent-message.entity';
+import { ErrorPagesService } from './error-pages.service';
+import { ErrorDiscoveryService } from './error-discovery.service';
+import { ErrorClusterSeederService } from './error-cluster-seeder.service';
+import { PublicErrorPagesController } from './public-error-pages.controller';
+import { InternalErrorPagesController } from './internal-error-pages.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PublicErrorPage, AgentMessage])],
+  controllers: [PublicErrorPagesController, InternalErrorPagesController],
+  providers: [ErrorPagesService, ErrorDiscoveryService, ErrorClusterSeederService],
+})
+export class ErrorPagesModule {}

--- a/packages/backend/src/error-pages/error-pages.module.ts
+++ b/packages/backend/src/error-pages/error-pages.module.ts
@@ -5,12 +5,18 @@ import { AgentMessage } from '../entities/agent-message.entity';
 import { ErrorPagesService } from './error-pages.service';
 import { ErrorDiscoveryService } from './error-discovery.service';
 import { ErrorClusterSeederService } from './error-cluster-seeder.service';
+import { ErrorPageSeederService } from './error-page-seeder.service';
 import { PublicErrorPagesController } from './public-error-pages.controller';
 import { InternalErrorPagesController } from './internal-error-pages.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([PublicErrorPage, AgentMessage])],
   controllers: [PublicErrorPagesController, InternalErrorPagesController],
-  providers: [ErrorPagesService, ErrorDiscoveryService, ErrorClusterSeederService],
+  providers: [
+    ErrorPagesService,
+    ErrorDiscoveryService,
+    ErrorClusterSeederService,
+    ErrorPageSeederService,
+  ],
 })
 export class ErrorPagesModule {}

--- a/packages/backend/src/error-pages/error-pages.service.spec.ts
+++ b/packages/backend/src/error-pages/error-pages.service.spec.ts
@@ -1,0 +1,237 @@
+import { BadRequestException } from '@nestjs/common';
+import { ErrorPagesService, MIN_TENANTS_FOR_PUBLIC } from './error-pages.service';
+import type { PublicErrorPage, ErrorPageStats } from '../entities/public-error-page.entity';
+import type { UpsertErrorPageDto } from './dto/upsert-error-page.dto';
+
+function makeStats(overrides: Partial<ErrorPageStats> = {}): ErrorPageStats {
+  return {
+    tenants: 12,
+    volume_7d: 100,
+    volume_30d: 400,
+    recovery_rate: 0.5,
+    last_seen: '2026-06-01T00:00:00.000Z',
+    trend: [],
+    ...overrides,
+  };
+}
+
+function makeDto(overrides: Partial<UpsertErrorPageDto> = {}): UpsertErrorPageDto {
+  return {
+    slug: 'gemini-429-rate-limit',
+    cluster_key: 'gemini|429',
+    provider: 'gemini',
+    title: 'Gemini 429 rate limit',
+    meta_description: 'A description',
+    h1: 'Gemini rate limit',
+    stats: makeStats(),
+    ...overrides,
+  } as UpsertErrorPageDto;
+}
+
+describe('ErrorPagesService', () => {
+  let service: ErrorPagesService;
+  let mockRepo: {
+    find: jest.Mock;
+    findOne: jest.Mock;
+    save: jest.Mock;
+    delete: jest.Mock;
+    count: jest.Mock;
+  };
+
+  beforeEach(() => {
+    mockRepo = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    };
+    service = new ErrorPagesService(mockRepo as never);
+  });
+
+  it('exposes the k-anonymity floor constant', () => {
+    expect(MIN_TENANTS_FOR_PUBLIC).toBe(10);
+  });
+
+  describe('listPublished', () => {
+    it('returns pages ordered by published_at DESC', async () => {
+      const pages = [{ slug: 'a' }, { slug: 'b' }] as PublicErrorPage[];
+      mockRepo.find.mockResolvedValue(pages);
+
+      const result = await service.listPublished();
+
+      expect(result).toBe(pages);
+      expect(mockRepo.find).toHaveBeenCalledWith({ order: { published_at: 'DESC' } });
+    });
+  });
+
+  describe('getBySlug', () => {
+    it('looks up a single page by slug', async () => {
+      const page = { slug: 'gemini-429' } as PublicErrorPage;
+      mockRepo.findOne.mockResolvedValue(page);
+
+      const result = await service.getBySlug('gemini-429');
+
+      expect(result).toBe(page);
+      expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { slug: 'gemini-429' } });
+    });
+
+    it('returns null when no page matches', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      expect(await service.getBySlug('missing')).toBeNull();
+    });
+  });
+
+  describe('upsert', () => {
+    it('rejects when tenants is below the k-anonymity floor', async () => {
+      const dto = makeDto({ stats: makeStats({ tenants: 9 }) });
+
+      await expect(service.upsert(dto)).rejects.toBeInstanceOf(BadRequestException);
+      await expect(service.upsert(dto)).rejects.toThrow(
+        'cluster affects 9 tenants, below the k-anonymity floor of 10',
+      );
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects when stats is missing entirely (defaults tenants to 0)', async () => {
+      const dto = { ...makeDto(), stats: undefined } as unknown as UpsertErrorPageDto;
+
+      await expect(service.upsert(dto)).rejects.toBeInstanceOf(BadRequestException);
+      await expect(service.upsert(dto)).rejects.toThrow('cluster affects 0 tenants');
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects when tenants is non-finite (NaN)', async () => {
+      const dto = makeDto({
+        stats: makeStats({ tenants: 'oops' as unknown as number }),
+      });
+
+      await expect(service.upsert(dto)).rejects.toBeInstanceOf(BadRequestException);
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('accepts exactly the floor (10 tenants)', async () => {
+      const dto = makeDto({ stats: makeStats({ tenants: MIN_TENANTS_FOR_PUBLIC }) });
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.save.mockResolvedValue(undefined);
+
+      const result = await service.upsert(dto);
+
+      expect(result).toEqual({ ok: true, slug: dto.slug });
+      expect(mockRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('scrubs secrets from sample_message before persisting', async () => {
+      const dto = makeDto({
+        sample_message: 'token leaked: sk-proj-ABCDEF1234567890 in the body',
+      });
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.save.mockResolvedValue(undefined);
+
+      await service.upsert(dto);
+
+      const saved = mockRepo.save.mock.calls[0][0] as PublicErrorPage;
+      expect(saved.sample_message).toBe('token leaked: [REDACTED] in the body');
+      expect(saved.sample_message).not.toContain('sk-proj-ABCDEF1234567890');
+    });
+
+    it('preserves an existing published_at on re-upsert', async () => {
+      const original = '2026-01-01T00:00:00.000Z';
+      mockRepo.findOne.mockResolvedValue({ published_at: original } as PublicErrorPage);
+      mockRepo.save.mockResolvedValue(undefined);
+
+      await service.upsert(makeDto());
+
+      const saved = mockRepo.save.mock.calls[0][0] as PublicErrorPage;
+      expect(saved.published_at).toBe(original);
+      // updated_at is always refreshed to "now", distinct from the preserved value.
+      expect(saved.updated_at).not.toBe(original);
+    });
+
+    it('sets published_at to now for a brand-new page', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.save.mockResolvedValue(undefined);
+
+      await service.upsert(makeDto());
+
+      const saved = mockRepo.save.mock.calls[0][0] as PublicErrorPage;
+      expect(saved.published_at).toBe(saved.updated_at);
+      expect(() => new Date(saved.published_at).toISOString()).not.toThrow();
+    });
+
+    it('fills defaults for optional fields', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.save.mockResolvedValue(undefined);
+
+      await service.upsert(makeDto({ provider: 'gemini' }));
+
+      const saved = mockRepo.save.mock.calls[0][0] as PublicErrorPage;
+      expect(saved.provider_label).toBe('gemini'); // ← provider
+      expect(saved.http_status).toBeNull();
+      expect(saved.category).toBe('unknown');
+      expect(saved.category_label).toBe('');
+      expect(saved.body_what).toBe('');
+      expect(saved.body_fix).toBe('');
+      expect(saved.body_manifest).toBe('');
+      expect(saved.sample_message).toBe('');
+      expect(saved.faq).toEqual([]);
+      expect(saved.related).toEqual([]);
+      expect(saved.noindex).toBe(false);
+    });
+
+    it('keeps explicitly provided optional fields', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.save.mockResolvedValue(undefined);
+      const dto = makeDto({
+        provider_label: 'Google Gemini',
+        http_status: 429,
+        category: 'rate_limit',
+        category_label: 'Rate limit',
+        body_what: 'what',
+        body_fix: 'fix',
+        body_manifest: 'manifest',
+        faq: [{ q: 'why?', a: 'because' }],
+        related: [{ slug: 'other', title: 'Other' }],
+        noindex: true,
+      });
+
+      await service.upsert(dto);
+
+      const saved = mockRepo.save.mock.calls[0][0] as PublicErrorPage;
+      expect(saved.provider_label).toBe('Google Gemini');
+      expect(saved.http_status).toBe(429);
+      expect(saved.category).toBe('rate_limit');
+      expect(saved.category_label).toBe('Rate limit');
+      expect(saved.body_what).toBe('what');
+      expect(saved.body_fix).toBe('fix');
+      expect(saved.body_manifest).toBe('manifest');
+      expect(saved.faq).toEqual([{ q: 'why?', a: 'because' }]);
+      expect(saved.related).toEqual([{ slug: 'other', title: 'Other' }]);
+      expect(saved.noindex).toBe(true);
+      expect(saved.cluster_key).toBe(dto.cluster_key);
+      expect(saved.stats).toBe(dto.stats);
+    });
+
+    it('treats an explicit null http_status as null', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.save.mockResolvedValue(undefined);
+
+      await service.upsert(makeDto({ http_status: null }));
+
+      const saved = mockRepo.save.mock.calls[0][0] as PublicErrorPage;
+      expect(saved.http_status).toBeNull();
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes by slug and echoes the slug', async () => {
+      mockRepo.delete.mockResolvedValue(undefined);
+
+      const result = await service.remove('gemini-429');
+
+      expect(result).toEqual({ ok: true, slug: 'gemini-429' });
+      expect(mockRepo.delete).toHaveBeenCalledWith({ slug: 'gemini-429' });
+    });
+  });
+});

--- a/packages/backend/src/error-pages/error-pages.service.ts
+++ b/packages/backend/src/error-pages/error-pages.service.ts
@@ -1,0 +1,86 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PublicErrorPage } from '../entities/public-error-page.entity';
+import { scrubSecrets } from '../common/utils/secret-scrub';
+import { UpsertErrorPageDto } from './dto/upsert-error-page.dto';
+
+/**
+ * k-anonymity floor: a cluster is never published as a public page unless it
+ * affected at least this many distinct tenants. Enforced here (defensively) in
+ * addition to the Peacock CMS, so even a CMS bug can't leak a sub-threshold
+ * cluster through the push endpoint.
+ */
+export const MIN_TENANTS_FOR_PUBLIC = 10;
+
+// Public valve scrub: provider-credential redaction (shared util) PLUS email
+// redaction. This is the single choke point — every sample reaching
+// `public_error_pages` passes through here regardless of which source pushed it.
+const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+function scrubForPublic(text: string | null | undefined): string {
+  return scrubSecrets(text ?? '').replace(EMAIL_RE, '[email]');
+}
+
+@Injectable()
+export class ErrorPagesService {
+  constructor(
+    @InjectRepository(PublicErrorPage)
+    private readonly repo: Repository<PublicErrorPage>,
+  ) {}
+
+  listPublished(): Promise<PublicErrorPage[]> {
+    return this.repo.find({ order: { published_at: 'DESC' } });
+  }
+
+  getBySlug(slug: string): Promise<PublicErrorPage | null> {
+    return this.repo.findOne({ where: { slug } });
+  }
+
+  /**
+   * Publish or refresh a page. Re-validates the k-anonymity floor and re-scrubs
+   * the public sample message before persisting, regardless of what the caller
+   * sent — the public table must never hold an un-vetted row.
+   */
+  async upsert(dto: UpsertErrorPageDto): Promise<{ ok: true; slug: string }> {
+    const tenants = Number(dto.stats?.tenants ?? 0);
+    if (!Number.isFinite(tenants) || tenants < MIN_TENANTS_FOR_PUBLIC) {
+      throw new BadRequestException(
+        `Refusing to publish "${dto.slug}": cluster affects ${tenants} tenants, below the k-anonymity floor of ${MIN_TENANTS_FOR_PUBLIC}.`,
+      );
+    }
+
+    const now = new Date().toISOString();
+    const existing = await this.repo.findOne({ where: { slug: dto.slug } });
+
+    const row: PublicErrorPage = {
+      slug: dto.slug,
+      cluster_key: dto.cluster_key,
+      provider: dto.provider,
+      provider_label: dto.provider_label ?? dto.provider,
+      http_status: dto.http_status ?? null,
+      category: dto.category ?? 'unknown',
+      category_label: dto.category_label ?? '',
+      title: dto.title,
+      meta_description: dto.meta_description,
+      h1: dto.h1,
+      body_what: dto.body_what ?? '',
+      body_fix: dto.body_fix ?? '',
+      body_manifest: dto.body_manifest ?? '',
+      sample_message: scrubForPublic(dto.sample_message),
+      faq: dto.faq ?? [],
+      stats: dto.stats,
+      related: dto.related ?? [],
+      noindex: dto.noindex ?? false,
+      published_at: existing?.published_at ?? now,
+      updated_at: now,
+    };
+
+    await this.repo.save(row);
+    return { ok: true, slug: dto.slug };
+  }
+
+  async remove(slug: string): Promise<{ ok: true; slug: string }> {
+    await this.repo.delete({ slug });
+    return { ok: true, slug };
+  }
+}

--- a/packages/backend/src/error-pages/internal-error-pages.controller.spec.ts
+++ b/packages/backend/src/error-pages/internal-error-pages.controller.spec.ts
@@ -1,0 +1,118 @@
+import { UnauthorizedException } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import { InternalErrorPagesController } from './internal-error-pages.controller';
+import type { ErrorPagesService } from './error-pages.service';
+import type { ErrorDiscoveryService } from './error-discovery.service';
+import type { UpsertErrorPageDto } from './dto/upsert-error-page.dto';
+
+const SECRET = 'super-secret-push-token';
+
+function makeConfig(secret: string | undefined): ConfigService {
+  return {
+    get: jest.fn((key: string) => (key === 'app.errorPagePushSecret' ? secret : undefined)),
+  } as unknown as ConfigService;
+}
+
+describe('InternalErrorPagesController', () => {
+  let mockService: { upsert: jest.Mock; remove: jest.Mock };
+  let mockDiscovery: { discover: jest.Mock };
+
+  beforeEach(() => {
+    mockService = { upsert: jest.fn(), remove: jest.fn() };
+    mockDiscovery = { discover: jest.fn() };
+  });
+
+  function makeController(secret: string | undefined): InternalErrorPagesController {
+    return new InternalErrorPagesController(
+      mockService as unknown as ErrorPagesService,
+      mockDiscovery as unknown as ErrorDiscoveryService,
+      makeConfig(secret),
+    );
+  }
+
+  const dto = { slug: 'gemini-429' } as UpsertErrorPageDto;
+
+  describe('secret rejection', () => {
+    it('rejects clusters when the header is missing', async () => {
+      const controller = makeController(SECRET);
+
+      await expect(controller.clusters(undefined as unknown as string)).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      expect(mockDiscovery.discover).not.toHaveBeenCalled();
+    });
+
+    it('rejects clusters when the header is wrong', async () => {
+      const controller = makeController(SECRET);
+
+      await expect(controller.clusters('nope')).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(mockDiscovery.discover).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the configured secret is empty even if header matches it', async () => {
+      const controller = makeController('');
+
+      // Both provided and expected would be '' — but an empty configured secret
+      // must never authorize, so this still rejects.
+      await expect(controller.clusters('')).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(mockDiscovery.discover).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the configured secret is unset (undefined → "")', async () => {
+      const controller = makeController(undefined);
+
+      await expect(controller.clusters('anything')).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('rejects upsert with a bad secret without touching the service', async () => {
+      const controller = makeController(SECRET);
+
+      await expect(controller.upsert('wrong', dto)).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(mockService.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects remove with a bad secret without touching the service', async () => {
+      const controller = makeController(SECRET);
+
+      await expect(controller.remove('wrong', 'gemini-429')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      expect(mockService.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with the correct secret', () => {
+    it('clusters delegates to the discovery service', async () => {
+      const clusters = [{ cluster_key: 'gemini|429' }];
+      mockDiscovery.discover.mockResolvedValue(clusters);
+      const controller = makeController(SECRET);
+
+      const result = await controller.clusters(SECRET);
+
+      expect(result).toBe(clusters);
+      expect(mockDiscovery.discover).toHaveBeenCalledTimes(1);
+    });
+
+    it('upsert delegates to the pages service', async () => {
+      const response = { ok: true as const, slug: 'gemini-429' };
+      mockService.upsert.mockResolvedValue(response);
+      const controller = makeController(SECRET);
+
+      const result = await controller.upsert(SECRET, dto);
+
+      expect(result).toBe(response);
+      expect(mockService.upsert).toHaveBeenCalledWith(dto);
+    });
+
+    it('remove delegates to the pages service', async () => {
+      const response = { ok: true as const, slug: 'gemini-429' };
+      mockService.remove.mockResolvedValue(response);
+      const controller = makeController(SECRET);
+
+      const result = await controller.remove(SECRET, 'gemini-429');
+
+      expect(result).toBe(response);
+      expect(mockService.remove).toHaveBeenCalledWith('gemini-429');
+    });
+  });
+});

--- a/packages/backend/src/error-pages/internal-error-pages.controller.ts
+++ b/packages/backend/src/error-pages/internal-error-pages.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  Param,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Public } from '../common/decorators/public.decorator';
+import { ErrorPagesService } from './error-pages.service';
+import { ErrorDiscoveryService } from './error-discovery.service';
+import { UpsertErrorPageDto } from './dto/upsert-error-page.dto';
+
+/**
+ * Internal write API. The Peacock CMS pushes published pages here (and deletes
+ * on unpublish). Marked @Public() to skip the session/api-key guards, then
+ * gated by a shared secret in the `x-internal-secret` header — this is the only
+ * way a row reaches `public_error_pages`. Lives under /api/* so the SPA static
+ * fallback never shadows it.
+ */
+@Controller('api/v1/internal/error-pages')
+export class InternalErrorPagesController {
+  constructor(
+    private readonly service: ErrorPagesService,
+    private readonly discovery: ErrorDiscoveryService,
+    private readonly config: ConfigService,
+  ) {}
+
+  private assertSecret(provided: string | undefined): void {
+    const expected = this.config.get<string>('app.errorPagePushSecret') ?? '';
+    if (!expected || provided !== expected) {
+      throw new UnauthorizedException('Invalid or missing push secret');
+    }
+  }
+
+  // Live cross-tenant cluster rollup the Peacock CMS pulls from to discover and
+  // refresh clusters. Same secret as the push endpoints.
+  @Public()
+  @Get('clusters')
+  async clusters(@Headers('x-internal-secret') secret: string) {
+    this.assertSecret(secret);
+    return this.discovery.discover();
+  }
+
+  @Public()
+  @Post()
+  async upsert(@Headers('x-internal-secret') secret: string, @Body() dto: UpsertErrorPageDto) {
+    this.assertSecret(secret);
+    return this.service.upsert(dto);
+  }
+
+  @Public()
+  @Delete(':slug')
+  async remove(@Headers('x-internal-secret') secret: string, @Param('slug') slug: string) {
+    this.assertSecret(secret);
+    return this.service.remove(slug);
+  }
+}

--- a/packages/backend/src/error-pages/public-error-pages.controller.spec.ts
+++ b/packages/backend/src/error-pages/public-error-pages.controller.spec.ts
@@ -1,0 +1,153 @@
+import { NotFoundException } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import { PublicErrorPagesController } from './public-error-pages.controller';
+import type { ErrorPagesService } from './error-pages.service';
+import type { PublicErrorPage } from '../entities/public-error-page.entity';
+
+function makeConfig(enabled: boolean): ConfigService {
+  return {
+    get: jest.fn((key: string) => (key === 'app.publicStatsEnabled' ? enabled : undefined)),
+  } as unknown as ConfigService;
+}
+
+function makePage(overrides: Partial<PublicErrorPage> = {}): PublicErrorPage {
+  return {
+    slug: 'gemini-429-rate-limit',
+    cluster_key: 'gemini|429',
+    provider: 'gemini',
+    provider_label: 'Google Gemini',
+    http_status: 429,
+    category: 'rate_limit',
+    category_label: 'Rate limit',
+    title: 'Gemini 429',
+    meta_description: 'desc',
+    h1: 'Gemini rate limit',
+    body_what: 'what',
+    body_fix: 'fix',
+    body_manifest: 'manifest',
+    sample_message: 'sample',
+    faq: [],
+    stats: {
+      tenants: 42,
+      volume_7d: 100,
+      volume_30d: 400,
+      recovery_rate: 0.74,
+      last_seen: '2026-06-01T00:00:00.000Z',
+      trend: [],
+    },
+    related: [],
+    noindex: false,
+    published_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('PublicErrorPagesController', () => {
+  let mockService: { listPublished: jest.Mock; getBySlug: jest.Mock };
+
+  beforeEach(() => {
+    mockService = {
+      listPublished: jest.fn(),
+      getBySlug: jest.fn(),
+    };
+  });
+
+  function makeController(enabled: boolean): PublicErrorPagesController {
+    return new PublicErrorPagesController(
+      mockService as unknown as ErrorPagesService,
+      makeConfig(enabled),
+    );
+  }
+
+  describe('when public stats are disabled', () => {
+    it('throws NotFoundException from list without calling the service', async () => {
+      const controller = makeController(false);
+
+      await expect(controller.list()).rejects.toBeInstanceOf(NotFoundException);
+      expect(mockService.listPublished).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException from detail without calling the service', async () => {
+      const controller = makeController(false);
+
+      await expect(controller.detail('gemini-429')).rejects.toBeInstanceOf(NotFoundException);
+      expect(mockService.getBySlug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('list (enabled)', () => {
+    it('projects only the public summary fields plus cached_at', async () => {
+      mockService.listPublished.mockResolvedValue([makePage()]);
+      const controller = makeController(true);
+
+      const result = await controller.list();
+
+      expect(mockService.listPublished).toHaveBeenCalledTimes(1);
+      expect(result.cached_at).toBeDefined();
+      expect(typeof result.cached_at).toBe('string');
+      expect(result.pages).toHaveLength(1);
+
+      const page = result.pages[0];
+      expect(page).toEqual({
+        slug: 'gemini-429-rate-limit',
+        title: 'Gemini 429',
+        h1: 'Gemini rate limit',
+        meta_description: 'desc',
+        provider: 'gemini',
+        provider_label: 'Google Gemini',
+        http_status: 429,
+        category: 'rate_limit',
+        category_label: 'Rate limit',
+        stats: makePage().stats,
+        noindex: false,
+        published_at: '2026-05-01T00:00:00.000Z',
+        updated_at: '2026-06-01T00:00:00.000Z',
+      });
+    });
+
+    it('does not leak internal/body fields in the projection', async () => {
+      mockService.listPublished.mockResolvedValue([makePage()]);
+      const controller = makeController(true);
+
+      const page = (await controller.list()).pages[0] as Record<string, unknown>;
+
+      expect(page).not.toHaveProperty('cluster_key');
+      expect(page).not.toHaveProperty('body_what');
+      expect(page).not.toHaveProperty('body_fix');
+      expect(page).not.toHaveProperty('body_manifest');
+      expect(page).not.toHaveProperty('sample_message');
+      expect(page).not.toHaveProperty('faq');
+      expect(page).not.toHaveProperty('related');
+    });
+
+    it('returns an empty pages array when nothing is published', async () => {
+      mockService.listPublished.mockResolvedValue([]);
+      const controller = makeController(true);
+
+      const result = await controller.list();
+
+      expect(result.pages).toEqual([]);
+    });
+  });
+
+  describe('detail (enabled)', () => {
+    it('returns the full page when found', async () => {
+      const page = makePage();
+      mockService.getBySlug.mockResolvedValue(page);
+      const controller = makeController(true);
+
+      const result = await controller.detail('gemini-429-rate-limit');
+
+      expect(result).toBe(page);
+      expect(mockService.getBySlug).toHaveBeenCalledWith('gemini-429-rate-limit');
+    });
+
+    it('throws NotFoundException when the page is missing', async () => {
+      mockService.getBySlug.mockResolvedValue(null);
+      const controller = makeController(true);
+
+      await expect(controller.detail('missing')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/packages/backend/src/error-pages/public-error-pages.controller.ts
+++ b/packages/backend/src/error-pages/public-error-pages.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Public } from '../common/decorators/public.decorator';
+import { ErrorPagesService } from './error-pages.service';
+
+/**
+ * Public, unauthenticated read API consumed by the marketing site
+ * (manifest.build/errors/...). Gated by the same MANIFEST_PUBLIC_STATS flag as
+ * the other /api/v1/public/* endpoints — 404 (not 403) when disabled so probes
+ * can't distinguish "off" from "absent".
+ */
+@Controller('api/v1/public/error-pages')
+export class PublicErrorPagesController {
+  constructor(
+    private readonly service: ErrorPagesService,
+    private readonly config: ConfigService,
+  ) {}
+
+  private assertEnabled(): void {
+    if (!this.config.get<boolean>('app.publicStatsEnabled')) {
+      throw new NotFoundException();
+    }
+  }
+
+  @Public()
+  @Get()
+  async list() {
+    this.assertEnabled();
+    const pages = await this.service.listPublished();
+    return {
+      pages: pages.map((p) => ({
+        slug: p.slug,
+        title: p.title,
+        h1: p.h1,
+        meta_description: p.meta_description,
+        provider: p.provider,
+        provider_label: p.provider_label,
+        http_status: p.http_status,
+        category: p.category,
+        category_label: p.category_label,
+        stats: p.stats,
+        noindex: p.noindex,
+        published_at: p.published_at,
+        updated_at: p.updated_at,
+      })),
+      cached_at: new Date().toISOString(),
+    };
+  }
+
+  @Public()
+  @Get(':slug')
+  async detail(@Param('slug') slug: string) {
+    this.assertEnabled();
+    const page = await this.service.getBySlug(slug);
+    if (!page) throw new NotFoundException();
+    return page;
+  }
+}

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -37,6 +37,7 @@ import { PlaygroundColumn } from '../src/entities/playground-column.entity';
 import { ReasoningContentCacheEntry } from '../src/entities/reasoning-content-cache-entry.entity';
 import { AgentEnabledProvider } from '../src/entities/agent-enabled-provider.entity';
 import { BackfillState } from '../src/entities/backfill-state.entity';
+import { PublicErrorPage } from '../src/entities/public-error-page.entity';
 import { HealthModule } from '../src/health/health.module';
 import { AnalyticsModule } from '../src/analytics/analytics.module';
 import { OtlpModule } from '../src/otlp/otlp.module';
@@ -77,6 +78,7 @@ const entities = [
   ReasoningContentCacheEntry,
   AgentEnabledProvider,
   BackfillState,
+  PublicErrorPage,
 ];
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 const OPENROUTER_MODELS_FIXTURE = {


### PR DESCRIPTION
### 💭 Why
We want SEO landing pages for common provider errors (like the `/providers/` and `/agents/` pages), built from real cross-tenant error data. Operators decide which clusters go public; this is the backend valve that serves them.

### ✨ What changed
- Public `GET /api/v1/public/error-pages[/:slug]`, gated by `MANIFEST_PUBLIC_STATS` (off by default).
- Secret-guarded `POST/DELETE /api/v1/internal/error-pages` for the Peacock CMS to publish or pull pages.
- `GET /api/v1/internal/error-pages/clusters` exposes the live cross-tenant rollup for triage.
- New `public_error_pages` table (migration auto-runs on boot).

### 🔧 For operators
- `MANIFEST_PUBLIC_STATS=true` to expose the public endpoint (cloud marketing only).
- `ERROR_PAGE_PUSH_SECRET=<secret>` to allow CMS writes. Empty by default rejects all writes.

### 📝 Notes
Privacy is enforced here: a cluster is eligible only at >=10 distinct tenants, and every public sample is scrubbed of secrets and emails before storage.
Part of a 3-repo feature (website + Peacock CMS land separately).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve curated cross-tenant error pages for the marketing site. Adds a public read API and a secret-guarded internal API for the CMS, plus dev seeders that populate realistic data and a full demo catalog with 14-day trends.

- New Features
  - Public read: GET `/api/v1/public/error-pages` and `/api/v1/public/error-pages/:slug`.
  - Internal CMS: GET `/api/v1/internal/error-pages/clusters` for discovery, and POST/DELETE `/api/v1/internal/error-pages` to publish/unpublish.
  - Live discovery rolls up clusters from `agent_messages`, includes trends and top scrubbed variants.
  - Privacy: only clusters with >=10 tenants are eligible; samples and variants are scrubbed of secrets and emails before storage.
  - New `public_error_pages` table and `PublicErrorPage` entity; module wired into the app.
  - Dev seeders (`SEED_DATA=true`): generate realistic `agent_messages` and publish a curated demo error-page catalog with 14-day trends so marketing renders without a live CMS (idempotent, dev/test only).

- Migration
  - Enable public read API by setting `MANIFEST_PUBLIC_STATS=true` (cloud marketing only).
  - Allow CMS writes by setting `ERROR_PAGE_PUSH_SECRET` and sending it via the `x-internal-secret` header. Empty or unset rejects all writes.

<sup>Written for commit f628f3f842eb45afaa0b09af178f266afb39a73c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

