### PR TITLE
feat: show cache usage breakdown

### DIFF
--- a/.changeset/cache-usage-breakdown.md
+++ b/.changeset/cache-usage-breakdown.md
@@ -1,6 +1,5 @@
 ---
-'manifest-backend': patch
-'manifest-frontend': patch
+'manifest': patch
 ---
 
 Expose aggregate cache read/write token totals and show the cache breakdown on overview token cards.

--- a/.changeset/cache-usage-breakdown.md
+++ b/.changeset/cache-usage-breakdown.md
@@ -1,0 +1,6 @@
+---
+'manifest-backend': patch
+'manifest-frontend': patch
+---
+
+Expose aggregate cache read/write token totals and show the cache breakdown on overview token cards.

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -129,6 +129,24 @@ describe('OverviewController', () => {
     expect(result.summary.messages.trend_pct).toBe(11); // (50-45)/45
   });
 
+  it('defaults missing cache bucket totals to zero in the summary', async () => {
+    ts.getTimeseries.mockResolvedValueOnce({
+      tokenUsage: [{ input_tokens: 20, output_tokens: 5 }],
+      costUsage: [],
+      messageUsage: [],
+    });
+
+    const result = await controller.getOverview({ range: '24h' }, ctx as never);
+
+    expect(result.summary.tokens_today.sub_values).toEqual({
+      input: 20,
+      output: 5,
+      cache_read: 0,
+      cache_creation: 0,
+      fresh_input: 20,
+    });
+  });
+
   it('returns overview with daily timeseries for 7d range', async () => {
     const result = await controller.getOverview({ range: '7d' }, ctx as never);
 

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CacheModule } from '@nestjs/cache-manager';
+import { Reflector } from '@nestjs/core';
 import { OverviewController } from './overview.controller';
 import { AggregationService } from '../services/aggregation.service';
 import { TimeseriesQueriesService } from '../services/timeseries-queries.service';
@@ -20,7 +21,14 @@ function mockAggregation(): Record<string, jest.Mock> {
 function mockTimeseries(): Record<string, jest.Mock> {
   return {
     getTimeseries: jest.fn().mockResolvedValue({
-      tokenUsage: [{ input_tokens: 600, output_tokens: 400 }],
+      tokenUsage: [
+        {
+          input_tokens: 600,
+          output_tokens: 400,
+          cache_read_tokens: 250,
+          cache_creation_tokens: 100,
+        },
+      ],
       costUsage: [{ cost: 5.0 }],
       messageUsage: [{ count: 50 }],
     }),
@@ -75,6 +83,7 @@ describe('OverviewController', () => {
         { provide: ProviderService, useValue: { getProviders: mockGetProviders } },
         { provide: ResolveAgentService, useValue: { resolve: mockResolveAgent } },
         { provide: getRepositoryToken(AgentEnabledProvider), useValue: { find: mockAccessFind } },
+        Reflector,
       ],
     }).compile();
 
@@ -105,7 +114,13 @@ describe('OverviewController', () => {
 
     // 600 + 400 input/output tokens, $5 cost, 50 messages from the buckets.
     expect(result.summary.tokens_today.value).toBe(1000);
-    expect(result.summary.tokens_today.sub_values).toEqual({ input: 600, output: 400 });
+    expect(result.summary.tokens_today.sub_values).toEqual({
+      input: 600,
+      output: 400,
+      cache_read: 250,
+      cache_creation: 100,
+      fresh_input: 250,
+    });
     expect(result.summary.cost_today.value).toBe(5.0);
     expect(result.summary.messages.value).toBe(50);
     // Trends are computed against the previous-window totals.

--- a/packages/backend/src/analytics/controllers/overview.controller.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.ts
@@ -15,19 +15,35 @@ import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.enti
 
 /** Sum the timeseries buckets into current-window totals for the summary cards. */
 function sumTimeseries(tsData: {
-  tokenUsage: { input_tokens: number; output_tokens: number }[];
+  tokenUsage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_tokens?: number;
+    cache_creation_tokens?: number;
+  }[];
   costUsage: { cost: number }[];
   messageUsage: { count: number }[];
-}): { input: number; output: number; cost: number; messages: number } {
+}): {
+  input: number;
+  output: number;
+  cost: number;
+  messages: number;
+  cacheRead: number;
+  cacheCreation: number;
+} {
   let input = 0;
   let output = 0;
+  let cacheRead = 0;
+  let cacheCreation = 0;
   for (const b of tsData.tokenUsage) {
     input += b.input_tokens;
     output += b.output_tokens;
+    cacheRead += b.cache_read_tokens ?? 0;
+    cacheCreation += b.cache_creation_tokens ?? 0;
   }
   const cost = tsData.costUsage.reduce((sum, b) => sum + b.cost, 0);
   const messages = tsData.messageUsage.reduce((sum, b) => sum + b.count, 0);
-  return { input, output, cost, messages };
+  return { input, output, cost, messages, cacheRead, cacheCreation };
 }
 
 @Controller('api/v1')

--- a/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
@@ -45,7 +45,13 @@ describe('AgentAnalyticsService', () => {
   describe('getUsage', () => {
     it('returns token usage with trend', async () => {
       mockGetRawOne
-        .mockResolvedValueOnce({ input: 3000, output: 2000, cache_read: 500, messages: 10 })
+        .mockResolvedValueOnce({
+          input: 3000,
+          output: 2000,
+          cache_read: 500,
+          cache_creation: 300,
+          messages: 10,
+        })
         .mockResolvedValueOnce({ total: 4000 });
 
       const result = await service.getUsage('24h', scope);
@@ -55,13 +61,21 @@ describe('AgentAnalyticsService', () => {
       expect(result.input_tokens).toBe(3000);
       expect(result.output_tokens).toBe(2000);
       expect(result.cache_read_tokens).toBe(500);
+      expect(result.cache_creation_tokens).toBe(300);
+      expect(result.fresh_input_tokens).toBe(2200);
       expect(result.message_count).toBe(10);
       expect(result.trend_pct).toBe(25);
     });
 
     it('handles zero previous period', async () => {
       mockGetRawOne
-        .mockResolvedValueOnce({ input: 100, output: 50, cache_read: 0, messages: 1 })
+        .mockResolvedValueOnce({
+          input: 100,
+          output: 50,
+          cache_read: 0,
+          cache_creation: 0,
+          messages: 1,
+        })
         .mockResolvedValueOnce({ total: 0 });
 
       const result = await service.getUsage('24h', scope);
@@ -71,7 +85,13 @@ describe('AgentAnalyticsService', () => {
 
     it('passes tenant and agent params to queries', async () => {
       mockGetRawOne
-        .mockResolvedValueOnce({ input: 0, output: 0, cache_read: 0, messages: 0 })
+        .mockResolvedValueOnce({
+          input: 0,
+          output: 0,
+          cache_read: 0,
+          cache_creation: 0,
+          messages: 0,
+        })
         .mockResolvedValueOnce({ total: 0 });
 
       await service.getUsage('7d', scope);

--- a/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
@@ -83,6 +83,18 @@ describe('AgentAnalyticsService', () => {
       expect(result.trend_pct).toBe(0);
     });
 
+    it('defaults cache totals to zero when aggregate rows omit cache fields', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({ input: 100, output: 50, messages: 1 })
+        .mockResolvedValueOnce({ total: 0 });
+
+      const result = await service.getUsage('24h', scope);
+
+      expect(result.cache_read_tokens).toBe(0);
+      expect(result.cache_creation_tokens).toBe(0);
+      expect(result.fresh_input_tokens).toBe(100);
+    });
+
     it('passes tenant and agent params to queries', async () => {
       mockGetRawOne
         .mockResolvedValueOnce({

--- a/packages/backend/src/analytics/services/agent-analytics.service.ts
+++ b/packages/backend/src/analytics/services/agent-analytics.service.ts
@@ -17,6 +17,8 @@ export interface AgentUsageResult {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_creation_tokens: number;
+  fresh_input_tokens: number;
   message_count: number;
   trend_pct: number;
 }
@@ -47,6 +49,7 @@ export class AgentAnalyticsService {
         .select('COALESCE(SUM(at.input_tokens), 0)', 'input')
         .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'output')
         .addSelect('COALESCE(SUM(at.cache_read_tokens), 0)', 'cache_read')
+        .addSelect('COALESCE(SUM(at.cache_creation_tokens), 0)', 'cache_creation')
         .addSelect(sqlCountMessages(), 'messages')
         .where('at.timestamp >= :cutoff', { cutoff })
         .andWhere('at.tenant_id = :tenantId', { tenantId: scope.tenantId })
@@ -65,6 +68,8 @@ export class AgentAnalyticsService {
     const input = Number(currentRows?.input ?? 0);
     const output = Number(currentRows?.output ?? 0);
     const cacheRead = Number(currentRows?.cache_read ?? 0);
+    const cacheCreation = Number(currentRows?.cache_creation ?? 0);
+    const freshInput = Math.max(0, input - cacheRead - cacheCreation);
     const messages = Number(currentRows?.messages ?? 0);
     const currentTotal = input + output;
     const previousTotal = Number(prevRows?.total ?? 0);
@@ -75,6 +80,8 @@ export class AgentAnalyticsService {
       input_tokens: input,
       output_tokens: output,
       cache_read_tokens: cacheRead,
+      cache_creation_tokens: cacheCreation,
+      fresh_input_tokens: freshInput,
       message_count: messages,
       trend_pct: computeTrend(currentTotal, previousTotal),
     };

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -149,15 +149,31 @@ describe('AggregationService', () => {
   describe('getSummaryMetrics', () => {
     it('returns merged token, cost, and message metrics with trends', async () => {
       mockGetRawOne
-        .mockResolvedValueOnce({ msg_count: 50, inp: 3000, out: 2000, cost: 5.5 })
+        .mockResolvedValueOnce({
+          msg_count: 50,
+          inp: 3000,
+          out: 2000,
+          cache_read: 1000,
+          cache_creation: 400,
+          cost: 5.5,
+        })
         .mockResolvedValueOnce({ msg_count: 40, tokens: 4000, cost: 4.0 });
 
       const result = await service.getSummaryMetrics('24h', 'tenant-123');
       expect(result.tokens.tokens_today.value).toBe(5000);
       expect(result.tokens.tokens_today.trend_pct).toBe(25);
-      expect(result.tokens.tokens_today.sub_values).toEqual({ input: 3000, output: 2000 });
+      expect(result.tokens.tokens_today.sub_values).toEqual({
+        input: 3000,
+        output: 2000,
+        cache_read: 1000,
+        cache_creation: 400,
+        fresh_input: 1600,
+      });
       expect(result.tokens.input_tokens).toBe(3000);
       expect(result.tokens.output_tokens).toBe(2000);
+      expect(result.tokens.cache_read_tokens).toBe(1000);
+      expect(result.tokens.cache_creation_tokens).toBe(400);
+      expect(result.tokens.fresh_input_tokens).toBe(1600);
       expect(result.cost.value).toBe(5.5);
       expect(result.cost.trend_pct).toBeGreaterThan(0);
       expect(result.messages.value).toBe(50);
@@ -171,6 +187,9 @@ describe('AggregationService', () => {
       expect(result.tokens.tokens_today.value).toBe(0);
       expect(result.tokens.input_tokens).toBe(0);
       expect(result.tokens.output_tokens).toBe(0);
+      expect(result.tokens.cache_read_tokens).toBe(0);
+      expect(result.tokens.cache_creation_tokens).toBe(0);
+      expect(result.tokens.fresh_input_tokens).toBe(0);
       expect(result.cost.value).toBe(0);
       expect(result.messages.value).toBe(0);
     });
@@ -301,14 +320,23 @@ describe('AggregationService', () => {
   describe('buildSummary', () => {
     it('assembles summary cards with trends from current and previous totals', () => {
       const result = AggregationService.buildSummary(
-        { input: 3000, output: 2000, cost: 5.5, messages: 50 },
+        { input: 3000, output: 2000, cacheRead: 1000, cacheCreation: 400, cost: 5.5, messages: 50 },
         { tokens: 4000, cost: 4.0, messages: 40 },
       );
       expect(result.tokens.tokens_today.value).toBe(5000);
       expect(result.tokens.tokens_today.trend_pct).toBe(25); // (5000-4000)/4000
-      expect(result.tokens.tokens_today.sub_values).toEqual({ input: 3000, output: 2000 });
+      expect(result.tokens.tokens_today.sub_values).toEqual({
+        input: 3000,
+        output: 2000,
+        cache_read: 1000,
+        cache_creation: 400,
+        fresh_input: 1600,
+      });
       expect(result.tokens.input_tokens).toBe(3000);
       expect(result.tokens.output_tokens).toBe(2000);
+      expect(result.tokens.cache_read_tokens).toBe(1000);
+      expect(result.tokens.cache_creation_tokens).toBe(400);
+      expect(result.tokens.fresh_input_tokens).toBe(1600);
       expect(result.cost.value).toBe(5.5);
       expect(result.cost.trend_pct).toBe(38); // 37.5 rounded
       expect(result.messages.value).toBe(50);

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -15,6 +15,14 @@ import { computeCutoff, sqlSanitizeCost } from '../../common/utils/postgres-sql'
 
 export { MetricWithTrend };
 
+interface TokenBreakdown {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+  freshInput: number;
+}
+
 interface RangeWindow {
   cutoff: string;
   prevCutoff: string;
@@ -85,6 +93,8 @@ export class AggregationService {
       .select(sqlCountMessages(), 'msg_count')
       .addSelect('COALESCE(SUM(at.input_tokens), 0)', 'inp')
       .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'out')
+      .addSelect('COALESCE(SUM(at.cache_read_tokens), 0)', 'cache_read')
+      .addSelect('COALESCE(SUM(at.cache_creation_tokens), 0)', 'cache_creation')
       .addSelect(`COALESCE(SUM(${safeCost}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff });
     addTenantFilter(currentQb, tenantId, agentName);
@@ -112,6 +122,9 @@ export class AggregationService {
 
     const inputTotal = Number(cur?.inp ?? 0);
     const outputTotal = Number(cur?.out ?? 0);
+    const cacheReadTotal = Number(cur?.cache_read ?? 0);
+    const cacheCreationTotal = Number(cur?.cache_creation ?? 0);
+    const freshInputTotal = Math.max(0, inputTotal - cacheReadTotal - cacheCreationTotal);
     const curTokens = inputTotal + outputTotal;
     const prevTokens = Number(prev?.tokens ?? 0);
     const curCost = Number(cur?.cost ?? 0);
@@ -124,10 +137,19 @@ export class AggregationService {
         tokens_today: {
           value: curTokens,
           trend_pct: computeTrend(curTokens, prevTokens),
-          sub_values: { input: inputTotal, output: outputTotal },
+          sub_values: {
+            input: inputTotal,
+            output: outputTotal,
+            cache_read: cacheReadTotal,
+            cache_creation: cacheCreationTotal,
+            fresh_input: freshInputTotal,
+          },
         } as MetricWithTrend,
         input_tokens: inputTotal,
         output_tokens: outputTotal,
+        cache_read_tokens: cacheReadTotal,
+        cache_creation_tokens: cacheCreationTotal,
+        fresh_input_tokens: freshInputTotal,
       },
       cost: { value: curCost, trend_pct: computeTrend(curCost, prevCost) } as MetricWithTrend,
       messages: { value: curMsgs, trend_pct: computeTrend(curMsgs, prevMsgs) } as MetricWithTrend,
@@ -176,29 +198,70 @@ export class AggregationService {
    * DB) so the current totals can be sourced from the timeseries buckets.
    */
   static buildSummary(
-    current: { input: number; output: number; cost: number; messages: number },
+    current: {
+      input: number;
+      output: number;
+      cost: number;
+      messages: number;
+      cacheRead?: number;
+      cacheCreation?: number;
+    },
     previous: { tokens: number; cost: number; messages: number },
   ): {
-    tokens: { tokens_today: MetricWithTrend; input_tokens: number; output_tokens: number };
+    tokens: {
+      tokens_today: MetricWithTrend;
+      input_tokens: number;
+      output_tokens: number;
+      cache_read_tokens: number;
+      cache_creation_tokens: number;
+      fresh_input_tokens: number;
+    };
     cost: MetricWithTrend;
     messages: MetricWithTrend;
   } {
     const curTokens = current.input + current.output;
+    const tokenBreakdown = this.computeTokenBreakdown(current);
     return {
       tokens: {
         tokens_today: {
           value: curTokens,
           trend_pct: computeTrend(curTokens, previous.tokens),
-          sub_values: { input: current.input, output: current.output },
+          sub_values: {
+            input: tokenBreakdown.input,
+            output: tokenBreakdown.output,
+            cache_read: tokenBreakdown.cacheRead,
+            cache_creation: tokenBreakdown.cacheCreation,
+            fresh_input: tokenBreakdown.freshInput,
+          },
         },
         input_tokens: current.input,
         output_tokens: current.output,
+        cache_read_tokens: tokenBreakdown.cacheRead,
+        cache_creation_tokens: tokenBreakdown.cacheCreation,
+        fresh_input_tokens: tokenBreakdown.freshInput,
       },
       cost: { value: current.cost, trend_pct: computeTrend(current.cost, previous.cost) },
       messages: {
         value: current.messages,
         trend_pct: computeTrend(current.messages, previous.messages),
       },
+    };
+  }
+
+  private static computeTokenBreakdown(current: {
+    input: number;
+    output: number;
+    cacheRead?: number;
+    cacheCreation?: number;
+  }): TokenBreakdown {
+    const cacheRead = current.cacheRead ?? 0;
+    const cacheCreation = current.cacheCreation ?? 0;
+    return {
+      input: current.input,
+      output: current.output,
+      cacheRead,
+      cacheCreation,
+      freshInput: Math.max(0, current.input - cacheRead - cacheCreation),
     };
   }
 

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -122,9 +122,15 @@ export class AggregationService {
 
     const inputTotal = Number(cur?.inp ?? 0);
     const outputTotal = Number(cur?.out ?? 0);
-    const cacheReadTotal = Number(cur?.cache_read ?? 0);
-    const cacheCreationTotal = Number(cur?.cache_creation ?? 0);
-    const freshInputTotal = Math.max(0, inputTotal - cacheReadTotal - cacheCreationTotal);
+    const tokenBreakdown = AggregationService.computeTokenBreakdown({
+      input: inputTotal,
+      output: outputTotal,
+      cacheRead: Number(cur?.cache_read ?? 0),
+      cacheCreation: Number(cur?.cache_creation ?? 0),
+    });
+    const cacheReadTotal = tokenBreakdown.cacheRead;
+    const cacheCreationTotal = tokenBreakdown.cacheCreation;
+    const freshInputTotal = tokenBreakdown.freshInput;
     const curTokens = inputTotal + outputTotal;
     const prevTokens = Number(prev?.tokens ?? 0);
     const curCost = Number(cur?.cost ?? 0);

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -344,8 +344,24 @@ describe('TimeseriesQueriesService', () => {
   describe('getTimeseries', () => {
     it('returns merged token, cost, and message timeseries for hourly', async () => {
       mockGetRawMany.mockResolvedValue([
-        { hour: '2026-02-16T10:00:00', input_tokens: 100, output_tokens: 50, cost: 1.5, count: 5 },
-        { hour: '2026-02-16T11:00:00', input_tokens: 200, output_tokens: 80, cost: 2.0, count: 8 },
+        {
+          hour: '2026-02-16T10:00:00',
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_tokens: 20,
+          cache_creation_tokens: 5,
+          cost: 1.5,
+          count: 5,
+        },
+        {
+          hour: '2026-02-16T11:00:00',
+          input_tokens: 200,
+          output_tokens: 80,
+          cache_read_tokens: 40,
+          cache_creation_tokens: 10,
+          cost: 2.0,
+          count: 8,
+        },
       ]);
 
       const result = await service.getTimeseries('24h', 'tenant-123', true);
@@ -356,6 +372,8 @@ describe('TimeseriesQueriesService', () => {
         hour: '2026-02-16T10:00:00',
         input_tokens: 100,
         output_tokens: 50,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 5,
       });
       expect(result.costUsage[1]).toEqual({ hour: '2026-02-16T11:00:00', cost: 2.0 });
       expect(result.messageUsage[0]).toEqual({ hour: '2026-02-16T10:00:00', count: 5 });
@@ -363,7 +381,15 @@ describe('TimeseriesQueriesService', () => {
 
     it('returns merged timeseries for daily buckets', async () => {
       mockGetRawMany.mockResolvedValue([
-        { date: '2026-02-15', input_tokens: 500, output_tokens: 300, cost: 5.0, count: 20 },
+        {
+          date: '2026-02-15',
+          input_tokens: 500,
+          output_tokens: 300,
+          cache_read_tokens: 100,
+          cache_creation_tokens: 25,
+          cost: 5.0,
+          count: 20,
+        },
       ]);
 
       const result = await service.getTimeseries('7d', 'tenant-123', false);
@@ -372,6 +398,8 @@ describe('TimeseriesQueriesService', () => {
         date: '2026-02-15',
         input_tokens: 500,
         output_tokens: 300,
+        cache_read_tokens: 100,
+        cache_creation_tokens: 25,
       });
       expect(result.costUsage[0]).toEqual({ date: '2026-02-15', cost: 5.0 });
       expect(result.messageUsage[0]).toEqual({ date: '2026-02-15', count: 20 });
@@ -391,6 +419,8 @@ describe('TimeseriesQueriesService', () => {
           hour: '2026-02-16T10:00:00',
           input_tokens: null,
           output_tokens: null,
+          cache_read_tokens: null,
+          cache_creation_tokens: null,
           cost: null,
           count: null,
         },
@@ -401,6 +431,8 @@ describe('TimeseriesQueriesService', () => {
         hour: '2026-02-16T10:00:00',
         input_tokens: 0,
         output_tokens: 0,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
       });
       expect(result.costUsage[0]).toEqual({ hour: '2026-02-16T10:00:00', cost: 0 });
       expect(result.messageUsage[0]).toEqual({ hour: '2026-02-16T10:00:00', count: 0 });

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -27,6 +27,8 @@ interface TimeseriesBucketRow {
   date?: string;
   input_tokens: number;
   output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
   cost: number;
   count: number;
 }
@@ -72,6 +74,8 @@ export class TimeseriesQueriesService {
       .select(bucketExpr, bucketAlias)
       .addSelect('COALESCE(SUM(at.input_tokens), 0)', 'input_tokens')
       .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'output_tokens')
+      .addSelect('COALESCE(SUM(at.cache_read_tokens), 0)', 'cache_read_tokens')
+      .addSelect('COALESCE(SUM(at.cache_creation_tokens), 0)', 'cache_creation_tokens')
       .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'cost')
       .addSelect(sqlCountMessages(), 'count')
       .where('at.timestamp >= :cutoff', { cutoff });
@@ -89,6 +93,8 @@ export class TimeseriesQueriesService {
       date?: string;
       input_tokens: number;
       output_tokens: number;
+      cache_read_tokens: number;
+      cache_creation_tokens: number;
     }[] = [];
     const costUsage: { hour?: string; date?: string; cost: number }[] = [];
     const messageUsage: { hour?: string; date?: string; count: number }[] = [];
@@ -100,6 +106,8 @@ export class TimeseriesQueriesService {
         ...bucketKey,
         input_tokens: parsed.input_tokens,
         output_tokens: parsed.output_tokens,
+        cache_read_tokens: parsed.cache_read_tokens,
+        cache_creation_tokens: parsed.cache_creation_tokens,
       });
       costUsage.push({ ...bucketKey, cost: parsed.cost });
       messageUsage.push({ ...bucketKey, count: parsed.count });
@@ -720,6 +728,8 @@ export class TimeseriesQueriesService {
     const row: TimeseriesBucketRow = {
       input_tokens: Number(r['input_tokens'] ?? 0),
       output_tokens: Number(r['output_tokens'] ?? 0),
+      cache_read_tokens: Number(r['cache_read_tokens'] ?? 0),
+      cache_creation_tokens: Number(r['cache_creation_tokens'] ?? 0),
       cost: Number(r['cost'] ?? 0),
       count: Number(r['count'] ?? 0),
     };

--- a/packages/frontend/src/components/ProviderChartCard.tsx
+++ b/packages/frontend/src/components/ProviderChartCard.tsx
@@ -8,6 +8,12 @@ const MultiAgentTokenChart = lazy(() => import('./MultiAgentTokenChart.jsx'));
 
 type ProviderView = 'messages' | 'tokens' | 'cost';
 
+interface TokenBreakdown {
+  fresh_input?: number;
+  cache_read?: number;
+  cache_creation?: number;
+}
+
 const trendBadge = (pct: number, value: number) => {
   if (pct === 0 || Math.abs(value) < 0.005) return null;
   const clamped = Math.max(-999, Math.min(999, Math.round(pct)));
@@ -33,6 +39,7 @@ interface ProviderChartCardProps {
   messagesTrendPct: number;
   tokensValue: number;
   tokensTrendPct: number;
+  tokenBreakdown?: TokenBreakdown;
   costValue?: number;
   costTrendPct?: number;
   costInfoTooltip?: string;
@@ -51,6 +58,10 @@ const EMPTY = (msg: string) => (
 
 const ProviderChartCard: Component<ProviderChartCardProps> = (props) => {
   const showCost = () => props.costValue != null;
+  const showTokenBreakdown = () =>
+    (props.tokenBreakdown?.fresh_input ?? 0) > 0 ||
+    (props.tokenBreakdown?.cache_read ?? 0) > 0 ||
+    (props.tokenBreakdown?.cache_creation ?? 0) > 0;
 
   return (
     <div class="chart-card">
@@ -97,6 +108,13 @@ const ProviderChartCard: Component<ProviderChartCardProps> = (props) => {
             <span class="chart-card__value">{formatNumber(props.tokensValue)}</span>
             {trendBadge(props.tokensTrendPct, props.tokensValue)}
           </div>
+          <Show when={showTokenBreakdown()}>
+            <span class="chart-card__subvalue">
+              Fresh {formatNumber(props.tokenBreakdown?.fresh_input ?? 0)} / Cache read{' '}
+              {formatNumber(props.tokenBreakdown?.cache_read ?? 0)} / write{' '}
+              {formatNumber(props.tokenBreakdown?.cache_creation ?? 0)}
+            </span>
+          </Show>
         </button>
       </div>
       <div class="chart-card__body">

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -87,7 +87,17 @@ interface RecentActivityRow {
 
 interface OverviewResponse {
   summary: {
-    tokens_today: { value: number; trend_pct: number };
+    tokens_today: {
+      value: number;
+      trend_pct: number;
+      sub_values?: {
+        input: number;
+        output: number;
+        fresh_input?: number;
+        cache_read?: number;
+        cache_creation?: number;
+      };
+    };
     cost_today: { value: number; trend_pct: number };
     messages: { value: number; trend_pct: number };
   };
@@ -566,6 +576,7 @@ const GlobalOverview: Component = () => {
                 messagesTrendPct={o().summary.messages.trend_pct}
                 tokensValue={o().summary.tokens_today.value}
                 tokensTrendPct={o().summary.tokens_today.trend_pct}
+                tokenBreakdown={o().summary.tokens_today.sub_values}
                 costValue={o().summary.cost_today.value}
                 costTrendPct={o().summary.cost_today.trend_pct}
                 costInfoTooltip="Actual API key costs only. Subscription usage is not included."

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -47,7 +47,13 @@ interface OverviewData {
     tokens_today: {
       value: number;
       trend_pct: number;
-      sub_values?: { input: number; output: number };
+      sub_values?: {
+        input: number;
+        output: number;
+        fresh_input?: number;
+        cache_read?: number;
+        cache_creation?: number;
+      };
     };
     cost_today: { value: number; trend_pct: number };
     messages: { value: number; trend_pct: number };
@@ -439,6 +445,7 @@ const Overview: Component = () => {
                     costTrendPct={d().summary?.cost_today?.trend_pct ?? 0}
                     tokensValue={d().summary?.tokens_today?.value ?? 0}
                     tokensTrendPct={d().summary?.tokens_today?.trend_pct ?? 0}
+                    tokenBreakdown={d().summary?.tokens_today?.sub_values}
                     messagesValue={d().summary?.messages?.value ?? 0}
                     messagesTrendPct={d().summary?.messages?.trend_pct ?? 0}
                     costInfoTooltip="Actual API key costs only. Subscription usage is not included."

--- a/packages/frontend/src/pages/providers/ConnectionDetail.tsx
+++ b/packages/frontend/src/pages/providers/ConnectionDetail.tsx
@@ -98,7 +98,17 @@ interface DetailResponse {
 interface AnalyticsResponse {
   summary: {
     messages: { value: number; trend_pct: number };
-    tokens: { value: number; trend_pct: number };
+    tokens: {
+      value: number;
+      trend_pct: number;
+      sub_values?: {
+        input: number;
+        output: number;
+        fresh_input?: number;
+        cache_read?: number;
+        cache_creation?: number;
+      };
+    };
   };
   token_usage: Array<{ hour?: string; date?: string; input_tokens: number; output_tokens: number }>;
   message_usage: Array<{ hour?: string; date?: string; count: number }>;
@@ -681,6 +691,7 @@ const ConnectionDetail: Component = () => {
                       messagesTrendPct={analytics()!.summary.messages.trend_pct}
                       tokensValue={analytics()!.summary.tokens.value}
                       tokensTrendPct={analytics()!.summary.tokens.trend_pct}
+                      tokenBreakdown={analytics()!.summary.tokens.sub_values}
                       costValue={isByok() ? (totalCost() ?? 0) : undefined}
                       range={chartRange()}
                       agentTimeseries={filteredAgentTimeseries() ?? undefined}

--- a/packages/frontend/src/styles/cards.css
+++ b/packages/frontend/src/styles/cards.css
@@ -161,6 +161,14 @@
   gap: var(--gap-sm);
 }
 
+.chart-card__subvalue {
+  display: block;
+  margin-top: 2px;
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+  color: hsl(var(--muted-foreground));
+}
+
 .chart-card__controls {
   margin-left: auto;
   display: flex;

--- a/packages/frontend/tests/components/AnalyticsChartSurfaces.test.tsx
+++ b/packages/frontend/tests/components/AnalyticsChartSurfaces.test.tsx
@@ -100,6 +100,7 @@ describe('analytics chart surface components', () => {
         messagesTrendPct={10}
         tokensValue={1234}
         tokensTrendPct={5}
+        tokenBreakdown={{ fresh_input: 700, cache_read: 400, cache_creation: 100 }}
         costValue={4.56}
         costTrendPct={-2}
         costInfoTooltip="API key cost only"
@@ -123,6 +124,7 @@ describe('analytics chart surface components', () => {
     expect(screen.getByText('Cost')).toBeDefined();
     expect(screen.getByText('Messages')).toBeDefined();
     expect(screen.getByText('Token usage')).toBeDefined();
+    expect(screen.getByText('Fresh 700 / Cache read 400 / write 100')).toBeDefined();
     expect(screen.getByTestId('info-tooltip')).toBeDefined();
     await buildLazyChart();
 
@@ -296,7 +298,11 @@ describe('analytics chart surface components', () => {
     // Token axis uses formatLegendTokens (mocked to String()).
     expect(capturedChartOpts.axes[1].values({}, [1234])).toEqual(['1234']);
     expect(
-      capturedChartOpts.cursor.move({ posToIdx: () => 0, data: [[1700000000]], valToPos: () => 5 }, 7, 3),
+      capturedChartOpts.cursor.move(
+        { posToIdx: () => 0, data: [[1700000000]], valToPos: () => 5 },
+        7,
+        3,
+      ),
     ).toEqual([5, 3]);
   });
 
@@ -348,9 +354,7 @@ describe('analytics chart surface components', () => {
     // Series are rendered in reverse agent order; each must get the default
     // color for its ORIGINAL index, so colors don't all collapse onto index 0.
     // reversed = ['anthropic'(idx1), 'openai'(idx0)] → AGENT_COLORS[1], [0].
-    const strokes = capturedChartOpts.series
-      .slice(1)
-      .map((s: { stroke: string }) => s.stroke);
+    const strokes = capturedChartOpts.series.slice(1).map((s: { stroke: string }) => s.stroke);
     expect(strokes).toEqual([AGENT_COLORS[1], AGENT_COLORS[0]]);
     // A real per-series distinction: the two strokes differ.
     expect(strokes[0]).not.toBe(strokes[1]);
@@ -376,9 +380,7 @@ describe('analytics chart surface components', () => {
 
     buildCapturedChart();
     // reversed order: anthropic (no map → AGENT_COLORS[1]), openai (mapped).
-    const strokes = capturedChartOpts.series
-      .slice(1)
-      .map((s: { stroke: string }) => s.stroke);
+    const strokes = capturedChartOpts.series.slice(1).map((s: { stroke: string }) => s.stroke);
     expect(strokes).toEqual([AGENT_COLORS[1], '#abcdef']);
   });
 });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -154,7 +154,17 @@ import Overview from '../../src/pages/Overview';
 
 const overviewData = {
   summary: {
-    tokens_today: { value: 50000, trend_pct: 12, sub_values: { input: 30000, output: 20000 } },
+    tokens_today: {
+      value: 50000,
+      trend_pct: 12,
+      sub_values: {
+        input: 30000,
+        output: 20000,
+        fresh_input: 15000,
+        cache_read: 12000,
+        cache_creation: 3000,
+      },
+    },
     cost_today: { value: 3.5, trend_pct: -5 },
     messages: { value: 42, trend_pct: 8 },
     services_hit: { total: 3, healthy: 3, issues: 0 },
@@ -263,6 +273,7 @@ describe('Overview', () => {
     await vi.waitFor(() => {
       expect(container.textContent).toContain('$3.50');
       expect(container.textContent).toContain('50000');
+      expect(container.textContent).toContain('Fresh 15000 / Cache read 12000 / write 3000');
       expect(container.textContent).toContain('42');
     });
   });


### PR DESCRIPTION
### ✨ What changed
- Add aggregate cache read, write, and fresh input token totals.
- Include cache totals in overview timeseries summaries.
- Show Fresh / Cache read / write under token cards.

### 💭 Why
Subscription costs can look flat while cache reads still count against provider usage. The dashboard needs to show whether prompts are being served from cache.

### 👤 For users
Overview token cards now show how much prompt input was fresh, cache-read, or cache-written.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cache usage breakdown (fresh input, cache read, cache write) across analytics and shows it on token cards. This makes it clear when prompts are served from cache and how that affects provider usage.

- **New Features**
  - Backend (`packages/backend`): timeseries and aggregation return `cache_read_tokens`, `cache_creation_tokens`, and computed `fresh_input_tokens`; summaries include these in `tokens_today.sub_values` and default missing cache fields to 0 (tests added).
  - Agent usage (`AgentAnalyticsService`): API includes `cache_read_tokens`, `cache_creation_tokens`, and `fresh_input_tokens` with trend.
  - Frontend (`packages/frontend`): token cards show “Fresh / Cache read / write” under “Token usage” only when non-zero; types/tests updated; minor subtext style.

- **Refactors**
  - Reused a shared cache-breakdown helper to compute fresh/cache totals across aggregation and summary builders.

<sup>Written for commit 890bd23787ac706752c514722d9de20014217448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

