### PR TITLE
fix: unwrap CodeAssist Playground Gemini streams

### DIFF
--- a/.changeset/gemini-playground-codeassist-stream.md
+++ b/.changeset/gemini-playground-codeassist-stream.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix Playground streaming for Gemini subscription responses that use the CodeAssist envelope.

--- a/packages/backend/src/playground/playground-stream.spec.ts
+++ b/packages/backend/src/playground/playground-stream.spec.ts
@@ -17,7 +17,7 @@ function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
   });
 }
 
-type Forward = Pick<ForwardResult, 'isGoogle' | 'isAnthropic' | 'isChatGpt'>;
+type Forward = Pick<ForwardResult, 'isGoogle' | 'isAnthropic' | 'isChatGpt' | 'isCodeAssist'>;
 const OPENAI: Forward = { isGoogle: false, isAnthropic: false, isChatGpt: false };
 
 function providerClientStub(over: Partial<ProviderClient> = {}): ProviderClient {
@@ -112,6 +112,29 @@ describe('consumeProviderStream', () => {
     );
     expect(convertGoogleStreamChunk).toHaveBeenCalledWith('{"candidates":[]}', 'gemini/x');
     expect(result.content).toBe('G');
+  });
+
+  it('unwraps CodeAssist Google stream payloads before conversion', async () => {
+    const convertGoogleStreamChunk = jest.fn(
+      (_e: string, _m: string): { chunk: string | null } => ({
+        chunk: 'data: {"choices":[{"delta":{"content":"C"}}]}\n\n',
+      }),
+    );
+    const pc = providerClientStub({
+      convertGoogleStreamChunk: convertGoogleStreamChunk as never,
+    });
+    const inner = { candidates: [{ content: { parts: [{ text: 'from-codeassist' }] } }] };
+    const result = await consumeProviderStream(
+      sseStream([`data: ${JSON.stringify({ response: inner, traceId: 'trace-1' })}\n\n`]),
+      { isGoogle: true, isAnthropic: false, isChatGpt: false, isCodeAssist: true },
+      'gemini/x',
+      pc,
+      () => undefined,
+      Date.now(),
+    );
+
+    expect(convertGoogleStreamChunk).toHaveBeenCalledWith(JSON.stringify(inner), 'gemini/x');
+    expect(result.content).toBe('C');
   });
 
   it('skips Google chunks that convert to a null chunk', async () => {

--- a/packages/backend/src/playground/playground-stream.ts
+++ b/packages/backend/src/playground/playground-stream.ts
@@ -1,4 +1,5 @@
 import type { ForwardResult, ProviderClient } from '../routing/proxy/provider-client';
+import { unwrapCodeAssistStreamPayload } from '../routing/oauth/gemini/codeassist-envelope';
 import { createSsePayloadParser } from '../routing/proxy/sse-parser';
 import { parseUsageObject, type StreamUsage } from '../routing/proxy/stream-writer';
 
@@ -21,12 +22,15 @@ export interface ConsumeStreamResult {
 type ChunkTransform = (event: string) => string | null;
 
 function buildChunkTransform(
-  forward: Pick<ForwardResult, 'isGoogle' | 'isAnthropic' | 'isChatGpt'>,
+  forward: Pick<ForwardResult, 'isGoogle' | 'isAnthropic' | 'isChatGpt' | 'isCodeAssist'>,
   model: string,
   providerClient: ProviderClient,
 ): ChunkTransform {
   if (forward.isGoogle) {
-    return (event) => providerClient.convertGoogleStreamChunk(event, model).chunk;
+    return (event) => {
+      const innerEvent = forward.isCodeAssist ? unwrapCodeAssistStreamPayload(event) : event;
+      return providerClient.convertGoogleStreamChunk(innerEvent, model).chunk;
+    };
   }
   if (forward.isAnthropic) {
     // Stateful: must be created once per stream and fed events in order.
@@ -78,7 +82,7 @@ const MAX_STREAM_BUFFER = 1_048_576;
  */
 export async function consumeProviderStream(
   body: ReadableStream<Uint8Array>,
-  forward: Pick<ForwardResult, 'isGoogle' | 'isAnthropic' | 'isChatGpt'>,
+  forward: Pick<ForwardResult, 'isGoogle' | 'isAnthropic' | 'isChatGpt' | 'isCodeAssist'>,
   model: string,
   providerClient: ProviderClient,
   onDelta: (text: string) => void,


### PR DESCRIPTION
## Summary

- unwrap CodeAssist SSE payloads before passing Gemini Playground chunks to the Google stream converter
- add regression coverage for CodeAssist-wrapped Gemini Playground events
- add a patch changeset for the self-hosted Manifest package

Fixes #2375

## Testing

- `npm test --workspace=manifest-backend -- playground-stream.spec.ts --runInBand`
- `npm run lint` (passes with existing warnings)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Gemini Playground streaming when responses come via CodeAssist by unwrapping the SSE envelope before conversion. Adds regression tests and prepares a patch release for `manifest`.

- **Bug Fixes**
  - Unwrap CodeAssist SSE payloads before passing Gemini chunks to the Google stream converter.
  - Add regression test covering CodeAssist‑wrapped Gemini Playground events.

<sup>Written for commit ccb748d9beb6ba105b59c3a67bec42c3b1720478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

