### PR TITLE
fix: record DeepSeek prompt cache hits

### DIFF
--- a/.changeset/deepseek-cache-usage.md
+++ b/.changeset/deepseek-cache-usage.md
@@ -1,0 +1,5 @@
+---
+'manifest-backend': patch
+---
+
+Record DeepSeek prompt cache hits from `prompt_cache_hit_tokens`.

--- a/.changeset/deepseek-cache-usage.md
+++ b/.changeset/deepseek-cache-usage.md
@@ -1,5 +1,5 @@
 ---
-'manifest-backend': patch
+'manifest': patch
 ---
 
 Record DeepSeek prompt cache hits from `prompt_cache_hit_tokens`.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
@@ -217,6 +217,30 @@ describe('issue #1871: cache_control round-trip through /v1/messages', () => {
         cache_creation_input_tokens: 0,
         cache_read_input_tokens: 40,
       });
+    });
+
+    it('carries DeepSeek prompt_cache_hit_tokens through the messages conversion', () => {
+      const deepSeekChatResponse = {
+        id: 'cc_deepseek',
+        model: 'deepseek-chat',
+        choices: [{ message: { content: 'pong' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 5,
+          prompt_cache_hit_tokens: 40,
+          prompt_cache_miss_tokens: 60,
+        },
+      };
+      const messagesResponse = chatCompletionsResponseToMessages(
+        deepSeekChatResponse,
+        'deepseek-chat',
+      );
+      expect(messagesResponse.usage).toEqual({
+        input_tokens: 60,
+        output_tokens: 5,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 40,
+      });
 
       const streamUsage = parseUsageObject(messagesResponse.usage);
       expect(streamUsage).toEqual({

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -1025,6 +1025,22 @@ describe('parseUsageObject', () => {
     });
   });
 
+  it('maps DeepSeek prompt cache hit tokens to cache reads', () => {
+    expect(
+      parseUsageObject({
+        prompt_tokens: 120,
+        completion_tokens: 8,
+        prompt_cache_hit_tokens: 90,
+        prompt_cache_miss_tokens: 30,
+      }),
+    ).toEqual({
+      prompt_tokens: 120,
+      completion_tokens: 8,
+      cache_read_tokens: 90,
+      cache_creation_tokens: undefined,
+    });
+  });
+
   it('preserves provider-reported OpenAI-compatible usage cost', () => {
     expect(
       parseUsageObject({

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -276,11 +276,13 @@ function toAnthropicUsage(usage: unknown): JsonRecord {
   const cacheRead =
     typeof u.cache_read_tokens === 'number'
       ? u.cache_read_tokens
-      : typeof u.cached_tokens === 'number'
-        ? u.cached_tokens
-      : typeof promptDetails?.cached_tokens === 'number'
-        ? promptDetails.cached_tokens
-        : 0;
+      : typeof u.prompt_cache_hit_tokens === 'number'
+        ? u.prompt_cache_hit_tokens
+        : typeof u.cached_tokens === 'number'
+          ? u.cached_tokens
+          : typeof promptDetails?.cached_tokens === 'number'
+            ? promptDetails.cached_tokens
+            : 0;
   const cacheCreation = typeof u.cache_creation_tokens === 'number' ? u.cache_creation_tokens : 0;
   // Chat-shape prompt_tokens is the full input total (uncached + cache reads +
   // cache creation). Anthropic Messages' input_tokens is the uncached portion

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -18,11 +18,10 @@ export interface StreamUsage {
  * or Anthropic-native (`input_tokens`/`output_tokens`) shape and normalise it
  * to a `StreamUsage`. Returns null when neither shape is present.
  *
- * OpenAI-compatible providers expose cached prompt tokens under the nested
- * `prompt_tokens_details.cached_tokens` field, not the top-level
- * `cache_read_tokens` key — DeepSeek, Z.AI, MiniMax, Mistral, etc. all use the
- * nested form. Falling back to the nested key keeps the cache column populated
- * for those providers.
+ * OpenAI-compatible providers expose cached prompt tokens under provider-specific
+ * usage fields, not always the top-level `cache_read_tokens` key. Falling back
+ * to those keys keeps the cache column populated for providers such as DeepSeek,
+ * Z.AI, MiniMax, and Mistral.
  */
 export function parseUsageObject(usage: unknown): StreamUsage | null {
   if (!usage || typeof usage !== 'object') return null;
@@ -37,11 +36,13 @@ export function parseUsageObject(usage: unknown): StreamUsage | null {
     const cacheRead =
       typeof u.cache_read_tokens === 'number'
         ? u.cache_read_tokens
-        : typeof u.cached_tokens === 'number'
-          ? u.cached_tokens
-        : typeof promptDetails?.cached_tokens === 'number'
-          ? promptDetails.cached_tokens
-          : undefined;
+        : typeof u.prompt_cache_hit_tokens === 'number'
+          ? u.prompt_cache_hit_tokens
+          : typeof u.cached_tokens === 'number'
+            ? u.cached_tokens
+            : typeof promptDetails?.cached_tokens === 'number'
+              ? promptDetails.cached_tokens
+              : undefined;
     return {
       prompt_tokens: u.prompt_tokens,
       completion_tokens: typeof u.completion_tokens === 'number' ? u.completion_tokens : 0,


### PR DESCRIPTION
### ✨ What changed
- Record DeepSeek `prompt_cache_hit_tokens` as prompt cache reads in streaming and Anthropic-message conversion paths.
- Add focused regressions for both usage parsers.

### 💭 Why
DeepSeek enables context caching by default, but reports cache hits in provider-specific usage fields Manifest did not account for.

### 👤 For users
DeepSeek subscription usage now shows cache-read token savings instead of under-reporting cache hits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DeepSeek usage accounting by mapping `prompt_cache_hit_tokens` to cache reads in streaming and Anthropic Messages paths. This corrects under-reported cache savings so DeepSeek usage shows accurate cache-read tokens.

- **Bug Fixes**
  - Map DeepSeek `prompt_cache_hit_tokens` to `cache_read_tokens` in the stream writer and Anthropic messages adapter.
  - Prefer provider-specific cache fields when present to keep cache columns accurate.
  - Add regression tests for streaming usage parsing and messages conversion, plus a changeset targeting a `manifest` patch release.

<sup>Written for commit 8fb5ee6ac2ad851f29ad57d2c034a90c5f1b04e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

