### PR TITLE
fix: keep route metadata on streamed errors

### DIFF
--- a/.changeset/route-error-metadata.md
+++ b/.changeset/route-error-metadata.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Preserve route metadata on streamed provider errors so message logs keep model and provider fields.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -533,6 +533,85 @@ describe('ProxyController', () => {
     expect(res.json).toHaveBeenCalledWith(collectedBody);
   });
 
+  it('should record route metadata when collected SSE response fails after routing', async () => {
+    const sseText = 'event: error\ndata: {"error":{"message":"too large"}}\n\n';
+    const errorBody = JSON.stringify({
+      error: {
+        message: 'Your input exceeds the context window of this model.',
+        code: 'context_length_exceeded',
+        type: 'invalid_request_error',
+      },
+    });
+    const mockProviderResp = new Response(sseText, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: {
+        response: mockProviderResp,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: true,
+      },
+      meta: {
+        tier: 'standard',
+        model: 'gpt-5.3-codex',
+        provider: 'openai',
+        confidence: 0.8,
+        reason: 'scored',
+        auth_type: 'subscription',
+        provider_key_label: 'Work',
+        tenantProviderId: 'tenant-provider-1',
+        request_params: { reasoning_effort: 'medium' },
+        header_tier_id: 'header-tier-1',
+        header_tier_name: 'Premium',
+        header_tier_color: 'indigo',
+      },
+    });
+    (providerClient as Record<string, jest.Mock>).collectChatGptSseResponse = jest
+      .fn()
+      .mockImplementation(() => {
+        throw new ResponsesSseError(
+          'Your input exceeds the context window of this model.',
+          400,
+          errorBody,
+        );
+      });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await flushRecorderMicrotasks();
+
+    expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        error_http_status: 400,
+        error_message: errorBody,
+        model: 'gpt-5.3-codex',
+        provider: 'openai',
+        routing_tier: 'standard',
+        routing_reason: 'scored',
+        auth_type: 'subscription',
+        provider_key_label: 'Work',
+        tenant_provider_id: 'tenant-provider-1',
+        request_params: { reasoning_effort: 'medium' },
+        header_tier_id: 'header-tier-1',
+        header_tier_name: 'Premium',
+        header_tier_color: 'indigo',
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5.3-codex',
+      }),
+    });
+  });
+
   it('should not record success message for non-fallback responses (OTLP pipeline records them)', async () => {
     const responseBody = {
       choices: [{ message: { content: 'hello' } }],

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -14,7 +14,7 @@ import { SkipThrottle } from '@nestjs/throttler';
 import { Public } from '../../common/decorators/public.decorator';
 import { AgentKeyAuthGuard } from '../../otlp/guards/agent-key-auth.guard';
 import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interface';
-import { ProxyService } from './proxy.service';
+import { ProxyService, type RoutingMeta } from './proxy.service';
 import { ProxyRateLimiter } from './proxy-rate-limiter';
 import { ProviderClient } from './provider-client';
 import { ProxyMessageRecorder } from './proxy-message-recorder';
@@ -152,6 +152,7 @@ export class ProxyController {
     let routingBody = body;
     let headersSent = false;
     let slotAcquired = false;
+    let currentMeta: RoutingMeta | undefined;
 
     const clientAbort = new AbortController();
     res.once('close', () => clientAbort.abort());
@@ -178,6 +179,7 @@ export class ProxyController {
         headers: req.headers,
         apiMode,
       });
+      currentMeta = meta;
 
       this.trackFirstProxyRequest(tenantId);
 
@@ -266,6 +268,7 @@ export class ProxyController {
         traceId,
         callerAttribution,
         requestHeaders,
+        currentMeta,
       );
     } finally {
       if (slotAcquired) this.rateLimiter.releaseSlot(tenantId);
@@ -281,6 +284,7 @@ export class ProxyController {
     traceId: string | undefined,
     callerAttribution: ReturnType<typeof classifyCaller>,
     requestHeaders: ReturnType<typeof sanitizeRequestHeaders>,
+    meta?: RoutingMeta,
   ): void {
     if (clientAbort.signal.aborted) {
       if (!res.writableEnded) res.end();
@@ -299,6 +303,24 @@ export class ProxyController {
 
     this.recorder
       .recordProviderError(req.ingestionContext, status, providerErrorBody, {
+        ...(meta
+          ? {
+              model: meta.model,
+              provider: meta.provider,
+              tier: meta.tier,
+              fallbackFromModel: meta.fallbackFromModel,
+              fallbackIndex: meta.fallbackIndex,
+              authType: meta.auth_type,
+              reason: meta.reason,
+              specificityCategory: meta.specificity_category,
+              providerKeyLabel: meta.provider_key_label,
+              tenantProviderId: meta.tenantProviderId,
+              requestParams: meta.request_params,
+              headerTierId: meta.header_tier_id,
+              headerTierName: meta.header_tier_name,
+              headerTierColor: meta.header_tier_color,
+            }
+          : {}),
         traceId,
         callerAttribution,
         requestHeaders,
@@ -312,7 +334,11 @@ export class ProxyController {
 
     if (err instanceof ResponsesSseError) {
       res.status(err.status).json({
-        error: buildOpenAiCompatibleError(err.status, err.body),
+        error: buildOpenAiCompatibleError(
+          err.status,
+          err.body,
+          meta ? { provider: meta.provider, model: meta.model } : {},
+        ),
       });
       return;
     }


### PR DESCRIPTION
### ✨ What changed
- Routed errors now keep model, provider, tier, and key metadata.
- Responses SSE errors include model and provider in OpenAI-compatible error JSON.
- Proxy controller spec covers context-window failure after routing.

### 💭 Why
Collected streaming responses can fail after routing has already selected a provider. The catch path was recording the error without the route metadata, so Messages showed blank model/provider.

### 📝 Notes
Closes #2416
Local checks: `npm test --workspace=packages/backend -- --runInBand src/routing/proxy/__tests__/proxy.controller.spec.ts`, `npm run build --workspace=packages/backend`, `npm run check:changesets`, `git diff --check`, `npm run lint --workspace=packages/backend`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves route metadata on streamed provider errors so message logs and clients show the selected model/provider. SSE error responses now return OpenAI-compatible JSON that includes `provider` and `model`.

- **Bug Fixes**
  - Keep `RoutingMeta` during `chatCompletions` and pass it to the error recorder.
  - Include `provider` and `model` in OpenAI-compatible JSON for `ResponsesSseError`.
  - Record full routing fields on errors (model, provider, tier, reason, auth_type, provider_key_label, tenantProviderId, request_params, header_tier_*).
  - Add test for context-window failure after routing to ensure metadata is recorded and status/JSON are correct.

<sup>Written for commit b2b95f0d88e1672a6f44051f5b99ffeef21f4577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

