### PR TITLE
feat: publish custom provider usage in public stats

### DIFF
--- a/.changeset/custom-provider-public-stats.md
+++ b/.changeset/custom-provider-public-stats.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Public provider stats now include custom-provider usage, grouped under a single "Custom" provider with tenant-scoped endpoint ids scrubbed and rare model names folded into an aggregate bucket

--- a/packages/backend/src/public-stats/public-stats.service.pricing-edges.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.pricing-edges.spec.ts
@@ -75,7 +75,11 @@ describe('PublicStatsService — pricing edge cases', () => {
   }
 
   function setupProviderDailyQuery(rows: unknown) {
-    mockRepo.createQueryBuilder.mockReturnValueOnce(mockQueryBuilder(rows));
+    mockRepo.createQueryBuilder
+      .mockReturnValueOnce(mockQueryBuilder(rows))
+      // Second parallel query: distinct (custom model, tenant) pairs feeding
+      // the custom-model k-anonymity floor. Irrelevant to pricing edges.
+      .mockReturnValueOnce(mockQueryBuilder([]));
   }
 
   function setupAgentDailyQuery(rows: unknown) {

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -702,6 +702,8 @@ describe('PublicStatsService', () => {
         expect.objectContaining({ cutoff30d: expect.any(String) }),
       );
       expect(pairsQb.where).toHaveBeenCalledWith("at.model LIKE 'custom:%'");
+      // NULL tenants must not count toward the anonymity floor.
+      expect(pairsQb.andWhere).toHaveBeenCalledWith('at.tenant_id IS NOT NULL');
       expect(pairsQb.andWhere).toHaveBeenCalledWith(
         'at.timestamp >= :cutoff30d',
         expect.objectContaining({ cutoff30d: expect.any(String) }),

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -372,11 +372,24 @@ describe('PublicStatsService', () => {
   });
 
   describe('getProviderDailyTokens', () => {
-    function setupProviderQuery(rows: unknown) {
+    // Mocks the two parallel queries: aggregated daily rows, then the distinct
+    // (custom model, tenant) pairs backing the k-anonymity floor.
+    function setupProviderQuery(rows: unknown, customPairs: unknown = []) {
       const qb = mockQueryBuilder(rows);
       qb.addGroupBy = jest.fn().mockReturnValue(qb);
-      mockRepo.createQueryBuilder.mockReturnValueOnce(qb);
-      return qb;
+      const pairsQb = mockQueryBuilder(customPairs);
+      pairsQb.addGroupBy = jest.fn().mockReturnValue(pairsQb);
+      mockRepo.createQueryBuilder.mockReturnValueOnce(qb).mockReturnValueOnce(pairsQb);
+      return { qb, pairsQb };
+    }
+
+    // Distinct (raw model, tenant) pairs for `count` tenants, as the pairs
+    // query would return them.
+    function tenantPairs(model: string, count: number, tenantPrefix = 't') {
+      return Array.from({ length: count }, (_, i) => ({
+        model,
+        tenant_id: `${tenantPrefix}${i}`,
+      }));
     }
 
     it('groups tokens by provider and model with daily breakdown', async () => {
@@ -466,21 +479,181 @@ describe('PublicStatsService', () => {
       expect(result).toEqual([]);
     });
 
-    it('excludes custom models', async () => {
-      setupProviderQuery([
+    it('groups custom models under the Custom provider with scrubbed names', async () => {
+      setupProviderQuery(
+        [
+          {
+            model: 'custom:abc/llama-3-70b',
+            date: '2026-04-06',
+            tokens: '1000',
+            auth_type: 'api_key',
+            cost: null,
+          },
+          // A second tenant-scoped endpoint serving the same model merges into
+          // the same scrubbed row.
+          {
+            model: 'custom:def/llama-3-70b',
+            date: '2026-04-07',
+            tokens: '500',
+            auth_type: 'api_key',
+            cost: null,
+          },
+        ],
+        tenantPairs('custom:abc/llama-3-70b', 10),
+      );
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('Custom');
+      expect(result[0].total_tokens).toBe(1500);
+      expect(result[0].models).toEqual([
         {
-          model: 'custom:abc/gpt-4o',
-          date: '2026-04-07',
-          tokens: '1000',
-          auth_type: null,
-          cost: null,
+          model: 'llama-3-70b',
+          auth_type: 'api_key',
+          total_tokens: 1500,
+          total_cost: null,
+          daily: [
+            { date: '2026-04-06', tokens: 1000 },
+            { date: '2026-04-07', tokens: 500 },
+          ],
         },
       ]);
+      // The pricing cache is never consulted for custom models.
+      expect(mockPricingCache.getByModel).not.toHaveBeenCalled();
+    });
+
+    it('folds custom models below the tenant floor into one bucket row', async () => {
+      setupProviderQuery(
+        [
+          {
+            model: 'custom:abc/my-fine-tune',
+            date: '2026-04-07',
+            tokens: '1000',
+            auth_type: 'api_key',
+            cost: null,
+          },
+          {
+            model: 'custom:def/other-tune',
+            date: '2026-04-07',
+            tokens: '200',
+            auth_type: 'api_key',
+            cost: null,
+          },
+        ],
+        [...tenantPairs('custom:abc/my-fine-tune', 9), ...tenantPairs('custom:def/other-tune', 2)],
+      );
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('Custom');
+      // Neither name reaches 10 tenants, so both collapse into the bucket and
+      // the provider total still counts every token.
+      expect(result[0].models).toHaveLength(1);
+      expect(result[0].models[0].model).toBe('other-custom-models');
+      expect(result[0].models[0].total_tokens).toBe(1200);
+    });
+
+    it('counts distinct tenants per scrubbed name, not per raw ref', async () => {
+      // The same 5 tenants route the same model through two custom endpoints:
+      // 10 pairs, but only 5 distinct tenants — below the floor.
+      setupProviderQuery(
+        [
+          {
+            model: 'custom:abc/shared-model',
+            date: '2026-04-07',
+            tokens: '100',
+            auth_type: 'api_key',
+            cost: null,
+          },
+        ],
+        [
+          ...tenantPairs('custom:abc/shared-model', 5),
+          ...tenantPairs('custom:def/shared-model', 5),
+        ],
+      );
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result[0].models[0].model).toBe('other-custom-models');
+    });
+
+    it('never exposes a custom ref without a model segment', async () => {
+      setupProviderQuery(
+        [
+          {
+            model: 'custom:abc-uuid-only',
+            date: '2026-04-07',
+            tokens: '100',
+            auth_type: 'api_key',
+            cost: null,
+          },
+        ],
+        tenantPairs('custom:abc-uuid-only', 15),
+      );
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result[0].models[0].model).toBe('other-custom-models');
+    });
+
+    it('keeps a custom model separate from a catalog model with the same name', async () => {
+      setupProviderQuery(
+        [
+          { model: 'gpt-4o', date: '2026-04-07', tokens: '700', auth_type: 'api_key', cost: null },
+          {
+            model: 'custom:abc/gpt-4o',
+            date: '2026-04-07',
+            tokens: '300',
+            auth_type: 'api_key',
+            cost: null,
+          },
+        ],
+        tenantPairs('custom:abc/gpt-4o', 12),
+      );
       mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
 
       const result = await service.getProviderDailyTokens();
 
-      expect(result).toEqual([]);
+      expect(result).toHaveLength(2);
+      const openai = result.find((p) => p.provider === 'OpenAI');
+      const custom = result.find((p) => p.provider === 'Custom');
+      expect(openai!.models).toEqual([
+        expect.objectContaining({ model: 'gpt-4o', total_tokens: 700 }),
+      ]);
+      expect(custom!.models).toEqual([
+        expect.objectContaining({ model: 'gpt-4o', total_tokens: 300 }),
+      ]);
+    });
+
+    it('breaks the Custom provider down by auth type', async () => {
+      setupProviderQuery(
+        [
+          {
+            model: 'custom:abc/llama-3-70b',
+            date: '2026-04-07',
+            tokens: '900',
+            auth_type: 'api_key',
+            cost: null,
+          },
+          {
+            model: 'custom:abc/llama-3-70b',
+            date: '2026-04-07',
+            tokens: '400',
+            auth_type: 'local',
+            cost: null,
+          },
+        ],
+        tenantPairs('custom:abc/llama-3-70b', 10),
+      );
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result[0].auth_types).toEqual([
+        { auth_type: 'api_key', total_tokens: 900, model_count: 1 },
+        { auth_type: 'local', total_tokens: 400, model_count: 1 },
+      ]);
     });
 
     it('excludes Unknown provider models', async () => {
@@ -519,14 +692,17 @@ describe('PublicStatsService', () => {
       expect(dates).toEqual(['2026-04-05', '2026-04-06', '2026-04-07']);
     });
 
-    it('applies 30-day cutoff', async () => {
-      const qb = mockQueryBuilder([]);
-      qb.addGroupBy = jest.fn().mockReturnValue(qb);
-      mockRepo.createQueryBuilder.mockReturnValueOnce(qb);
+    it('applies 30-day cutoff to both queries', async () => {
+      const { qb, pairsQb } = setupProviderQuery([]);
 
       await service.getProviderDailyTokens();
 
       expect(qb.andWhere).toHaveBeenCalledWith(
+        'at.timestamp >= :cutoff30d',
+        expect.objectContaining({ cutoff30d: expect.any(String) }),
+      );
+      expect(pairsQb.where).toHaveBeenCalledWith("at.model LIKE 'custom:%'");
+      expect(pairsQb.andWhere).toHaveBeenCalledWith(
         'at.timestamp >= :cutoff30d',
         expect.objectContaining({ cutoff30d: expect.any(String) }),
       );

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -249,6 +249,9 @@ export class PublicStatsService {
         .select('at.model', 'model')
         .addSelect('at.tenant_id', 'tenant_id')
         .where("at.model LIKE 'custom:%'")
+        // NULL tenants would collapse into one phantom Set member and lower
+        // the effective anonymity floor by one.
+        .andWhere('at.tenant_id IS NOT NULL')
         .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
         .groupBy('at.model')
         .addGroupBy('at.tenant_id')

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -88,6 +88,27 @@ function isCustomModel(model: string): boolean {
   return model.startsWith('custom:');
 }
 
+// All custom-provider traffic is published under this single synthetic
+// provider so the public site can show one aggregate "Custom" entry instead
+// of one page per (tenant-scoped, unpublishable) custom endpoint.
+export const CUSTOM_PROVIDER_LABEL = 'Custom';
+// Custom model names are user-supplied strings. Publish one only when this
+// many distinct tenants used it in the window — the same k-anonymity idea as
+// the error-pages publishing floor — and fold everything below into a single
+// bucket row so provider totals stay exact.
+export const MIN_TENANTS_PER_CUSTOM_MODEL = 10;
+export const OTHER_CUSTOM_MODELS = 'other-custom-models';
+// "custom:<provider-id>/<model>" -> "<model>". The provider id is a
+// tenant-scoped UUID and must never appear in public output.
+const CUSTOM_MODEL_REF_RE = /^custom:[^/]+\//;
+
+function scrubCustomModel(model: string): string {
+  const scrubbed = model.replace(CUSTOM_MODEL_REF_RE, '');
+  // A ref without a "/<model>" part falls through unchanged; never let the
+  // raw provider id out.
+  return isCustomModel(scrubbed) ? OTHER_CUSTOM_MODELS : scrubbed;
+}
+
 @Injectable()
 export class PublicStatsService {
   constructor(
@@ -195,27 +216,60 @@ export class PublicStatsService {
     const cutoff30d = computeCutoff('30 days');
     const dateBucket = sqlDateBucket('at.timestamp');
 
-    const rows: {
-      model: string;
-      date: string;
-      tokens: string;
-      auth_type: string | null;
-      cost: string | null;
-    }[] = await this.messageRepo
-      .createQueryBuilder('at')
-      .select('at.model', 'model')
-      .addSelect(dateBucket, 'date')
-      .addSelect('at.auth_type', 'auth_type')
-      .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
-      .addSelect('SUM(at.cost_usd)', 'cost')
-      .where('at.model IS NOT NULL')
-      .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
-      .groupBy('at.model')
-      .addGroupBy('date')
-      .addGroupBy('at.auth_type')
-      .orderBy('date', 'ASC')
-      .limit(MAX_PROVIDER_DAILY_ROWS)
-      .getRawMany();
+    const [rows, customPairs]: [
+      {
+        model: string;
+        date: string;
+        tokens: string;
+        auth_type: string | null;
+        cost: string | null;
+      }[],
+      { model: string; tenant_id: string }[],
+    ] = await Promise.all([
+      this.messageRepo
+        .createQueryBuilder('at')
+        .select('at.model', 'model')
+        .addSelect(dateBucket, 'date')
+        .addSelect('at.auth_type', 'auth_type')
+        .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
+        .addSelect('SUM(at.cost_usd)', 'cost')
+        .where('at.model IS NOT NULL')
+        .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
+        .groupBy('at.model')
+        .addGroupBy('date')
+        .addGroupBy('at.auth_type')
+        .orderBy('date', 'ASC')
+        .limit(MAX_PROVIDER_DAILY_ROWS)
+        .getRawMany(),
+      // Distinct (model, tenant) pairs for custom traffic, so the k-anonymity
+      // floor counts real tenants per scrubbed name (summing per-raw-name
+      // counts would overcount a tenant with several custom endpoints).
+      this.messageRepo
+        .createQueryBuilder('at')
+        .select('at.model', 'model')
+        .addSelect('at.tenant_id', 'tenant_id')
+        .where("at.model LIKE 'custom:%'")
+        .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
+        .groupBy('at.model')
+        .addGroupBy('at.tenant_id')
+        .limit(MAX_PROVIDER_DAILY_ROWS)
+        .getRawMany(),
+    ]);
+
+    const customTenantsByModel = new Map<string, Set<string>>();
+    for (const pair of customPairs) {
+      const scrubbed = scrubCustomModel(pair.model);
+      let tenants = customTenantsByModel.get(scrubbed);
+      if (!tenants) {
+        tenants = new Set();
+        customTenantsByModel.set(scrubbed, tenants);
+      }
+      tenants.add(pair.tenant_id);
+    }
+    const publishableCustomModels = new Set<string>();
+    for (const [name, tenants] of customTenantsByModel) {
+      if (tenants.size >= MIN_TENANTS_PER_CUSTOM_MODEL) publishableCustomModels.add(name);
+    }
 
     const modelMap = new Map<
       string,
@@ -230,13 +284,21 @@ export class PublicStatsService {
     >();
 
     for (const r of rows) {
-      const modelName = r.model;
-      if (isCustomModel(modelName)) continue;
-      const pricing = this.pricingCache.getByModel(modelName);
-      const provider = pricing?.provider || 'Unknown';
-      if (EXCLUDED_PROVIDERS.has(provider)) continue;
+      let modelName = r.model;
+      let provider: string;
+      if (isCustomModel(modelName)) {
+        provider = CUSTOM_PROVIDER_LABEL;
+        const scrubbed = scrubCustomModel(modelName);
+        modelName = publishableCustomModels.has(scrubbed) ? scrubbed : OTHER_CUSTOM_MODELS;
+      } else {
+        const pricing = this.pricingCache.getByModel(modelName);
+        provider = pricing?.provider || 'Unknown';
+        if (EXCLUDED_PROVIDERS.has(provider)) continue;
+      }
 
-      const key = `${modelName}:${r.auth_type ?? ''}`;
+      // Provider is part of the key: a scrubbed custom name can collide with
+      // a real catalog model, and those must stay separate entries.
+      const key = `${provider}:${modelName}:${r.auth_type ?? ''}`;
       let entry = modelMap.get(key);
       if (!entry) {
         entry = {

--- a/packages/backend/test/public-stats.e2e-spec.ts
+++ b/packages/backend/test/public-stats.e2e-spec.ts
@@ -30,6 +30,19 @@ beforeAll(async () => {
     ['ps-msg-3', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 150, 75, 'claude-opus-4-6', 'ok'],
   );
 
+  // Custom-endpoint traffic: two tenant-scoped provider refs from one tenant,
+  // exercising the Custom grouping + k-anonymity fold on real SQL.
+  await ds.query(
+    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+    ['ps-msg-4', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 400, 200, 'custom:d0c5ce41-0000-4000-8000-000000000001/private-model', 'ok'],
+  );
+  await ds.query(
+    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, status)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+    ['ps-msg-5', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 200, 100, 'custom:d0c5ce41-0000-4000-8000-000000000002/other-private-model', 'ok'],
+  );
+
   // Tag the seeded agent so the agent-tokens endpoint has a recognised
   // (category, platform) pair to aggregate the seeded messages under.
   await ds.query(
@@ -79,6 +92,30 @@ describe('GET /api/v1/public/free-models', () => {
     expect(Array.isArray(res.body.models)).toBe(true);
     expect(res.body).toHaveProperty('total_models');
     expect(res.body).toHaveProperty('cached_at');
+  });
+});
+
+describe('GET /api/v1/public/provider-tokens', () => {
+  it('groups custom-endpoint traffic under one Custom provider without leaking refs', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/public/provider-tokens')
+      .expect(200);
+
+    expect(Array.isArray(res.body.providers)).toBe(true);
+    const custom = res.body.providers.find(
+      (p: { provider: string }) => p.provider === 'Custom',
+    );
+    expect(custom).toBeDefined();
+    // A single tenant sits below the k-anonymity floor, so both seeded model
+    // names fold into the aggregate bucket while the totals stay exact.
+    expect(custom.models).toEqual([
+      expect.objectContaining({ model: 'other-custom-models', total_tokens: 900 }),
+    ]);
+    expect(custom.total_tokens).toBe(900);
+    // The tenant-scoped provider refs must never appear anywhere in the payload.
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toContain('d0c5ce41');
+    expect(payload).not.toContain('private-model');
   });
 });
 


### PR DESCRIPTION
### 💭 Why
Custom endpoints carry about a quarter of all tokens routed through Manifest (24.4B of 96B over the last 30 days), but the public provider stats drop them entirely. The website can't show a providers page for that traffic.

### ✨ What changed
- `provider-tokens` groups all `custom:*` traffic under one synthetic "Custom" provider.
- Tenant-scoped `custom:<uuid>/` refs are stripped from model names before publishing.
- A model name is published only when 10+ distinct tenants used it in the window (same k-anonymity idea as the error pages). Everything below folds into an `other-custom-models` bucket, so provider totals stay exact.
- Distinct (model, tenant) pairs are counted in a second parallel query, so a tenant with several endpoints can't inflate the floor.
- Top-models and free-models endpoints still exclude custom traffic (they are catalog-model leaderboards).

### 👤 For users
manifest.build/providers/ can now show custom-endpoint consumption as a single "Custom" provider with real 30-day numbers.

### 🔧 For operators
Deploy this before the matching website PR (mnfst/website) so the new /providers/custom/ page has data. No migrations, no env changes.

### 📝 Notes
Verified against prod data shape: top scrubbed names pass the floor with 91-174 tenants each; e2e covers the fold + ref-scrubbing path on real Postgres.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds custom-endpoint usage to public provider stats by grouping all `custom:*` traffic under a single `Custom` provider. Scrubs tenant-scoped refs and enforces a 10-tenant floor so we don’t leak private endpoints.

- **New Features**
  - Groups all `custom:*` traffic under `Custom` in `/api/v1/public/provider-tokens`.
  - Strips `custom:<uuid>/` from model names; never exposes endpoint refs, and refs without a model segment collapse into `other-custom-models`.
  - Publishes a custom model name only if 10+ distinct tenants used it; counts per scrubbed name via a parallel pairs query and ignores NULL tenant IDs.
  - Keeps custom models separate from catalog models even if names match; keeps auth-type breakdown; still excludes custom from top/free model leaderboards.
  - Applies the 30-day cutoff to both aggregation and tenant-pair queries.

- **Migration**
  - Deploy this backend change before the website update so `/providers/custom/` shows data. No DB migrations or env changes.

<sup>Written for commit 781b037ae15d1f65567604c59ccbf80d92ca66cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

