### PR TITLE
Fix waitlist sync reading empty tenant email

### DIFF
--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -24,7 +24,8 @@ import { PlaygroundColumn } from '../entities/playground-column.entity';
 import { ReasoningContentCacheEntry } from '../entities/reasoning-content-cache-entry.entity';
 import { AgentEnabledProvider } from '../entities/agent-enabled-provider.entity';
 import { PublicErrorPage } from '../entities/public-error-page.entity';
-import { AutofixWaitlistSignup } from '../entities/autofix-waitlist-signup.entity';
+import { WaitlistClaim } from '../entities/waitlist-claim.entity';
+import { RenameWaitlistClaimsTable1800000000000 } from './migrations/1800000000000-RenameWaitlistClaimsTable';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -156,7 +157,7 @@ export const entities = [
   AgentEnabledProvider,
   BackfillState,
   PublicErrorPage,
-  AutofixWaitlistSignup,
+  WaitlistClaim,
 ];
 
 export const migrations = [
@@ -268,4 +269,5 @@ export const migrations = [
   AddPublicErrorPages1797000000000,
   AddErrorClassification1798000000000,
   AddAutofixWaitlistSignups1799000000000,
+  RenameWaitlistClaimsTable1800000000000,
 ];

--- a/packages/backend/src/database/migrations/1800000000000-RenameWaitlistClaimsTable.spec.ts
+++ b/packages/backend/src/database/migrations/1800000000000-RenameWaitlistClaimsTable.spec.ts
@@ -11,7 +11,7 @@ describe('RenameWaitlistClaimsTable1800000000000', () => {
   });
 
   describe('up', () => {
-    it('renames the table and column', async () => {
+    it('renames the table, column, and constraints', async () => {
       await migration.up(queryRunner as unknown as QueryRunner);
 
       expect(queryRunner.query).toHaveBeenCalledWith(
@@ -20,6 +20,16 @@ describe('RenameWaitlistClaimsTable1800000000000', () => {
       expect(queryRunner.query).toHaveBeenCalledWith(
         expect.stringContaining('RENAME COLUMN "signed_up_at" TO "claimed_at"'),
       );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "PK_autofix_waitlist_signups" TO "PK_waitlist_claims"',
+        ),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "UQ_autofix_waitlist_signups_email" TO "UQ_waitlist_claims_email"',
+        ),
+      );
     });
   });
 
@@ -27,6 +37,16 @@ describe('RenameWaitlistClaimsTable1800000000000', () => {
     it('reverts the rename', async () => {
       await migration.down(queryRunner as unknown as QueryRunner);
 
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "UQ_waitlist_claims_email" TO "UQ_autofix_waitlist_signups_email"',
+        ),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'RENAME CONSTRAINT "PK_waitlist_claims" TO "PK_autofix_waitlist_signups"',
+        ),
+      );
       expect(queryRunner.query).toHaveBeenCalledWith(
         expect.stringContaining('RENAME COLUMN "claimed_at" TO "signed_up_at"'),
       );

--- a/packages/backend/src/database/migrations/1800000000000-RenameWaitlistClaimsTable.spec.ts
+++ b/packages/backend/src/database/migrations/1800000000000-RenameWaitlistClaimsTable.spec.ts
@@ -1,0 +1,42 @@
+import { QueryRunner } from 'typeorm';
+import { RenameWaitlistClaimsTable1800000000000 } from './1800000000000-RenameWaitlistClaimsTable';
+
+describe('RenameWaitlistClaimsTable1800000000000', () => {
+  let migration: RenameWaitlistClaimsTable1800000000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new RenameWaitlistClaimsTable1800000000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('renames the table and column', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('RENAME TO "waitlist_claims"'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('RENAME COLUMN "signed_up_at" TO "claimed_at"'),
+      );
+    });
+  });
+
+  describe('down', () => {
+    it('reverts the rename', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('RENAME COLUMN "claimed_at" TO "signed_up_at"'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('RENAME TO "autofix_waitlist_signups"'),
+      );
+    });
+  });
+
+  it('exposes a stable migration name', () => {
+    expect(migration.name).toBe('RenameWaitlistClaimsTable1800000000000');
+  });
+});

--- a/packages/backend/src/database/migrations/1800000000000-RenameWaitlistClaimsTable.ts
+++ b/packages/backend/src/database/migrations/1800000000000-RenameWaitlistClaimsTable.ts
@@ -12,9 +12,21 @@ export class RenameWaitlistClaimsTable1800000000000 implements MigrationInterfac
     await queryRunner.query(
       `ALTER TABLE "waitlist_claims" RENAME COLUMN "signed_up_at" TO "claimed_at"`,
     );
+    await queryRunner.query(
+      `ALTER TABLE "waitlist_claims" RENAME CONSTRAINT "PK_autofix_waitlist_signups" TO "PK_waitlist_claims"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "waitlist_claims" RENAME CONSTRAINT "UQ_autofix_waitlist_signups_email" TO "UQ_waitlist_claims_email"`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "waitlist_claims" RENAME CONSTRAINT "UQ_waitlist_claims_email" TO "UQ_autofix_waitlist_signups_email"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "waitlist_claims" RENAME CONSTRAINT "PK_waitlist_claims" TO "PK_autofix_waitlist_signups"`,
+    );
     await queryRunner.query(
       `ALTER TABLE "waitlist_claims" RENAME COLUMN "claimed_at" TO "signed_up_at"`,
     );

--- a/packages/backend/src/database/migrations/1800000000000-RenameWaitlistClaimsTable.ts
+++ b/packages/backend/src/database/migrations/1800000000000-RenameWaitlistClaimsTable.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Renames `autofix_waitlist_signups` → `waitlist_claims` and
+ * `signed_up_at` → `claimed_at` for clarity.
+ */
+export class RenameWaitlistClaimsTable1800000000000 implements MigrationInterface {
+  name = 'RenameWaitlistClaimsTable1800000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "autofix_waitlist_signups" RENAME TO "waitlist_claims"`);
+    await queryRunner.query(
+      `ALTER TABLE "waitlist_claims" RENAME COLUMN "signed_up_at" TO "claimed_at"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "waitlist_claims" RENAME COLUMN "claimed_at" TO "signed_up_at"`,
+    );
+    await queryRunner.query(`ALTER TABLE "waitlist_claims" RENAME TO "autofix_waitlist_signups"`);
+  }
+}

--- a/packages/backend/src/entities/waitlist-claim.entity.ts
+++ b/packages/backend/src/entities/waitlist-claim.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 
-@Entity('autofix_waitlist_signups')
-export class AutofixWaitlistSignup {
+@Entity('waitlist_claims')
+export class WaitlistClaim {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
@@ -12,5 +12,5 @@ export class AutofixWaitlistSignup {
   source!: string;
 
   @Column('timestamp with time zone', { default: () => 'now()' })
-  signed_up_at!: string;
+  claimed_at!: string;
 }

--- a/packages/backend/src/waitlist/dto/waitlist-claim.dto.spec.ts
+++ b/packages/backend/src/waitlist/dto/waitlist-claim.dto.spec.ts
@@ -1,23 +1,23 @@
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { WaitlistSignupDto } from './waitlist-signup.dto';
+import { WaitlistClaimDto } from './waitlist-claim.dto';
 
-describe('WaitlistSignupDto', () => {
+describe('WaitlistClaimDto', () => {
   it('accepts a valid email', async () => {
-    const dto = plainToInstance(WaitlistSignupDto, { email: 'user@example.com' });
+    const dto = plainToInstance(WaitlistClaimDto, { email: 'user@example.com' });
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);
   });
 
   it('rejects an invalid email', async () => {
-    const dto = plainToInstance(WaitlistSignupDto, { email: 'not-an-email' });
+    const dto = plainToInstance(WaitlistClaimDto, { email: 'not-an-email' });
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0].property).toBe('email');
   });
 
   it('rejects a missing email', async () => {
-    const dto = plainToInstance(WaitlistSignupDto, {});
+    const dto = plainToInstance(WaitlistClaimDto, {});
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
   });

--- a/packages/backend/src/waitlist/dto/waitlist-claim.dto.ts
+++ b/packages/backend/src/waitlist/dto/waitlist-claim.dto.ts
@@ -1,6 +1,6 @@
 import { IsEmail } from 'class-validator';
 
-export class WaitlistSignupDto {
+export class WaitlistClaimDto {
   @IsEmail()
   email!: string;
 }

--- a/packages/backend/src/waitlist/waitlist.controller.spec.ts
+++ b/packages/backend/src/waitlist/waitlist.controller.spec.ts
@@ -1,13 +1,20 @@
 import { WaitlistController } from './waitlist.controller';
 import { WaitlistSyncService } from './waitlist-sync.service';
 import { Repository } from 'typeorm';
+import { Request } from 'express';
 import { Tenant } from '../entities/tenant.entity';
-import { AutofixWaitlistSignup } from '../entities/autofix-waitlist-signup.entity';
+import { WaitlistClaim } from '../entities/waitlist-claim.entity';
+
+type ReqWithUser = Request & { user?: { email?: string } };
+
+function fakeReq(email?: string): ReqWithUser {
+  return { user: email !== undefined ? { email } : undefined } as ReqWithUser;
+}
 
 describe('WaitlistController', () => {
   let controller: WaitlistController;
   let tenantRepo: jest.Mocked<Pick<Repository<Tenant>, 'findOne' | 'update'>>;
-  let signupRepo: jest.Mocked<Pick<Repository<AutofixWaitlistSignup>, 'upsert'>>;
+  let claimRepo: jest.Mocked<Pick<Repository<WaitlistClaim>, 'upsert'>>;
   let waitlistSync: jest.Mocked<WaitlistSyncService>;
 
   beforeEach(() => {
@@ -15,7 +22,7 @@ describe('WaitlistController', () => {
       findOne: jest.fn(),
       update: jest.fn().mockResolvedValue(undefined),
     };
-    signupRepo = {
+    claimRepo = {
       upsert: jest.fn().mockResolvedValue(undefined),
     };
     waitlistSync = {
@@ -23,7 +30,7 @@ describe('WaitlistController', () => {
     } as unknown as jest.Mocked<WaitlistSyncService>;
     controller = new WaitlistController(
       tenantRepo as unknown as Repository<Tenant>,
-      signupRepo as unknown as Repository<AutofixWaitlistSignup>,
+      claimRepo as unknown as Repository<WaitlistClaim>,
       waitlistSync,
     );
   });
@@ -57,8 +64,10 @@ describe('WaitlistController', () => {
 
   describe('join', () => {
     it('sets autofix_waitlist_at and returns joined status', async () => {
-      tenantRepo.findOne.mockResolvedValue({ email: 'user@example.com' } as Tenant);
-      const result = await controller.join({ tenantId: 't1', userId: 'u1' });
+      const result = await controller.join(
+        { tenantId: 't1', userId: 'u1' },
+        fakeReq('user@example.com'),
+      );
       expect(tenantRepo.update).toHaveBeenCalledWith('t1', {
         autofix_waitlist_at: expect.any(String),
       });
@@ -66,28 +75,31 @@ describe('WaitlistController', () => {
       expect(result.joinedAt).toBeTruthy();
     });
 
-    it('calls waitlistSync.syncClaim with the tenant email', async () => {
-      tenantRepo.findOne.mockResolvedValue({ email: 'user@example.com' } as Tenant);
-      await controller.join({ tenantId: 't1', userId: 'u1' });
+    it('calls waitlistSync.syncClaim with the user email from session', async () => {
+      await controller.join({ tenantId: 't1', userId: 'u1' }, fakeReq('user@example.com'));
       expect(waitlistSync.syncClaim).toHaveBeenCalledWith('user@example.com');
     });
 
-    it('calls waitlistSync.syncClaim with empty string when tenant has no email', async () => {
-      tenantRepo.findOne.mockResolvedValue({ email: null } as Tenant);
-      await controller.join({ tenantId: 't1', userId: 'u1' });
+    it('calls waitlistSync.syncClaim with empty string when user has no email', async () => {
+      await controller.join({ tenantId: 't1', userId: 'u1' }, fakeReq());
       expect(waitlistSync.syncClaim).toHaveBeenCalledWith('');
     });
 
     it('returns not joined when tenantId is null', async () => {
-      const result = await controller.join({ tenantId: null, userId: 'u1' });
+      const result = await controller.join(
+        { tenantId: null, userId: 'u1' },
+        fakeReq('user@example.com'),
+      );
       expect(tenantRepo.update).not.toHaveBeenCalled();
       expect(result.joined).toBe(false);
     });
 
     it('does not fail when waitlistSync.syncClaim rejects', async () => {
-      tenantRepo.findOne.mockResolvedValue({ email: 'user@example.com' } as Tenant);
       waitlistSync.syncClaim.mockRejectedValue(new Error('boom'));
-      const result = await controller.join({ tenantId: 't1', userId: 'u1' });
+      const result = await controller.join(
+        { tenantId: 't1', userId: 'u1' },
+        fakeReq('user@example.com'),
+      );
       expect(result.joined).toBe(true);
     });
   });
@@ -95,11 +107,11 @@ describe('WaitlistController', () => {
   describe('receiveClaim', () => {
     it('upserts the email and returns ok', async () => {
       const result = await controller.receiveClaim({ email: 'user@example.com' });
-      expect(signupRepo.upsert).toHaveBeenCalledWith(
+      expect(claimRepo.upsert).toHaveBeenCalledWith(
         {
           email: 'user@example.com',
           source: 'self-hosted',
-          signed_up_at: expect.any(String),
+          claimed_at: expect.any(String),
         },
         { conflictPaths: ['email'] },
       );
@@ -107,7 +119,7 @@ describe('WaitlistController', () => {
     });
 
     it('handles duplicate emails via upsert', async () => {
-      signupRepo.upsert.mockResolvedValue(undefined as never);
+      claimRepo.upsert.mockResolvedValue(undefined as never);
       const result = await controller.receiveClaim({ email: 'dup@example.com' });
       expect(result).toEqual({ ok: true });
     });

--- a/packages/backend/src/waitlist/waitlist.controller.ts
+++ b/packages/backend/src/waitlist/waitlist.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Req } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { Request } from 'express';
 import { Tenant } from '../entities/tenant.entity';
-import { AutofixWaitlistSignup } from '../entities/autofix-waitlist-signup.entity';
+import { WaitlistClaim } from '../entities/waitlist-claim.entity';
 import { TenantCtx, TenantContext } from '../common/decorators/tenant-context.decorator';
 import { Public } from '../common/decorators/public.decorator';
 import { WaitlistSyncService } from './waitlist-sync.service';
@@ -13,8 +14,8 @@ export class WaitlistController {
   constructor(
     @InjectRepository(Tenant)
     private readonly tenantRepo: Repository<Tenant>,
-    @InjectRepository(AutofixWaitlistSignup)
-    private readonly signupRepo: Repository<AutofixWaitlistSignup>,
+    @InjectRepository(WaitlistClaim)
+    private readonly claimRepo: Repository<WaitlistClaim>,
     private readonly waitlistSync: WaitlistSyncService,
   ) {}
 
@@ -35,18 +36,18 @@ export class WaitlistController {
 
   @Post('autofix')
   @HttpCode(HttpStatus.OK)
-  async join(@TenantCtx() ctx: TenantContext): Promise<{ joined: boolean; joinedAt: string }> {
+  async join(
+    @TenantCtx() ctx: TenantContext,
+    @Req() req: Request & { user?: { email?: string } },
+  ): Promise<{ joined: boolean; joinedAt: string }> {
     if (!ctx.tenantId) {
       return { joined: false, joinedAt: '' };
     }
     const now = new Date().toISOString();
     await this.tenantRepo.update(ctx.tenantId, { autofix_waitlist_at: now });
 
-    const tenant = await this.tenantRepo.findOne({
-      where: { id: ctx.tenantId },
-      select: ['email'],
-    });
-    this.waitlistSync.syncClaim(tenant?.email ?? '').catch(() => {});
+    const email = req.user?.email ?? '';
+    this.waitlistSync.syncClaim(email).catch(() => {});
 
     return { joined: true, joinedAt: now };
   }
@@ -55,8 +56,8 @@ export class WaitlistController {
   @Post('autofix/claim')
   @HttpCode(HttpStatus.OK)
   async receiveClaim(@Body() dto: WaitlistSignupDto): Promise<{ ok: boolean }> {
-    await this.signupRepo.upsert(
-      { email: dto.email, source: 'self-hosted', signed_up_at: new Date().toISOString() },
+    await this.claimRepo.upsert(
+      { email: dto.email, source: 'self-hosted', claimed_at: new Date().toISOString() },
       { conflictPaths: ['email'] },
     );
     return { ok: true };

--- a/packages/backend/src/waitlist/waitlist.controller.ts
+++ b/packages/backend/src/waitlist/waitlist.controller.ts
@@ -7,7 +7,7 @@ import { WaitlistClaim } from '../entities/waitlist-claim.entity';
 import { TenantCtx, TenantContext } from '../common/decorators/tenant-context.decorator';
 import { Public } from '../common/decorators/public.decorator';
 import { WaitlistSyncService } from './waitlist-sync.service';
-import { WaitlistSignupDto } from './dto/waitlist-signup.dto';
+import { WaitlistClaimDto } from './dto/waitlist-claim.dto';
 
 @Controller('api/v1/waitlist')
 export class WaitlistController {
@@ -55,7 +55,7 @@ export class WaitlistController {
   @Public()
   @Post('autofix/claim')
   @HttpCode(HttpStatus.OK)
-  async receiveClaim(@Body() dto: WaitlistSignupDto): Promise<{ ok: boolean }> {
+  async receiveClaim(@Body() dto: WaitlistClaimDto): Promise<{ ok: boolean }> {
     await this.claimRepo.upsert(
       { email: dto.email, source: 'self-hosted', claimed_at: new Date().toISOString() },
       { conflictPaths: ['email'] },

--- a/packages/backend/src/waitlist/waitlist.module.ts
+++ b/packages/backend/src/waitlist/waitlist.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Tenant } from '../entities/tenant.entity';
-import { AutofixWaitlistSignup } from '../entities/autofix-waitlist-signup.entity';
+import { WaitlistClaim } from '../entities/waitlist-claim.entity';
 import { WaitlistController } from './waitlist.controller';
 import { WaitlistSyncService } from './waitlist-sync.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Tenant, AutofixWaitlistSignup])],
+  imports: [TypeOrmModule.forFeature([Tenant, WaitlistClaim])],
   controllers: [WaitlistController],
   providers: [WaitlistSyncService],
 })

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -38,7 +38,7 @@ import { ReasoningContentCacheEntry } from '../src/entities/reasoning-content-ca
 import { AgentEnabledProvider } from '../src/entities/agent-enabled-provider.entity';
 import { BackfillState } from '../src/entities/backfill-state.entity';
 import { PublicErrorPage } from '../src/entities/public-error-page.entity';
-import { AutofixWaitlistSignup } from '../src/entities/autofix-waitlist-signup.entity';
+import { WaitlistClaim } from '../src/entities/waitlist-claim.entity';
 import { HealthModule } from '../src/health/health.module';
 import { AnalyticsModule } from '../src/analytics/analytics.module';
 import { OtlpModule } from '../src/otlp/otlp.module';
@@ -80,7 +80,7 @@ const entities = [
   AgentEnabledProvider,
   BackfillState,
   PublicErrorPage,
-  AutofixWaitlistSignup,
+  WaitlistClaim,
 ];
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 const OPENROUTER_MODELS_FIXTURE = {


### PR DESCRIPTION
## What changed
- Waitlist sync now reads the email from the authenticated session instead of the tenant record
- Renamed table `autofix_waitlist_signups` to `waitlist_claims` (migration renames in place)
- Renamed column `signed_up_at` to `claimed_at`

## Why
The tenant `email` column is often empty because it's not populated during the normal onboarding flow. Self-hosted users clicking "Claim my spot" were silently skipped because the sync received an empty string. The session (Better Auth) always has the email.

## For users
"Claim my spot" on self-hosted instances now actually sends the email to the cloud. Previously it looked like it worked but nothing was synced.

## For operators
- New migration renames the table and column (automatic on startup, no manual step)
- Query `SELECT email, source, claimed_at FROM waitlist_claims` to see claims

## How to test
1. Start a self-hosted instance (`MANIFEST_MODE=local`)
2. Register with any email, create an agent
3. Open the autofix modal, click "Claim my spot"
4. On the cloud DB, run `SELECT * FROM waitlist_claims` and verify the email appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes waitlist sync by reading the email from the authenticated session instead of the tenant record. Renames the waitlist model to `waitlist_claims`/`claimed_at`, including related constraints.

- **Bug Fixes**
  - Read email from `request.user.email` (Better Auth) when joining the waitlist to avoid empty tenant emails.
  - Update controller and tests to use `WaitlistClaim`, `WaitlistClaimDto`, and `claimed_at`.

- **Migration**
  - Adds an automatic migration to rename the table, column, and constraints on startup.
  - To inspect data: run `SELECT email, source, claimed_at FROM waitlist_claims`.

<sup>Written for commit 062124fbdf34077e541aba1e167099d0fb6e0964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

