### PR TITLE
fix: recover faster from provider rate-limit cooldowns

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -264,6 +264,78 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
     ).toBe(true);
   });
 
+  describe('rate-limit cooldown TTL derived from Retry-After', () => {
+    // Drive one real 429 carrying the given Retry-After header, then read the
+    // stored cooldown expiry so we can assert the TTL parseRetryAfterMs derived.
+    // A fresh service (beforeEach) means exactly one cooldown entry exists after
+    // the call. Returns the duration in ms measured from just before the call,
+    // so assertions allow small upper-bound slack for test runtime.
+    const recordCooldownTtl = async (retryAfter: string | null): Promise<number> => {
+      const headers: Record<string, string> = {};
+      if (retryAfter !== null) headers['retry-after'] = retryAfter;
+      providerClient.forward.mockResolvedValueOnce({
+        response: new Response('rate limit', { status: 429, headers }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+
+      const before = Date.now();
+      await service.tryForwardToProvider({
+        provider: 'anthropic',
+        apiKey: 'sk-ant-oat-token',
+        model: 'claude-sonnet-4-6',
+        body,
+        stream: false,
+        sessionKey: 'sess-1',
+        agentId: 'agent-1',
+        providerKeyLabel: 'Claude Code',
+        authType: 'subscription',
+      });
+
+      const cooldowns = (service as unknown as { rateLimitCooldowns: Map<string, number> })
+        .rateLimitCooldowns;
+      expect(cooldowns.size).toBe(1);
+      const [expiresAt] = [...cooldowns.values()];
+      return expiresAt - before;
+    };
+
+    it('uses the short 15s default when the 429 carries no Retry-After', async () => {
+      const ttl = await recordCooldownTtl(null);
+      expect(ttl).toBeGreaterThanOrEqual(15_000);
+      expect(ttl).toBeLessThan(16_000);
+    });
+
+    it('uses the short default when Retry-After is unparseable', async () => {
+      const ttl = await recordCooldownTtl('not-a-date');
+      expect(ttl).toBeGreaterThanOrEqual(15_000);
+      expect(ttl).toBeLessThan(16_000);
+    });
+
+    it('honors an HTTP-date Retry-After under a minute instead of flooring it to 60s', async () => {
+      // Before this fix the date form was floored to 60s; a ~10s instant now
+      // yields a ~10s cooldown, matching the numeric-seconds path.
+      const future = new Date(Date.now() + 10_000).toUTCString();
+      const ttl = await recordCooldownTtl(future);
+      expect(ttl).toBeGreaterThan(8_000);
+      expect(ttl).toBeLessThanOrEqual(10_000);
+    });
+
+    it('falls back to the short default when the Retry-After date is in the past', async () => {
+      const past = new Date(Date.now() - 5_000).toUTCString();
+      const ttl = await recordCooldownTtl(past);
+      expect(ttl).toBeGreaterThanOrEqual(15_000);
+      expect(ttl).toBeLessThan(16_000);
+    });
+
+    it('caps an HTTP-date Retry-After beyond the 5-minute ceiling', async () => {
+      const future = new Date(Date.now() + 30 * 60_000).toUTCString();
+      const ttl = await recordCooldownTtl(future);
+      expect(ttl).toBeGreaterThanOrEqual(5 * 60_000);
+      expect(ttl).toBeLessThan(5 * 60_000 + 1_000);
+    });
+  });
+
   it('does NOT short-circuit on 401 auth errors — continues to next route (current contract)', async () => {
     // shouldTriggerFallback(401) === true, so an auth failure on the first
     // route keeps the loop going. This test pins that behavior: if anyone

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -79,7 +79,12 @@ import {
   resolveApiKey,
 } from './oauth-credentials';
 
-const RATE_LIMIT_COOLDOWN_DEFAULT_MS = 60_000;
+// Fallback cooldown applied when an upstream 429 carries no usable Retry-After.
+// Kept short (15s) on purpose: many providers rate-limit on brief RPM/burst
+// windows and omit Retry-After entirely, so a long blackout would sideline a
+// route that recovered seconds later. Explicit Retry-After values are always
+// honored (capped at MAX) regardless of this default.
+const RATE_LIMIT_COOLDOWN_DEFAULT_MS = 15_000;
 const RATE_LIMIT_COOLDOWN_MAX_MS = 5 * 60_000;
 const MAX_RATE_LIMIT_COOLDOWNS = 2_000;
 
@@ -466,12 +471,15 @@ export class ProxyFallbackService {
     if (Number.isFinite(seconds) && seconds > 0) {
       return Math.min(seconds * 1000, RATE_LIMIT_COOLDOWN_MAX_MS);
     }
+    // HTTP-date form (RFC 9110): honor the provider's stated instant the same
+    // way as the numeric-seconds form — respect the actual delta, capped at
+    // MAX, with no artificial floor. A past or nonsensical date carries no
+    // usable duration, so fall back to the short default.
     const retryAt = Date.parse(retryAfter);
     if (Number.isNaN(retryAt)) return RATE_LIMIT_COOLDOWN_DEFAULT_MS;
-    return Math.min(
-      Math.max(retryAt - Date.now(), RATE_LIMIT_COOLDOWN_DEFAULT_MS),
-      RATE_LIMIT_COOLDOWN_MAX_MS,
-    );
+    const deltaMs = retryAt - Date.now();
+    if (deltaMs <= 0) return RATE_LIMIT_COOLDOWN_DEFAULT_MS;
+    return Math.min(deltaMs, RATE_LIMIT_COOLDOWN_MAX_MS);
   }
 
   private rateLimitCooldownKey(opts: ForwardProviderOptions): string | null {


### PR DESCRIPTION
## What

Two small refinements to the provider rate-limit cooldown — the circuit breaker behind the `Provider route temporarily cooling down after an upstream 429` response in `ProxyFallbackService`.

1. **Shorter default cooldown.** When a 429 carries no usable `Retry-After`, the route was blacked out for 60s. Many providers rate-limit on short RPM/burst windows and omit `Retry-After`, so a route that recovered in ~1s sat idle for a full minute. Lowered the default to **15s**.

2. **Consistent `Retry-After` handling.** The numeric-seconds form was honored as-is, but the HTTP-date form was floored to 60s. Both forms now respect the provider's stated delay (still capped at the 5-minute ceiling), falling back to the short default only when the value is missing, unparseable, or already in the past.

Explicit `Retry-After` values are still honored and still capped at 5 minutes. Only the *duration a route stays sidelined* changes; the fallback cascade and everything else are untouched.

## Why

A single stray 429 with no `Retry-After` sidelined a route for a full minute even when the provider recovered seconds later — an over-long blackout for bursty per-second limits. The date-vs-numeric asymmetry also meant two providers describing the same 5-second backoff produced different cooldowns.

## Tests

- New unit tests in `proxy-fallback.failures.spec.ts` cover the no-header, unparseable, sub-minute date, past-date, and over-max cases (changed lines fully covered).
- Full backend unit suite green (6836 tests); `tsc --noEmit` and eslint clean; `proxy.e2e-spec.ts` + `proxy-fallback-auth.e2e-spec.ts` pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce cooldown after upstream 429s so healthy routes recover faster. Align `Retry-After` parsing so both numeric seconds and HTTP-date values are honored (still capped at 5 minutes).

- **Bug Fixes**
  - When no `Retry-After` is present, default cooldown drops from 60s to 15s.
  - HTTP-date `Retry-After` now uses the real delta (no 60s floor); past or invalid dates fall back to 15s; cap remains 5 minutes.
  - Added unit tests for no-header, unparseable, sub-minute date, past-date, and over-max cases.

<sup>Written for commit df1088a04c18c22654fc94722f9bdf0d5d949ee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

