### PR TITLE
fix: preserve Copilot reasoning summaries

### DIFF
--- a/.changeset/copilot-chat-reasoning-summary.md
+++ b/.changeset/copilot-chat-reasoning-summary.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Preserve Responses reasoning summaries when Copilot responses-only models are used through Chat Completions.

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
@@ -276,6 +276,52 @@ describe('chatgpt-adapter', () => {
       ]);
     });
 
+    it('surfaces reasoning summary output as Chat Completions reasoning_content', () => {
+      const out = fromResponsesResponse(
+        {
+          output: [
+            {
+              type: 'reasoning',
+              summary: [{ type: 'summary_text', text: 'Checked the constraints.' }],
+            },
+            { type: 'message', content: [{ type: 'output_text', text: 'Done.' }] },
+          ],
+        },
+        'gpt-5.5',
+      );
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+
+      expect(message.content).toBe('Done.');
+      expect(message.reasoning_content).toBe('Checked the constraints.');
+    });
+
+    it('joins reasoning summary and content text while ignoring malformed parts', () => {
+      const out = fromResponsesResponse(
+        {
+          output: [
+            {
+              type: 'reasoning',
+              summary: [
+                { type: 'summary_text', text: 'Summary text.' },
+                { type: 'summary_text' },
+                'invalid',
+              ],
+              content: [{ type: 'reasoning_text', text: 'Reasoning text.' }],
+            },
+            { type: 'reasoning', summary: 'invalid' },
+            { type: 'message', content: [{ type: 'output_text', text: 'Done.' }] },
+          ],
+        },
+        'gpt-5.5',
+      );
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+
+      expect(message.content).toBe('Done.');
+      expect(message.reasoning_content).toBe('Summary text.\n\nReasoning text.');
+    });
+
     it('defaults missing usage fields to zero', () => {
       const out = fromResponsesResponse({ output: [] }, 'gpt-5');
       expect(out.usage).toEqual({
@@ -316,6 +362,39 @@ describe('chatgpt-adapter', () => {
         delta: { content: 'hi' },
         finish_reason: null,
       });
+    });
+
+    it('converts reasoning summary deltas into a Chat Completion reasoning_content delta', () => {
+      const chunk =
+        'event: response.reasoning_summary_text.delta\ndata: {"delta":"Checked constraints."}';
+      const parsed = parseFrame(transformResponsesStreamChunk(chunk, 'gpt-5.5'));
+      expect(parsed.choices[0]).toEqual({
+        index: 0,
+        delta: { reasoning_content: 'Checked constraints.' },
+        finish_reason: null,
+      });
+    });
+
+    it('converts alternate reasoning delta event names', () => {
+      const summaryChunk = 'event: response.reasoning_summary.delta\ndata: {"delta":"Summary."}';
+      const emptyChunk = 'event: response.reasoning_summary.delta\ndata: {"delta":{}}';
+      const summary = parseFrame(transformResponsesStreamChunk(summaryChunk, 'gpt-5.5'));
+      const empty = parseFrame(transformResponsesStreamChunk(emptyChunk, 'gpt-5.5'));
+
+      expect(summary.choices[0].delta).toEqual({ reasoning_content: 'Summary.' });
+      expect(empty.choices[0].delta).toEqual({ reasoning_content: '' });
+    });
+
+    it('does not expose raw reasoning text deltas as summaries', () => {
+      const chunk = 'event: response.reasoning_text.delta\ndata: {"delta":"Private chain."}';
+
+      expect(transformResponsesStreamChunk(chunk, 'gpt-5.5')).toBeNull();
+    });
+
+    it('returns null for malformed reasoning delta payloads', () => {
+      const chunk = 'event: response.reasoning_summary.delta\ndata: {';
+
+      expect(transformResponsesStreamChunk(chunk, 'gpt-5.5')).toBeNull();
     });
 
     it('converts function_call_arguments.delta into a tool_calls.arguments delta', () => {
@@ -383,6 +462,99 @@ describe('chatgpt-adapter', () => {
       expect((choices[0].message as Record<string, unknown>).content).toBe('Hello world');
       expect(choices[0].finish_reason).toBe('stop');
       expect(out.usage).toMatchObject({ prompt_tokens: 1, completion_tokens: 2 });
+    });
+
+    it('collects reasoning summary deltas into non-streaming reasoning_content', () => {
+      const sse = [
+        'event: response.reasoning_summary_text.delta\ndata: {"delta":"I checked "}',
+        'event: response.reasoning_summary_text.delta\ndata: {"delta":"the constraints."}',
+        'event: response.output_text.delta\ndata: {"delta":"Done."}',
+        'event: response.completed\ndata: {"response":{"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5.5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+
+      expect(message.content).toBe('Done.');
+      expect(message.reasoning_content).toBe('I checked the constraints.');
+    });
+
+    it('uses completed reasoning output as the authoritative non-streaming summary', () => {
+      const sse = [
+        'event: response.reasoning_summary_text.delta\ndata: {"delta":"Partial"}',
+        'event: response.output_text.delta\ndata: {"delta":"Done."}',
+        'event: response.completed\ndata: {"response":{"output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"Complete summary."}]},{"type":"message"}]}}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5.5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+
+      expect(message.reasoning_content).toBe('Complete summary.');
+    });
+
+    it('clears partial reasoning when completed output has no reasoning item', () => {
+      const sse = [
+        'event: response.reasoning_summary_text.delta\ndata: {"delta":"Partial"}',
+        'event: response.output_text.delta\ndata: {"delta":"Done."}',
+        'event: response.completed\ndata: {"response":{"output":[{"type":"message"}]}}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5.5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+
+      expect(message.reasoning_content).toBeUndefined();
+    });
+
+    it('uses incomplete reasoning output as the authoritative non-streaming summary', () => {
+      const sse = [
+        'event: response.reasoning_summary_text.delta\ndata: {"delta":"Partial"}',
+        'event: response.output_text.delta\ndata: {"delta":"Done."}',
+        'event: response.incomplete\ndata: {"response":{"incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"Incomplete summary."}]}]}}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5.5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+
+      expect(message.reasoning_content).toBe('Incomplete summary.');
+      expect(choices[0].finish_reason).toBe('length');
+    });
+
+    it('clears partial reasoning when incomplete output has no reasoning item', () => {
+      const sse = [
+        'event: response.reasoning_summary_text.delta\ndata: {"delta":"Partial"}',
+        'event: response.output_text.delta\ndata: {"delta":"Done."}',
+        'event: response.incomplete\ndata: {"response":{"incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message"}]}}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5.5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+
+      expect(message.reasoning_content).toBeUndefined();
+      expect(choices[0].finish_reason).toBe('length');
+    });
+
+    it('tolerates a completed terminal event without a response object', () => {
+      const sse = [
+        'event: response.output_text.delta\ndata: {"delta":"Done."}',
+        'event: response.completed\ndata: {"response":null}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5.5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+
+      expect((choices[0].message as Record<string, unknown>).content).toBe('Done.');
+      expect(choices[0].finish_reason).toBe('stop');
+    });
+
+    it('tolerates an incomplete terminal event without a response object', () => {
+      const sse = [
+        'event: response.output_text.delta\ndata: {"delta":"Done."}',
+        'event: response.incomplete\ndata: {"response":null}',
+      ].join('\n\n');
+      const out = collectChatGptSseResponse(sse, 'gpt-5.5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+
+      expect((choices[0].message as Record<string, unknown>).content).toBe('Done.');
+      expect(choices[0].finish_reason).toBe('length');
     });
 
     it('reconstructs tool calls across multiple deltas and reports finish_reason=tool_calls', () => {

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -131,6 +131,51 @@ export function toResponsesRequest(
   return request;
 }
 
+function textFromReasoningParts(parts: unknown): string {
+  if (!Array.isArray(parts)) return '';
+  return parts
+    .filter(isObjectRecord)
+    .map((part) => (typeof part.text === 'string' ? part.text : ''))
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function reasoningContentFromItem(item: Record<string, unknown>): string {
+  return [textFromReasoningParts(item.summary), textFromReasoningParts(item.content)]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function responseOutputItems(
+  response: Record<string, unknown> | undefined,
+): Record<string, unknown>[] {
+  const output = Array.isArray(response?.output) ? response.output : [];
+  return output.filter(isObjectRecord);
+}
+
+function hasResponseOutput(response: Record<string, unknown> | undefined): boolean {
+  return Array.isArray(response?.output);
+}
+
+function reasoningContentFromOutput(output: Record<string, unknown>[]): string {
+  return output
+    .filter((item) => item.type === 'reasoning')
+    .map(reasoningContentFromItem)
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function isReasoningDeltaEvent(eventType: string): boolean {
+  return (
+    eventType === 'response.reasoning_summary.delta' ||
+    eventType === 'response.reasoning_summary_text.delta'
+  );
+}
+
+function reasoningDeltaText(data: Record<string, unknown>): string {
+  return typeof data.delta === 'string' ? data.delta : '';
+}
+
 /* ── Non-streaming response conversion ── */
 
 export function fromResponsesResponse(
@@ -139,10 +184,17 @@ export function fromResponsesResponse(
 ): Record<string, unknown> {
   const output = (data.output ?? []) as Record<string, unknown>[];
   let text = '';
+  const reasoningParts: string[] = [];
   const toolCalls: { id: string; type: string; function: { name: string; arguments: string } }[] =
     [];
 
   for (const item of output) {
+    if (item.type === 'reasoning') {
+      const reasoning = reasoningContentFromItem(item);
+      if (reasoning) reasoningParts.push(reasoning);
+      continue;
+    }
+
     if (item.type === 'message') {
       const content = item.content as { type?: string; text?: string }[] | undefined;
       if (!content) continue;
@@ -171,6 +223,8 @@ export function fromResponsesResponse(
     role: 'assistant',
     content: text || null,
   };
+  const reasoningContent = reasoningParts.join('\n\n');
+  if (reasoningContent) message.reasoning_content = reasoningContent;
 
   if (toolCalls.length > 0) {
     message.tool_calls = toolCalls;
@@ -226,6 +280,15 @@ export function transformResponsesStreamChunk(chunk: string, model: string): str
     if (!data) return null;
     const delta = typeof data.delta === 'string' ? data.delta : '';
     return formatSSE({ delta: { content: delta }, finish_reason: null }, model);
+  }
+
+  if (isReasoningDeltaEvent(eventType)) {
+    const data = safeParse(dataStr);
+    if (!data) return null;
+    return formatSSE(
+      { delta: { reasoning_content: reasoningDeltaText(data) }, finish_reason: null },
+      model,
+    );
   }
 
   if (eventType === 'response.function_call_arguments.delta') {
@@ -289,9 +352,7 @@ export function transformResponsesStreamChunk(chunk: string, model: string): str
 function handleCompletedEvent(dataStr: string, model: string): string {
   const data = safeParse(dataStr);
   const response = isObjectRecord(data?.response) ? data.response : undefined;
-  const responseOutput = Array.isArray(response?.output)
-    ? (response.output as Array<{ type?: string }>)
-    : [];
+  const responseOutput = responseOutputItems(response);
   const hasFunctionCalls = responseOutput.some((item) => item.type === 'function_call');
   const finish = formatSSE(
     { delta: {}, finish_reason: hasFunctionCalls ? 'tool_calls' : 'stop' },
@@ -383,6 +444,7 @@ export function collectChatGptSseResponse(sseText: string, model: string): Recor
   let usage: Record<string, unknown> | undefined;
   let hasFunctionCalls = false;
   let finishReasonOverride: string | undefined;
+  let reasoningContent = '';
 
   const events = sseText.split('\n\n');
   for (const event of events) {
@@ -402,6 +464,8 @@ export function collectChatGptSseResponse(sseText: string, model: string): Recor
       throw buildResponsesSseError(data);
     } else if (eventType === 'response.output_text.delta') {
       text += typeof data.delta === 'string' ? data.delta : '';
+    } else if (isReasoningDeltaEvent(eventType)) {
+      reasoningContent += reasoningDeltaText(data);
     } else if (eventType === 'response.output_item.added') {
       const item = isObjectRecord(data.item) ? data.item : undefined;
       if (item?.type === 'function_call') {
@@ -421,19 +485,24 @@ export function collectChatGptSseResponse(sseText: string, model: string): Recor
     } else if (eventType === 'response.completed') {
       const response = isObjectRecord(data.response) ? data.response : undefined;
       usage = extractResponseUsage(response) ?? usage;
-      const output = Array.isArray(response?.output)
-        ? (response.output as Array<{ type?: string }>)
-        : [];
+      const output = responseOutputItems(response);
       hasFunctionCalls = output.some((item) => item.type === 'function_call');
+      if (hasResponseOutput(response)) {
+        reasoningContent = reasoningContentFromOutput(output);
+      }
     } else if (eventType === 'response.incomplete') {
       const response = isObjectRecord(data.response) ? data.response : undefined;
       usage = extractResponseUsage(response) ?? usage;
       finishReasonOverride = incompleteFinishReason(response);
+      if (hasResponseOutput(response)) {
+        reasoningContent = reasoningContentFromOutput(responseOutputItems(response));
+      }
     }
   }
 
   const toolCalls = [...toolCallMap.values()];
   const message: Record<string, unknown> = { role: 'assistant', content: text || null };
+  if (reasoningContent) message.reasoning_content = reasoningContent;
   if (toolCalls.length > 0) message.tool_calls = toolCalls;
 
   return {


### PR DESCRIPTION
### ✨ What changed
- Preserve Responses reasoning summaries in Chat Completions output.
- Stream reasoning summary deltas through `reasoning_content`.

### 💭 Why
Copilot responses-only models expose summaries through Responses reasoning items. Chat Completions clients lost that summary after normalization.

### 👤 For users
OpenWebUI and compatible clients can show Copilot GPT-5.5 reasoning summaries through Chat Completions.

### 📝 Notes
Fixes #2359

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Copilot Responses reasoning summaries in Chat Completions by emitting them as `reasoning_content`, including streaming deltas and non‑streaming aggregation, so OpenWebUI and similar clients can show GPT-5.5 summaries. Fixes #2359.

- **Bug Fixes**
  - Non‑streaming: extract and merge summary/content from Responses output into `message.reasoning_content`; ignore malformed parts.
  - Streaming: map `response.reasoning_summary_text.delta` and `response.reasoning_summary.delta` to `reasoning_content`; accumulate partials; prefer final summaries from `response.completed`/`response.incomplete` and clear partials if none; ignore `response.reasoning_text.delta`; tolerate missing/invalid payloads.

<sup>Written for commit a0f55493fabc866906feeea00eb0d7168e1c42fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

