### PR TITLE
fix: let Auto-fix heal auto-routed requests

### DIFF
--- a/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
@@ -363,6 +363,86 @@ describe('AutofixService', () => {
   });
 
   // -------------------------------------------------------------------------
+  // maybeHeal — resolved model reported to Phoenix (routing-alias fix)
+  // -------------------------------------------------------------------------
+  describe('maybeHeal resolved model', () => {
+    it('reports the resolved model to Phoenix but reforwards with the routing alias', async () => {
+      const client = makeHealingClient();
+      // A drop_param heal: Phoenix echoes back the model it received (the
+      // resolved one) with the offending param removed.
+      client.heal.mockResolvedValue(
+        patchedHeal({
+          status: 'unverified',
+          operations: [{ type: 'drop_param' }],
+          healedBody: { model: 'gpt-5.1', messages: [] },
+        }),
+      );
+      const reforward = reforwardMock('{"ok":true}', 200);
+      const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
+      const service = makeService({ client: client as unknown as HealingClient, repo });
+
+      const result = await service.maybeHeal(
+        makeParams({
+          reforward,
+          provider: 'openai',
+          requestBody: { model: 'auto', messages: [], top_k: 40 },
+          resolvedModel: 'gpt-5.1',
+        }),
+      );
+
+      expect(result!.record.outcome).toBe('healed');
+
+      // Phoenix receives the RESOLVED model so its model-keyed catalog can map
+      // it — never the `auto` routing alias.
+      const healArg = client.heal.mock.calls[0][0] as { request: Record<string, unknown> };
+      expect(healArg.request.model).toBe('gpt-5.1');
+      expect(healArg.request.top_k).toBe(40);
+
+      // The reforward goes back through the agent's routing, so the body it gets
+      // carries the ORIGINAL `auto` alias (a bare `gpt-5.1` would re-resolve to
+      // no_provider), while the heal itself (top_k dropped) is preserved.
+      const reforwardedBody = reforward.mock.calls[0][0];
+      expect(reforwardedBody.model).toBe('auto');
+      expect(reforwardedBody).not.toHaveProperty('top_k');
+    });
+
+    it('does not mutate the caller requestBody when substituting the resolved model', async () => {
+      const client = makeHealingClient();
+      client.heal.mockResolvedValue(
+        patchedHeal({ healedBody: { model: 'gpt-5.1', messages: [] } }),
+      );
+      const reforward = reforwardMock('{"ok":true}', 200);
+      const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
+      const service = makeService({ client: client as unknown as HealingClient, repo });
+      const requestBody = { model: 'auto', messages: [], top_k: 40 };
+
+      await service.maybeHeal(makeParams({ reforward, resolvedModel: 'gpt-5.1', requestBody }));
+
+      // Substitution spreads into a new object; the caller's body is untouched.
+      expect(requestBody.model).toBe('auto');
+    });
+
+    it('leaves the heal request and reforward untouched when no resolvedModel is given', async () => {
+      const client = makeHealingClient();
+      const heal = patchedHeal({ healedBody: { model: 'gpt', max_output_tokens: 100 } });
+      client.heal.mockResolvedValue(heal);
+      const reforward = reforwardMock('{"ok":true}', 200);
+      const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
+      const service = makeService({ client: client as unknown as HealingClient, repo });
+
+      await service.maybeHeal(
+        makeParams({ reforward, requestBody: { model: 'gpt', max_tokens: 100 } }),
+      );
+
+      // Backward compatible: Phoenix gets the body verbatim and the reforward
+      // gets the healedBody verbatim (no alias restoration).
+      const healArg = client.heal.mock.calls[0][0] as { request: Record<string, unknown> };
+      expect(healArg.request.model).toBe('gpt');
+      expect(reforward.mock.calls[0][0]).toEqual(heal.healedBody);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // maybeHeal — unfixable / resolving / missing body
   // -------------------------------------------------------------------------
   describe('maybeHeal non-patch decisions', () => {

--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -19,6 +19,14 @@ export interface MaybeHealParams {
   apiMode: ProxyApiMode;
   /** The request body that was actually forwarded and failed. */
   requestBody: Record<string, unknown>;
+  /**
+   * The resolved provider model (e.g. `gpt-5.1`) the request was routed to.
+   * `requestBody.model` may be a routing alias (`auto`) Phoenix can't map to its
+   * model-keyed catalog; this concrete model is reported to Phoenix instead so
+   * its resolver can identify the model. The reforward still goes through the
+   * agent's routing. Omit when the body already carries the concrete model.
+   */
+  resolvedModel?: string;
   /** Optional endpoint URL, forwarded to Phoenix as readability context. */
   url?: string;
   /** Re-send a patched body to the provider and return the fresh forward. */
@@ -197,6 +205,18 @@ export class AutofixService {
     };
     const chain: AutofixChainEntry[] = [entry];
 
+    // The agent's body may carry a routing alias as its model (e.g. `auto`), but
+    // Phoenix fingerprints and resolves against the concrete provider model.
+    // Report the resolved model to Phoenix so its model-keyed catalog resolver
+    // can identify the model; the reforward below still routes via the alias.
+    const routingModel = params.requestBody.model;
+    const phoenixRequest =
+      typeof params.resolvedModel === 'string' &&
+      params.resolvedModel.length > 0 &&
+      params.resolvedModel !== routingModel
+        ? { ...params.requestBody, model: params.resolvedModel }
+        : params.requestBody;
+
     let heal: HealResponse;
     try {
       heal = await this.client.heal({
@@ -204,7 +224,7 @@ export class AutofixService {
         provider: params.provider,
         api: params.apiMode,
         url: params.url,
-        request: params.requestBody,
+        request: phoenixRequest,
         response: { statusCode: status, error: normalized },
       });
     } catch (err) {
@@ -255,7 +275,17 @@ export class AutofixService {
     // allow-list. Keep it that way so a new Phoenix status never silently no-ops.
     const healAttemptId = heal.healAttemptId;
     const healedBody = heal.healedBody;
-    const next = await params.reforward(healedBody);
+    // Phoenix echoes back the model we sent it (the resolved provider model). The
+    // reforward must go through the agent's routing, so restore the original
+    // routing alias — unless Phoenix itself changed the model (a model-fix patch),
+    // which `reforwardHealed` intentionally re-resolves.
+    const bodyToReforward =
+      typeof routingModel === 'string' &&
+      healedBody.model === phoenixRequest.model &&
+      phoenixRequest.model !== routingModel
+        ? { ...healedBody, model: routingModel }
+        : healedBody;
+    const next = await params.reforward(bodyToReforward);
     const ok = next.response.ok;
     entry.patch_worked = ok;
 
@@ -265,7 +295,7 @@ export class AutofixService {
       chain.push({
         attempt: 1,
         origin: 'autofix',
-        request: healedBody,
+        request: bodyToReforward,
         http_status: next.response.status,
       });
       return {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -343,6 +343,9 @@ export class ProxyService {
       provider: route.provider,
       apiMode,
       requestBody: body,
+      // Report the resolved provider model to Phoenix (the body may carry the
+      // `auto` routing alias, which Phoenix's model-keyed catalog can't map).
+      resolvedModel: primaryModel,
       reforward: (healedBody) =>
         this.reforwardHealed(healedBody, {
           agentId,


### PR DESCRIPTION
### 💭 Why
Auto-fix only heals when Phoenix can tell which model failed. It was sending the routing alias `auto` (what agents actually send), which Phoenix's model-keyed catalog can't map, so every auto-routed request came back `no_fix_found` and never healed.

### ✨ What changed
- Proxy passes the resolved provider model to the healer.
- Heal request carries the resolved model; the reforward restores the `auto` alias so routing still works.
- 3 unit tests cover the split; backward-compatible when no resolved model is passed.

### 👤 For users
Agents that use model routing (the default) now get repairable 4xx errors healed, not just requests that name a concrete model.

### 📝 Notes
Fixes the Auto-fix engine on #2379. Verified live end to end: `model:"auto"` + an unknown param heals through the proxy and Phoenix logs a succeeded attempt on the real model's issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-fix now heals auto-routed requests by sending Phoenix the resolved provider model and restoring the `auto` alias on reforward. Agents using model routing now get 4xx repair attempts instead of `no_fix_found`.

- **Bug Fixes**
  - Proxy passes `resolvedModel` (e.g., `gpt-5.1`) to the healer so Phoenix can map it.
  - `AutofixService` sends the resolved model to Phoenix, then reforward keeps the original `auto` alias; request bodies are not mutated; works the same when `resolvedModel` is missing.
  - Added 3 unit tests for model reporting, immutability, and backward compatibility.

<sup>Written for commit 85ff7ee9daf824137095a8d8b9ae7d72c278fbd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

