### PR TITLE
fix: harden request validation, OAuth, CSP; patch dep CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -490,7 +490,7 @@
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.3",
@@ -502,7 +502,7 @@
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
       "version": "10.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
@@ -1384,7 +1384,7 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1402,7 +1402,7 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "2.1.4",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1424,7 +1424,7 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1450,7 +1450,7 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1471,7 +1471,7 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -1494,7 +1494,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1511,7 +1510,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1528,7 +1526,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1545,7 +1542,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1562,7 +1558,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1579,7 +1574,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1596,7 +1590,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1613,7 +1606,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1630,7 +1622,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1647,7 +1638,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1664,7 +1654,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1681,7 +1670,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1698,7 +1686,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1715,7 +1702,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1732,7 +1718,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1749,7 +1734,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1781,7 +1765,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1798,7 +1781,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1815,7 +1797,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1832,7 +1813,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1849,7 +1829,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1866,7 +1845,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1883,7 +1861,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1900,7 +1877,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1917,7 +1893,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2689,7 +2664,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2715,7 +2690,7 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2729,7 +2704,7 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -4005,7 +3980,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4019,7 +3993,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4033,7 +4006,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4047,7 +4019,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4061,7 +4032,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4075,7 +4045,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4089,7 +4058,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4103,7 +4071,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4117,7 +4084,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4131,7 +4097,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4145,7 +4110,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4159,7 +4123,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4173,7 +4136,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4187,7 +4149,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4201,7 +4162,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4215,7 +4175,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4227,7 +4186,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4239,7 +4197,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4253,7 +4210,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4267,7 +4223,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4281,7 +4236,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4295,7 +4249,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4309,7 +4262,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4323,7 +4275,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5103,14 +5054,152 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -5118,8 +5207,37 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5130,11 +5248,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -5143,11 +5263,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -5156,7 +5278,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5167,11 +5291,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -5381,7 +5507,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -5842,9 +5968,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6570,7 +6696,7 @@
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
@@ -6586,7 +6712,7 @@
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
@@ -6617,7 +6743,7 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6998,7 +7124,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8244,15 +8370,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8334,7 +8462,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8595,7 +8722,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8626,7 +8755,7 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
@@ -8696,7 +8825,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -8708,7 +8837,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -8945,7 +9074,7 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -10033,7 +10162,7 @@
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.2.1",
@@ -10854,7 +10983,7 @@
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -11086,7 +11215,7 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -11097,7 +11226,7 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11483,7 +11612,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11846,7 +11975,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11875,7 +12003,7 @@
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -11931,7 +12059,7 @@
     },
     "node_modules/saxes": {
       "version": "6.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -12500,6 +12628,8 @@
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -12511,6 +12641,8 @@
     },
     "node_modules/strip-literal/node_modules/js-tokens": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -12592,7 +12724,7 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -12624,7 +12756,7 @@
     },
     "node_modules/terser": {
       "version": "5.46.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -12734,12 +12866,12 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -12747,7 +12879,7 @@
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -12866,6 +12998,8 @@
     },
     "node_modules/tinyspy": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -12874,7 +13008,7 @@
     },
     "node_modules/tldts": {
       "version": "6.1.86",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
@@ -12885,7 +13019,7 @@
     },
     "node_modules/tldts-core": {
       "version": "6.1.86",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -12941,7 +13075,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
@@ -12952,7 +13086,7 @@
     },
     "node_modules/tr46": {
       "version": "5.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -13446,9 +13580,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13694,7 +13828,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13746,9 +13879,89 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -13787,7 +14000,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -13938,7 +14151,7 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -13949,7 +14162,7 @@
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13960,7 +14173,7 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13968,7 +14181,7 @@
     },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
@@ -14144,8 +14357,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "dev": true,
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -14165,7 +14380,7 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -14173,7 +14388,7 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
@@ -14197,7 +14412,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -14528,20 +14743,12 @@
         "@solidjs/testing-library": "^0.8.0",
         "@types/dompurify": "^3.0.5",
         "@types/node": "^22.0.0",
-        "@vitest/coverage-v8": "^3.2.4",
+        "@vitest/coverage-v8": "^3.2.6",
         "jsdom": "^26.0.0",
         "typescript": "^5.7.0",
         "vite": "^6.1.0",
         "vite-plugin-solid": "^2.11.0",
-        "vitest": "^3.0.0"
-      }
-    },
-    "packages/frontend/node_modules/@bcoe/v8-coverage": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
+        "vitest": "^3.2.6"
       }
     },
     "packages/frontend/node_modules/@codecov/vite-plugin": {
@@ -14577,38 +14784,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "packages/frontend/node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "@bcoe/v8-coverage": "^1.0.2",
-        "ast-v8-to-istanbul": "^0.3.3",
-        "debug": "^4.4.1",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.17",
-        "magicast": "^0.3.5",
-        "std-env": "^3.9.0",
-        "test-exclude": "^7.0.1",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
       }
     },
     "packages/frontend/node_modules/better-auth": {
@@ -14752,57 +14927,6 @@
         }
       }
     },
-    "packages/frontend/node_modules/glob": {
-      "version": "10.5.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/frontend/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/frontend/node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/frontend/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "dev": true,
-      "license": "ISC"
-    },
     "packages/frontend/node_modules/marked": {
       "version": "18.0.3",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
@@ -14815,44 +14939,11 @@
         "node": ">= 20"
       }
     },
-    "packages/frontend/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/frontend/node_modules/test-exclude": {
-      "version": "7.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^10.4.1",
-        "minimatch": "^10.2.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/frontend/node_modules/tinyexec": {
-      "version": "0.3.2",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "packages/frontend/node_modules/vite": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -14959,102 +15050,6 @@
         "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0"
       },
       "peerDependenciesMeta": {
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "packages/frontend/node_modules/vitest": {
-      "version": "3.2.4",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/debug": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "packages/frontend/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.2.4",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
         "vite": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,10 @@
     "defu": "^6.1.5",
     "picomatch": "^4.0.4",
     "path-to-regexp": "8.4.1",
-    "brace-expansion": "5.0.5"
+    "brace-expansion": "5.0.5",
+    "undici": "^6.27.0",
+    "form-data": "^4.0.6",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.0",

--- a/packages/backend/src/common/middleware/rate-limit-log.spec.ts
+++ b/packages/backend/src/common/middleware/rate-limit-log.spec.ts
@@ -1,0 +1,67 @@
+import { Logger } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+import { createRateLimitReachedHandler } from './rate-limit-log';
+
+function makeRes(): Response & { status: jest.Mock; send: jest.Mock } {
+  const res = {} as Response & { status: jest.Mock; send: jest.Mock };
+  res.status = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('createRateLimitReachedHandler', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('logs a structured WARN and sends the default 429 response unchanged', () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    const handler = createRateLimitReachedHandler('sign-in');
+    const req = {
+      method: 'POST',
+      originalUrl: '/api/auth/sign-in',
+      ip: '203.0.113.5',
+    } as unknown as Request;
+    const res = makeRes();
+    const message = { error: 'Too many login attempts. Try again later.' };
+
+    handler(req, res, jest.fn() as unknown as NextFunction, { statusCode: 429, message });
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.send).toHaveBeenCalledWith(message);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const line = warn.mock.calls[0][0] as string;
+    expect(line).toContain('sign-in');
+    expect(line).toContain('POST');
+    expect(line).toContain('/api/auth/sign-in');
+    expect(line).toContain('203.0.113.5');
+  });
+
+  it('falls back to socket.remoteAddress when req.ip is absent', () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    const handler = createRateLimitReachedHandler('sign-up');
+    const req = {
+      method: 'POST',
+      originalUrl: '/api/auth/sign-up',
+      socket: { remoteAddress: '198.51.100.9' },
+    } as unknown as Request;
+
+    handler(req, makeRes(), jest.fn() as unknown as NextFunction, {
+      statusCode: 429,
+      message: 'x',
+    });
+
+    expect(warn.mock.calls[0][0] as string).toContain('198.51.100.9');
+  });
+
+  it("uses 'unknown' when neither req.ip nor a socket is available", () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    const handler = createRateLimitReachedHandler('verify-email');
+    const req = { method: 'POST', originalUrl: '/api/auth/verify-email' } as unknown as Request;
+
+    handler(req, makeRes(), jest.fn() as unknown as NextFunction, {
+      statusCode: 429,
+      message: 'x',
+    });
+
+    expect(warn.mock.calls[0][0] as string).toContain('ip=unknown');
+  });
+});

--- a/packages/backend/src/common/middleware/rate-limit-log.ts
+++ b/packages/backend/src/common/middleware/rate-limit-log.ts
@@ -1,0 +1,34 @@
+import { Logger } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+
+const logger = new Logger('RateLimit');
+
+/** Minimal slice of express-rate-limit's options that the handler reads. */
+interface RateLimitResponseOptions {
+  statusCode: number;
+  message: unknown;
+}
+
+/**
+ * Build an express-rate-limit `handler` that emits one structured security
+ * WARN when an auth endpoint's rate limit trips, then sends the library's
+ * default 429 response unchanged.
+ *
+ * express-rate-limit only sets response headers by default — it writes no
+ * application log — so a credential-stuffing or account-enumeration burst
+ * against the auth endpoints is otherwise invisible in the app logs until it
+ * succeeds. This restores an app-layer signal (limiter name, method, path,
+ * client IP) without altering the client-facing response at all.
+ */
+export function createRateLimitReachedHandler(name: string) {
+  return (
+    req: Request,
+    res: Response,
+    _next: NextFunction,
+    options: RateLimitResponseOptions,
+  ): void => {
+    const ip = req.ip ?? req.socket?.remoteAddress ?? 'unknown';
+    logger.warn(`Rate limit reached on ${name}: ${req.method} ${req.originalUrl} ip=${ip}`);
+    res.status(options.statusCode).send(options.message);
+  };
+}

--- a/packages/backend/src/cors-csp-config.spec.ts
+++ b/packages/backend/src/cors-csp-config.spec.ts
@@ -4,6 +4,7 @@ import {
   buildDevAllowedOrigins,
   buildFrameSrc,
   createCorsOriginHandler,
+  parseFrameAncestors,
 } from './cors-csp-config';
 
 describe('HOSTED_WINGMAN_ORIGIN', () => {
@@ -55,6 +56,53 @@ describe('buildFrameSrc', () => {
 
   it('respects a custom Wingman port in dev', () => {
     expect(buildFrameSrc({ isDev: true, wingmanPort: 38239 })).toContain('http://localhost:38239');
+  });
+});
+
+describe('parseFrameAncestors', () => {
+  it("defaults to 'none' when unset", () => {
+    expect(parseFrameAncestors(undefined)).toEqual(["'none'"]);
+  });
+
+  it("defaults to 'none' for an empty string", () => {
+    expect(parseFrameAncestors('')).toEqual(["'none'"]);
+  });
+
+  it('keeps a single well-formed https origin', () => {
+    expect(parseFrameAncestors('https://app.example.com')).toEqual(['https://app.example.com']);
+  });
+
+  it('keeps multiple valid origins in order and trims whitespace', () => {
+    expect(parseFrameAncestors('https://a.example.com , http://localhost:3000')).toEqual([
+      'https://a.example.com',
+      'http://localhost:3000',
+    ]);
+  });
+
+  it("keeps the 'self' and 'none' CSP keywords", () => {
+    expect(parseFrameAncestors("'self', 'none'")).toEqual(["'self'", "'none'"]);
+  });
+
+  it('keeps a wildcard-subdomain origin', () => {
+    expect(parseFrameAncestors('https://*.example.com')).toEqual(['https://*.example.com']);
+  });
+
+  it('keeps an origin with an explicit port', () => {
+    expect(parseFrameAncestors('https://example.com:8443')).toEqual(['https://example.com:8443']);
+  });
+
+  it('drops the bare wildcard (would allow any site to frame the app)', () => {
+    expect(parseFrameAncestors('*')).toEqual(["'none'"]);
+  });
+
+  it('drops malformed entries (scheme-only, raw CIDR) but keeps valid ones', () => {
+    expect(parseFrameAncestors('https:, 192.168.1.0/24, https://good.example.com')).toEqual([
+      'https://good.example.com',
+    ]);
+  });
+
+  it("falls back to 'none' when every entry is malformed", () => {
+    expect(parseFrameAncestors('https:, not a url, javascript:alert(1)')).toEqual(["'none'"]);
   });
 });
 

--- a/packages/backend/src/cors-csp-config.ts
+++ b/packages/backend/src/cors-csp-config.ts
@@ -42,6 +42,30 @@ export function buildFrameSrc({ isDev, wingmanPort }: FrameSrcOptions): string[]
   ];
 }
 
+// Matches a well-formed CSP host-source: an http(s) origin with an optional
+// `*.` subdomain wildcard, a host, and an optional port — no path, query, or
+// fragment. Anything else (scheme-only `https:`, a raw CIDR like
+// `192.168.1.0/24`, a bare `*`, junk) is rejected so a typo in FRAME_ANCESTORS
+// can't weaken clickjacking protection or emit a malformed CSP token.
+const FRAME_ANCESTOR_ORIGIN_RE = /^https?:\/\/(\*\.)?[a-zA-Z0-9.-]+(:\d+)?$/;
+
+/**
+ * Parse the operator-supplied `FRAME_ANCESTORS` env value into a validated CSP
+ * `frame-ancestors` directive. Each comma-separated entry is kept only when it
+ * is the `'self'` / `'none'` keyword or a well-formed http(s) origin; malformed
+ * entries (and the wildcard `*`, which would allow any site to frame the app)
+ * are dropped. Falls back to `'none'` when unset or when nothing valid remains,
+ * so a fully-malformed value never silently disables framing protection.
+ */
+export function parseFrameAncestors(raw: string | undefined): string[] {
+  if (!raw) return ["'none'"];
+  const valid = raw
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v === "'self'" || v === "'none'" || FRAME_ANCESTOR_ORIGIN_RE.test(v));
+  return valid.length > 0 ? valid : ["'none'"];
+}
+
 export type CorsOriginCallback = (err: Error | null, allow?: boolean) => void;
 export type CorsOriginHandler = (origin: string | undefined, callback: CorsOriginCallback) => void;
 

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -18,7 +18,9 @@ import {
   buildDevAllowedOrigins,
   buildFrameSrc,
   createCorsOriginHandler,
+  parseFrameAncestors,
 } from './cors-csp-config';
+import { createRateLimitReachedHandler } from './common/middleware/rate-limit-log';
 import { shouldCompress } from './routing/proxy/compression-filter';
 
 export async function bootstrap() {
@@ -57,12 +59,7 @@ export async function bootstrap() {
           fontSrc: ["'self'"],
           objectSrc: ["'none'"],
           frameSrc,
-          frameAncestors: process.env['FRAME_ANCESTORS']
-            ? process.env['FRAME_ANCESTORS']
-                .split(',')
-                .map((v) => v.trim())
-                .filter((v) => v !== '*')
-            : ["'none'"],
+          frameAncestors: parseFrameAncestors(process.env['FRAME_ANCESTORS']),
           // Disable helmet's default `upgrade-insecure-requests`: it breaks
           // HTTP-only LAN deployments (10.x / 192.168.x / 172.16-31.x) where
           // browsers don't treat the origin as trustworthy and rewrite
@@ -115,6 +112,11 @@ export async function bootstrap() {
     new ValidationPipe({
       transform: true,
       whitelist: true,
+      // Reject requests carrying unknown fields with a 400 instead of silently
+      // stripping them. `whitelist` alone drops extras without a signal, which
+      // hides client/API misuse; forbidding them surfaces it and keeps the DTO
+      // contract strict.
+      forbidNonWhitelisted: true,
     }),
   );
 
@@ -156,6 +158,7 @@ export async function bootstrap() {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: 'Too many login attempts. Try again later.' },
+    handler: createRateLimitReachedHandler('sign-in'),
   });
   const signupLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
@@ -163,6 +166,7 @@ export async function bootstrap() {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: 'Too many sign-up attempts. Try again later.' },
+    handler: createRateLimitReachedHandler('sign-up'),
   });
   // forget-password is the worst offender: each request sends an email and
   // can be used for account enumeration via timing differences. Tight cap.
@@ -172,6 +176,7 @@ export async function bootstrap() {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: 'Too many password reset requests. Try again later.' },
+    handler: createRateLimitReachedHandler('password-reset'),
   });
   const verifyEmailLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
@@ -179,6 +184,7 @@ export async function bootstrap() {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: 'Too many verification requests. Try again later.' },
+    handler: createRateLimitReachedHandler('verify-email'),
   });
   expressApp.use('/api/auth/sign-in', loginLimiter);
   expressApp.use('/api/auth/sign-up', signupLimiter);

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.edge.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.edge.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AgentKeyAuthGuard } from './agent-key-auth.guard';
 import { hashKey } from '../../common/utils/hash.util';
@@ -94,14 +94,12 @@ describe('AgentKeyAuthGuard edge cases', () => {
   });
 
   describe('validateMnfstToken with broken relations', () => {
-    // Lines 206-207 of the source dereference keyRecord.agent.name and
-    // keyRecord.tenant.name without null checks. If either relation fails
+    // The candidate query left-joins agent + tenant. If either relation fails
     // to hydrate (race during a delete, foreign-key drift, missing JOIN
-    // result), the code throws a TypeError when assembling the cache entry.
-    // These tests pin that behavior so future refactors can intentionally
-    // tighten it (e.g. throwing UnauthorizedException instead) without
-    // silently regressing.
-    it('throws when keyRecord.agent is null', async () => {
+    // result), the guard now rejects with a clean UnauthorizedException (401)
+    // instead of dereferencing null and surfacing a TypeError as a 500. These
+    // tests pin that hardened behavior.
+    it('rejects with 401 when keyRecord.agent is null', async () => {
       const token = 'mnfst_missing-agent-key';
       mockGetMany.mockResolvedValue([
         {
@@ -116,13 +114,10 @@ describe('AgentKeyAuthGuard edge cases', () => {
       ]);
 
       const { ctx } = makeContext({ authorization: `Bearer ${token}` });
-      // Source accesses keyRecord.agent.name without null-check on line 206.
-      // Assert on a generic Error so the test does not couple to a specific
-      // V8 TypeError wording.
-      await expect(guard.canActivate(ctx)).rejects.toThrow();
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
     });
 
-    it('throws when keyRecord.tenant is null', async () => {
+    it('rejects with 401 when keyRecord.tenant is null', async () => {
       const token = 'mnfst_missing-tenant-key';
       mockGetMany.mockResolvedValue([
         {
@@ -137,11 +132,10 @@ describe('AgentKeyAuthGuard edge cases', () => {
       ]);
 
       const { ctx } = makeContext({ authorization: `Bearer ${token}` });
-      // Source accesses keyRecord.tenant.name without null-check on line 207.
-      await expect(guard.canActivate(ctx)).rejects.toThrow();
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
     });
 
-    it('throws when both keyRecord.agent and keyRecord.tenant are null', async () => {
+    it('rejects with 401 when both keyRecord.agent and keyRecord.tenant are null', async () => {
       const token = 'mnfst_both-null-key';
       mockGetMany.mockResolvedValue([
         {
@@ -156,10 +150,34 @@ describe('AgentKeyAuthGuard edge cases', () => {
       ]);
 
       const { ctx } = makeContext({ authorization: `Bearer ${token}` });
-      await expect(guard.canActivate(ctx)).rejects.toThrow();
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
     });
 
-    it('does not cache the entry when agent is null (cache write fails before set)', async () => {
+    it('remembers the rejection so an identical retry is served from the negative cache', async () => {
+      const token = 'mnfst_orphan-retry-key';
+      mockGetMany.mockResolvedValue([
+        {
+          id: 'key-orphan-retry',
+          tenant_id: 'tenant-1',
+          agent_id: 'agent-orphan',
+          key_hash: hashKey(token),
+          expires_at: null,
+          agent: null,
+          tenant: { owner_user_id: 'user-1' },
+        },
+      ]);
+
+      const first = makeContext({ authorization: `Bearer ${token}` });
+      await expect(guard.canActivate(first.ctx)).rejects.toThrow(UnauthorizedException);
+      const second = makeContext({ authorization: `Bearer ${token}` });
+      await expect(guard.canActivate(second.ctx)).rejects.toThrow(UnauthorizedException);
+
+      // The unhydrated-relation path calls rememberInvalid(), so the second
+      // attempt short-circuits on the negative cache without a second DB hit.
+      expect(mockGetMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a positive entry when agent is null (rejects before cache.set)', async () => {
       const token = 'mnfst_no-cache-on-fail-key';
       mockGetMany.mockResolvedValue([
         {
@@ -174,11 +192,11 @@ describe('AgentKeyAuthGuard edge cases', () => {
       ]);
 
       const { ctx } = makeContext({ authorization: `Bearer ${token}` });
-      await expect(guard.canActivate(ctx)).rejects.toThrow();
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
 
-      // The cache.set call is on the same statement that dereferences the
-      // null relation, so the entry never lands in the cache. A retry must
-      // still hit the DB rather than serving a poisoned cache entry.
+      // The guard rejects on the null relation before reaching cache.set, so
+      // no positive entry lands in the cache — a poisoned entry can never be
+      // served on a later request.
       const internalCache = (guard as unknown as { cache: Map<string, unknown> }).cache;
       expect(internalCache.size).toBe(0);
     });

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -231,6 +231,21 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
       throw new UnauthorizedException('Invalid API key');
     }
 
+    // The candidate query left-joins agent + tenant. If either relation fails
+    // to hydrate — e.g. the agent is soft-deleted in the race between the query
+    // above and the dereference below — reading keyRecord.agent.name /
+    // keyRecord.tenant.owner_user_id would throw a TypeError and surface a 500
+    // that leaks an internal error. Treat an unhydrated relation as an invalid
+    // key: remember the rejection (so an identical retry is served from the
+    // negative cache) and return a clean 401.
+    if (!keyRecord.agent || !keyRecord.tenant) {
+      this.rememberInvalid(hashed);
+      this.logger.warn(
+        `Rejected agent key with unhydrated relations (prefix: ${API_KEY_PREFIX}...)`,
+      );
+      throw new UnauthorizedException('Invalid API key');
+    }
+
     if (keyRecord.expires_at && new Date(keyRecord.expires_at) < new Date()) {
       throw new UnauthorizedException('API key expired');
     }

--- a/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.callback.spec.ts
+++ b/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.callback.spec.ts
@@ -150,6 +150,22 @@ describe('RedirectPkceOauthBaseService — sendDoneResponse', () => {
     });
   });
 
+  it('redirects to the stored [::1] IPv6 loopback backendUrl on error', async () => {
+    const svc = buildSvc();
+    const url = await svc.generateAuthorizationUrl('a', 'u', 'http://[::1]:3001');
+    const state = new URL(url).searchParams.get('state')!;
+
+    const { req, res, done, writeHead } = buildCallbackPair(
+      `/auth/callback?state=${state}&error=access_denied`,
+    );
+    invokeHandler(svc, req, res);
+    await done;
+
+    expect(writeHead).toHaveBeenCalledWith(302, {
+      Location: 'http://[::1]:3001/api/v1/oauth/test-provider/done?ok=0',
+    });
+  });
+
   it('redirects to localhost backendUrl with ok=0 when exchange fails', async () => {
     const svc = buildSvc();
     const originalFetch = global.fetch;

--- a/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.spec.ts
+++ b/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.spec.ts
@@ -111,15 +111,14 @@ describe('RedirectPkceOauthBaseService — backendUrl validation', () => {
       expect(readPendingBackendUrl(svc, state)).toBe('http://127.0.0.1:8080');
     });
 
-    it('rejects http://[::1]:port (current isAllowedRedirectOrigin compares to "::1", not "[::1]")', async () => {
-      // The URL parser returns hostname='[::1]' for IPv6 literals, and the
-      // check uses === '::1'. This documents the current behaviour: the
-      // IPv6 loopback path is effectively dead code today. A future patch
-      // that strips the brackets should flip this test.
+    it('stores a valid http://[::1] (IPv6 loopback) backendUrl verbatim', async () => {
+      // The URL parser returns hostname='[::1]' for IPv6 literals;
+      // isAllowedRedirectOrigin now strips the brackets before comparing, so
+      // IPv6 loopback is accepted the same as localhost / 127.0.0.1.
       const svc = buildSvc();
       const url = await svc.generateAuthorizationUrl('a', 'u', 'http://[::1]:3001');
       const state = new URL(url).searchParams.get('state')!;
-      expect(readPendingBackendUrl(svc, state)).toBe('');
+      expect(readPendingBackendUrl(svc, state)).toBe('http://[::1]:3001');
     });
 
     it('accepts loopback hosts on non-standard ports', async () => {

--- a/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.ts
@@ -435,8 +435,12 @@ export abstract class RedirectPkceOauthBaseService {
 
   private isAllowedRedirectOrigin(url: string): boolean {
     try {
-      const parsed = new URL(url);
-      const hostname = parsed.hostname;
+      // Node's WHATWG URL parser wraps IPv6 hosts in brackets (`[::1]`), so a
+      // bare `'::1'` comparison never matches — IPv6 loopback would be dropped
+      // at storage and fall back to the inline HTML page. Strip the brackets
+      // before comparing so `[::1]` is treated the same as localhost /
+      // 127.0.0.1 in both the storage gate and the redirect gate.
+      const hostname = new URL(url).hostname.replace(/^\[|\]$/g, '');
       return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
     } catch {
       return false;

--- a/packages/backend/test/csp.e2e-spec.ts
+++ b/packages/backend/test/csp.e2e-spec.ts
@@ -2,9 +2,12 @@ import express from 'express';
 import helmet from 'helmet';
 import request from 'supertest';
 import type { Server } from 'http';
+import { parseFrameAncestors } from '../src/cors-csp-config';
 
 // Mirrors the helmet config in src/main.ts. If the two drift, this test
-// stops guarding the real deployment — keep them in sync.
+// stops guarding the real deployment — keep them in sync. The
+// frame-ancestors directive routes through the same parseFrameAncestors
+// helper as production so the validation path is exercised here.
 function buildApp() {
   const app = express();
   app.use(
@@ -18,12 +21,7 @@ function buildApp() {
           connectSrc: ["'self'"],
           fontSrc: ["'self'"],
           objectSrc: ["'none'"],
-          frameAncestors: process.env['FRAME_ANCESTORS']
-            ? process.env['FRAME_ANCESTORS']
-                .split(',')
-                .map((v) => v.trim())
-                .filter((v) => v !== '*')
-            : ["'none'"],
+          frameAncestors: parseFrameAncestors(process.env['FRAME_ANCESTORS']),
           upgradeInsecureRequests: null,
         },
       },
@@ -59,5 +57,23 @@ describe('CSP header', () => {
     expect(csp).toContain("connect-src 'self'");
     expect(csp).toContain("frame-ancestors 'none'");
     expect(csp).toContain("object-src 'none'");
+  });
+
+  it('honors a configured FRAME_ANCESTORS and drops the bare wildcard', async () => {
+    const prev = process.env['FRAME_ANCESTORS'];
+    process.env['FRAME_ANCESTORS'] = 'https://app.example.com, *';
+    const scopedServer = buildApp().listen(0);
+    try {
+      const res = await request(scopedServer).get('/').expect(200);
+      const csp = res.headers['content-security-policy'] as string;
+      expect(csp).toContain('frame-ancestors https://app.example.com');
+      // The bare wildcard would let any site frame the app — it must be dropped.
+      expect(csp).not.toContain('frame-ancestors *');
+      expect(csp).not.toMatch(/frame-ancestors[^;]*\s\*/);
+    } finally {
+      await new Promise<void>((resolve) => scopedServer.close(() => resolve()));
+      if (prev === undefined) delete process.env['FRAME_ANCESTORS'];
+      else process.env['FRAME_ANCESTORS'] = prev;
+    }
   });
 });

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -235,6 +235,9 @@ export async function createTestApp(): Promise<INestApplication> {
       new ValidationPipe({
         transform: true,
         whitelist: true,
+        // Mirror the global pipe in main.ts so E2E exercises the real
+        // strict-DTO behavior (unknown fields → 400, not silently stripped).
+        forbidNonWhitelisted: true,
       }),
     );
     await app.init();

--- a/packages/backend/test/setup.e2e-spec.ts
+++ b/packages/backend/test/setup.e2e-spec.ts
@@ -45,10 +45,10 @@ describe('First-run setup wizard', () => {
 
     it('returns needsSetup=false after a user has been inserted', async () => {
       const ds = app.get(DataSource);
-      await ds.query(
-        `INSERT INTO "user" (id, email, "emailVerified") VALUES ($1, $2, true)`,
-        ['test-user-id', 'founder@example.com'],
-      );
+      await ds.query(`INSERT INTO "user" (id, email, "emailVerified") VALUES ($1, $2, true)`, [
+        'test-user-id',
+        'founder@example.com',
+      ]);
 
       const res = await request(app.getHttpServer()).get('/api/v1/setup/status').expect(200);
       expect(res.body).toMatchObject({ needsSetup: false });
@@ -63,18 +63,16 @@ describe('First-run setup wizard', () => {
   describe('POST /api/v1/setup/admin', () => {
     it('rejects with 409 when a user already exists', async () => {
       const ds = app.get(DataSource);
-      await ds.query(
-        `INSERT INTO "user" (id, email, "emailVerified") VALUES ($1, $2, true)`,
-        ['existing-admin', 'admin@example.com'],
-      );
+      await ds.query(`INSERT INTO "user" (id, email, "emailVerified") VALUES ($1, $2, true)`, [
+        'existing-admin',
+        'admin@example.com',
+      ]);
 
-      const res = await request(app.getHttpServer())
-        .post('/api/v1/setup/admin')
-        .send({
-          email: 'founder@example.com',
-          name: 'Founder',
-          password: 'secret-password',
-        });
+      const res = await request(app.getHttpServer()).post('/api/v1/setup/admin').send({
+        email: 'founder@example.com',
+        name: 'Founder',
+        password: 'secret-password',
+      });
 
       expect(res.status).toBe(409);
     });
@@ -146,10 +144,10 @@ describe('First-run setup wizard', () => {
       ['founder.tag@sub.example.co.uk', 'dotted local + multi-label TLD'],
     ])('accepts valid email %p (%s) past DTO validation', async (email) => {
       const ds = app.get(DataSource);
-      await ds.query(
-        `INSERT INTO "user" (id, email, "emailVerified") VALUES ($1, $2, true)`,
-        ['blocking-admin', 'admin@example.com'],
-      );
+      await ds.query(`INSERT INTO "user" (id, email, "emailVerified") VALUES ($1, $2, true)`, [
+        'blocking-admin',
+        'admin@example.com',
+      ]);
 
       const res = await request(app.getHttpServer())
         .post('/api/v1/setup/admin')
@@ -164,6 +162,23 @@ describe('First-run setup wizard', () => {
       const res = await request(app.getHttpServer())
         .post('/api/v1/setup/admin')
         .send({ email: 'founder@example.com', password: 'secret-password' })
+        .expect(400);
+      expect(res.body.message).toBeDefined();
+    });
+
+    it('rejects an unknown field with 400 (forbidNonWhitelisted)', async () => {
+      // With the global ValidationPipe's forbidNonWhitelisted, a body carrying
+      // a property that isn't on the DTO is rejected outright rather than
+      // silently stripped — the user table is empty here, so a non-strict pipe
+      // would otherwise let this reach the service.
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/setup/admin')
+        .send({
+          email: 'founder@example.com',
+          name: 'Founder',
+          password: 'secret-password',
+          role: 'superadmin',
+        })
         .expect(400);
       expect(res.body.message).toBeDefined();
     });

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,11 +27,11 @@
     "@solidjs/testing-library": "^0.8.0",
     "@types/dompurify": "^3.0.5",
     "@types/node": "^22.0.0",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.6",
     "jsdom": "^26.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.1.0",
     "vite-plugin-solid": "^2.11.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.2.6"
   }
 }


### PR DESCRIPTION
### 💭 Why
Applies the parts of the 2026-06-29 OWASP audit that need zero operator or user action. Leaves out anything that would break an existing deployment.

### ✨ What changed
- Strict DTOs: unknown request fields now return 400 instead of being silently dropped.
- OAuth: IPv6 loopback `[::1]` is accepted as a redirect origin, like `localhost`/`127.0.0.1`.
- Agent-key auth: a null agent/tenant relation returns 401 instead of a 500.
- Rate limits: auth limiters log a structured WARN when they trip (429 response unchanged).
- CSP: `FRAME_ANCESTORS` entries are validated against an origin allow-list; malformed tokens and bare `*` are dropped.
- Deps: undici 6.27.0, form-data 4.0.6, ws 8.21.0 (transitive CVEs), vitest + coverage-v8 3.2.6.

### 👤 For users
Only malformed requests are affected: sending a field that isn't on the endpoint's schema now gets a 400. Well-formed clients and the `/v1/*` LLM proxy (raw body, no DTO) are untouched.

### 🔧 For operators
None. No new env vars, migrations, or config.

### 📝 Notes
Intentionally not included (would need operator action or risk breakage):
- Encryption-key reuse fail-fast (would force setting `MANIFEST_ENCRYPTION_KEY`).
- `DATABASE_URL` fail-fast (would break deployments relying on the default).
- multer bump (exact-pinned by `@nestjs/platform-express`; no multipart endpoints, CVE unreachable).
- vite bump (needs a 6→7 major bump; Windows-only dev CVE).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens security without breaking deployments: stricter request validation, safer OAuth loopback handling, validated CSP frame-ancestors, hardened agent-key auth, and auth rate-limit WARN logs. Also patches CVE-flagged deps; valid clients are unaffected.

- **Bug Fixes**
  - Reject unknown request fields with 400 (global ValidationPipe; LLM proxy unaffected).
  - Accept IPv6 loopback `[::1]` as an OAuth redirect origin (brackets stripped for host check).
  - Agent-key auth returns 401 when agent/tenant relations are missing; adds negative caching and a WARN.
  - Emit structured WARN logs when auth rate limits trip; 429 responses unchanged.
  - Validate `FRAME_ANCESTORS`: keep `'self'`/`'none'` and well-formed http(s) origins; drop bare `*` and malformed entries; default to `'none'`. E2E test now uses the same parser.

- **Dependencies**
  - Bump `undici` to 6.27.0, `form-data` to 4.0.6, `ws` to 8.21.0.
  - Update test tooling: `vitest` and `@vitest/coverage-v8` to 3.2.6.

<sup>Written for commit 74c685b45fac2e799f70143bd5eae802b065cbb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

