### PR TITLE
fix: mark Xiaomi subscriptions cacheable

### DIFF
--- a/.changeset/xiaomi-cache-capability.md
+++ b/.changeset/xiaomi-cache-capability.md
@@ -1,5 +1,5 @@
 ---
-'manifest-shared': patch
+'manifest': patch
 ---
 
 Mark Xiaomi MiMo Token Plan subscriptions as prompt-cache capable.

--- a/.changeset/xiaomi-cache-capability.md
+++ b/.changeset/xiaomi-cache-capability.md
@@ -1,0 +1,5 @@
+---
+'manifest-shared': patch
+---
+
+Mark Xiaomi MiMo Token Plan subscriptions as prompt-cache capable.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -554,7 +554,7 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('xiaomi');
     expect(caps).toMatchObject({
       maxContextWindow: 1048576,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     });
   });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -112,7 +112,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 1048576,
-      supportsPromptCaching: false,
+      supportsPromptCaching: true,
       supportsBatching: false,
     }),
   }),


### PR DESCRIPTION
### ✨ What changed
- Mark Xiaomi MiMo Token Plan subscriptions as prompt-cache capable.
- Update subscription capability coverage.

### 💭 Why
Xiaomi MiMo reports OpenAI-compatible cached-token usage, and Manifest already maps that shape into cache-read accounting.

### 👤 For users
Xiaomi MiMo subscriptions now correctly advertise prompt-cache support in shared provider metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks Xiaomi MiMo Token Plan subscriptions as prompt-cache capable so clients see the correct capability and cached-token usage is counted correctly. Updates the `xiaomi` subscription config and test, and adds a patch changeset for `manifest`.

<sup>Written for commit 4851276b72eabee57aa7ae22b7203f7e8f664517. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

