### PR TITLE
fix: keep custom-provider errors out of public error pages

### DIFF
--- a/packages/backend/src/error-pages/error-pages.service.spec.ts
+++ b/packages/backend/src/error-pages/error-pages.service.spec.ts
@@ -111,6 +111,13 @@ describe('ErrorPagesService', () => {
       expect(mockRepo.save).not.toHaveBeenCalled();
     });
 
+    it('rejects a custom: provider even above the floor (never a public page)', async () => {
+      const dto = makeDto({ provider: 'custom:1aee1812', stats: makeStats({ tenants: 500 }) });
+      await expect(service.upsert(dto)).rejects.toBeInstanceOf(BadRequestException);
+      await expect(service.upsert(dto)).rejects.toThrow('custom providers are tenant-specific');
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
     it('accepts exactly the floor (10 tenants)', async () => {
       const dto = makeDto({ stats: makeStats({ tenants: MIN_TENANTS_FOR_PUBLIC }) });
       mockRepo.findOne.mockResolvedValue(null);

--- a/packages/backend/src/error-pages/error-pages.service.ts
+++ b/packages/backend/src/error-pages/error-pages.service.ts
@@ -21,6 +21,14 @@ function scrubForPublic(text: string | null | undefined): string {
   return scrubSecrets(text ?? '').replace(EMAIL_RE, '[email]');
 }
 
+// A `custom:<id>` provider is a single tenant's private endpoint — its errors
+// are tenant-specific and can never become a public page. Rejected here at the
+// valve (the single choke point) no matter what the caller pushes, mirroring the
+// `custom:%` exclusion already applied in discovery.
+function isCustomProvider(provider: string | null | undefined): boolean {
+  return /^custom($|[:/])/i.test(provider ?? '');
+}
+
 @Injectable()
 export class ErrorPagesService {
   constructor(
@@ -42,6 +50,12 @@ export class ErrorPagesService {
    * sent — the public table must never hold an un-vetted row.
    */
   async upsert(dto: UpsertErrorPageDto): Promise<{ ok: true; slug: string }> {
+    if (isCustomProvider(dto.provider)) {
+      throw new BadRequestException(
+        `Refusing to publish "${dto.slug}": custom providers are tenant-specific and cannot be public pages.`,
+      );
+    }
+
     const tenants = Number(dto.stats?.tenants ?? 0);
     if (!Number.isFinite(tenants) || tenants < MIN_TENANTS_FOR_PUBLIC) {
       throw new BadRequestException(

--- a/packages/backend/src/error-pages/error-pages.service.ts
+++ b/packages/backend/src/error-pages/error-pages.service.ts
@@ -25,8 +25,8 @@ function scrubForPublic(text: string | null | undefined): string {
 // are tenant-specific and can never become a public page. Rejected here at the
 // valve (the single choke point) no matter what the caller pushes, mirroring the
 // `custom:%` exclusion already applied in discovery.
-function isCustomProvider(provider: string | null | undefined): boolean {
-  return /^custom($|[:/])/i.test(provider ?? '');
+function isCustomProvider(provider: string): boolean {
+  return /^custom($|[:/])/i.test(provider);
 }
 
 @Injectable()


### PR DESCRIPTION
### 💭 Why
Custom providers are a single tenant's private endpoints, so their errors are tenant-specific and must never become a public page. Discovery already excludes `custom:%`, but the publish valve did not, so a buggy or malicious push could still store one.

### ✨ What changed
- `ErrorPagesService.upsert()` rejects any `custom:` provider with a 400, before the k-anonymity check.

### 📝 Notes
Enforced at the valve, the single choke point every push passes through. Pairs with the Peacock CMS now skipping custom providers (mnfst/peacock#168).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block publishing of custom-provider error pages so tenant-specific errors never become public. `ErrorPagesService.upsert()` now rejects any `custom:` provider with a 400 before the k-anonymity check.

- **Bug Fixes**
  - Early-reject `custom:` providers in `upsert()` via `isCustomProvider`; dropped an unreachable null-guard by typing its param as `string`.
  - Added a unit test to ensure rejection and block saves.

<sup>Written for commit 5adde239a9e32049a7f458633ab170ffb74d8eb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

