### PR TITLE
fix: drop unsigned Anthropic thinking blocks

### DIFF
--- a/.changeset/anthropic-thinking-signature.md
+++ b/.changeset/anthropic-thinking-signature.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Drop unsigned Anthropic thinking blocks before forwarding native Messages requests to Anthropic.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -2372,6 +2372,25 @@ describe('Anthropic Adapter', () => {
       expect(messages[0].content).toEqual([cached[0], toolUse]);
     });
 
+    it('drops assistant turns that only contain unsigned thinking blocks', () => {
+      const invalidThinking = { type: 'thinking', thinking: 'foreign reasoning', signature: '' };
+      const inbound = {
+        messages: [
+          { role: 'user', content: 'first' },
+          { role: 'assistant', content: [invalidThinking] },
+          { role: 'user', content: 'next' },
+        ],
+      };
+
+      const result = applyAnthropicMessagesMutations(inbound);
+
+      expect(result.messages).toEqual([
+        { role: 'user', content: 'first' },
+        { role: 'user', content: 'next' },
+      ]);
+      expect(inbound.messages[1].content).toEqual([invalidThinking]);
+    });
+
     it('does not touch messages when thinkingLookup returns nothing', () => {
       const inboundMessages = [
         { role: 'user', content: 'hi' },

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -2318,6 +2318,60 @@ describe('Anthropic Adapter', () => {
       expect(messages[1].content).toEqual(echoed.content);
     });
 
+    it('drops unsigned thinking blocks before forwarding native Anthropic messages', () => {
+      const invalidThinking = { type: 'thinking', thinking: 'foreign reasoning', signature: '' };
+      const missingSignature = { type: 'thinking', thinking: 'fallback reasoning' };
+      const toolUse = { type: 'tool_use', id: 'call_1', name: 'web_search', input: { q: 'cats' } };
+      const inbound = {
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              invalidThinking,
+              missingSignature,
+              { type: 'text', text: 'visible answer' },
+              toolUse,
+            ],
+          },
+        ],
+      };
+
+      const result = applyAnthropicMessagesMutations(inbound);
+
+      const messages = result.messages as Array<Record<string, unknown>>;
+      expect(messages[0].content).toEqual([{ type: 'text', text: 'visible answer' }, toolUse]);
+      expect(inbound.messages[0].content).toEqual([
+        invalidThinking,
+        missingSignature,
+        { type: 'text', text: 'visible answer' },
+        toolUse,
+      ]);
+    });
+
+    it('replays cached thinking after removing an unsigned client echo', () => {
+      const cached = [
+        { type: 'thinking' as const, thinking: 'signed reasoning', signature: 'sigA' },
+      ];
+      const toolUse = { type: 'tool_use', id: 'call_1', name: 'web_search', input: { q: 'cats' } };
+      const result = applyAnthropicMessagesMutations(
+        {
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                { type: 'thinking', thinking: 'foreign reasoning', signature: '' },
+                toolUse,
+              ],
+            },
+          ],
+        },
+        { thinkingLookup: () => cached },
+      );
+
+      const messages = result.messages as Array<Record<string, unknown>>;
+      expect(messages[0].content).toEqual([cached[0], toolUse]);
+    });
+
     it('does not touch messages when thinkingLookup returns nothing', () => {
       const inboundMessages = [
         { role: 'user', content: 'hi' },

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -2372,6 +2372,51 @@ describe('Anthropic Adapter', () => {
       expect(messages[0].content).toEqual([cached[0], toolUse]);
     });
 
+    it('does not replay cached thinking when a redacted thinking echo remains after stripping', () => {
+      const cached = [{ type: 'thinking' as const, thinking: 'cached', signature: 'sigA' }];
+      const redacted = { type: 'redacted_thinking', data: 'opaque' };
+      const toolUse = { type: 'tool_use', id: 'call_1', name: 'web_search', input: { q: 'cats' } };
+      const result = applyAnthropicMessagesMutations(
+        {
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                { type: 'thinking', thinking: 'foreign reasoning', signature: '' },
+                redacted,
+                toolUse,
+              ],
+            },
+          ],
+        },
+        { thinkingLookup: () => cached },
+      );
+
+      const messages = result.messages as Array<Record<string, unknown>>;
+      expect(messages[0].content).toEqual([redacted, toolUse]);
+    });
+
+    it('keeps sanitized tool_use turns when no cached thinking is available', () => {
+      const toolUse = { type: 'tool_use', id: 'call_1', name: 'web_search', input: { q: 'cats' } };
+      const result = applyAnthropicMessagesMutations(
+        {
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                { type: 'thinking', thinking: 'foreign reasoning', signature: '' },
+                toolUse,
+              ],
+            },
+          ],
+        },
+        { thinkingLookup: () => null },
+      );
+
+      const messages = result.messages as Array<Record<string, unknown>>;
+      expect(messages[0].content).toEqual([toolUse]);
+    });
+
     it('drops assistant turns that only contain unsigned thinking blocks', () => {
       const invalidThinking = { type: 'thinking', thinking: 'foreign reasoning', signature: '' };
       const inbound = {

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -19,7 +19,8 @@ interface ContentBlock {
   content?: unknown;
   cache_control?: { type: string };
   // Extended-thinking fields. Only populated on `thinking` /
-  // `redacted_thinking` blocks. We never inspect them beyond pass-through.
+  // `redacted_thinking` blocks. Anthropic `thinking` blocks must carry a
+  // non-empty signature to be replayed to Anthropic.
   thinking?: string;
   signature?: string;
   data?: string;
@@ -108,6 +109,24 @@ function normalizeOutputConfigForModel(outputConfig: unknown, model: string | un
   if (!isObjectRecord(outputConfig)) return outputConfig;
   if (outputConfig.effort !== 'xhigh' || !isClaudeSonnetModel(model)) return outputConfig;
   return { ...outputConfig, effort: 'high' };
+}
+
+function hasReplayableThinkingSignature(block: ContentBlock): boolean {
+  return typeof block.signature === 'string' && block.signature.trim().length > 0;
+}
+
+function stripUnsignedThinkingBlocks(content: ContentBlock[]): {
+  content: ContentBlock[];
+  changed: boolean;
+} {
+  let changed = false;
+  const filtered = content.filter((block) => {
+    if (block.type !== 'thinking') return true;
+    if (hasReplayableThinkingSignature(block)) return true;
+    changed = true;
+    return false;
+  });
+  return changed ? { content: filtered, changed } : { content, changed: false };
 }
 
 /* ── Request helpers ── */
@@ -435,27 +454,48 @@ export function applyAnthropicMessagesMutations(
 
   const thinkingLookup = options?.thinkingLookup;
   const thinkingRouteContext = options?.thinkingRouteContext;
-  if (thinkingLookup && Array.isArray(body.messages)) {
-    result.messages = (body.messages as Array<Record<string, unknown>>).map((m) => {
+  if (Array.isArray(body.messages)) {
+    let messagesChanged = false;
+    const messages = (body.messages as Array<Record<string, unknown>>).map((m) => {
       if (m.role !== 'assistant' || !Array.isArray(m.content)) return m;
-      const content = m.content as ContentBlock[];
+      const sanitized = stripUnsignedThinkingBlocks(m.content as ContentBlock[]);
+      const content = sanitized.content;
+      const messageChanged = sanitized.changed;
+
       const firstToolUse = content.find((b) => b.type === 'tool_use');
-      if (!firstToolUse || typeof firstToolUse.id !== 'string') return m;
+      if (!firstToolUse || typeof firstToolUse.id !== 'string' || !thinkingLookup) {
+        if (!messageChanged) return m;
+        messagesChanged = true;
+        return { ...m, content };
+      }
       // Native Messages clients may already echo the previous assistant's
       // signed thinking blocks before the tool_use block. Prepending the
       // cached copy in that case would duplicate signed blocks and the
       // upstream would reject the conversation. Only replay when the turn
-      // is missing the thinking prelude.
+      // is missing the thinking prelude. Unsigned `thinking` blocks can be
+      // produced by non-Anthropic upstreams in Anthropic-compatible sessions;
+      // strip them before this check so they do not suppress valid replay or
+      // reach Anthropic with an invalid signature.
       const alreadyHasThinking = content.some(
         (b) => b.type === 'thinking' || b.type === 'redacted_thinking',
       );
-      if (alreadyHasThinking) return m;
+      if (alreadyHasThinking) {
+        if (!messageChanged) return m;
+        messagesChanged = true;
+        return { ...m, content };
+      }
       const cached = thinkingRouteContext
         ? thinkingLookup(firstToolUse.id, thinkingRouteContext)
         : thinkingLookup(firstToolUse.id);
-      if (!cached || cached.length === 0) return m;
+      if (!cached || cached.length === 0) {
+        if (!messageChanged) return m;
+        messagesChanged = true;
+        return { ...m, content };
+      }
+      messagesChanged = true;
       return { ...m, content: [...(cached as ContentBlock[]), ...content] };
     });
+    if (messagesChanged) result.messages = messages;
   }
 
   return result;

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -398,6 +398,7 @@ export function extractThinkingBlocksFromMessagesResponse(
  * - Default `max_tokens` to 4096 if unset.
  * - Inject the subscription-identity system block for OAuth tokens.
  * - Place a `cache_control` breakpoint on the last system block and last tool.
+ * - Strip unsigned `thinking` blocks that are not replayable to Anthropic.
  * - Replay cached extended-thinking blocks at the head of assistant turns
  *   whose first content block is a `tool_use`.
  */
@@ -456,45 +457,51 @@ export function applyAnthropicMessagesMutations(
   const thinkingRouteContext = options?.thinkingRouteContext;
   if (Array.isArray(body.messages)) {
     let messagesChanged = false;
-    const messages = (body.messages as Array<Record<string, unknown>>).map((m) => {
-      if (m.role !== 'assistant' || !Array.isArray(m.content)) return m;
-      const sanitized = stripUnsignedThinkingBlocks(m.content as ContentBlock[]);
-      const content = sanitized.content;
-      const messageChanged = sanitized.changed;
+    const messages = (body.messages as Array<Record<string, unknown>>)
+      .map((m): Record<string, unknown> | null => {
+        if (m.role !== 'assistant' || !Array.isArray(m.content)) return m;
+        const sanitized = stripUnsignedThinkingBlocks(m.content as ContentBlock[]);
+        const content = sanitized.content;
+        const messageChanged = sanitized.changed;
+        if (messageChanged && content.length === 0) {
+          messagesChanged = true;
+          return null;
+        }
 
-      const firstToolUse = content.find((b) => b.type === 'tool_use');
-      if (!firstToolUse || typeof firstToolUse.id !== 'string' || !thinkingLookup) {
-        if (!messageChanged) return m;
+        const firstToolUse = content.find((b) => b.type === 'tool_use');
+        if (!firstToolUse || typeof firstToolUse.id !== 'string' || !thinkingLookup) {
+          if (!messageChanged) return m;
+          messagesChanged = true;
+          return { ...m, content };
+        }
+        // Native Messages clients may already echo the previous assistant's
+        // signed thinking blocks before the tool_use block. Prepending the
+        // cached copy in that case would duplicate signed blocks and the
+        // upstream would reject the conversation. Only replay when the turn
+        // is missing the thinking prelude. Unsigned `thinking` blocks can be
+        // produced by non-Anthropic upstreams in Anthropic-compatible sessions;
+        // strip them before this check so they do not suppress valid replay or
+        // reach Anthropic with an invalid signature.
+        const alreadyHasThinking = content.some(
+          (b) => b.type === 'thinking' || b.type === 'redacted_thinking',
+        );
+        if (alreadyHasThinking) {
+          if (!messageChanged) return m;
+          messagesChanged = true;
+          return { ...m, content };
+        }
+        const cached = thinkingRouteContext
+          ? thinkingLookup(firstToolUse.id, thinkingRouteContext)
+          : thinkingLookup(firstToolUse.id);
+        if (!cached || cached.length === 0) {
+          if (!messageChanged) return m;
+          messagesChanged = true;
+          return { ...m, content };
+        }
         messagesChanged = true;
-        return { ...m, content };
-      }
-      // Native Messages clients may already echo the previous assistant's
-      // signed thinking blocks before the tool_use block. Prepending the
-      // cached copy in that case would duplicate signed blocks and the
-      // upstream would reject the conversation. Only replay when the turn
-      // is missing the thinking prelude. Unsigned `thinking` blocks can be
-      // produced by non-Anthropic upstreams in Anthropic-compatible sessions;
-      // strip them before this check so they do not suppress valid replay or
-      // reach Anthropic with an invalid signature.
-      const alreadyHasThinking = content.some(
-        (b) => b.type === 'thinking' || b.type === 'redacted_thinking',
-      );
-      if (alreadyHasThinking) {
-        if (!messageChanged) return m;
-        messagesChanged = true;
-        return { ...m, content };
-      }
-      const cached = thinkingRouteContext
-        ? thinkingLookup(firstToolUse.id, thinkingRouteContext)
-        : thinkingLookup(firstToolUse.id);
-      if (!cached || cached.length === 0) {
-        if (!messageChanged) return m;
-        messagesChanged = true;
-        return { ...m, content };
-      }
-      messagesChanged = true;
-      return { ...m, content: [...(cached as ContentBlock[]), ...content] };
-    });
+        return { ...m, content: [...(cached as ContentBlock[]), ...content] };
+      })
+      .filter((m): m is Record<string, unknown> => m !== null);
     if (messagesChanged) result.messages = messages;
   }
 


### PR DESCRIPTION
### ✨ What changed
- Drop unsigned `thinking` blocks before forwarding native Messages requests to Anthropic.
- Replay cached signed thinking after stripping invalid client echoes so Anthropic receives a valid prelude.
- Add regression coverage for empty/missing signatures from mixed-provider Claude Code sessions.

### 💭 Why
Claude Code can echo non-Anthropic reasoning as Anthropic-shaped `thinking` blocks with no valid signature. If a later turn routes to Anthropic, forwarding that block causes `Invalid signature in thinking block` 400s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Anthropic 400s by stripping unsigned `thinking`, dropping empty assistant turns, and replaying cached signed `thinking` where needed in native Messages requests. Fixes mixed-provider Claude Code sessions that echo Anthropic-shaped thinking without a signature.

- **Bug Fixes**
  - Sanitize and conditionally replay: remove unsigned `thinking`; drop the turn if empty; prepend cached signed `thinking` before the first `tool_use` only when no `thinking` or `redacted_thinking` remains; otherwise keep sanitized content (preserves `tool_use` when no cache).
  - Expand regression tests to cover stripping, empty-turn drops, and replay/no-replay branches in mixed-provider flows.

<sup>Written for commit 4cb76590b45b7e10dd42a8241115d7d105169f15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

