### PR TITLE
fix: cache xAI Responses prompts

### DIFF
--- a/.changeset/xai-responses-prompt-cache.md
+++ b/.changeset/xai-responses-prompt-cache.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Send prompt cache keys to xAI Responses requests from Manifest session affinity.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -2307,6 +2307,81 @@ describe('ProviderClient', () => {
       expect(sentBody.max_tokens).toBeUndefined();
     });
 
+    it('adds prompt_cache_key to xAI Responses requests from the Manifest session', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'xai',
+        apiKey: 'sk-xai',
+        model: 'grok-4.20-multi-agent',
+        body,
+        sessionKey: 'session-xai',
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.prompt_cache_key).toBe('session-xai');
+    });
+
+    it('keeps caller-supplied prompt_cache_key for xAI Responses requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'xai',
+        apiKey: 'sk-xai',
+        model: 'grok-4.20-multi-agent',
+        body: { ...body, prompt_cache_key: 'caller-conversation' },
+        sessionKey: 'session-xai',
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.prompt_cache_key).toBe('caller-conversation');
+    });
+
+    it('omits prompt_cache_key for xAI Responses requests without a session', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'xai',
+        apiKey: 'sk-xai',
+        model: 'grok-4.20-multi-agent',
+        body,
+        stream: false,
+      });
+      await client.forward({
+        provider: 'xai',
+        apiKey: 'sk-xai',
+        model: 'grok-4.20-multi-agent',
+        body,
+        sessionKey: '   ',
+        stream: false,
+      });
+
+      const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+      expect(firstBody.prompt_cache_key).toBeUndefined();
+      expect(secondBody.prompt_cache_key).toBeUndefined();
+    });
+
+    it('adds prompt_cache_key for native xAI Responses requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'xai',
+        apiKey: 'sk-xai',
+        model: 'grok-4.3',
+        apiMode: 'responses',
+        body: { input: 'Hello' },
+        sessionKey: 'native-session',
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.prompt_cache_key).toBe('native-session');
+      expect(sentBody.input).toBe('Hello');
+    });
+
     it('leaves regular xAI models on /v1/chat/completions for Chat Completions requests', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -670,14 +670,17 @@ describe('ProxyFallbackService', () => {
         sessionKey: 'my-session',
       });
 
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'xai',
-        apiKey: 'sk-xai',
-        model: 'grok-2',
-        body,
-        stream: false,
-        extraHeaders: { 'x-grok-conv-id': 'my-session' },
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'xai',
+          apiKey: 'sk-xai',
+          model: 'grok-2',
+          body,
+          stream: false,
+          extraHeaders: { 'x-grok-conv-id': 'my-session' },
+          sessionKey: 'my-session',
+        }),
+      );
     });
 
     it('exchanges copilot token before forwarding', async () => {
@@ -698,13 +701,16 @@ describe('ProxyFallbackService', () => {
       });
 
       expect(copilotToken.getCopilotToken).toHaveBeenCalledWith('ghu_token');
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'copilot',
-        apiKey: 'tid=copilot-session-token',
-        model: 'claude-sonnet-4.6',
-        body,
-        stream: false,
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'copilot',
+          apiKey: 'tid=copilot-session-token',
+          model: 'claude-sonnet-4.6',
+          body,
+          stream: false,
+          sessionKey: 'sess-1',
+        }),
+      );
     });
 
     it('builds custom endpoint for custom providers', async () => {
@@ -735,14 +741,17 @@ describe('ProxyFallbackService', () => {
         where: { id: 'cp-1', tenant_id: 'tenant-1' },
       });
 
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'custom:cp-1',
-        apiKey: 'key',
-        model: 'llama',
-        body,
-        stream: false,
-        customEndpoint: expect.objectContaining({ baseUrl: 'https://api.groq.com/openai' }),
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'custom:cp-1',
+          apiKey: 'key',
+          model: 'llama',
+          body,
+          stream: false,
+          customEndpoint: expect.objectContaining({ baseUrl: 'https://api.groq.com/openai' }),
+          sessionKey: 'sess-1',
+        }),
+      );
     });
 
     it('skips the custom-provider lookup entirely when no tenantId is supplied (fail closed)', async () => {
@@ -818,18 +827,21 @@ describe('ProxyFallbackService', () => {
         resourceUrl: 'https://api.minimax.io/anthropic',
       });
 
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'minimax',
-        apiKey: 'token',
-        model: 'MiniMax-M2.5',
-        body,
-        stream: false,
-        customEndpoint: expect.objectContaining({
-          baseUrl: 'https://api.minimax.io/anthropic',
-          format: 'anthropic',
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'minimax',
+          apiKey: 'token',
+          model: 'MiniMax-M2.5',
+          body,
+          stream: false,
+          customEndpoint: expect.objectContaining({
+            baseUrl: 'https://api.minimax.io/anthropic',
+            format: 'anthropic',
+          }),
+          authType: 'subscription',
+          sessionKey: 'sess-1',
         }),
-        authType: 'subscription',
-      });
+      );
     });
 
     it('ignores invalid minimax resource URL', async () => {
@@ -852,14 +864,17 @@ describe('ProxyFallbackService', () => {
       });
 
       // Should forward without custom endpoint
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'minimax',
-        apiKey: 'token',
-        model: 'MiniMax-M2.5',
-        body,
-        stream: false,
-        authType: 'subscription',
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'minimax',
+          apiKey: 'token',
+          model: 'MiniMax-M2.5',
+          body,
+          stream: false,
+          authType: 'subscription',
+          sessionKey: 'sess-1',
+        }),
+      );
     });
 
     it('falls back to providerRegion=cn for pasted minimax subscription tokens', async () => {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -64,6 +64,16 @@ function shouldApplyAnthropicAutomaticCacheControl(
   return endpointKey === 'anthropic' && authType === 'subscription';
 }
 
+function applyXaiResponsesPromptCacheKey(
+  body: Record<string, unknown>,
+  sessionKey: string | undefined,
+): void {
+  if (typeof body.prompt_cache_key === 'string' && body.prompt_cache_key) return;
+  const trimmedSessionKey = sessionKey?.trim();
+  if (!trimmedSessionKey) return;
+  body.prompt_cache_key = trimmedSessionKey;
+}
+
 /**
  * Strip vendor prefix from model name (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").
  * Models synced from OpenRouter use vendor prefixes, but native APIs expect bare names.
@@ -170,6 +180,7 @@ export class ProviderClient {
       thinkingRouteContext: opts.thinkingRouteContext,
       reasoningContentLookup: opts.reasoningContentLookup,
       providerResource: opts.providerResource,
+      sessionKey: opts.sessionKey,
     });
 
     // The Codex backend only serves prompt-cache hits with session affinity
@@ -362,6 +373,7 @@ export class ProviderClient {
     thinkingRouteContext?: ForwardOptions['thinkingRouteContext'];
     reasoningContentLookup?: ForwardOptions['reasoningContentLookup'];
     providerResource?: string;
+    sessionKey?: string;
   }): { url: string; headers: Record<string, string>; requestBody: Record<string, unknown> } {
     const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
     // For non-chat_completions inbound modes ('responses', 'messages'), the
@@ -463,11 +475,16 @@ export class ProviderClient {
                 endpointKey === 'openai-responses' ||
                 endpointKey === 'copilot-responses' ||
                 endpointKey === 'xai-responses',
-              // Only OpenAI's /responses endpoints are known to accept
-              // prompt_cache_key; other Responses-shaped backends may 400.
+              // OpenAI and xAI /responses endpoints accept prompt_cache_key.
+              // Other Responses-shaped backends may 400 on unknown params.
               forwardPromptCacheKey:
-                endpointKey === 'openai-subscription' || endpointKey === 'openai-responses',
+                endpointKey === 'openai-subscription' ||
+                endpointKey === 'openai-responses' ||
+                endpointKey === 'xai-responses',
             });
+      if (endpointKey === 'xai-responses') {
+        applyXaiResponsesPromptCacheKey(requestBody, ctx.sessionKey);
+      }
       // Force upstream streaming for copilot-responses so the SSE collector in
       // handleNonStreamResponse stays the single source of truth. Without this,
       // an explicit `stream: false` from the caller could hand us a plain JSON

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -641,6 +641,7 @@ export class ProxyFallbackService {
       customEndpoint,
       authType,
       apiMode: opts.apiMode,
+      sessionKey: opts.sessionKey,
       signatureLookup,
       thinkingLookup,
       ...(thinkingLookup

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -49,6 +49,8 @@ export interface ForwardOptions {
   body: Record<string, unknown>;
   chatBody?: Record<string, unknown>;
   apiMode?: ProxyApiMode;
+  /** Stable Manifest conversation/session key for provider prompt-cache affinity. */
+  sessionKey?: string;
   stream: boolean;
   signal?: AbortSignal;
   extraHeaders?: Record<string, string>;

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -554,7 +554,7 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('xai');
     expect(caps).toMatchObject({
       maxContextWindow: 128000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     });
   });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -252,7 +252,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     // Model list is fetched dynamically from xAI's OpenAI-compatible /v1/models endpoint.
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 128000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Sends `prompt_cache_key` on xAI Responses requests from Manifest session affinity.
- Marks xAI subscriptions as prompt-cache capable.

### 💭 Why
xAI Responses cache affinity uses `prompt_cache_key`. Chat completions already receive `x-grok-conv-id`.

### 👤 For users
Repeated xAI Responses subscription prompts can reuse provider-side cache.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send `prompt_cache_key` on xAI `responses` requests using the Manifest session key to enable provider-side cache hits for repeated prompts. Also marks xAI subscriptions as prompt-cache capable.

- **Bug Fixes**
  - Add `prompt_cache_key` from `sessionKey` for xAI `responses`; keep caller value if set; omit when no session.
  - Propagate `sessionKey` through `ProxyFallbackService` to `ProviderClient` for all forwards; keep `x-grok-conv-id` for chat completions.
  - Apply to native xAI `responses` requests as well.

<sup>Written for commit 22a15a4b6317e12099feb86dd5c967b4888f4ccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

