### PR TITLE
fix: preserve structured output routing

### DIFF
--- a/.changeset/structured-output-responses.md
+++ b/.changeset/structured-output-responses.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release. Backend proxy adapter fix only.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -231,6 +231,133 @@ describe('Anthropic Adapter', () => {
       expect(tools[1].cache_control).toEqual({ type: 'ephemeral' });
     });
 
+    it('maps json_schema response_format to native Anthropic output_config', () => {
+      const schema = {
+        type: 'object',
+        properties: { summary: { type: 'string' } },
+        required: ['summary'],
+        additionalProperties: false,
+      };
+      const body = {
+        messages: [{ role: 'user', content: 'Summarize the visit.' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'lookup_patient',
+              parameters: { type: 'object', properties: { id: { type: 'string' } } },
+            },
+          },
+        ],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'patient_summary',
+            description: 'Patient summary payload',
+            schema,
+            strict: true,
+          },
+        },
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
+
+      expect(result.tool_choice).toBeUndefined();
+      expect(result.output_config).toEqual({
+        format: { type: 'json_schema', schema },
+      });
+      expect(result.tools).toEqual([
+        {
+          name: 'lookup_patient',
+          input_schema: { type: 'object', properties: { id: { type: 'string' } } },
+          cache_control: { type: 'ephemeral' },
+        },
+      ]);
+    });
+
+    it('uses default schema details when json_schema response_format is incomplete', () => {
+      const result = toAnthropicRequest(
+        {
+          messages: [{ role: 'user', content: 'Return structured data.' }],
+          response_format: { type: 'json_schema' },
+        },
+        'claude-sonnet-4-20250514',
+      );
+
+      expect(result.tool_choice).toBeUndefined();
+      expect(result.tools).toBeUndefined();
+      expect(result.output_config).toEqual({
+        format: { type: 'json_schema', schema: { type: 'object' } },
+      });
+    });
+
+    it('maps json_object response_format to native Anthropic object output', () => {
+      const result = toAnthropicRequest(
+        {
+          messages: [{ role: 'user', content: 'Return JSON.' }],
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'structured_output',
+                parameters: { type: 'object' },
+              },
+            },
+          ],
+          response_format: { type: 'json_object' },
+        },
+        'claude-sonnet-4-20250514',
+      );
+
+      expect(result.tool_choice).toBeUndefined();
+      expect(result.output_config).toEqual({
+        format: {
+          type: 'json_schema',
+          schema: { type: 'object' },
+        },
+      });
+      expect(result.tools).toEqual([
+        {
+          name: 'structured_output',
+          input_schema: { type: 'object' },
+          cache_control: { type: 'ephemeral' },
+        },
+      ]);
+    });
+
+    it('does not add output_config for unsupported response_format types', () => {
+      const result = toAnthropicRequest(
+        {
+          messages: [{ role: 'user', content: 'Return text.' }],
+          response_format: { type: 'text' },
+        },
+        'claude-sonnet-4-20250514',
+      );
+
+      expect(result.tool_choice).toBeUndefined();
+      expect(result.tools).toBeUndefined();
+      expect(result.output_config).toBeUndefined();
+    });
+
+    it('preserves thinking when native structured output is requested', () => {
+      const result = toAnthropicRequest(
+        {
+          messages: [{ role: 'user', content: 'Return JSON.' }],
+          thinking: { type: 'enabled', budget_tokens: 1024 },
+          response_format: { type: 'json_object' },
+        },
+        'claude-sonnet-4-20250514',
+      );
+
+      expect(result.tool_choice).toBeUndefined();
+      expect(result.output_config).toEqual({
+        format: {
+          type: 'json_schema',
+          schema: { type: 'object' },
+        },
+      });
+      expect(result.thinking).toEqual({ type: 'enabled', budget_tokens: 1024 });
+    });
+
     it('converts tool_calls in assistant messages to tool_use blocks', () => {
       const body = {
         messages: [

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -119,6 +119,136 @@ describe('Google Adapter', () => {
       });
     });
 
+    it('maps OpenAI json_schema response_format to sanitized Gemini response schema', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Return structured data' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'patient_summary',
+            schema: {
+              type: 'object',
+              properties: {
+                title: { type: 'string', default: 'ignored' },
+                metadata: {
+                  type: 'object',
+                  properties: { source: { type: 'string' } },
+                  additionalProperties: false,
+                },
+              },
+              required: ['title'],
+              additionalProperties: false,
+              oneOf: [{ required: ['title'] }],
+              $ref: '#/$defs/PatientSummary',
+            },
+          },
+        },
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      expect(result.generationConfig).toEqual({
+        responseMimeType: 'application/json',
+        responseSchema: {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            metadata: {
+              type: 'object',
+              properties: { source: { type: 'string' } },
+            },
+          },
+          required: ['title'],
+        },
+      });
+    });
+
+    it('maps OpenAI json_object response_format to Gemini JSON mime type only', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Return JSON' }],
+        generationConfig: {
+          responseSchema: { type: 'object', properties: { stale: { type: 'string' } } },
+        },
+        response_format: { type: 'json_object' },
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      expect(result.generationConfig).toEqual({ responseMimeType: 'application/json' });
+    });
+
+    it('ignores unsupported OpenAI response_format types', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Return text' }],
+        generationConfig: {
+          temperature: 0.2,
+          responseSchema: { type: 'object', properties: { kept: { type: 'string' } } },
+        },
+        response_format: { type: 'text' },
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      expect(result.generationConfig).toEqual({
+        temperature: 0.2,
+        responseSchema: { type: 'object', properties: { kept: { type: 'string' } } },
+      });
+    });
+
+    it('drops stale responseSchema when json_schema metadata is malformed', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Return structured data' }],
+        generationConfig: {
+          responseSchema: { type: 'object', properties: { stale: { type: 'string' } } },
+        },
+        response_format: { type: 'json_schema', json_schema: 'not-an-object' },
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      expect(result.generationConfig).toEqual({ responseMimeType: 'application/json' });
+    });
+
+    it('drops stale responseSchema when json_schema response_format has no schema', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Return structured data' }],
+        generationConfig: {
+          responseSchema: { type: 'object', properties: { stale: { type: 'string' } } },
+        },
+        response_format: { type: 'json_schema', json_schema: { name: 'missing_schema' } },
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      expect(result.generationConfig).toEqual({ responseMimeType: 'application/json' });
+    });
+
+    it('normalizes nullable JSON Schema type arrays for Gemini response schemas', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Return structured data' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'nullable_payload',
+            schema: {
+              type: 'object',
+              properties: {
+                title: { type: ['string', 'null'] },
+                score: { type: ['number', 'null'] },
+              },
+            },
+          },
+        },
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      expect(result.generationConfig).toEqual({
+        responseMimeType: 'application/json',
+        responseSchema: {
+          type: 'object',
+          properties: {
+            title: { type: 'string', nullable: true },
+            score: { type: 'number', nullable: true },
+          },
+        },
+      });
+    });
+
     it('converts tools to functionDeclarations', () => {
       const body = {
         messages: [{ role: 'user', content: 'Search for cats' }],

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -51,6 +51,27 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('temperature', 0.5);
     });
 
+    it('should preserve response_format for OpenAI-wire providers', () => {
+      const responseFormat = {
+        type: 'json_schema',
+        json_schema: {
+          name: 'summary',
+          schema: { type: 'object', properties: { text: { type: 'string' } } },
+          strict: true,
+        },
+      };
+      const result = sanitizeOpenAiBody(
+        {
+          messages: [{ role: 'user', content: 'Hi' }],
+          response_format: responseFormat,
+        },
+        'mistral',
+        'mistral-large',
+      );
+
+      expect(result.response_format).toBe(responseFormat);
+    });
+
     it('should convert max_completion_tokens to max_tokens for non-passthrough providers', () => {
       const body = {
         messages: [],

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -726,6 +726,113 @@ describe('ProviderClient', () => {
       expect(sent.tools[0]).toMatchObject({ name: 'lookup', input_schema: { type: 'object' } });
     });
 
+    it('returns structured-output metadata for Responses requests routed to Anthropic', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const schema = { type: 'object', properties: { title: { type: 'string' } } };
+
+      const result = await client.forward({
+        provider: 'anthropic',
+        apiKey: 'sk-ant-test',
+        model: 'claude-sonnet-4-5-20250929',
+        body: {
+          input: 'Return JSON.',
+          text: {
+            format: {
+              type: 'json_schema',
+              name: 'patient_summary',
+              description: 'Patient summary',
+              schema,
+              strict: true,
+            },
+          },
+        },
+        chatBody: {
+          messages: [{ role: 'user', content: 'Return JSON.' }],
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              name: 'patient_summary',
+              description: 'Patient summary',
+              schema,
+              strict: true,
+            },
+          },
+        },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent.tool_choice).toBeUndefined();
+      expect(sent.output_config).toEqual({
+        format: { type: 'json_schema', schema },
+      });
+      expect(result.structuredOutputToolName).toBeUndefined();
+      expect(result.responsesTextFormat).toEqual({
+        type: 'json_schema',
+        name: 'patient_summary',
+        description: 'Patient summary',
+        schema,
+        strict: true,
+      });
+    });
+
+    it('returns json_object text metadata for Responses requests routed to Anthropic', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'anthropic',
+        apiKey: 'sk-ant-test',
+        model: 'claude-sonnet-4-5-20250929',
+        body: {
+          input: 'Return JSON.',
+          text: { format: { type: 'json_object' } },
+        },
+        chatBody: {
+          messages: [{ role: 'user', content: 'Return JSON.' }],
+          response_format: { type: 'json_object' },
+        },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent.tool_choice).toBeUndefined();
+      expect(sent.output_config).toEqual({
+        format: {
+          type: 'json_schema',
+          schema: { type: 'object' },
+        },
+      });
+      expect(result.structuredOutputToolName).toBeUndefined();
+      expect(result.responsesTextFormat).toEqual({ type: 'json_object' });
+    });
+
+    it('does not attach structured metadata for text Responses formats routed to Anthropic', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'anthropic',
+        apiKey: 'sk-ant-test',
+        model: 'claude-sonnet-4-5-20250929',
+        body: {
+          input: 'Return text.',
+          text: { format: { type: 'text' } },
+        },
+        chatBody: {
+          messages: [{ role: 'user', content: 'Return text.' }],
+          response_format: { type: 'text' },
+        },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent.tool_choice).toBeUndefined();
+      expect(result.structuredOutputToolName).toBeUndefined();
+      expect(result.responsesTextFormat).toBeUndefined();
+    });
+
     it('forwards Responses image inputs to Anthropic image content blocks', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -1570,6 +1570,63 @@ describe('proxy-response-handler', () => {
       expect(res.json).toHaveBeenCalledWith(response);
     });
 
+    it('unwraps Anthropic synthetic structured-output tool calls for Responses clients', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const schema = { type: 'object', properties: { title: { type: 'string' } } };
+      client.convertAnthropicResponse.mockReturnValue({
+        model: 'claude-sonnet-4',
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'toolu_1',
+                  type: 'function',
+                  function: { name: 'patient_summary', arguments: '{"title":"ok"}' },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      const forward = mockForward({}, { isAnthropic: true }) as ReturnType<typeof mockForward> & {
+        structuredOutputToolName?: string;
+        responsesTextFormat?: Record<string, unknown>;
+      };
+      forward.structuredOutputToolName = 'patient_summary';
+      forward.responsesTextFormat = {
+        type: 'json_schema',
+        name: 'patient_summary',
+        schema,
+        strict: true,
+      };
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        makeMeta({ model: 'claude-sonnet-4' }),
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'responses',
+      );
+
+      const responseBody = res.json.mock.calls[0][0];
+      expect(responseBody.output).toEqual([
+        expect.objectContaining({
+          type: 'message',
+          content: [{ type: 'output_text', text: '{"title":"ok"}', annotations: [] }],
+        }),
+      ]);
+      expect(responseBody.text).toEqual({
+        format: { type: 'json_schema', name: 'patient_summary', schema, strict: true },
+      });
+    });
+
     it('converts a chat_completions response into Anthropic Messages when apiMode=messages', async () => {
       const { res } = mockResponse();
       const client = mockProviderClient();

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -89,6 +89,62 @@ describe('Responses adapter', () => {
       expect(result.tool_choice).toEqual({ type: 'function', function: { name: 'lookup' } });
     });
 
+    it('maps Responses json_schema text format to Chat Completions response_format', () => {
+      const result = toChatCompletionsRequest({
+        input: 'Return patient data.',
+        text: {
+          format: {
+            type: 'json_schema',
+            name: 'patient_summary',
+            description: 'Structured patient summary',
+            schema: {
+              type: 'object',
+              properties: { summary: { type: 'string' } },
+              required: ['summary'],
+              additionalProperties: false,
+            },
+            strict: true,
+          },
+        },
+      });
+
+      expect(result.response_format).toEqual({
+        type: 'json_schema',
+        json_schema: {
+          name: 'patient_summary',
+          description: 'Structured patient summary',
+          schema: {
+            type: 'object',
+            properties: { summary: { type: 'string' } },
+            required: ['summary'],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      });
+    });
+
+    it('maps Responses json_object text format to Chat Completions response_format', () => {
+      const result = toChatCompletionsRequest({
+        input: 'Return JSON.',
+        text: { format: { type: 'json_object' } },
+      });
+
+      expect(result.response_format).toEqual({ type: 'json_object' });
+    });
+
+    it('omits Chat Completions response_format for text or absent Responses formats', () => {
+      expect(
+        toChatCompletionsRequest({
+          input: 'Return text.',
+          text: { format: { type: 'text' } },
+        }),
+      ).not.toHaveProperty('response_format');
+      expect(toChatCompletionsRequest({ input: 'Return text.' })).not.toHaveProperty(
+        'response_format',
+      );
+    });
+
     it('converts item lists, images, function calls, and tool outputs', () => {
       const result = toChatCompletionsRequest({
         input: [
@@ -402,6 +458,125 @@ describe('Responses adapter', () => {
       expect(result.model).toBe('m');
       expect(result.output).toEqual([]);
       expect(result.usage).toBeNull();
+    });
+
+    it('keeps tool calls when the structured-output tool name does not match', () => {
+      const result = fromChatCompletionResponse(
+        {
+          choices: [
+            {
+              message: {
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call_1',
+                    type: 'function',
+                    function: { name: 'lookup', arguments: '{"id":1}' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        'claude-sonnet-4',
+        { structuredOutputToolName: 'patient_summary' },
+      );
+
+      expect(result.output).toEqual([
+        expect.objectContaining({
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{"id":1}',
+        }),
+      ]);
+    });
+
+    it('uses safe defaults for malformed structured-output tool calls', () => {
+      const result = fromChatCompletionResponse(
+        {
+          choices: [
+            {
+              message: {
+                content: null,
+                tool_calls: [
+                  null,
+                  { id: 'bad_call', type: 'function' },
+                  {
+                    id: 'call_1',
+                    type: 'function',
+                    function: { name: 'patient_summary' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        'claude-sonnet-4',
+        {
+          structuredOutputToolName: 'patient_summary',
+          textFormat: { type: 'text' },
+        },
+      );
+
+      expect(result.output).toEqual([
+        expect.objectContaining({
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '{}', annotations: [] }],
+        }),
+      ]);
+      expect(result.text).toEqual({ format: { type: 'text' } });
+    });
+
+    it('unwraps the configured structured-output tool call into response text', () => {
+      const schema = { type: 'object', properties: { title: { type: 'string' } } };
+      const result = fromChatCompletionResponse(
+        {
+          choices: [
+            {
+              message: {
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call_1',
+                    type: 'function',
+                    function: { name: 'patient_summary', arguments: '{"title":"ok"}' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        'claude-sonnet-4',
+        {
+          structuredOutputToolName: 'patient_summary',
+          textFormat: {
+            type: 'json_schema',
+            name: 'patient_summary',
+            description: 'Patient summary',
+            schema,
+            strict: true,
+          },
+        },
+      );
+
+      expect(result.output).toEqual([
+        expect.objectContaining({
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '{"title":"ok"}', annotations: [] }],
+        }),
+      ]);
+      expect(result.text).toEqual({
+        format: {
+          type: 'json_schema',
+          name: 'patient_summary',
+          description: 'Patient summary',
+          schema,
+          strict: true,
+        },
+      });
     });
   });
 
@@ -774,6 +949,52 @@ describe('Responses adapter', () => {
       // `finish_reason` chunk carried no text delta, so the tail before finalize
       // is empty.
       expect(tail).toBe('');
+    });
+
+    it('streams configured structured-output tool arguments as response text', () => {
+      const t = createResponsesStreamTransformer('claude-sonnet-4', {
+        structuredOutputToolName: 'patient_summary',
+        textFormat: { type: 'json_object' },
+      });
+      const first =
+        t.transform(
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_1","function":{"name":"patient_summary","arguments":"{\\"title\\""}}]}}]}\n\n',
+        ) ?? '';
+      const second =
+        t.transform(
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\\"ok\\"}"}}]}}]}\n\n',
+        ) ?? '';
+      const end = t.finalize() ?? '';
+
+      expect(firstEventData(first, 'response.output_text.delta')!.delta).toBe('{"title"');
+      expect(firstEventData(second, 'response.output_text.delta')!.delta).toBe(':"ok"}');
+      const completed = firstEventData(end, 'response.completed')!;
+      expect(completed.response.output).toEqual([
+        expect.objectContaining({
+          type: 'message',
+          content: [{ type: 'output_text', text: '{"title":"ok"}', annotations: [] }],
+        }),
+      ]);
+      expect(completed.response.text).toEqual({ format: { type: 'json_object' } });
+    });
+
+    it('ignores malformed structured-output stream tool-call entries', () => {
+      const t = createResponsesStreamTransformer('claude-sonnet-4', {
+        structuredOutputToolName: 'patient_summary',
+      });
+      const out =
+        t.transform(
+          'data: {"choices":[{"delta":{"tool_calls":[null,{"index":1},{"function":{"name":"patient_summary","arguments":"{}"}}]}}]}\n\n',
+        ) ?? '';
+
+      expect(firstEventData(out, 'response.output_text.delta')!.delta).toBe('{}');
+      const completed = firstEventData(t.finalize() ?? '', 'response.completed')!;
+      expect(completed.response.output).toEqual([
+        expect.objectContaining({
+          type: 'message',
+          content: [{ type: 'output_text', text: '{}', annotations: [] }],
+        }),
+      ]);
     });
 
     it('emits no item events and an empty output for usage-only streams', () => {

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -292,6 +292,33 @@ function convertTools(tools?: Array<Record<string, unknown>>): AnthropicTool[] |
   return out.length > 0 ? out : undefined;
 }
 
+function toAnthropicOutputConfig(
+  responseFormat: unknown,
+  outputConfig: unknown,
+): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = isObjectRecord(outputConfig) ? { ...outputConfig } : {};
+  if (!isObjectRecord(responseFormat)) return Object.keys(out).length > 0 ? out : undefined;
+
+  if (responseFormat.type === 'json_object') {
+    // Anthropic has no `json_object` shorthand; use native JSON output with
+    // an unconstrained object schema instead of forcing tool use.
+    out.format = {
+      type: 'json_schema',
+      schema: { type: 'object' },
+    };
+    return out;
+  } else if (responseFormat.type === 'json_schema') {
+    const jsonSchema = isObjectRecord(responseFormat.json_schema) ? responseFormat.json_schema : {};
+    out.format = {
+      type: 'json_schema',
+      schema: jsonSchema.schema ?? { type: 'object' },
+    };
+    return out;
+  } else {
+    return Object.keys(out).length > 0 ? out : undefined;
+  }
+}
+
 /* ── Request conversion ── */
 
 export interface AnthropicRequestOptions {
@@ -338,10 +365,18 @@ export function toAnthropicRequest(
   // bypass translation entirely via applyAnthropicMessagesMutations, so
   // server tools never reach this code path and the OpenAI function-shape
   // assumption is safe.
-  const tools = convertTools(body.tools as Array<Record<string, unknown>> | undefined);
-  if (tools) {
+  const tools = convertTools(body.tools as Array<Record<string, unknown>> | undefined) ?? [];
+  if (tools.length > 0) {
     tools[tools.length - 1].cache_control = CACHE;
     result.tools = tools;
+  }
+
+  const outputConfig = toAnthropicOutputConfig(body.response_format, body.output_config);
+  if (outputConfig) {
+    result.output_config = normalizeOutputConfigForModel(
+      outputConfig,
+      options?.targetModel ?? _model,
+    );
   }
 
   if (body.temperature !== undefined) result.temperature = body.temperature;

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -112,6 +112,18 @@ function sanitizeSchema(schema: unknown, isPropertiesMap = false): unknown {
     // (e.g. "title", "default"), not JSON Schema keywords — keep them all.
     // Their values are sub-schemas, so recurse normally (not as properties map).
     if (!isPropertiesMap && UNSUPPORTED_SCHEMA_FIELDS.has(key)) continue;
+    if (key === 'type' && Array.isArray(value)) {
+      const types = value.filter((item): item is string => typeof item === 'string');
+      const nonNullTypes = types.filter((item) => item !== 'null');
+      if (nonNullTypes.length > 0) {
+        // Gemini doesn't accept JSON Schema type arrays. Preserve the common
+        // nullable-union case with its OpenAPI-style `nullable` flag; if a
+        // schema lists multiple concrete types, keep the first as best-effort.
+        result.type = nonNullTypes[0];
+      }
+      if (types.includes('null')) result.nullable = true;
+      continue;
+    }
     result[key] = sanitizeSchema(value, key === 'properties');
   }
   return result;
@@ -273,6 +285,32 @@ function convertTools(tools?: Record<string, unknown>[]): Record<string, unknown
   return [{ functionDeclarations: declarations }];
 }
 
+function applyResponseFormatToGenerationConfig(
+  genConfig: Record<string, unknown>,
+  responseFormat: unknown,
+): void {
+  if (!isRecord(responseFormat)) return;
+
+  if (responseFormat.type === 'json_object') {
+    genConfig.responseMimeType = 'application/json';
+    delete genConfig.responseSchema;
+    return;
+  }
+  if (responseFormat.type !== 'json_schema') return;
+
+  genConfig.responseMimeType = 'application/json';
+  const jsonSchema = isRecord(responseFormat.json_schema) ? responseFormat.json_schema : null;
+  if (!jsonSchema || jsonSchema.schema === undefined) {
+    delete genConfig.responseSchema;
+    return;
+  }
+
+  // Gemini rejects several OpenAI-compatible JSON Schema keywords. In
+  // particular, dropping `additionalProperties: false` means strict mode is
+  // best-effort here, not identical to OpenAI's constrained output.
+  genConfig.responseSchema = sanitizeSchema(jsonSchema.schema);
+}
+
 /** Extracted thought_signature entries from a Gemini response. */
 export interface ExtractedSignature {
   toolCallId: string;
@@ -339,6 +377,7 @@ export function toGoogleRequest(
   if (body.max_tokens !== undefined) genConfig.maxOutputTokens = body.max_tokens;
   if (body.temperature !== undefined) genConfig.temperature = body.temperature;
   if (body.top_p !== undefined) genConfig.topP = body.top_p;
+  applyResponseFormatToGenerationConfig(genConfig, body.response_format);
   if (Object.keys(genConfig).length > 0) result.generationConfig = genConfig;
 
   return result;

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -47,6 +47,17 @@ export interface ForwardResult {
    * passing the inner body to the standard Google converters.
    */
   isCodeAssist?: boolean;
+  /** Internal: Anthropic synthetic tool used to emulate Responses structured output. */
+  structuredOutputToolName?: string;
+  /** Internal: original Responses text.format metadata for synthesized Responses bodies. */
+  responsesTextFormat?: Record<string, unknown>;
+}
+
+interface BuiltProviderRequest {
+  url: string;
+  headers: Record<string, string>;
+  requestBody: Record<string, unknown>;
+  structuredOutputToolName?: string;
 }
 
 const parsedProviderTimeout = Number.parseInt(process.env.PROVIDER_TIMEOUT_MS ?? '', 10);
@@ -63,6 +74,49 @@ function shouldApplyAnthropicAutomaticCacheControl(
   authType: string | undefined,
 ): boolean {
   return endpointKey === 'anthropic' && authType === 'subscription';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function responsesTextFormat(
+  body: Record<string, unknown>,
+  apiMode: ForwardOptions['apiMode'],
+): Record<string, unknown> | undefined {
+  if (apiMode !== 'responses' || !isRecord(body.text) || !isRecord(body.text.format)) {
+    return undefined;
+  }
+
+  const format = body.text.format;
+  if (format.type === 'json_object') return { type: 'json_object' };
+  if (format.type !== 'json_schema') return undefined;
+
+  const out: Record<string, unknown> = { type: 'json_schema' };
+  if (format.name !== undefined) out.name = format.name;
+  if (format.schema !== undefined) out.schema = format.schema;
+  if (format.strict !== undefined) out.strict = format.strict;
+  if (typeof format.description === 'string' && format.description) {
+    out.description = format.description;
+  }
+  return out;
+}
+
+function isStructuredResponseFormat(responseFormat: unknown): boolean {
+  return (
+    isRecord(responseFormat) &&
+    (responseFormat.type === 'json_object' || responseFormat.type === 'json_schema')
+  );
+}
+
+function structuredOutputToolName(
+  requestSource: Record<string, unknown>,
+  requestBody: Record<string, unknown>,
+): string | undefined {
+  if (!isStructuredResponseFormat(requestSource.response_format)) return undefined;
+  const toolChoice = requestBody.tool_choice;
+  if (!isRecord(toolChoice) || toolChoice.type !== 'tool') return undefined;
+  return typeof toolChoice.name === 'string' ? toolChoice.name : undefined;
 }
 
 function buildPromptCacheKey(sessionKey: string): string {
@@ -167,6 +221,7 @@ export class ProviderClient {
     const isResponses = opts.apiMode === 'responses' && endpoint.format === 'chatgpt';
     const isChatGpt = endpoint.format === 'chatgpt' && !isResponses;
     const isCodeAssist = !!endpoint.codeAssistEnvelope;
+    const textFormat = responsesTextFormat(body, opts.apiMode);
 
     const bareModel = stripModelPrefix(model, endpointKey);
     if (endpoint.format === 'kiro') {
@@ -186,9 +241,10 @@ export class ProviderClient {
         isGoogle: false,
         isAnthropic: false,
         isChatGpt: false,
+        responsesTextFormat: textFormat,
       };
     }
-    const { url, headers, requestBody } = this.buildRequest({
+    const { url, headers, requestBody, structuredOutputToolName } = this.buildRequest({
       endpoint,
       endpointKey,
       provider,
@@ -240,6 +296,8 @@ export class ProviderClient {
       isChatGpt,
       isResponses,
       isCodeAssist,
+      structuredOutputToolName,
+      responsesTextFormat: textFormat,
     });
     if (affinity) this.codexAffinity.capture(affinity.storeKey, result.response);
     return result;
@@ -399,7 +457,7 @@ export class ProviderClient {
     reasoningContentLookup?: ForwardOptions['reasoningContentLookup'];
     providerResource?: string;
     sessionKey?: string;
-  }): { url: string; headers: Record<string, string>; requestBody: Record<string, unknown> } {
+  }): BuiltProviderRequest {
     const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
     // For non-chat_completions inbound modes ('responses', 'messages'), the
     // routing layer pre-translated the request into chat_completions form
@@ -463,6 +521,10 @@ export class ProviderClient {
               thinkingLookup: ctx.thinkingLookup,
               thinkingRouteContext,
             });
+      const syntheticToolName =
+        ctx.apiMode === 'responses'
+          ? structuredOutputToolName(requestSource, requestBody)
+          : undefined;
       requestBody.model = bareModel;
       if (stream) requestBody.stream = true;
       if (shouldApplyAnthropicAutomaticCacheControl(endpointKey, authType)) {
@@ -472,6 +534,7 @@ export class ProviderClient {
         url: `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`,
         headers: endpoint.buildHeaders(apiKey, authType),
         requestBody,
+        structuredOutputToolName: syntheticToolName,
       };
     }
 
@@ -574,6 +637,8 @@ export class ProviderClient {
       isChatGpt: boolean;
       isResponses?: boolean;
       isCodeAssist?: boolean;
+      structuredOutputToolName?: string;
+      responsesTextFormat?: Record<string, unknown>;
     },
   ): Promise<ForwardResult> {
     let fetchSignal: AbortSignal;

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -355,7 +355,12 @@ export async function handleStreamResponse(
   // shape, and likewise owns stream termination via `finalize` (which emits
   // the trailing `[DONE]` that pipeStream then skips).
   const responsesTransformer =
-    apiMode === 'responses' ? createResponsesStreamTransformer(meta.model) : null;
+    apiMode === 'responses'
+      ? createResponsesStreamTransformer(meta.model, {
+          structuredOutputToolName: forward.structuredOutputToolName,
+          textFormat: forward.responsesTextFormat,
+        })
+      : null;
   const streamTransformer = messagesTransformer ?? responsesTransformer;
   const finalize = streamTransformer ? () => streamTransformer.finalize() : undefined;
   const toClientChunk = streamTransformer
@@ -566,7 +571,10 @@ export async function handleNonStreamResponse(
   }
 
   if (apiMode === 'responses' && !forward.isResponses) {
-    responseBody = fromChatCompletionResponse(responseBody as Record<string, unknown>, meta.model);
+    responseBody = fromChatCompletionResponse(responseBody as Record<string, unknown>, meta.model, {
+      structuredOutputToolName: forward.structuredOutputToolName,
+      textFormat: forward.responsesTextFormat,
+    });
   } else if (apiMode === 'messages' && !forward.isAnthropic) {
     // Anthropic upstreams already returned a Messages-shaped body via the
     // passthrough branch above. Skip the round-trip translation that would

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -350,6 +350,8 @@ export class ProxyService {
           isChatGpt: forward.isChatGpt,
           isResponses: forward.isResponses,
           isCodeAssist: forward.isCodeAssist,
+          structuredOutputToolName: forward.structuredOutputToolName,
+          responsesTextFormat: forward.responsesTextFormat,
         };
         this.recordTierIfScoring(sessionKey, resolved.tier);
         this.recordCategoryIfValid(sessionKey, resolved.specificity_category);
@@ -376,6 +378,8 @@ export class ProxyService {
         isChatGpt: forward.isChatGpt,
         isResponses: forward.isResponses,
         isCodeAssist: forward.isCodeAssist,
+        structuredOutputToolName: forward.structuredOutputToolName,
+        responsesTextFormat: forward.responsesTextFormat,
       };
       if (!explicitModelOverride && paramMergeContext) {
         const fallbackResult = await this.tryFallbackChain({

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -5,6 +5,11 @@ import { OpenAIMessage } from './proxy-types';
 
 type JsonRecord = Record<string, unknown>;
 
+interface ChatCompletionToResponsesOptions {
+  structuredOutputToolName?: string;
+  textFormat?: JsonRecord;
+}
+
 function isRecord(value: unknown): value is JsonRecord {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -110,10 +115,31 @@ export function toChatCompletionsRequest(body: JsonRecord): JsonRecord {
   }
 
   if (body.max_output_tokens !== undefined) chatBody.max_tokens = body.max_output_tokens;
+  const responseFormat = toChatResponseFormat(body.text);
+  if (responseFormat) chatBody.response_format = responseFormat;
   if (Array.isArray(body.tools)) chatBody.tools = toChatTools(body.tools);
   if (body.tool_choice !== undefined) chatBody.tool_choice = toChatToolChoice(body.tool_choice);
 
   return chatBody;
+}
+
+function toChatResponseFormat(text: unknown): JsonRecord | undefined {
+  if (!isRecord(text) || !isRecord(text.format)) return undefined;
+
+  const format = text.format;
+  if (format.type === 'json_object') {
+    return { type: 'json_object' };
+  }
+  if (format.type !== 'json_schema') return undefined;
+
+  const jsonSchema: JsonRecord = {};
+  if (format.name !== undefined) jsonSchema.name = format.name;
+  if (format.schema !== undefined) jsonSchema.schema = format.schema;
+  if (format.strict !== undefined) jsonSchema.strict = format.strict;
+  if (typeof format.description === 'string' && format.description) {
+    jsonSchema.description = format.description;
+  }
+  return { type: 'json_schema', json_schema: jsonSchema };
 }
 
 function toChatTools(tools: unknown[]): JsonRecord[] {
@@ -260,26 +286,70 @@ function extractImageDetail(part: JsonRecord): { detail?: string } {
   return typeof detail === 'string' ? { detail } : {};
 }
 
-export function fromChatCompletionResponse(body: JsonRecord, model: string): JsonRecord {
+function findStructuredOutputToolCall(
+  toolCalls: unknown,
+  toolName: string | undefined,
+): JsonRecord | null {
+  if (!toolName || !Array.isArray(toolCalls)) return null;
+  for (const toolCall of toolCalls) {
+    if (!isRecord(toolCall) || !isRecord(toolCall.function)) continue;
+    if (toolCall.function.name === toolName) return toolCall;
+  }
+  return null;
+}
+
+function toolCallArguments(toolCall: JsonRecord | null): string | null {
+  const fn = isRecord(toolCall?.function) ? toolCall.function : null;
+  if (!fn) return null;
+  return typeof fn.arguments === 'string' ? fn.arguments : '{}';
+}
+
+function responseTextFormat(format: unknown): JsonRecord {
+  if (!isRecord(format)) return { type: 'text' };
+  if (format.type === 'json_object') return { type: 'json_object' };
+  if (format.type !== 'json_schema') return { type: 'text' };
+
+  const out: JsonRecord = { type: 'json_schema' };
+  if (format.name !== undefined) out.name = format.name;
+  if (format.schema !== undefined) out.schema = format.schema;
+  if (format.strict !== undefined) out.strict = format.strict;
+  if (typeof format.description === 'string' && format.description) {
+    out.description = format.description;
+  }
+  return out;
+}
+
+export function fromChatCompletionResponse(
+  body: JsonRecord,
+  model: string,
+  options: ChatCompletionToResponsesOptions = {},
+): JsonRecord {
   const choices = Array.isArray(body.choices) ? body.choices : [];
   const firstChoice = isRecord(choices[0]) ? choices[0] : {};
   const message = isRecord(firstChoice.message) ? firstChoice.message : {};
   const output: JsonRecord[] = [];
+  const structuredToolCall = findStructuredOutputToolCall(
+    message.tool_calls,
+    options.structuredOutputToolName,
+  );
+  const structuredText = toolCallArguments(structuredToolCall);
   const contentText = textFromContent(message.content);
+  const outputText = structuredText ?? contentText;
 
-  if (contentText) {
+  if (outputText || structuredText !== null) {
     output.push({
       type: 'message',
       id: `msg_${randomUUID().replace(/-/g, '')}`,
       status: 'completed',
       role: 'assistant',
-      content: [{ type: 'output_text', text: contentText, annotations: [] }],
+      content: [{ type: 'output_text', text: outputText, annotations: [] }],
     });
   }
 
   if (Array.isArray(message.tool_calls)) {
     for (const toolCall of message.tool_calls) {
       if (!isRecord(toolCall) || !isRecord(toolCall.function)) continue;
+      if (toolCall === structuredToolCall) continue;
       output.push({
         type: 'function_call',
         id: `fc_${randomUUID().replace(/-/g, '')}`,
@@ -310,7 +380,7 @@ export function fromChatCompletionResponse(body: JsonRecord, model: string): Jso
     reasoning: { effort: null, summary: null },
     store: false,
     temperature: null,
-    text: { format: { type: 'text' } },
+    text: { format: responseTextFormat(options.textFormat) },
     tool_choice: 'auto',
     tools: [],
     top_p: null,
@@ -507,6 +577,11 @@ export interface ResponsesStreamTransformer {
   finalize: () => string | null;
 }
 
+export interface ResponsesStreamTransformerOptions {
+  structuredOutputToolName?: string;
+  textFormat?: JsonRecord;
+}
+
 interface ResponsesStreamState {
   responseId: string;
   itemId: string;
@@ -514,6 +589,9 @@ interface ResponsesStreamState {
   createdAt: number;
   usage: unknown;
   text: string;
+  structuredOutputToolName?: string;
+  structuredToolCallIndexes: Set<number>;
+  textFormat?: JsonRecord;
   createdEmitted: boolean;
   itemOpened: boolean;
   completed: boolean;
@@ -535,7 +613,10 @@ interface ResponsesStreamState {
  * the terminal `data: [DONE]`. When a `finalize` is supplied, `pipeStream`
  * delegates termination to it (it does not add its own `[DONE]`).
  */
-export function createResponsesStreamTransformer(model: string): ResponsesStreamTransformer {
+export function createResponsesStreamTransformer(
+  model: string,
+  options: ResponsesStreamTransformerOptions = {},
+): ResponsesStreamTransformer {
   const state: ResponsesStreamState = {
     responseId: `resp_${randomUUID().replace(/-/g, '')}`,
     itemId: `msg_${randomUUID().replace(/-/g, '')}`,
@@ -546,6 +627,9 @@ export function createResponsesStreamTransformer(model: string): ResponsesStream
     createdAt: Math.floor(Date.now() / 1000),
     usage: undefined,
     text: '',
+    structuredOutputToolName: options.structuredOutputToolName,
+    structuredToolCallIndexes: new Set(),
+    textFormat: options.textFormat,
     createdEmitted: false,
     itemOpened: false,
     completed: false,
@@ -561,6 +645,7 @@ function inProgressResponse(state: ResponsesStreamState): JsonRecord {
   const response = fromChatCompletionResponse(
     { model: state.model, created: state.createdAt, choices: [{ message: { content: '' } }] },
     state.model,
+    { textFormat: state.textFormat },
   );
   response.id = state.responseId;
   response.status = 'in_progress';
@@ -604,6 +689,45 @@ function emitItemOpen(state: ResponsesStreamState): string[] {
   ];
 }
 
+function structuredOutputTextDelta(toolCalls: unknown, state: ResponsesStreamState): string {
+  if (!state.structuredOutputToolName || !Array.isArray(toolCalls)) return '';
+
+  let text = '';
+  for (const toolCall of toolCalls) {
+    if (!isRecord(toolCall)) continue;
+    const index = typeof toolCall.index === 'number' ? toolCall.index : 0;
+    const fn = isRecord(toolCall.function) ? toolCall.function : null;
+    if (!fn) continue;
+    if (fn.name === state.structuredOutputToolName) {
+      state.structuredToolCallIndexes.add(index);
+    }
+    if (
+      state.structuredToolCallIndexes.has(index) &&
+      typeof fn.arguments === 'string' &&
+      fn.arguments.length > 0
+    ) {
+      text += fn.arguments;
+    }
+  }
+  return text;
+}
+
+function emitOutputTextDelta(state: ResponsesStreamState, delta: string): string[] {
+  if (!delta) return [];
+  const events = emitItemOpen(state);
+  state.text += delta;
+  events.push(
+    formatResponsesEvent('response.output_text.delta', {
+      type: 'response.output_text.delta',
+      item_id: state.itemId,
+      output_index: 0,
+      content_index: 0,
+      delta,
+    }),
+  );
+  return events;
+}
+
 function transformResponsesStreamChunk(chunk: string, state: ResponsesStreamState): string | null {
   const events: string[] = [];
 
@@ -622,17 +746,12 @@ function transformResponsesStreamChunk(chunk: string, state: ResponsesStreamStat
     const delta = isRecord(choice?.delta) ? choice.delta : {};
 
     if (typeof delta.content === 'string' && delta.content.length > 0) {
-      events.push(...emitItemOpen(state));
-      state.text += delta.content;
-      events.push(
-        formatResponsesEvent('response.output_text.delta', {
-          type: 'response.output_text.delta',
-          item_id: state.itemId,
-          output_index: 0,
-          content_index: 0,
-          delta: delta.content,
-        }),
-      );
+      events.push(...emitOutputTextDelta(state, delta.content));
+    }
+
+    const structuredDelta = structuredOutputTextDelta(delta.tool_calls, state);
+    if (structuredDelta) {
+      events.push(...emitOutputTextDelta(state, structuredDelta));
     }
   }
 
@@ -683,6 +802,10 @@ function finalizeResponsesStream(state: ResponsesStreamState): string | null {
       choices: [{ message: { content: state.text } }],
     },
     state.model,
+    {
+      structuredOutputToolName: state.structuredOutputToolName,
+      textFormat: state.textFormat,
+    },
   );
   response.id = state.responseId;
   // `created_at` is the stream-start stamp (shared across every snapshot for


### PR DESCRIPTION
### ✨ What changed
- Forward Responses `text.format` through chat routing as Chat Completions `response_format`.
- Map Google JSON response format to Gemini `generationConfig`, including sanitized schemas and nullable union coercion.
- Map Anthropic structured output to native `output_config.format` JSON output.
- Echo structured `text.format` metadata on synthesized Responses objects.

### 💭 Why
Responses requests with `text.format` lost schema constraints whenever routed to non-native providers.

### 👤 For users
`/v1/responses` structured-output requests now keep JSON behavior across non-native routes instead of silently degrading to prose.

### 📝 Notes
Fixes #2.

Some OpenAI-wire providers may now return upstream 400s when a model does not support `response_format`. Anthropic may likewise return 400s for models or schemas outside native structured-output support. That is preferable to silently returning schema-breaking prose.