### PR TITLE
Add missing changeset for waitlist sync fix

### DIFF
--- a/.changeset/waitlist-sync-fix.md
+++ b/.changeset/waitlist-sync-fix.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix waitlist sync reading email from session instead of empty tenant field, rename table to waitlist_claims


### PR DESCRIPTION
## What changed
- Adds the changeset file that was missing from PR #2420

## Why
PR #2420 merged without a changeset, so the release workflow had nothing to version.

## For users
No code change. This just triggers the version bump.

## For operators
No impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing changeset to trigger a patch release of `manifest` for the waitlist sync fix. No code changes; it only records reading email from the session and renaming the table to `waitlist_claims`.

<sup>Written for commit 797f529ffbbece9a79621530b39718dc534fe5d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

