### PR TITLE
docs: lead with multi-provider routing, not cost savings

### DIFF
--- a/.changeset/provider-connectivity-copy.md
+++ b/.changeset/provider-connectivity-copy.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Lead README, Docker docs, and app meta tags with connecting agents to any provider instead of cost savings.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 <p align="center">
-Reduce your AI costs 
+Plug your AI agents into any provider
 </p>
 
 ![manifest-gh](https://github.com/user-attachments/assets/7dd74fc2-f7d6-4558-a95a-014ed754a125)
@@ -35,7 +35,7 @@ Reduce your AI costs
 
 ## What is Manifest?
 
-Manifest is a smart model router for agents and AI applications that redirects each query to the right model, saving up to 70% in AI costs.
+Manifest is a smart model router for AI agents and apps. Connect your API keys, subscriptions, and local models to one OpenAI-compatible endpoint, and each query goes to the right model. No single-provider lock-in.
 
 - 🔀 Routing based on complexity, specificity and custom HTTP headers
 - 🎛️ Mix your providers: API keys, Subscriptions, Local models, Custom providers

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -17,9 +17,9 @@
 
 ## What is Manifest?
 
-Manifest is a smart model router for **AI agents** like OpenClaw, Hermes, or anything speaking the OpenAI-compatible HTTP API. It sits between your agent and your LLM providers, scores each request, and routes it to the cheapest model that can handle it. Simple questions go to fast, cheap models. Hard problems go to expensive ones. You save money without thinking about it.
+Manifest is a smart model router for **AI agents** like OpenClaw, Hermes, or anything speaking the OpenAI-compatible HTTP API. It sits between your agents and your providers (API keys, subscriptions, or local models) and sends each request to the right one. Simple questions go to fast, cheap models. Hard problems go to the powerful ones. One endpoint for every provider, and a smaller bill as a bonus.
 
-- Route requests to the right model: cut costs up to 70%
+- One endpoint, every provider: send each request to the right model
 - Automatic fallbacks: if a model fails, the next one picks up
 - Set limits: don't exceed your budget
 - Self-hosted: your requests, your providers, your data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ FROM gcr.io/distroless/nodejs24-debian13:nonroot@sha256:f16acace4aa70086d4a2caad
 WORKDIR /app
 
 LABEL org.opencontainers.image.title="Manifest" \
-      org.opencontainers.image.description="Open-source AI model router. Save up to 70% on LLM costs." \
+      org.opencontainers.image.description="Open-source AI model router. Plug your agents into any provider and send each query to the right model." \
       org.opencontainers.image.url="https://manifest.build" \
       org.opencontainers.image.documentation="https://manifest.build/docs" \
       org.opencontainers.image.source="https://github.com/mnfst/manifest" \

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -12,12 +12,12 @@
     <link href="/fonts/boxicons/boxicons-duotone.min.css" rel="stylesheet" />
     <meta
       name="description"
-      content="Monitor and control your AI agent costs."
+      content="Plug your AI agents into any provider. Route every query to the right model."
     />
     <meta property="og:title" content="Manifest" />
     <meta
       property="og:description"
-      content="Monitor and control your AI agent costs."
+      content="Plug your AI agents into any provider. Route every query to the right model."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://app.manifest.build" />
@@ -26,7 +26,7 @@
     <meta name="twitter:title" content="Manifest" />
     <meta
       name="twitter:description"
-      content="Monitor and control your AI agent costs."
+      content="Plug your AI agents into any provider. Route every query to the right model."
     />
     <meta name="twitter:image" content="https://app.manifest.build/og-image.png" />
     <script src="/theme-init.js"></script>


### PR DESCRIPTION
### 💭 Why
The manifest.build homepage now leads with connecting agents to any provider. The repo still pitched "reduce your AI costs" and "up to 70% cheaper", so the public copy was out of sync with the site.

### ✨ What changed
- README tagline and intro now lead with multi-provider routing. Dropped the "70%" claim.
- Docker image label and DOCKER_README reworded the same way.
- App meta description (description + og + twitter) moved from "monitor and control costs" to provider connectivity.
- Added a patch changeset.

### 👤 For users
Anyone landing on the GitHub repo, Docker Hub, or a shared app link sees the current pitch. No product behavior change.

### 📝 Notes
Flagged for follow-up, not in this PR: the README "complexity/specificity" bullet still advertises the routing modes being retired, and package.json still says "observability".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shifted repo and app copy to lead with multi‑provider routing (connect agents to any provider) instead of cost savings. Updated README tagline/intro, Docker image label and DOCKER_README, and app meta descriptions; removed the “up to 70%” claim and added a patch changeset.

<sup>Written for commit f8a5a5df6027326b4da56fc53207c6aa4b2db5e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

