### PR TITLE
fix: mark OpenAI subscriptions cacheable

### DIFF
--- a/.changeset/openai-subscription-cache-metadata.md
+++ b/.changeset/openai-subscription-cache-metadata.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Mark OpenAI subscriptions as supporting prompt caching in shared provider metadata.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -477,6 +477,15 @@ describe('getSubscriptionCapabilities', () => {
     });
   });
 
+  it('returns capabilities for OpenAI subscription', () => {
+    const caps = getSubscriptionCapabilities('openai');
+    expect(caps).toMatchObject({
+      maxContextWindow: 200000,
+      supportsPromptCaching: true,
+      supportsBatching: false,
+    });
+  });
+
   it('returns capabilities for all supported providers', () => {
     for (const id of SUPPORTED_SUBSCRIPTION_PROVIDER_IDS) {
       const caps = getSubscriptionCapabilities(id);

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -57,7 +57,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Marks OpenAI subscriptions as prompt-cache capable in shared metadata.
- Adds subscription capability coverage for OpenAI.

### 💭 Why
The runtime already forwards OpenAI cache affinity. Shared metadata still reported no prompt caching.

### 👤 For users
OpenAI subscription capability displays now match runtime behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks OpenAI subscriptions as supporting prompt caching in shared provider metadata. Fixes the mismatch with runtime behavior so capability displays are correct.

- **Bug Fixes**
  - Set supportsPromptCaching to true for OpenAI in subscription configs.
  - Added a unit test to assert OpenAI capabilities.

<sup>Written for commit abec17782fc444b315f847829c98f18da7caf208. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

