### PR TITLE
fix: report Opus 4.8 subscription context

### DIFF
--- a/.changeset/anthropic-opus-context.md
+++ b/.changeset/anthropic-opus-context.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Report Claude Opus 4.8 with a 1M context window for Anthropic subscription routing.

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -308,6 +308,48 @@ describe('buildSubscriptionFallbackModels', () => {
     expect(ids.some((id) => id.includes('-fast'))).toBe(false);
   });
 
+  it('uses the Anthropic Opus 4.8 subscription context override', () => {
+    const cache = new Map([
+      [
+        'anthropic/claude-opus-4-8',
+        {
+          input: 0.015,
+          output: 0.075,
+          contextWindow: 200000,
+          displayName: 'Claude Opus 4.8',
+        },
+      ],
+    ]);
+
+    const model = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic').find(
+      (m) => m.id === 'claude-opus-4-8',
+    );
+
+    expect(model).toBeDefined();
+    expect(model!.contextWindow).toBe(1000000);
+  });
+
+  it('applies Anthropic Opus 4.8 context override to dated variants', () => {
+    const cache = new Map([
+      [
+        'anthropic/claude-opus-4-8-20260929',
+        {
+          input: 0.015,
+          output: 0.075,
+          contextWindow: 200000,
+          displayName: 'Claude Opus 4.8',
+        },
+      ],
+    ]);
+
+    const model = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic').find(
+      (m) => m.id === 'claude-opus-4-8-20260929',
+    );
+
+    expect(model).toBeDefined();
+    expect(model!.contextWindow).toBe(1000000);
+  });
+
   it('surfaces claude-fable-5 even when the pricing cache lacks it', () => {
     // claude-fable-5 is a valid Anthropic subscription model with no pricing
     // cache entry; the knownModels fallback must still offer it.

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -8,6 +8,7 @@ import {
   getSubscriptionKnownModelsMatch,
   getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
+  type SubscriptionCapabilities,
 } from 'manifest-shared';
 import { normalizeAnthropicShortModelId } from '../common/utils/anthropic-model-id';
 import { GOOGLE_VARIANT_RE } from '../model-prices/model-name-normalizer';
@@ -147,6 +148,41 @@ function providerPrefixedModelId(prefix: string, modelId: string): string | null
   return `${prefix}-${modelId}`;
 }
 
+function resolveSubscriptionContextWindow(
+  modelId: string,
+  contextWindow: number,
+  capabilities: Readonly<SubscriptionCapabilities> | null,
+): number {
+  let modelContextWindow: number | undefined;
+  let matchLength = -1;
+  const normalizedModelId = modelId.toLowerCase();
+  for (const [configuredModelId, configuredContextWindow] of Object.entries(
+    capabilities?.modelContextWindows ?? {},
+  )) {
+    const normalizedConfiguredModelId = configuredModelId.toLowerCase();
+    if (
+      normalizedModelId !== normalizedConfiguredModelId &&
+      !normalizedModelId.startsWith(`${normalizedConfiguredModelId}-`)
+    ) {
+      continue;
+    }
+    if (
+      typeof configuredContextWindow === 'number' &&
+      Number.isFinite(configuredContextWindow) &&
+      configuredContextWindow > 0 &&
+      normalizedConfiguredModelId.length > matchLength
+    ) {
+      modelContextWindow = configuredContextWindow;
+      matchLength = normalizedConfiguredModelId.length;
+    }
+  }
+  if (modelContextWindow) return modelContextWindow;
+  if (capabilities?.maxContextWindow && contextWindow > capabilities.maxContextWindow) {
+    return capabilities.maxContextWindow;
+  }
+  return contextWindow;
+}
+
 /**
  * Build a fallback model list from models.dev cache.
  * Uses native provider model IDs — no prefix stripping or variant matching needed.
@@ -273,10 +309,11 @@ export function buildSubscriptionFallbackModels(
       if (seen.has(modelId)) continue;
       seen.add(modelId);
 
-      let contextWindow = entry.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
-      if (capabilities?.maxContextWindow && contextWindow > capabilities.maxContextWindow) {
-        contextWindow = capabilities.maxContextWindow;
-      }
+      const contextWindow = resolveSubscriptionContextWindow(
+        modelId,
+        entry.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+        capabilities,
+      );
 
       models.push({
         id: modelId,
@@ -308,7 +345,7 @@ export function buildSubscriptionFallbackModels(
       id: modelId,
       displayName: modelId,
       provider: providerId,
-      contextWindow: defaultCtx,
+      contextWindow: resolveSubscriptionContextWindow(modelId, defaultCtx, capabilities),
       inputPricePerToken: 0,
       outputPricePerToken: 0,
       capabilityReasoning: false,
@@ -350,7 +387,7 @@ export function supplementWithKnownModels(
       id: modelId,
       displayName: modelId,
       provider: providerId,
-      contextWindow: defaultCtx,
+      contextWindow: resolveSubscriptionContextWindow(modelId, defaultCtx, capabilities),
       inputPricePerToken: 0,
       outputPricePerToken: 0,
       capabilityReasoning: false,

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -475,6 +475,7 @@ describe('getSubscriptionCapabilities', () => {
       supportsPromptCaching: true,
       supportsBatching: false,
     });
+    expect(caps?.modelContextWindows?.['claude-opus-4-8']).toBe(1000000);
   });
 
   it('returns capabilities for OpenAI subscription', () => {

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -22,6 +22,9 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModelsExclude: Object.freeze(['-fast']),
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
+      modelContextWindows: Object.freeze({
+        'claude-opus-4-8': 1000000,
+      }),
       supportsPromptCaching: true,
       supportsBatching: false,
     }),

--- a/packages/shared/src/subscription/types.ts
+++ b/packages/shared/src/subscription/types.ts
@@ -1,5 +1,6 @@
 export interface SubscriptionCapabilities {
   maxContextWindow: number;
+  modelContextWindows?: Readonly<Record<string, number>>;
   supportsPromptCaching: boolean;
   supportsBatching: boolean;
 }


### PR DESCRIPTION
### ✨ What changed
- Added per-model subscription context metadata.
- Reports `claude-opus-4-8` as 1M for Anthropic subscriptions.

### 💭 Why
Anthropic documents Opus 4.8 at 1M context on the Claude API, but Manifest capped subscription metadata at 200k.

### 👤 For users
Clients using `/v1/models` can avoid compacting Opus 4.8 at 200k.

### 📝 Notes
Fixes #2344

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic subscription context for `claude-opus-4-8` (including dated variants) to 1M so `/v1/models` reports the correct window and clients avoid unnecessary prompt compaction.

- **Bug Fixes**
  - Added per-model context overrides (`modelContextWindows`) to subscription capabilities.
  - Implemented a resolver that prefers per-model overrides over global caps and applies to dated variants; used in fallback and known-model builders.
  - Updated types and tests to verify 1M for `claude-opus-4-8` variants.

<sup>Written for commit 4e3fdde2bcb848ea0b67ef53dd1032b8ea448954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

