### PR TITLE
fix: mark Gemini subscriptions cacheable

### DIFF
--- a/.changeset/gemini-subscription-cache-metadata.md
+++ b/.changeset/gemini-subscription-cache-metadata.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Mark Gemini subscriptions as supporting prompt caching in shared provider metadata.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -257,7 +257,7 @@ describe('getSubscriptionProviderConfig', () => {
     );
     expect(config?.subscriptionCapabilities).toMatchObject({
       maxContextWindow: 1000000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     });
   });
@@ -555,6 +555,15 @@ describe('getSubscriptionCapabilities', () => {
     expect(caps).toMatchObject({
       maxContextWindow: 128000,
       supportsPromptCaching: false,
+      supportsBatching: false,
+    });
+  });
+
+  it('returns capabilities for Gemini subscription', () => {
+    const caps = getSubscriptionCapabilities('gemini');
+    expect(caps).toMatchObject({
+      maxContextWindow: 1000000,
+      supportsPromptCaching: true,
       supportsBatching: false,
     });
   });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -182,7 +182,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     ]),
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 1000000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),
@@ -241,7 +241,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 1000000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Marks Gemini subscriptions as prompt-cache capable in shared metadata.
- Adds subscription capability coverage for Gemini.

### 💭 Why
Gemini subscription responses already report cached token usage. Shared metadata still reported no prompt caching.

### 👤 For users
Gemini subscription capability displays now match runtime behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes capability reporting: Gemini subscriptions now correctly advertise prompt caching support in shared provider metadata. This aligns UI/tooling with runtime behavior.

- **Bug Fixes**
  - Set `supportsPromptCaching: true` for Gemini in subscription configs.
  - Updated tests to validate Gemini subscription capabilities.

<sup>Written for commit a46c3dc6ca9af3938c5d0f61730926239efa2c16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

