### PR TITLE
fix: skip Ollama thinking param

### DIFF
--- a/.changeset/ollama-thinking-param.md
+++ b/.changeset/ollama-thinking-param.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop forwarding Anthropic-style thinking params to Ollama endpoints.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -88,6 +88,34 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('metadata');
     });
 
+    it('should strip Anthropic-style thinking params for Ollama endpoints', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        thinking: { type: 'enabled' },
+        max_tokens: 4096,
+        temperature: 0.5,
+      };
+
+      for (const endpointKey of ['ollama', 'ollama-cloud', 'Ollama']) {
+        const result = sanitizeOpenAiBody(body, endpointKey, 'qwen3.5:9b-q4_K_M');
+
+        expect(result).not.toHaveProperty('thinking');
+        expect(result).toHaveProperty('max_tokens', 4096);
+        expect(result).toHaveProperty('temperature', 0.5);
+      }
+    });
+
+    it('should keep thinking params for compatible OpenAI-format providers', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        thinking: { type: 'enabled' },
+      };
+
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-v4-flash');
+
+      expect(result).toHaveProperty('thinking', { type: 'enabled' });
+    });
+
     /* ── DeepSeek max_tokens normalization ── */
 
     it('should cap max_tokens at 8192 for deepseek provider', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -3519,6 +3519,34 @@ describe('ProviderClient', () => {
       expect(sentBody.stream_options).toEqual({ include_usage: true });
     });
 
+    it('does not forward Anthropic-style thinking params to Ollama endpoints', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      for (const provider of ['ollama', 'ollama-cloud']) {
+        mockFetch.mockClear();
+        await client.forward({
+          provider,
+          apiKey: provider === 'ollama-cloud' ? 'ollama-key' : '',
+          model: 'qwen3.5:9b-q4_K_M',
+          body: {
+            messages: [{ role: 'user', content: 'Hello' }],
+            thinking: { type: 'enabled' },
+            max_tokens: 4096,
+          },
+          stream: false,
+        });
+
+        const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(sentBody).not.toHaveProperty('thinking');
+        expect(sentBody).toEqual(
+          expect.objectContaining({
+            model: 'qwen3.5:9b-q4_K_M',
+            max_tokens: 4096,
+          }),
+        );
+      }
+    });
+
     it('injects stream_options.include_usage for Groq streaming requests', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -109,6 +109,7 @@ const OPENAI_ONLY_FIELDS = new Set([
  * Nested message fields may still need target-aware cleanup.
  */
 const PASSTHROUGH_PROVIDERS = new Set(['openai', 'openrouter']);
+const OLLAMA_ENDPOINTS = new Set(['ollama', 'ollama-cloud']);
 const MISTRAL_TOOL_CALL_ID_REGEX = /^[A-Za-z0-9]{9}$/;
 const DEEPSEEK_MAX_TOKENS_LIMIT = 8192;
 
@@ -387,6 +388,7 @@ export function sanitizeOpenAiBody(
       continue;
     }
     if (OPENAI_ONLY_FIELDS.has(key)) continue;
+    if (key === 'thinking' && OLLAMA_ENDPOINTS.has(endpointKey.toLowerCase())) continue;
     if (key === 'max_completion_tokens') {
       // Preserve max_completion_tokens for endpoints that require it; otherwise
       // downconvert to max_tokens for OpenAI-compatible providers that only know


### PR DESCRIPTION
### ✨ What changed
- Ollama and Ollama Cloud drop `thinking` before upstream forwarding.
- Added sanitizer and provider-client regressions for Ollama requests.

### 💭 Why
Ollama reports thinking-capable models but does not accept Anthropic-style `thinking` objects on the OpenAI-compatible API.

### 👤 For users
Ollama thinking-capable models can route without failing on unsupported `thinking`.

### 📝 Notes
Fixes #2035

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips Anthropic-style `thinking` from OpenAI-format requests sent to `ollama` and `ollama-cloud`, preventing errors on their OpenAI-compatible API. Adds sanitizer handling and tests so thinking-capable Ollama models route without failing.

- **Bug Fixes**
  - Strip `thinking` when endpoint is `ollama` or `ollama-cloud`.
  - Keep `thinking` for compatible providers (e.g., `deepseek`).
  - Added sanitizer and forwarding tests to guard against regressions.

<sup>Written for commit a4fd8aa58c113c3afd43e2529ad3a442fe1ced34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

