### PR TITLE
fix: enable Anthropic subscription caching

### DIFF
--- a/.changeset/anthropic-subscription-cache.md
+++ b/.changeset/anthropic-subscription-cache.md
@@ -1,0 +1,6 @@
+---
+'manifest-backend': patch
+'manifest-shared': patch
+---
+
+Enable prompt caching support metadata for Anthropic subscriptions and send first-party subscription requests with Anthropic automatic cache control.

--- a/.changeset/anthropic-subscription-cache.md
+++ b/.changeset/anthropic-subscription-cache.md
@@ -1,6 +1,5 @@
 ---
-'manifest-backend': patch
-'manifest-shared': patch
+'manifest': patch
 ---
 
 Enable prompt caching support metadata for Anthropic subscriptions and send first-party subscription requests with Anthropic automatic cache control.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -2248,6 +2248,19 @@ describe('Anthropic Adapter', () => {
       expect(countCacheControls(body)).toBe(2);
     });
 
+    it('keeps caller-supplied top-level automatic cache_control', () => {
+      const existing = { type: 'ephemeral' };
+      const body = {
+        cache_control: existing,
+        messages: [{ role: 'user', content: 'hi' }],
+      };
+
+      applyAnthropicAutomaticCacheControl(body);
+
+      expect(body.cache_control).toBe(existing);
+      expect(countCacheControls(body)).toBe(1);
+    });
+
     it('does not add top-level automatic cache_control when the body is already at the Anthropic cap', () => {
       const cache = { type: 'ephemeral' };
       const body = {

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -1,4 +1,5 @@
 import {
+  applyAnthropicAutomaticCacheControl,
   applyAnthropicMessagesMutations,
   extractThinkingBlocksFromMessagesResponse,
   toAnthropicRequest,
@@ -2232,6 +2233,43 @@ describe('Anthropic Adapter', () => {
       expect(system[0].cache_control).toBeUndefined();
       const tools = result.tools as Array<Record<string, unknown>>;
       expect(tools[0].cache_control).toBeUndefined();
+    });
+
+    it('adds top-level automatic cache_control when a breakpoint slot is available', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'hi' }],
+        system: [{ type: 'text', text: 'instructions', cache_control: { type: 'ephemeral' } }],
+        tools: [{ type: 'web_search_20250305', name: 'web_search' }],
+      };
+
+      applyAnthropicAutomaticCacheControl(body);
+
+      expect((body as Record<string, unknown>).cache_control).toEqual({ type: 'ephemeral' });
+      expect(countCacheControls(body)).toBe(2);
+    });
+
+    it('does not add top-level automatic cache_control when the body is already at the Anthropic cap', () => {
+      const cache = { type: 'ephemeral' };
+      const body = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'cached 1', cache_control: cache },
+              { type: 'text', text: 'cached 2', cache_control: cache },
+            ],
+          },
+        ],
+        system: [
+          { type: 'text', text: 'cached 3', cache_control: cache },
+          { type: 'text', text: 'cached 4', cache_control: cache },
+        ],
+      };
+
+      applyAnthropicAutomaticCacheControl(body);
+
+      expect((body as Record<string, unknown>).cache_control).toBeUndefined();
+      expect(countCacheControls(body)).toBe(4);
     });
 
     it('defaults max_tokens to 4096 when not provided', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -818,7 +818,7 @@ describe('ProviderClient', () => {
       expect(sentBody.stream).toBeUndefined();
     });
 
-    it('injects cache_control breakpoints for subscription auth', async () => {
+    it('injects automatic and block-level cache_control for subscription auth', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       const bodyWithSystem = {
@@ -839,7 +839,7 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.cache_control).toBeUndefined();
+      expect(sentBody.cache_control).toEqual({ type: 'ephemeral' });
       const system = sentBody.system as Array<{ text?: string; cache_control?: unknown }>;
       // First system block is the subscription identity prompt
       expect(system[0].text).toContain('Claude agent');
@@ -1887,6 +1887,7 @@ describe('ProviderClient', () => {
       );
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.model).toBe('minimax-m2.7');
+      expect(sentBody.cache_control).toBeUndefined();
       expect(result.isAnthropic).toBe(true);
     });
 

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -100,6 +100,12 @@ function tryAddCacheControl(
   budget.remaining -= 1;
 }
 
+export function applyAnthropicAutomaticCacheControl(body: Record<string, unknown>): void {
+  if (body.cache_control !== undefined) return;
+  if (countCacheControlBlocks(body) >= MAX_CACHE_CONTROL_BLOCKS) return;
+  body.cache_control = CACHE;
+}
+
 function isClaudeSonnetModel(model: string | undefined): boolean {
   if (!model) return false;
   return bareAnthropicModel(model).replace(/\./g, '-').startsWith('claude-sonnet-');

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -5,6 +5,7 @@ import {
   type GoogleStreamChunkResult,
 } from './google-adapter';
 import {
+  applyAnthropicAutomaticCacheControl,
   applyAnthropicMessagesMutations,
   extractThinkingBlocksFromMessagesResponse,
   toAnthropicRequest,
@@ -74,6 +75,7 @@ export function createAnthropicTransformer(
 
 // Re-export adapter functions used by ProviderClient.forward()
 export {
+  applyAnthropicAutomaticCacheControl,
   applyAnthropicMessagesMutations,
   extractThinkingBlocksFromMessagesResponse,
   toGoogleRequest,

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -7,6 +7,7 @@ import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import { resolveSubscriptionEndpointKey } from './provider-hooks';
 import { injectOpenRouterCacheControl } from './cache-injection';
 import {
+  applyAnthropicAutomaticCacheControl,
   applyAnthropicMessagesMutations,
   toGoogleRequest,
   toAnthropicRequest,
@@ -55,6 +56,13 @@ const PROVIDER_TIMEOUT_MS =
 const QWEN_TOKEN_PLAN_RESPONSES_RE = /^qwen3\.7-max$/i;
 const COPILOT_CHAT_COMPLETIONS_ENDPOINT = '/chat/completions';
 const COPILOT_RESPONSES_ENDPOINTS = new Set(['/responses', 'ws:/responses']);
+
+function shouldApplyAnthropicAutomaticCacheControl(
+  endpointKey: string,
+  authType: string | undefined,
+): boolean {
+  return endpointKey === 'anthropic' && authType === 'subscription';
+}
 
 /**
  * Strip vendor prefix from model name (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").
@@ -420,6 +428,9 @@ export class ProviderClient {
             });
       requestBody.model = bareModel;
       if (stream) requestBody.stream = true;
+      if (shouldApplyAnthropicAutomaticCacheControl(endpointKey, authType)) {
+        applyAnthropicAutomaticCacheControl(requestBody);
+      }
       return {
         url: `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`,
         headers: endpoint.buildHeaders(apiKey, authType),

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -472,7 +472,7 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('anthropic');
     expect(caps).toMatchObject({
       maxContextWindow: 200000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     });
   });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -22,7 +22,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModelsExclude: Object.freeze(['-fast']),
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Mark Anthropic subscriptions as prompt-cache capable.
- Add first-party subscription top-level cache_control when safe.
- Keep Anthropic-compatible gateways on explicit block cache markers.

### 💭 Why
Claude subscription traffic should use the same cache capabilities Manifest already records. First-party Anthropic supports automatic cache control, while gateway compatibility varies.

### 👤 For users
Anthropic subscription requests can get better cache reuse, and provider capabilities no longer underreport prompt caching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable prompt caching for Anthropic subscriptions and auto‑add top‑level cache control on first‑party subscription requests when safe. This improves cache reuse for Claude subscription traffic without changing gateway behavior.

- **Bug Fixes**
  - Marked Anthropic subscription capabilities `supportsPromptCaching: true`.
  - Apply automatic top‑level `cache_control: { type: 'ephemeral' }` for first‑party `anthropic` subscription requests when under the cap, and preserve any caller‑supplied top‑level value.
  - Do not inject top‑level cache control for Anthropic‑compatible gateways (e.g., `minimax`); keep explicit block markers only.
  - Added tests for automatic cache control, cap guard, and gateway behavior.

<sup>Written for commit aa58cf7e1add6a756d4c3f15c178db65eaf65960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

