### PR TITLE
fix: send Fireworks prompt cache keys

### DIFF
--- a/.changeset/fireworks-prompt-cache-key.md
+++ b/.changeset/fireworks-prompt-cache-key.md
@@ -1,5 +1,5 @@
 ---
-'manifest-backend': patch
+'manifest': patch
 ---
 
 Send Fireworks prompt cache keys from Manifest sessions.

--- a/.changeset/fireworks-prompt-cache-key.md
+++ b/.changeset/fireworks-prompt-cache-key.md
@@ -1,0 +1,5 @@
+---
+'manifest-backend': patch
+---
+
+Send Fireworks prompt cache keys from Manifest sessions.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -256,6 +256,73 @@ describe('ProviderClient', () => {
       expect(secondBody.prompt_cache_key).toBeUndefined();
     });
 
+    it('adds stable Fireworks prompt cache affinity without leaking identifiers', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'fireworks',
+        apiKey: 'fw-key',
+        model: 'accounts/fireworks/models/kimi-k2-instruct-0905',
+        body,
+        sessionKey: 'session-1',
+        stream: false,
+      });
+      await client.forward({
+        provider: 'fireworks',
+        apiKey: 'fw-key',
+        model: 'accounts/fireworks/models/kimi-k2-instruct-0905',
+        body,
+        sessionKey: 'session-1',
+        stream: false,
+      });
+
+      const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+      expect(firstBody.prompt_cache_key).toMatch(/^manifest-[a-f0-9]{32}$/);
+      expect(secondBody.prompt_cache_key).toBe(firstBody.prompt_cache_key);
+      expect(firstBody.prompt_cache_key).not.toContain('fw-key');
+      expect(firstBody.prompt_cache_key).not.toContain('session-1');
+    });
+
+    it('keeps caller-supplied Fireworks prompt cache keys', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'fireworks',
+        apiKey: 'fw-key',
+        model: 'accounts/fireworks/models/kimi-k2-instruct-0905',
+        body: { ...body, prompt_cache_key: 'caller-conversation' },
+        sessionKey: 'session-1',
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.prompt_cache_key).toBe('caller-conversation');
+    });
+
+    it('omits Fireworks prompt_cache_key when no session is available', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'fireworks',
+        apiKey: 'fw-key',
+        model: 'accounts/fireworks/models/kimi-k2-instruct-0905',
+        body,
+        stream: false,
+      });
+      await client.forward({
+        provider: 'fireworks',
+        apiKey: 'fw-key',
+        model: 'accounts/fireworks/models/kimi-k2-instruct-0905',
+        body,
+        sessionKey: '   ',
+        stream: false,
+      });
+
+      const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+      expect(firstBody.prompt_cache_key).toBeUndefined();
+      expect(secondBody.prompt_cache_key).toBeUndefined();
+    });
+
     it('builds Bedrock Mantle chat completions requests with bearer API-key auth', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -545,6 +545,9 @@ export class ProviderClient {
     if (endpointKey === 'moonshot') {
       applyHashedPromptCacheKey(requestBody, ctx.sessionKey);
     }
+    if (endpointKey === 'fireworks') {
+      applyHashedPromptCacheKey(requestBody, ctx.sessionKey);
+    }
     if (endpointKey === 'qwen' || endpointKey === 'qwen-subscription') {
       injectOpenAiMessageCacheControl(requestBody);
     }


### PR DESCRIPTION
### ✨ What changed
- Send stable Fireworks `prompt_cache_key` values from Manifest sessions.
- Preserve caller-supplied Fireworks cache keys.
- Add focused provider-client regressions.

### 💭 Why
Fireworks prompt caching is automatic, and `prompt_cache_key` improves routing affinity for cached prefixes.

### 👤 For users
Fireworks requests are more likely to hit provider-side prompt cache across a Manifest session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a stable, hashed `prompt_cache_key` to `fireworks` requests based on the session to improve provider-side cache hits and routing affinity. Preserves caller-supplied keys, avoids leaking identifiers, and omits the key when no session is present.

- **Bug Fixes**
  - Use shared `applyHashedPromptCacheKey` for both `moonshot` and `fireworks`.
  - Add provider-client tests for cache-key stability, caller override, and no-session cases.
  - Include a changeset to release this in `manifest` as a patch.

<sup>Written for commit 95e0ea35b6d5e8cf95ba4d878d78d5ca4c77e11e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

