### PR TITLE
fix: send Mistral prompt cache keys

### DIFF
--- a/.changeset/mistral-prompt-cache-key.md
+++ b/.changeset/mistral-prompt-cache-key.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Send stable prompt cache keys to Mistral when callers do not provide one.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -112,6 +112,83 @@ describe('ProviderClient', () => {
       );
     });
 
+    it('adds stable Mistral prompt cache affinity without leaking identifiers', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'mistral',
+        apiKey: 'sk-mi',
+        model: 'mistral-large-latest',
+        body,
+        sessionKey: 'session-1',
+        stream: false,
+      });
+      await client.forward({
+        provider: 'mistral',
+        apiKey: 'sk-mi',
+        model: 'mistral-large-latest',
+        body,
+        sessionKey: 'session-1',
+        stream: false,
+      });
+      await client.forward({
+        provider: 'mistral',
+        apiKey: 'sk-mi',
+        model: 'mistral-large-latest',
+        body,
+        sessionKey: 'session-2',
+        stream: false,
+      });
+
+      const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+      const thirdBody = JSON.parse(mockFetch.mock.calls[2][1].body);
+      expect(firstBody.prompt_cache_key).toMatch(/^manifest-[a-f0-9]{32}$/);
+      expect(secondBody.prompt_cache_key).toBe(firstBody.prompt_cache_key);
+      expect(thirdBody.prompt_cache_key).not.toBe(firstBody.prompt_cache_key);
+      expect(firstBody.prompt_cache_key).not.toContain('sk-mi');
+      expect(firstBody.prompt_cache_key).not.toContain('session-1');
+    });
+
+    it('keeps caller-supplied Mistral prompt cache keys', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'mistral',
+        apiKey: 'sk-mi',
+        model: 'mistral-large-latest',
+        body: { ...body, prompt_cache_key: 'caller-conversation' },
+        sessionKey: 'session-1',
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.prompt_cache_key).toBe('caller-conversation');
+    });
+
+    it('omits Mistral prompt_cache_key when no session is available', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'mistral',
+        apiKey: 'sk-mi',
+        model: 'mistral-large-latest',
+        body,
+        stream: false,
+      });
+      await client.forward({
+        provider: 'mistral',
+        apiKey: 'sk-mi',
+        model: 'mistral-large-latest',
+        body,
+        sessionKey: '   ',
+        stream: false,
+      });
+
+      const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+      expect(firstBody.prompt_cache_key).toBeUndefined();
+      expect(secondBody.prompt_cache_key).toBeUndefined();
+    });
+
     it('builds Bedrock Mantle chat completions requests with bearer API-key auth', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { OPENAI_RESPONSES_ONLY_RE, stripVendorPrefix } from '../../common/constants/openai-models';
 import { XAI_RESPONSES_ONLY_RE } from '../../common/constants/xai-models';
@@ -64,6 +65,11 @@ function shouldApplyAnthropicAutomaticCacheControl(
   return endpointKey === 'anthropic' && authType === 'subscription';
 }
 
+function buildPromptCacheKey(sessionKey: string): string {
+  const digest = createHash('sha256').update(sessionKey).digest('hex').slice(0, 32);
+  return `manifest-${digest}`;
+}
+
 function applyXaiResponsesPromptCacheKey(
   body: Record<string, unknown>,
   sessionKey: string | undefined,
@@ -72,6 +78,16 @@ function applyXaiResponsesPromptCacheKey(
   const trimmedSessionKey = sessionKey?.trim();
   if (!trimmedSessionKey) return;
   body.prompt_cache_key = trimmedSessionKey;
+}
+
+function applyMistralPromptCacheKey(
+  body: Record<string, unknown>,
+  sessionKey: string | undefined,
+): void {
+  if (typeof body.prompt_cache_key === 'string' && body.prompt_cache_key) return;
+  const trimmedSessionKey = sessionKey?.trim();
+  if (!trimmedSessionKey) return;
+  body.prompt_cache_key = buildPromptCacheKey(trimmedSessionKey);
 }
 
 /**
@@ -514,6 +530,9 @@ export class ProviderClient {
       sanitized.stream_options = { ...existing, include_usage: true };
     }
     const requestBody = { ...sanitized, model: bareModel, stream };
+    if (endpointKey === 'mistral') {
+      applyMistralPromptCacheKey(requestBody, ctx.sessionKey);
+    }
     if (endpointKey === 'openrouter' && ctx.model.startsWith('anthropic/')) {
       injectOpenRouterCacheControl(requestBody);
     }

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -545,7 +545,7 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('mistral');
     expect(caps).toMatchObject({
       maxContextWindow: 200000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     });
   });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -92,7 +92,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Sends Mistral `prompt_cache_key` from Manifest session affinity.
- Marks Mistral subscriptions as prompt-cache capable.

### 💭 Why
Mistral caching needs a stable cache key. Manifest previously advertised no cache support and sent none.

### 👤 For users
Repeated Mistral subscription prompts can reuse provider-side cache.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send a stable `prompt_cache_key` for Mistral requests to enable provider-side prompt caching. The key is derived from the session key and never includes identifiers.

- **Bug Fixes**
  - Generate `manifest-<32-hex>` from a SHA-256 of `sessionKey` when callers don’t supply `prompt_cache_key`; omit it when no session is available.
  - Preserve caller-supplied `prompt_cache_key`.
  - Set `supportsPromptCaching: true` for Mistral subscriptions.

<sup>Written for commit dc3c4a9dae564d9dd9de18ba8ee07415d6865de2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

