### PR TITLE
fix: validate pinned provider routes

### DIFF
--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
@@ -80,7 +80,11 @@ describe('ResolveService — edge cases', () => {
   let providerKeyService: jest.Mocked<
     Pick<
       ProviderKeyService,
-      'isModelAvailable' | 'hasActiveProvider' | 'getAuthType' | 'getDefaultKeyLabel'
+      | 'isModelAvailable'
+      | 'isRouteAvailable'
+      | 'hasActiveProvider'
+      | 'getAuthType'
+      | 'getDefaultKeyLabel'
     >
   >;
   let specificityService: jest.Mocked<Pick<SpecificityService, 'getActiveAssignments'>>;
@@ -98,6 +102,7 @@ describe('ResolveService — edge cases', () => {
     tierService = { getTiers: jest.fn().mockResolvedValue([]) };
     providerKeyService = {
       isModelAvailable: jest.fn().mockResolvedValue(true),
+      isRouteAvailable: jest.fn().mockResolvedValue(true),
       hasActiveProvider: jest.fn().mockResolvedValue(true),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       getDefaultKeyLabel: jest.fn().mockResolvedValue(undefined),
@@ -240,6 +245,7 @@ describe('ResolveService — edge cases', () => {
       specificityService.getActiveAssignments.mockResolvedValue([codingSpecificity('orphaned')]);
       mockedScan.mockReturnValue({ category: 'coding', confidence: 0.9 } as never);
       providerKeyService.isModelAvailable.mockResolvedValue(false);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
       tierService.getTiers.mockResolvedValue([fallbackTierAssignment()]);
 
       await svc.resolve('agent-1', 'user-1', messages);
@@ -257,6 +263,7 @@ describe('ResolveService — edge cases', () => {
         } as unknown as TierAssignment,
       ]);
       providerKeyService.isModelAvailable.mockResolvedValue(false);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
 
       await svc.resolve('agent-1', 'user-1', messages);
 

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -49,7 +49,11 @@ describe('ResolveService', () => {
   let providerKeyService: jest.Mocked<
     Pick<
       ProviderKeyService,
-      'isModelAvailable' | 'hasActiveProvider' | 'getAuthType' | 'getDefaultKeyLabel'
+      | 'isModelAvailable'
+      | 'isRouteAvailable'
+      | 'hasActiveProvider'
+      | 'getAuthType'
+      | 'getDefaultKeyLabel'
     >
   >;
   let specificityService: jest.Mocked<Pick<SpecificityService, 'getActiveAssignments'>>;
@@ -68,6 +72,7 @@ describe('ResolveService', () => {
     tierService = { getTiers: jest.fn().mockResolvedValue([]) };
     providerKeyService = {
       isModelAvailable: jest.fn().mockResolvedValue(true),
+      isRouteAvailable: jest.fn().mockResolvedValue(true),
       hasActiveProvider: jest.fn().mockResolvedValue(true),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       // Default to undefined so resolved routes carry no `keyLabel` unless a
@@ -222,6 +227,7 @@ describe('ResolveService', () => {
       } as unknown as HeaderTier;
       headerTierService.list.mockResolvedValue([tier]);
       providerKeyService.isModelAvailable.mockResolvedValue(false);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
 
       const result = await svc.resolve(
         'agent-1',
@@ -236,6 +242,79 @@ describe('ResolveService', () => {
         { 'x-tier': 'gold' },
       );
       expect(result.reason).not.toBe('header-match');
+    });
+
+    it('validates the override with the route-aware check, not the name-only one', async () => {
+      // Regression: a pinned override whose model id exists on two connections
+      // (openai api_key + subscription) must stay available — the name-only
+      // isModelAvailable lookup reports ambiguous ids as unavailable (#2210).
+      const pinned = route('openai', 'subscription', 'gpt-5.5');
+      const tier = {
+        id: 'h1',
+        name: 'Premium',
+        header_key: 'x-tier',
+        header_value: 'gold',
+        enabled: true,
+        badge_color: 'red',
+        override_route: pinned,
+        fallback_routes: null,
+      } as unknown as HeaderTier;
+      headerTierService.list.mockResolvedValue([tier]);
+      providerKeyService.isModelAvailable.mockResolvedValue(false);
+      providerKeyService.isRouteAvailable.mockResolvedValue(true);
+
+      const result = await svc.resolve(
+        'agent-1',
+        'user-1',
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { 'x-tier': 'gold' },
+      );
+      expect(result.reason).toBe('header-match');
+      expect(result.route).toEqual(pinned);
+      expect(providerKeyService.isRouteAvailable).toHaveBeenCalledWith('user-1', pinned, 'agent-1');
+    });
+
+    it('promotes the first available fallback when the override is unavailable', async () => {
+      const primary = route('openai', 'subscription', 'gpt-5.5');
+      const deadFallback = route('gemini', 'api_key', 'gemini-pro-latest');
+      const liveFallback = route('minimax', 'subscription', 'MiniMax-M3');
+      const lastFallback = route('xai', 'subscription', 'grok-4.3');
+      const tier = {
+        id: 'h1',
+        name: 'Premium',
+        header_key: 'x-tier',
+        header_value: 'gold',
+        enabled: true,
+        badge_color: 'red',
+        override_route: primary,
+        fallback_routes: [deadFallback, liveFallback, lastFallback],
+      } as unknown as HeaderTier;
+      headerTierService.list.mockResolvedValue([tier]);
+      providerKeyService.isRouteAvailable.mockImplementation(
+        async (_tenantId: string, r: ModelRoute) => r === liveFallback || r === lastFallback,
+      );
+
+      const result = await svc.resolve(
+        'agent-1',
+        'user-1',
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { 'x-tier': 'gold' },
+      );
+      expect(result.reason).toBe('header-match');
+      expect(result.route).toEqual(liveFallback);
+      expect(result.fallback_routes).toEqual([lastFallback]);
     });
 
     it('matches when the header value is provided as an array', async () => {
@@ -506,6 +585,7 @@ describe('ResolveService', () => {
       ]);
       mockedScan.mockReturnValue({ category: 'coding', confidence: 0.9 } as never);
       providerKeyService.isModelAvailable.mockResolvedValue(false);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
       tierService.getTiers.mockResolvedValue([
         {
           tier: 'standard',
@@ -734,6 +814,7 @@ describe('ResolveService', () => {
         } as unknown as TierAssignment,
       ]);
       providerKeyService.isModelAvailable.mockResolvedValue(false);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
 
       const result = await svc.resolve('agent-1', 'user-1', messages);
       expect(result.tier).toBe('standard');
@@ -760,6 +841,7 @@ describe('ResolveService', () => {
         } as unknown as TierAssignment,
       ]);
       providerKeyService.isModelAvailable.mockResolvedValue(false);
+      providerKeyService.isRouteAvailable.mockResolvedValue(false);
 
       const result = await svc.resolve('agent-1', 'user-1', messages);
       expect(result.route).toEqual(route('anthropic', 'api_key', 'fallback-1'));

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -238,31 +238,54 @@ export class ResolveService {
     }
 
     // Guard against orphaned overrides (a model removed after the tier was
-    // configured). Mirrors the same check in resolveSpecificity().
-    if (!(await this.providerKeyService.isModelAvailable(tenantId, overrideRoute.model, agentId))) {
+    // configured). The route-aware check honors the override's pinned
+    // (provider, authType) so a model id shared by two connections — e.g.
+    // openai api_key + openai subscription both exposing gpt-5.5 — still
+    // counts as available (#2210).
+    const fallbackRoutes = readFallbackRoutes(match);
+    let primaryOverride: ModelRoute | null = overrideRoute;
+    let remainingFallbacks: ModelRoute[] | null = fallbackRoutes;
+    if (!(await this.providerKeyService.isRouteAvailable(tenantId, overrideRoute, agentId))) {
+      // An explicitly configured tier shouldn't die with its primary: promote
+      // the first available fallback instead of abandoning the whole tier.
       this.logger.warn(
         `Header tier "${match.name}" override ${overrideRoute.model} is unavailable ` +
-          `for agent=${agentId}; falling through to existing routing`,
+          `for agent=${agentId} — trying the tier's fallbacks`,
       );
-      return null;
+      primaryOverride = null;
+      const candidates = fallbackRoutes ?? [];
+      for (let i = 0; i < candidates.length; i++) {
+        if (await this.providerKeyService.isRouteAvailable(tenantId, candidates[i], agentId)) {
+          primaryOverride = candidates[i];
+          const rest = candidates.slice(i + 1);
+          remainingFallbacks = rest.length > 0 ? rest : null;
+          break;
+        }
+      }
+      if (!primaryOverride) {
+        this.logger.warn(
+          `Header tier "${match.name}" has no available route ` +
+            `for agent=${agentId}; falling through to existing routing`,
+        );
+        return null;
+      }
     }
 
     const provider =
-      overrideRoute.provider ||
-      (await this.resolveProviderForModel(agentId, tenantId, overrideRoute.model));
+      primaryOverride.provider ||
+      (await this.resolveProviderForModel(agentId, tenantId, primaryOverride.model));
     const authType: AuthType =
-      overrideRoute.authType ??
+      primaryOverride.authType ??
       (await this.providerKeyService.getAuthType(tenantId, provider ?? '', undefined, agentId));
     const baseRoute: ModelRoute | null =
       provider && authType
-        ? { provider, authType, model: overrideRoute.model, keyLabel: overrideRoute.keyLabel }
+        ? { provider, authType, model: primaryOverride.model, keyLabel: primaryOverride.keyLabel }
         : null;
     const route = baseRoute ? await this.enrichRouteKeyLabel(agentId, tenantId, baseRoute) : null;
 
     const outputModality = outputModalityFor(match);
     const responseMode = responseModeFor(match);
-    const fallbackRoutes = readFallbackRoutes(match);
-    const effectiveRoutes = effectiveRoutesForResponseMode(responseMode, route, fallbackRoutes);
+    const effectiveRoutes = effectiveRoutesForResponseMode(responseMode, route, remainingFallbacks);
 
     return {
       tier: 'standard',
@@ -322,10 +345,9 @@ export class ResolveService {
       // Validate the override still points to an available model. An orphaned
       // override (e.g. a deleted custom provider) returns null so resolve()
       // falls through to tier-based routing instead of pinning every matching
-      // request to a dead provider (#1603).
-      if (
-        !(await this.providerKeyService.isModelAvailable(tenantId, overrideRoute.model, agentId))
-      ) {
+      // request to a dead provider (#1603). Route-aware so a pinned
+      // (provider, authType) survives duplicate model ids (#2210).
+      if (!(await this.providerKeyService.isRouteAvailable(tenantId, overrideRoute, agentId))) {
         this.logger.warn(
           `Specificity override ${overrideRoute.model} is unavailable ` +
             `for agent=${agentId}; falling through to tier routing`,
@@ -378,7 +400,7 @@ export class ResolveService {
     // TierService.hasRoutableTier / effectiveRoute (see route-helpers.ts).
     const autoAssigned = readAutoAssignedRoute(assignment);
     if (override) {
-      if (await this.providerKeyService.isModelAvailable(tenantId, override.model, agentId)) {
+      if (await this.providerKeyService.isRouteAvailable(tenantId, override, agentId)) {
         return {
           primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, override),
           fallbackRoutes,

--- a/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
@@ -574,6 +574,22 @@ describe('ProviderKeyService', () => {
       ).toBe(false);
     });
 
+    it('does not accept an active provider record when discovery has other models for the pin', async () => {
+      discoveryService.getModelsForAgent.mockResolvedValue([
+        discovered('openai', 'gpt-4o', 'api_key'),
+      ]);
+      providerRepo.find.mockResolvedValue([
+        { provider: 'openai', auth_type: 'api_key', is_active: true } as TenantProvider,
+      ]);
+      expect(
+        await svc.isRouteAvailable('tenant-1', {
+          provider: 'openai',
+          authType: 'api_key',
+          model: 'retired-model',
+        }),
+      ).toBe(false);
+    });
+
     it('falls back to an active provider record when discovery is cold', async () => {
       discoveryService.getModelsForAgent.mockResolvedValue([]);
       providerRepo.find.mockResolvedValue([
@@ -598,6 +614,20 @@ describe('ProviderKeyService', () => {
           provider: 'openai',
           authType: 'subscription',
           model: 'gpt-5.5',
+        }),
+      ).toBe(false);
+    });
+
+    it('requires native discovery for pinned Qwen routes', async () => {
+      discoveryService.getModelsForAgent.mockResolvedValue([]);
+      providerRepo.find.mockResolvedValue([
+        { provider: 'qwen', auth_type: 'api_key', is_active: true } as TenantProvider,
+      ]);
+      expect(
+        await svc.isRouteAvailable('tenant-1', {
+          provider: 'qwen',
+          authType: 'api_key',
+          model: 'qwen-max',
         }),
       ).toBe(false);
     });

--- a/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
@@ -22,7 +22,9 @@ describe('ProviderKeyService', () => {
     findOne: jest.Mock;
   };
   let pricingCache: jest.Mocked<Pick<ModelPricingCacheService, 'getByModel'>>;
-  let discoveryService: jest.Mocked<Pick<ModelDiscoveryService, 'getModelForAgent'>>;
+  let discoveryService: jest.Mocked<
+    Pick<ModelDiscoveryService, 'getModelForAgent' | 'getModelsForAgent'>
+  >;
   let routingCache: {
     getApiKey: jest.Mock;
     setApiKey: jest.Mock;
@@ -39,7 +41,10 @@ describe('ProviderKeyService', () => {
       findOne: jest.fn().mockResolvedValue(null),
     };
     pricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
-    discoveryService = { getModelForAgent: jest.fn().mockResolvedValue(undefined) };
+    discoveryService = {
+      getModelForAgent: jest.fn().mockResolvedValue(undefined),
+      getModelsForAgent: jest.fn().mockResolvedValue([]),
+    };
     routingCache = {
       getApiKey: jest.fn().mockReturnValue(undefined),
       setApiKey: jest.fn(),
@@ -532,6 +537,98 @@ describe('ProviderKeyService', () => {
         { provider: 'openai', auth_type: 'api_key', is_active: true } as TenantProvider,
       ]);
       expect(await svc.isModelAvailable('agent-1', 'gpt-4o')).toBe(true);
+    });
+  });
+
+  describe('isRouteAvailable', () => {
+    const discovered = (provider: string, id: string, authType?: string) =>
+      ({ id, provider, authType }) as never;
+
+    it('resolves an ambiguous model id through the pinned provider/authType', async () => {
+      // Two connections expose the same model id — the name-only lookup
+      // (getModelForAgent) refuses to answer, which used to disable the tier.
+      discoveryService.getModelsForAgent.mockResolvedValue([
+        discovered('openai', 'gpt-5.5', 'api_key'),
+        discovered('openai', 'gpt-5.5', 'subscription'),
+      ]);
+      expect(
+        await svc.isRouteAvailable('tenant-1', {
+          provider: 'openai',
+          authType: 'subscription',
+          model: 'gpt-5.5',
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when the pinned provider does not expose the model and has no record', async () => {
+      discoveryService.getModelsForAgent.mockResolvedValue([
+        discovered('openai', 'gpt-5.5', 'api_key'),
+      ]);
+      providerRepo.find.mockResolvedValue([]);
+      expect(
+        await svc.isRouteAvailable('tenant-1', {
+          provider: 'anthropic',
+          authType: 'api_key',
+          model: 'gpt-5.5',
+        }),
+      ).toBe(false);
+    });
+
+    it('falls back to an active provider record when discovery is cold', async () => {
+      discoveryService.getModelsForAgent.mockResolvedValue([]);
+      providerRepo.find.mockResolvedValue([
+        { provider: 'openai', auth_type: 'subscription', is_active: true } as TenantProvider,
+      ]);
+      expect(
+        await svc.isRouteAvailable('tenant-1', {
+          provider: 'openai',
+          authType: 'subscription',
+          model: 'gpt-5.5',
+        }),
+      ).toBe(true);
+    });
+
+    it('respects the authType pin against provider records', async () => {
+      discoveryService.getModelsForAgent.mockResolvedValue([]);
+      providerRepo.find.mockResolvedValue([
+        { provider: 'openai', auth_type: 'api_key', is_active: true } as TenantProvider,
+      ]);
+      expect(
+        await svc.isRouteAvailable('tenant-1', {
+          provider: 'openai',
+          authType: 'subscription',
+          model: 'gpt-5.5',
+        }),
+      ).toBe(false);
+    });
+
+    it('treats discovered models without an authType as compatible with any pin', async () => {
+      discoveryService.getModelsForAgent.mockResolvedValue([
+        discovered('openai', 'gpt-5.5', undefined),
+      ]);
+      expect(
+        await svc.isRouteAvailable('tenant-1', {
+          provider: 'openai',
+          authType: 'subscription',
+          model: 'gpt-5.5',
+        }),
+      ).toBe(true);
+    });
+
+    it('delegates to isModelAvailable when the route has no provider pin', async () => {
+      discoveryService.getModelForAgent.mockResolvedValue({ id: 'gpt-4o' } as never);
+      expect(
+        await svc.isRouteAvailable('tenant-1', {
+          provider: '',
+          authType: 'api_key',
+          model: 'gpt-4o',
+        }),
+      ).toBe(true);
+      expect(discoveryService.getModelForAgent).toHaveBeenCalledWith(
+        'tenant-1',
+        'gpt-4o',
+        undefined,
+      );
     });
   });
 

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -358,17 +358,21 @@ export class ProviderKeyService {
     }
     const providerNames = expandProviderNames([route.provider]);
     const discovered = await this.discoveryService.getModelsForAgent(tenantId, agentId);
-    const matched = discovered.some(
+    const connectionModels = discovered.filter(
       (m) =>
-        m.id === route.model &&
         providerNames.has(m.provider.toLowerCase()) &&
         (!route.authType || !m.authType || m.authType === route.authType),
     );
-    if (matched) return true;
+    if (connectionModels.some((m) => m.id === route.model)) return true;
+    if (connectionModels.length > 0) return false;
 
-    // Discovery can be cold or partial for a connection; fall back to "an
-    // active, usable record for the pinned provider exists" — the same
-    // leniency isModelAvailable's tail applies to inferred providers.
+    // Qwen/Alibaba model IDs must come from native discovery. The provider has
+    // region-specific routable names, so an active key alone is not enough.
+    if (providerNames.has('qwen') || providerNames.has('alibaba')) return false;
+
+    // Discovery can be cold for a connection; fall back to "an active, usable
+    // record for the pinned provider exists" only when discovery returned no
+    // model evidence for that pinned provider/authType.
     const records = (
       await this.filterProvidersForAgent(
         await this.providerRepo.find({

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import type { AuthType } from 'manifest-shared';
+import type { AuthType, ModelRoute } from 'manifest-shared';
 import { TenantProvider } from '../../entities/tenant-provider.entity';
 import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
@@ -339,6 +339,49 @@ export class ProviderKeyService {
       if (records.find((r) => prefixNames.has(r.provider.toLowerCase()))) return true;
     }
     return false;
+  }
+
+  /**
+   * Availability check for an explicit ModelRoute. isModelAvailable() resolves
+   * the model by name alone, and getModelForAgent() deliberately refuses
+   * provider-less lookups once two connections expose the same model id — so a
+   * pinned override like {model: gpt-5.5, provider: openai, authType:
+   * subscription} would be reported unavailable the moment the tenant also
+   * connects an openai api_key. A route carries the (provider, authType) pin,
+   * so honor it: filter the discovered list down to the pinned pair instead of
+   * asking the ambiguous question. Routes without a provider pin keep the
+   * legacy name-only behavior.
+   */
+  async isRouteAvailable(tenantId: string, route: ModelRoute, agentId?: string): Promise<boolean> {
+    if (!route.provider) {
+      return this.isModelAvailable(tenantId, route.model, agentId);
+    }
+    const providerNames = expandProviderNames([route.provider]);
+    const discovered = await this.discoveryService.getModelsForAgent(tenantId, agentId);
+    const matched = discovered.some(
+      (m) =>
+        m.id === route.model &&
+        providerNames.has(m.provider.toLowerCase()) &&
+        (!route.authType || !m.authType || m.authType === route.authType),
+    );
+    if (matched) return true;
+
+    // Discovery can be cold or partial for a connection; fall back to "an
+    // active, usable record for the pinned provider exists" — the same
+    // leniency isModelAvailable's tail applies to inferred providers.
+    const records = (
+      await this.filterProvidersForAgent(
+        await this.providerRepo.find({
+          where: { tenant_id: tenantId, is_active: true },
+        }),
+        agentId,
+      )
+    ).filter(isManifestUsableProvider);
+    return records.some(
+      (r) =>
+        providerNames.has(r.provider.toLowerCase()) &&
+        (!route.authType || r.auth_type === route.authType),
+    );
   }
 
   /**


### PR DESCRIPTION
### ✨ What changed
- Route availability now checks pinned provider/authType pairs.
- Header tiers promote the first available fallback when primary is unavailable.
- Stale pinned routes stay unavailable when discovery has models for that pin.
- Qwen and Alibaba pinned routes still require native discovery.

### 💭 Why
Name-only validation treated duplicate model IDs as unavailable, even when the saved route had enough provider/authType data.

### 👤 For users
Header tiers pinned to duplicated model IDs keep matching instead of falling back to automatic routing.