### PR TITLE
fix: preserve Ollama model prefixes

### DIFF
--- a/.changeset/ollama-author-models.md
+++ b/.changeset/ollama-author-models.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Preserve author-prefixed Ollama model IDs when proxying requests.

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2042,6 +2042,24 @@ describe('ProviderModelFetcherService', () => {
       expect(result[0].id).toBe('mistral');
     });
 
+    it('should preserve author-prefixed third-party model ids', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          models: [
+            { name: 'mdq100/qwen3.5-flash:35b' },
+            { name: 'hf.co/acon96/Home-Llama-3.2-3B:F16' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('ollama', '');
+      expect(result.map((model) => model.id)).toEqual([
+        'mdq100/qwen3.5-flash:35b',
+        'hf.co/acon96/Home-Llama-3.2-3B:F16',
+      ]);
+    });
+
     it('should filter out entries without string name', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -2893,6 +2893,36 @@ describe('ProviderClient', () => {
       expect(sentBody.model).toBe('anthropic/claude-sonnet-4');
     });
 
+    it('preserves Ollama author-prefixed model names', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'ollama',
+        apiKey: '',
+        model: 'mdq100/qwen3.5-flash:35b',
+        body,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('mdq100/qwen3.5-flash:35b');
+    });
+
+    it('preserves Ollama Cloud author-prefixed model names', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'ollama-cloud',
+        apiKey: 'ollama-key',
+        model: 'mdq100/qwen3.5-flash:35b',
+        body,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('mdq100/qwen3.5-flash:35b');
+    });
+
     it('preserves slash in Groq model names (e.g. meta-llama/...)', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -107,7 +107,7 @@ function stripModelPrefix(model: string, endpointKey: string): string {
   if (endpointKey === 'commandcode' || endpointKey === 'commandcode-anthropic') {
     return model.startsWith('commandcode/') ? model.slice('commandcode/'.length) : model;
   }
-  // Custom providers, Fireworks, Groq, Kilo, Nous, NVIDIA NIM, and Pioneer: model IDs from these APIs contain
+  // Custom providers, Fireworks, Groq, Kilo, Nous, NVIDIA NIM, Ollama, and Pioneer: model IDs from these APIs contain
   // legitimate slash segments (e.g. "accounts/fireworks/models/deepseek-v3p1",
   // "MiniMaxAI/MiniMax-2.7", "meta-llama/llama-guard-4-12b", "anthropic/claude-sonnet-4.5").
   // Stripping would mangle the name the upstream API expects.
@@ -118,6 +118,8 @@ function stripModelPrefix(model: string, endpointKey: string): string {
     endpointKey === 'kilo' ||
     endpointKey === 'nous' ||
     endpointKey === 'nvidia' ||
+    endpointKey === 'ollama' ||
+    endpointKey === 'ollama-cloud' ||
     endpointKey === 'pioneer'
   )
     return model;


### PR DESCRIPTION
### ✨ What changed
- Preserve author-prefixed Ollama model IDs during proxy forwarding.
- Add regression coverage for Ollama discovery and proxy requests.

### 💭 Why
Ollama can return third-party model IDs such as `mdq100/qwen3.5-flash:35b`. Stripping the author prefix makes Manifest call a model Ollama does not have.

### 👤 For users
Third-party Ollama and Ollama Cloud models with author prefixes route correctly.

### 📝 Notes
Closes #2364.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves author-prefixed Ollama model IDs (e.g., mdq100/qwen3.5-flash:35b) in discovery and proxy so third‑party models route correctly through `ollama` and `ollama-cloud`. Fixes #2364.

- **Bug Fixes**
  - Stop stripping model prefixes for `ollama` and `ollama-cloud` when forwarding requests.
  - Keep prefixed IDs in Ollama discovery results; add regression tests for both paths.

<sup>Written for commit 884170d7c11dfd7aaccf5e1e142a6d6842046784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

