### PR TITLE
fix: mark Z.ai subscriptions cacheable

### DIFF
--- a/.changeset/zai-cache-capability.md
+++ b/.changeset/zai-cache-capability.md
@@ -1,5 +1,5 @@
 ---
-'manifest-shared': patch
+'manifest': patch
 ---
 
 Mark Z.ai Coding Plan subscriptions as prompt-cache capable.

--- a/.changeset/zai-cache-capability.md
+++ b/.changeset/zai-cache-capability.md
@@ -1,0 +1,5 @@
+---
+'manifest-shared': patch
+---
+
+Mark Z.ai Coding Plan subscriptions as prompt-cache capable.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -518,7 +518,7 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('zai');
     expect(caps).toMatchObject({
       maxContextWindow: 204800,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     });
   });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -203,7 +203,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionCapabilities: Object.freeze({
       // Z.ai advertises "200K" as 200 * 1024 = 204800, not 200000 like other providers.
       maxContextWindow: 204800,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Mark Z.ai Coding Plan subscriptions as prompt-cache capable.
- Update subscription capability coverage.

### 💭 Why
Z.ai documents automatic context caching, and Manifest already parses OpenAI-compatible cached-token usage fields for this provider.

### 👤 For users
Z.ai subscriptions now correctly advertise prompt-cache support in shared provider metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked Z.ai Coding Plan subscriptions as prompt-cache capable so clients can use prompt caching. Updated shared provider metadata and tests to set `supportsPromptCaching` to true, and added a changeset targeting the releasable `manifest` package.

<sup>Written for commit 12db783252e71a9a604a155d3a6c33670b9696bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

