### PR TITLE
ci: stop no-op changesets from breaking Docker releases

### DIFF
--- a/.changeset/direct-message-label.md
+++ b/.changeset/direct-message-label.md
@@ -1,7 +1,5 @@
 ---
-'manifest-backend': patch
-'manifest-frontend': patch
-'manifest-shared': patch
+'manifest': patch
 ---
 
 Show explicit SDK model overrides as Direct in Messages.

--- a/.changeset/openai-sdk-shipped-modal.md
+++ b/.changeset/openai-sdk-shipped-modal.md
@@ -1,5 +1,5 @@
 ---
-'manifest-frontend': patch
+'manifest': patch
 ---
 
 Update the shipped modal for OpenAI-compatible model discovery and direct model calls.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,5 @@ jobs:
       - name: Check changeset status
         run: npx changeset status --since=origin/main
         continue-on-error: true
+      - name: Check changesets target a releasable package
+        run: node scripts/check-changesets.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,26 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - name: Check for releasable changesets
+        id: releasable
+        run: |
+          # Skip the version-PR step only when we can PROVE nothing will be
+          # released. A changeset that targets only ignored packages
+          # (manifest-backend / -frontend / -shared) makes `changeset version` a
+          # no-op; changesets/action would then push an empty branch and fail
+          # with "No commits between main and changeset-release/main", aborting
+          # this job before the publish steps below ever run. Skipping (not
+          # failing) keeps the job green so Detect version bump can still fire.
+          skip=false
+          if npx changeset status --output=release-plan.json 2>/dev/null; then
+            if [ "$(jq '.releases | length' release-plan.json)" = "0" ]; then
+              skip=true
+            fi
+          fi
+          rm -f release-plan.json
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
       - uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
+        if: steps.releasable.outputs.skip != 'true'
         id: changesets
         with:
           createGithubReleases: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,7 +595,7 @@ There are **no publishable npm packages** in this repo. `packages/backend`, `pac
 
 `packages/manifest/` is a **code-free shell package** that exists only to hold the canonical "Manifest version". It has no `src/`, no tests, no dependencies — just `package.json`, `README.md`, and (after the first release) a `CHANGELOG.md`. The real backend and frontend live under `packages/backend/` and `packages/frontend/` as before.
 
-`.changeset/config.json` has `"ignore": ["manifest-backend", "manifest-frontend", "manifest-shared"]`, so when a contributor runs `npx changeset`, **only `manifest` is a selectable target**. Bumps to `manifest-backend` / `manifest-frontend` / `manifest-shared` are silently discarded. Always target `manifest` regardless of which files you actually changed.
+`.changeset/config.json` has `"ignore": ["manifest-backend", "manifest-frontend", "manifest-shared"]`, so when a contributor runs `npx changeset`, **only `manifest` is a selectable target**. Bumps to `manifest-backend` / `manifest-frontend` / `manifest-shared` are silently discarded. Always target `manifest` regardless of which files you actually changed. A CI check (`scripts/check-changesets.js`, wired into the `changeset-check` job) enforces this: a changeset that targets an ignored package fails the PR, because it makes `changeset version` a no-op and breaks the Release workflow with "No commits between main and changeset-release/main".
 
 ### Adding a changeset
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "turbo test",
     "start": "node packages/backend/dist/main.js",
     "check:api-prefix": "node scripts/check-api-prefix.js",
+    "check:changesets": "node scripts/check-changesets.js",
     "railway:http-logs": "node scripts/railway-http-logs.js",
     "test:scripts": "node --test scripts/*.test.js",
     "lint": "eslint packages/shared/src packages/backend/src packages/frontend/src",

--- a/scripts/check-changesets.js
+++ b/scripts/check-changesets.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+
+// Guardrail: every changeset must target a *releasable* package.
+//
+// `.changeset/config.json` ignores manifest-backend / -frontend / -shared, so a
+// changeset that targets only those is silently dropped by `changeset version`:
+// it produces no version bump, yet still trips changesets/action into pushing an
+// empty `changeset-release/main` branch. Creating the version PR then fails with
+// "No commits between main and changeset-release/main", which aborts the Release
+// job *before* the version-bump detection and Docker publish steps run.
+//
+// This check fails a PR early with a clear message instead. Empty changesets
+// (`changeset add --empty`) have no targets and are allowed.
+
+const DEFAULT_DIR = path.join(__dirname, '..', '.changeset');
+
+function loadIgnored(dir) {
+  const config = JSON.parse(
+    fs.readFileSync(path.join(dir, 'config.json'), 'utf8'),
+  );
+  return new Set(config.ignore ?? []);
+}
+
+function parseTargets(frontMatter) {
+  return frontMatter
+    .split('\n')
+    .map((line) => line.match(/^\s*["']?([^"':\s]+)["']?\s*:/))
+    .filter(Boolean)
+    .map((match) => match[1]);
+}
+
+function findViolations(dir = DEFAULT_DIR) {
+  const ignored = loadIgnored(dir);
+  const files = fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith('.md') && file !== 'README.md');
+
+  const violations = [];
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(dir, file), 'utf8');
+    const frontMatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!frontMatter) continue; // no front matter => nothing to release
+    const targets = parseTargets(frontMatter[1]);
+    const ignoredTargets = targets.filter((name) => ignored.has(name));
+    if (ignoredTargets.length > 0) {
+      violations.push({ file, ignoredTargets });
+    }
+  }
+  return violations;
+}
+
+function main() {
+  const violations = findViolations();
+  if (violations.length === 0) {
+    console.log('OK: all changesets target a releasable package.');
+    return;
+  }
+  console.error('Changeset(s) target ignored packages:\n');
+  for (const { file, ignoredTargets } of violations) {
+    console.error(`  .changeset/${file} -> ${ignoredTargets.join(', ')}`);
+  }
+  console.error(
+    '\nOnly "manifest" is releasable; manifest-backend / -frontend / -shared are\n' +
+      'ignored in .changeset/config.json and get silently dropped by `changeset\n' +
+      'version`. A changeset that targets them makes versioning a no-op and breaks\n' +
+      'the Release workflow ("No commits between main and changeset-release/main").\n\n' +
+      "Fix: change the front matter to `'manifest': patch` (or minor / major).",
+  );
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { findViolations, parseTargets };

--- a/scripts/check-changesets.test.js
+++ b/scripts/check-changesets.test.js
@@ -1,0 +1,84 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { findViolations, parseTargets } = require('./check-changesets.js');
+
+const IGNORE = ['manifest-backend', 'manifest-frontend', 'manifest-shared'];
+
+function makeChangesetDir(files, ignore = IGNORE) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'changeset-test-'));
+  fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify({ ignore }));
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), content);
+  }
+  return dir;
+}
+
+test('flags a changeset that targets only an ignored package', () => {
+  const dir = makeChangesetDir({
+    'bad.md': "---\n'manifest-frontend': patch\n---\n\nSummary.\n",
+  });
+  const violations = findViolations(dir);
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].file, 'bad.md');
+  assert.deepEqual(violations[0].ignoredTargets, ['manifest-frontend']);
+});
+
+test('flags a changeset with multiple ignored targets', () => {
+  const dir = makeChangesetDir({
+    'multi.md':
+      "---\n'manifest-backend': patch\n'manifest-shared': patch\n---\n\nSummary.\n",
+  });
+  const violations = findViolations(dir);
+  assert.equal(violations.length, 1);
+  assert.deepEqual(violations[0].ignoredTargets, [
+    'manifest-backend',
+    'manifest-shared',
+  ]);
+});
+
+test('flags a mix of manifest and an ignored target', () => {
+  const dir = makeChangesetDir({
+    'mixed.md':
+      "---\n'manifest': patch\n'manifest-backend': patch\n---\n\nSummary.\n",
+  });
+  const violations = findViolations(dir);
+  assert.equal(violations.length, 1);
+  assert.deepEqual(violations[0].ignoredTargets, ['manifest-backend']);
+});
+
+test('accepts a changeset that targets manifest', () => {
+  const dir = makeChangesetDir({
+    'good.md': "---\n'manifest': patch\n---\n\nSummary.\n",
+  });
+  assert.deepEqual(findViolations(dir), []);
+});
+
+test('accepts an unquoted manifest target', () => {
+  const dir = makeChangesetDir({ 'good.md': '---\nmanifest: minor\n---\n\nx\n' });
+  assert.deepEqual(findViolations(dir), []);
+});
+
+test('accepts an empty changeset', () => {
+  const dir = makeChangesetDir({ 'empty.md': '---\n---\n' });
+  assert.deepEqual(findViolations(dir), []);
+});
+
+test('ignores README.md even if it looks like a changeset', () => {
+  const dir = makeChangesetDir({
+    'README.md': "---\n'manifest-frontend': patch\n---\n\nnot a changeset\n",
+  });
+  assert.deepEqual(findViolations(dir), []);
+});
+
+test('parseTargets handles quoted, double-quoted and bare names', () => {
+  assert.deepEqual(parseTargets("'manifest': patch"), ['manifest']);
+  assert.deepEqual(parseTargets('"manifest-backend": patch'), [
+    'manifest-backend',
+  ]);
+  assert.deepEqual(parseTargets('manifest: minor'), ['manifest']);
+  assert.deepEqual(parseTargets(''), []);
+});


### PR DESCRIPTION
### 💭 Why
The last Docker release failed. `changesets/action` tried to open a version PR with an empty diff ("No commits between main and changeset-release/main") and aborted the release job before the publish step ran. Root cause: two changesets targeted only ignored packages (`manifest-backend`, `-frontend`, `-shared`), so `changeset version` bumped nothing.

### ✨ What changed
- Retarget the two stray changesets to `manifest` so they release.
- Add `scripts/check-changesets.js` (+ test) to fail such changesets at PR time.
- Guard `release.yml` to skip the version-PR step when nothing is releasable, so a no-op keeps the job green and the publish still fires.
- Document the check in `CLAUDE.md`.

### 🔧 For operators
`manifest@6.13.0` never published (the failed run skipped it). If it is missing on Docker Hub, publish it manually via Actions > Docker > Run workflow with `version` left blank. Merging this PR opens a clean 6.13.1 version PR but does not backfill 6.13.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents no‑op changesets from aborting Docker releases by enforcing releasable targets and skipping the version‑PR step when nothing will publish. Also retargets two stray changesets to `manifest`.

- **Bug Fixes**
  - Retargeted two changesets to `manifest` so they release.
  - Added `scripts/check-changesets.js` (+ tests) and CI hook to block changesets that only target ignored packages (`manifest-backend`, `manifest-frontend`, `manifest-shared`).
  - Updated `release.yml` to skip the version‑PR step when no releases are planned, keeping the job green so Docker publish still runs.

- **Migration**
  - `manifest@6.13.0` may be missing on Docker Hub. If so, run Actions > Docker > Run workflow with version left blank to publish it manually.
  - Merging this PR will open a clean `6.13.1` version PR; it does not backfill `6.13.0`.

<sup>Written for commit 86b1c2f33cfeb91995ec7b91932583a32303424d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

