### PR TITLE
fix: send Qwen prompt cache markers

### DIFF
--- a/.changeset/qwen-prompt-cache.md
+++ b/.changeset/qwen-prompt-cache.md
@@ -1,0 +1,6 @@
+---
+'manifest-backend': patch
+'manifest-shared': patch
+---
+
+Send Qwen cache-control markers and mark Qwen subscriptions cacheable.

--- a/.changeset/qwen-prompt-cache.md
+++ b/.changeset/qwen-prompt-cache.md
@@ -1,6 +1,5 @@
 ---
-'manifest-backend': patch
-'manifest-shared': patch
+'manifest': patch
 ---
 
 Send Qwen cache-control markers and mark Qwen subscriptions cacheable.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -2380,6 +2380,50 @@ describe('ProviderClient', () => {
     });
   });
 
+  describe('Qwen prompt cache injection', () => {
+    it('injects cache_control for native Qwen requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'qwen',
+        apiKey: 'sk-qwen',
+        model: 'qwen3-coder-plus',
+        body: {
+          messages: [
+            { role: 'system', content: 'You are helpful.' },
+            { role: 'user', content: 'Large reference block' },
+          ],
+        },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[0].content).toBe('You are helpful.');
+      expect(sentBody.messages[1].content[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+
+    it('injects cache_control for Qwen Token Plan chat-completions requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'qwen',
+        authType: 'subscription',
+        apiKey: 'sk-sp-qwen',
+        model: 'qwen3-coder-plus',
+        body: {
+          messages: [{ role: 'user', content: 'Large reference block' }],
+        },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions',
+      );
+      expect(sentBody.messages[0].content[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+  });
+
   describe('resolveEndpoint - xAI Responses-only routing', () => {
     const multiAgentModels = ['grok-4.20-multi-agent', 'grok-4.20-multi-agent-0309'];
 

--- a/packages/backend/src/routing/proxy/cache-injection.spec.ts
+++ b/packages/backend/src/routing/proxy/cache-injection.spec.ts
@@ -1,4 +1,4 @@
-import { injectOpenRouterCacheControl } from './cache-injection';
+import { injectOpenAiMessageCacheControl, injectOpenRouterCacheControl } from './cache-injection';
 
 const EPHEMERAL = { type: 'ephemeral' } as const;
 
@@ -179,6 +179,21 @@ describe('injectOpenRouterCacheControl', () => {
     expect(body.messages).toEqual([
       { role: 'system', content: { type: 'text', text: 'not an array' } },
       { role: 'user', content: [null, ['nested']] },
+    ]);
+  });
+
+  it('exposes message-mode injection for OpenAI-compatible providers', () => {
+    const body = {
+      messages: [
+        { role: 'system', content: 'Static instructions' },
+        { role: 'user', content: 'Large reference block' },
+      ],
+    };
+    injectOpenAiMessageCacheControl(body);
+
+    expect(body.messages[0].content).toBe('Static instructions');
+    expect(body.messages[1].content).toEqual([
+      { type: 'text', text: 'Large reference block', cache_control: EPHEMERAL },
     ]);
   });
 });

--- a/packages/backend/src/routing/proxy/cache-injection.ts
+++ b/packages/backend/src/routing/proxy/cache-injection.ts
@@ -1,6 +1,6 @@
 /**
  * Cache control injection utilities for providers that support
- * prompt caching via the OpenAI-compatible format (e.g. OpenRouter).
+ * prompt caching via the OpenAI-compatible format.
  */
 
 const CACHE_CONTROL = { type: 'ephemeral' } as const;
@@ -64,4 +64,8 @@ export function injectOpenRouterCacheControl(
   if (tools && tools.length > 0) {
     tools[tools.length - 1].cache_control = CACHE_CONTROL;
   }
+}
+
+export function injectOpenAiMessageCacheControl(body: Record<string, unknown>): void {
+  injectOpenRouterCacheControl(body, 'message');
 }

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -6,7 +6,7 @@ import { PROVIDER_ENDPOINTS, ProviderEndpoint, resolveEndpointKey } from './prov
 import { validatePublicUrl } from '../../common/utils/url-validation';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import { resolveSubscriptionEndpointKey } from './provider-hooks';
-import { injectOpenRouterCacheControl } from './cache-injection';
+import { injectOpenAiMessageCacheControl, injectOpenRouterCacheControl } from './cache-injection';
 import {
   applyAnthropicAutomaticCacheControl,
   applyAnthropicMessagesMutations,
@@ -539,6 +539,9 @@ export class ProviderClient {
     const requestBody = { ...sanitized, model: bareModel, stream };
     if (endpointKey === 'mistral') {
       applyMistralPromptCacheKey(requestBody, ctx.sessionKey);
+    }
+    if (endpointKey === 'qwen' || endpointKey === 'qwen-subscription') {
+      injectOpenAiMessageCacheControl(requestBody);
     }
     if (endpointKey === 'openrouter') {
       const cacheMode = openRouterCacheMode(ctx.model);

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -536,7 +536,7 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('qwen');
     expect(caps).toMatchObject({
       maxContextWindow: 991000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     });
   });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -124,7 +124,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionTokenPrefix: 'sk-sp-',
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 991000,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Send Qwen OpenAI-compatible message `cache_control` markers for native and Token Plan chat-completion routing.
- Mark Qwen subscriptions as prompt-cache capable.
- Add provider-client, cache-injection, and subscription capability coverage.

### 💭 Why
Qwen supports explicit context cache markers on OpenAI-compatible chat messages, but Manifest was not injecting them or advertising the capability.

### 👤 For users
Qwen Token Plan requests can reuse cached prompt prefixes where Qwen supports it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send Qwen OpenAI-compatible `cache_control` markers and advertise prompt-cache support. This enables prompt prefix caching for Qwen native and Token Plan chat completions.

- **Bug Fixes**
  - Inject `cache_control: { type: 'ephemeral' }` into Qwen OpenAI-compatible chat messages for both native and subscription routes.
  - Mark `qwen` subscription capabilities with `supportsPromptCaching: true`.

- **Refactors**
  - Introduced `injectOpenAiMessageCacheControl` and wired it for `qwen`/`qwen-subscription`; added tests for provider client and cache injection.

<sup>Written for commit 60cace713273dcb0c9b2d07cfdcd2870af4bb3e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

