### PR TITLE
fix: cache OpenRouter Gemini and Qwen prompts

### DIFF
--- a/.changeset/openrouter-prompt-cache.md
+++ b/.changeset/openrouter-prompt-cache.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add OpenRouter prompt cache breakpoints for Gemini and Qwen model families.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -2273,7 +2273,7 @@ describe('ProviderClient', () => {
     });
   });
 
-  describe('OpenRouter Anthropic cache injection', () => {
+  describe('OpenRouter prompt cache injection', () => {
     it('injects cache_control for anthropic/ models on openrouter', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
@@ -2295,6 +2295,67 @@ describe('ProviderClient', () => {
       const sysMsg = sentBody.messages[0];
       expect(Array.isArray(sysMsg.content)).toBe(true);
       expect(sysMsg.content[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+
+    it('injects cache_control for direct-routed anthropic models on openrouter', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const bodyWithSystem = {
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+      await client.forward({
+        provider: 'openrouter',
+        apiKey: 'sk-or',
+        model: '~anthropic/claude-sonnet-4-20250514',
+        body: bodyWithSystem,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[0].content[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+
+    it('injects message cache_control for google models on openrouter', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const bodyWithUserReference = {
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Large reference block' },
+        ],
+      };
+      await client.forward({
+        provider: 'openrouter',
+        apiKey: 'sk-or',
+        model: 'google/gemini-2.5-pro',
+        body: bodyWithUserReference,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[0].content).toBe('You are helpful.');
+      expect(sentBody.messages[1].content[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+
+    it('injects message cache_control for qwen models on openrouter', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const bodyWithUserReference = {
+        messages: [{ role: 'user', content: 'Large reference block' }],
+      };
+      await client.forward({
+        provider: 'openrouter',
+        apiKey: 'sk-or',
+        model: 'qwen/qwen3-coder-plus',
+        body: bodyWithUserReference,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[0].content[0].cache_control).toEqual({ type: 'ephemeral' });
     });
 
     it('does not inject cache_control for non-anthropic models on openrouter', async () => {

--- a/packages/backend/src/routing/proxy/cache-injection.spec.ts
+++ b/packages/backend/src/routing/proxy/cache-injection.spec.ts
@@ -121,4 +121,64 @@ describe('injectOpenRouterCacheControl', () => {
     injectOpenRouterCacheControl(body);
     expect(body.tools).toEqual([]);
   });
+
+  it('injects message-mode cache_control into the latest user message', () => {
+    const body = {
+      messages: [
+        { role: 'system', content: 'stable instructions' },
+        { role: 'user', content: 'reference text' },
+      ],
+    };
+    injectOpenRouterCacheControl(body, 'message');
+
+    expect(body.messages[0]).toEqual({ role: 'system', content: 'stable instructions' });
+    expect(body.messages[1].content).toEqual([
+      { type: 'text', text: 'reference text', cache_control: EPHEMERAL },
+    ]);
+  });
+
+  it('skips assistant messages in message mode', () => {
+    const body = {
+      messages: [
+        { role: 'user', content: 'cache this' },
+        { role: 'assistant', content: 'not a cache target' },
+      ],
+    };
+    injectOpenRouterCacheControl(body, 'message');
+
+    expect(body.messages[0].content).toEqual([
+      { type: 'text', text: 'cache this', cache_control: EPHEMERAL },
+    ]);
+    expect(body.messages[1]).toEqual({ role: 'assistant', content: 'not a cache target' });
+  });
+
+  it('does nothing in message mode when no cacheable content exists', () => {
+    const body = {
+      messages: [
+        { role: 'assistant', content: 'not a cache target' },
+        { role: 'user', content: [] },
+      ],
+    };
+    injectOpenRouterCacheControl(body, 'message');
+
+    expect(body.messages).toEqual([
+      { role: 'assistant', content: 'not a cache target' },
+      { role: 'user', content: [] },
+    ]);
+  });
+
+  it('skips malformed message-mode content without stamping invalid blocks', () => {
+    const body = {
+      messages: [
+        { role: 'system', content: { type: 'text', text: 'not an array' } },
+        { role: 'user', content: [null, ['nested']] },
+      ],
+    };
+    injectOpenRouterCacheControl(body, 'message');
+
+    expect(body.messages).toEqual([
+      { role: 'system', content: { type: 'text', text: 'not an array' } },
+      { role: 'user', content: [null, ['nested']] },
+    ]);
+  });
 });

--- a/packages/backend/src/routing/proxy/cache-injection.ts
+++ b/packages/backend/src/routing/proxy/cache-injection.ts
@@ -5,34 +5,57 @@
 
 const CACHE_CONTROL = { type: 'ephemeral' } as const;
 
+type OpenRouterCacheMode = 'anthropic' | 'message';
+
+function injectCacheControlIntoContent(message: Record<string, unknown>): boolean {
+  if (typeof message.content === 'string') {
+    message.content = [
+      {
+        type: 'text',
+        text: message.content,
+        cache_control: CACHE_CONTROL,
+      },
+    ];
+    return true;
+  }
+
+  if (!Array.isArray(message.content)) return false;
+  const blocks = message.content as Array<Record<string, unknown>>;
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const block = blocks[i];
+    if (!block || typeof block !== 'object' || Array.isArray(block)) continue;
+    block.cache_control = CACHE_CONTROL;
+    return true;
+  }
+  return false;
+}
+
 /**
  * Injects cache_control breakpoints into an OpenAI-format body for
- * OpenRouter requests targeting Anthropic models. OpenRouter passes
- * these through to the Anthropic backend.
+ * OpenRouter requests targeting models that require explicit prompt caching.
  */
-export function injectOpenRouterCacheControl(body: Record<string, unknown>): void {
+export function injectOpenRouterCacheControl(
+  body: Record<string, unknown>,
+  mode: OpenRouterCacheMode = 'anthropic',
+): void {
   const messages = body.messages as Array<Record<string, unknown>> | undefined;
   if (!messages) return;
+
+  if (mode === 'message') {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.role !== 'system' && msg.role !== 'developer' && msg.role !== 'user') continue;
+      if (injectCacheControlIntoContent(msg)) return;
+    }
+    return;
+  }
 
   // Find the last system/developer message and inject cache_control on its content
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (msg.role !== 'system' && msg.role !== 'developer') continue;
 
-    if (typeof msg.content === 'string') {
-      msg.content = [
-        {
-          type: 'text',
-          text: msg.content,
-          cache_control: CACHE_CONTROL,
-        },
-      ];
-    } else if (Array.isArray(msg.content)) {
-      const blocks = msg.content as Array<Record<string, unknown>>;
-      if (blocks.length > 0) {
-        blocks[blocks.length - 1].cache_control = CACHE_CONTROL;
-      }
-    }
+    injectCacheControlIntoContent(msg);
     break;
   }
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -90,6 +90,13 @@ function applyMistralPromptCacheKey(
   body.prompt_cache_key = buildPromptCacheKey(trimmedSessionKey);
 }
 
+function openRouterCacheMode(model: string): 'anthropic' | 'message' | null {
+  const normalized = model.toLowerCase().replace(/^~/, '');
+  if (normalized.startsWith('anthropic/')) return 'anthropic';
+  if (normalized.startsWith('google/') || normalized.startsWith('qwen/')) return 'message';
+  return null;
+}
+
 /**
  * Strip vendor prefix from model name (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").
  * Models synced from OpenRouter use vendor prefixes, but native APIs expect bare names.
@@ -533,8 +540,9 @@ export class ProviderClient {
     if (endpointKey === 'mistral') {
       applyMistralPromptCacheKey(requestBody, ctx.sessionKey);
     }
-    if (endpointKey === 'openrouter' && ctx.model.startsWith('anthropic/')) {
-      injectOpenRouterCacheControl(requestBody);
+    if (endpointKey === 'openrouter') {
+      const cacheMode = openRouterCacheMode(ctx.model);
+      if (cacheMode) injectOpenRouterCacheControl(requestBody, cacheMode);
     }
     return {
       url: `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`,


### PR DESCRIPTION
### ✨ What changed
- Adds OpenRouter cache breakpoints for Gemini and Qwen model families.
- Keeps non-cacheable OpenRouter routes unchanged.

### 💭 Why
OpenRouter prompt caching is provider-specific. Gemini and Qwen requests need cache markers on message content.

### 👤 For users
Repeated OpenRouter Gemini and Qwen prompts can reuse provider-side cache.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add prompt caching for OpenRouter Gemini (`google/*`) and Qwen (`qwen/*`) by injecting message-level cache markers so repeated prompts reuse provider-side caches. Anthropic caching is preserved, including direct-routed `~anthropic/*`; other OpenRouter routes are unchanged.

- **Bug Fixes**
  - Inject `cache_control: { type: 'ephemeral' }` into the latest cacheable message for `google/*` and `qwen/*` on `openrouter` (converts strings to text blocks; skips assistant and malformed/empty content).
  - Continue injecting cache markers on system/developer content for `anthropic/*` and `~anthropic/*`.

<sup>Written for commit fb632741c4c04a934103bf939d40662ffbc752da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

