### PR TITLE
fix: mark MiniMax subscriptions cacheable

### DIFF
--- a/.changeset/minimax-cache-capability.md
+++ b/.changeset/minimax-cache-capability.md
@@ -1,0 +1,5 @@
+---
+'manifest-shared': patch
+---
+
+Mark MiniMax Coding Plan subscriptions as prompt-cache capable.

--- a/.changeset/minimax-cache-capability.md
+++ b/.changeset/minimax-cache-capability.md
@@ -1,5 +1,5 @@
 ---
-'manifest-shared': patch
+'manifest': patch
 ---
 
 Mark MiniMax Coding Plan subscriptions as prompt-cache capable.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -486,6 +486,15 @@ describe('getSubscriptionCapabilities', () => {
     });
   });
 
+  it('returns capabilities for MiniMax Coding Plan', () => {
+    const caps = getSubscriptionCapabilities('minimax');
+    expect(caps).toMatchObject({
+      maxContextWindow: 1000000,
+      supportsPromptCaching: true,
+      supportsBatching: false,
+    });
+  });
+
   it('returns capabilities for all supported providers', () => {
     for (const id of SUPPORTED_SUBSCRIPTION_PROVIDER_IDS) {
       const caps = getSubscriptionCapabilities(id);

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -79,7 +79,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       // MiniMax-M3's 1M window (MSA); M2.x models keep their own lower
       // per-model contexts from the pricing cache — this is only the cap.
       maxContextWindow: 1000000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Mark MiniMax Coding Plan subscriptions as prompt-cache capable.
- Add explicit subscription capability coverage.

### 💭 Why
MiniMax documents prompt caching for its Anthropic-compatible API, and Manifest already sends Anthropic-style cache controls on that route.

### 👤 For users
MiniMax subscriptions now correctly advertise prompt-cache support in shared provider metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark MiniMax Coding Plan subscriptions as prompt-cache capable so they advertise support in shared provider metadata. Add a test to cover MiniMax capabilities and a patch changeset targeting `manifest`.

<sup>Written for commit ebed48dc6f505349ef1dcdd105f5c8abb3703025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

