### PR TITLE
fix: send Moonshot prompt cache keys

### DIFF
--- a/.changeset/moonshot-prompt-cache-key.md
+++ b/.changeset/moonshot-prompt-cache-key.md
@@ -1,0 +1,6 @@
+---
+'manifest-backend': patch
+'manifest-shared': patch
+---
+
+Send Moonshot prompt cache keys and record Kimi cached tokens.

--- a/.changeset/moonshot-prompt-cache-key.md
+++ b/.changeset/moonshot-prompt-cache-key.md
@@ -1,6 +1,5 @@
 ---
-'manifest-backend': patch
-'manifest-shared': patch
+'manifest': patch
 ---
 
 Send Moonshot prompt cache keys and record Kimi cached tokens.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
@@ -195,5 +195,36 @@ describe('issue #1871: cache_control round-trip through /v1/messages', () => {
         cache_creation_tokens: 0,
       });
     });
+
+    it('carries Moonshot top-level cached_tokens through the messages conversion', () => {
+      const moonshotChatResponse = {
+        id: 'cc_kimi',
+        model: 'kimi-k2-latest',
+        choices: [{ message: { content: 'pong' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 5,
+          cached_tokens: 40,
+        },
+      };
+      const messagesResponse = chatCompletionsResponseToMessages(
+        moonshotChatResponse,
+        'kimi-k2-latest',
+      );
+      expect(messagesResponse.usage).toEqual({
+        input_tokens: 60,
+        output_tokens: 5,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 40,
+      });
+
+      const streamUsage = parseUsageObject(messagesResponse.usage);
+      expect(streamUsage).toEqual({
+        prompt_tokens: 100,
+        completion_tokens: 5,
+        cache_read_tokens: 40,
+        cache_creation_tokens: 0,
+      });
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -189,6 +189,73 @@ describe('ProviderClient', () => {
       expect(secondBody.prompt_cache_key).toBeUndefined();
     });
 
+    it('adds stable Moonshot prompt cache affinity without leaking identifiers', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'moonshot',
+        apiKey: 'sk-kimi',
+        model: 'kimi-k2-latest',
+        body,
+        sessionKey: 'session-1',
+        stream: false,
+      });
+      await client.forward({
+        provider: 'moonshot',
+        apiKey: 'sk-kimi',
+        model: 'kimi-k2-latest',
+        body,
+        sessionKey: 'session-1',
+        stream: false,
+      });
+
+      const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+      expect(firstBody.prompt_cache_key).toMatch(/^manifest-[a-f0-9]{32}$/);
+      expect(secondBody.prompt_cache_key).toBe(firstBody.prompt_cache_key);
+      expect(firstBody.prompt_cache_key).not.toContain('sk-kimi');
+      expect(firstBody.prompt_cache_key).not.toContain('session-1');
+    });
+
+    it('keeps caller-supplied Moonshot prompt cache keys', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'moonshot',
+        apiKey: 'sk-kimi',
+        model: 'kimi-k2-latest',
+        body: { ...body, prompt_cache_key: 'caller-conversation' },
+        sessionKey: 'session-1',
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.prompt_cache_key).toBe('caller-conversation');
+    });
+
+    it('omits Moonshot prompt_cache_key when no session is available', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'moonshot',
+        apiKey: 'sk-kimi',
+        model: 'kimi-k2-latest',
+        body,
+        stream: false,
+      });
+      await client.forward({
+        provider: 'moonshot',
+        apiKey: 'sk-kimi',
+        model: 'kimi-k2-latest',
+        body,
+        sessionKey: '   ',
+        stream: false,
+      });
+
+      const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+      expect(firstBody.prompt_cache_key).toBeUndefined();
+      expect(secondBody.prompt_cache_key).toBeUndefined();
+    });
+
     it('builds Bedrock Mantle chat completions requests with bearer API-key auth', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -1010,6 +1010,21 @@ describe('parseUsageObject', () => {
     });
   });
 
+  it('maps Moonshot top-level cached_tokens to cache reads', () => {
+    expect(
+      parseUsageObject({
+        prompt_tokens: 100,
+        completion_tokens: 5,
+        cached_tokens: 40,
+      }),
+    ).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 5,
+      cache_read_tokens: 40,
+      cache_creation_tokens: undefined,
+    });
+  });
+
   it('preserves provider-reported OpenAI-compatible usage cost', () => {
     expect(
       parseUsageObject({

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -276,6 +276,8 @@ function toAnthropicUsage(usage: unknown): JsonRecord {
   const cacheRead =
     typeof u.cache_read_tokens === 'number'
       ? u.cache_read_tokens
+      : typeof u.cached_tokens === 'number'
+        ? u.cached_tokens
       : typeof promptDetails?.cached_tokens === 'number'
         ? promptDetails.cached_tokens
         : 0;

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -80,7 +80,7 @@ function applyXaiResponsesPromptCacheKey(
   body.prompt_cache_key = trimmedSessionKey;
 }
 
-function applyMistralPromptCacheKey(
+function applyHashedPromptCacheKey(
   body: Record<string, unknown>,
   sessionKey: string | undefined,
 ): void {
@@ -538,7 +538,10 @@ export class ProviderClient {
     }
     const requestBody = { ...sanitized, model: bareModel, stream };
     if (endpointKey === 'mistral') {
-      applyMistralPromptCacheKey(requestBody, ctx.sessionKey);
+      applyHashedPromptCacheKey(requestBody, ctx.sessionKey);
+    }
+    if (endpointKey === 'moonshot') {
+      applyHashedPromptCacheKey(requestBody, ctx.sessionKey);
     }
     if (endpointKey === 'openrouter') {
       const cacheMode = openRouterCacheMode(ctx.model);

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -37,6 +37,8 @@ export function parseUsageObject(usage: unknown): StreamUsage | null {
     const cacheRead =
       typeof u.cache_read_tokens === 'number'
         ? u.cache_read_tokens
+        : typeof u.cached_tokens === 'number'
+          ? u.cached_tokens
         : typeof promptDetails?.cached_tokens === 'number'
           ? promptDetails.cached_tokens
           : undefined;

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -527,7 +527,7 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('moonshot');
     expect(caps).toMatchObject({
       maxContextWindow: 262144,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     });
   });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -137,7 +137,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 262144,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Send stable Moonshot/Kimi `prompt_cache_key` values from Manifest sessions.
- Record top-level `cached_tokens` as prompt cache reads.
- Mark Moonshot subscriptions as prompt-cache capable and cover the parser/routing paths.

### 💭 Why
Moonshot exposes prompt-cache affinity and cached-token usage, but Manifest was not setting the cache key or parsing the top-level cached-token counter.

### 👤 For users
Kimi Coding Plan requests can get better cache affinity and visible cache-read usage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Moonshot/Kimi prompt caching by sending a stable, hashed `prompt_cache_key` and surfacing cache-read usage. This improves cache affinity for Kimi models and correctly reports `cached_tokens` as cache reads.

- **Bug Fixes**
  - Send a stable, hashed `prompt_cache_key` for `moonshot` when a session is present; preserve caller-supplied keys; omit when no session; never leak API keys or session IDs.
  - Map Moonshot `cached_tokens` to `cache_read_tokens` in messages and streaming usage.
  - Mark `moonshot` subscriptions as `supportsPromptCaching: true`.

<sup>Written for commit 210f7d281727ac822f4fdb5fe6b36d4c0371443e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

