### PR TITLE
feat: one-click dev sign-in on the dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,13 @@ Set `SEED_DATA=true` in `packages/backend/.env` to seed on startup (dev/test onl
 
 Seeding is idempotent — it checks for existing records before inserting.
 
+**Dev-login shortcut:** when running under the Vite dev server the login page shows a
+prominent one-click **⚡ Sign in as dev** button that submits the seeded
+`admin@manifest.build` / `manifest` credentials — no copy-paste. It's gated by
+`import.meta.env.DEV`, so Vite strips the button and the credential literals from
+production builds, and no password ever rides in a URL. See
+`packages/frontend/src/pages/Login.tsx`.
+
 **Minimal `.env` for development:**
 
 ```env

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -8,6 +8,13 @@ import { checkSocialProviders } from '../services/setup-status.js';
 
 const RESEND_COOLDOWN_SECONDS = 60;
 
+// Dev-only seed credentials (see packages/backend/src/database/database-seeder.service.ts,
+// seeded only when SEED_DATA=true / non-production). Referenced solely inside the
+// `import.meta.env.DEV` branch below, so Vite strips both the button and these literals
+// from production builds — they never ship. The account exists only in a dev database.
+const DEV_EMAIL = 'admin@manifest.build';
+const DEV_PASSWORD = 'manifest';
+
 const Login: Component = () => {
   const [email, setEmail] = createSignal('');
   const [password, setPassword] = createSignal('');
@@ -81,6 +88,26 @@ const Login: Component = () => {
     window.location.href = '/';
   };
 
+  // Dev shortcut: fill + submit the seed admin. One click, no credentials in the URL;
+  // compiled out of production (see DEV_EMAIL/DEV_PASSWORD).
+  const signInAsDev = async () => {
+    setEmail(DEV_EMAIL);
+    setPassword(DEV_PASSWORD);
+    setError('');
+    setLoading(true);
+    const { error: authError } = await authClient.signIn.email({
+      email: DEV_EMAIL,
+      password: DEV_PASSWORD,
+    });
+    setLoading(false);
+    if (authError) {
+      setError(authError.message ?? 'Dev sign-in failed');
+      return;
+    }
+    setLastAuthMethod('email');
+    window.location.href = '/';
+  };
+
   const handleResendVerification = async () => {
     if (resendCooldown() > 0) return;
 
@@ -116,6 +143,17 @@ const Login: Component = () => {
       </Show>
 
       <form class="auth-form" onSubmit={handleSubmit}>
+        {import.meta.env.DEV && (
+          <button
+            type="button"
+            class="auth-form__submit"
+            onClick={signInAsDev}
+            disabled={loading()}
+            style="background:#f59e0b;color:#1f1400;font-weight:700;margin-bottom:0.75rem;"
+          >
+            ⚡ Sign in as dev — admin@manifest.build
+          </button>
+        )}
         {error() && (
           <div id={errorId} class="auth-form__error" role="alert">
             {error()}

--- a/packages/frontend/tests/pages/Login.test.tsx
+++ b/packages/frontend/tests/pages/Login.test.tsx
@@ -74,6 +74,15 @@ describe("Login", () => {
     expect(getLastAuthMethod()).toBe("email");
   });
 
+  it("dev-only button surfaces an error when sign-in fails", async () => {
+    mockSignInEmail.mockResolvedValue({ error: {} });
+    const { container } = render(() => <Login />);
+    fireEvent.click(screen.getByRole("button", { name: /sign in as dev/i }));
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Dev sign-in failed");
+    });
+  });
+
   it("has link to register", () => {
     render(() => <Login />);
     expect(screen.getByText("Sign up")).toBeDefined();

--- a/packages/frontend/tests/pages/Login.test.tsx
+++ b/packages/frontend/tests/pages/Login.test.tsx
@@ -1,302 +1,367 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
 
 const mockSignInEmail = vi.fn().mockResolvedValue({});
 const mockSendVerificationEmail = vi.fn().mockResolvedValue({});
 
 let mockSearchParams: Record<string, string> = {};
-vi.mock("@solidjs/router", () => ({
-  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
+vi.mock('@solidjs/router', () => ({
+  A: (props: any) => (
+    <a href={props.href} class={props.class}>
+      {props.children}
+    </a>
+  ),
   useNavigate: () => vi.fn(),
   useSearchParams: () => [mockSearchParams],
 }));
 
-vi.mock("@solidjs/meta", () => ({
+vi.mock('@solidjs/meta', () => ({
   Title: (props: any) => <title>{props.children}</title>,
   Meta: () => null,
 }));
 
-vi.mock("../../src/services/auth-client.js", () => ({
+vi.mock('../../src/services/auth-client.js', () => ({
   authClient: {
     signIn: { email: (...args: unknown[]) => mockSignInEmail(...args), social: vi.fn() },
     sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
   },
 }));
 
-vi.mock("../../src/services/toast-store.js", () => ({
+vi.mock('../../src/services/toast-store.js', () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
 const mockCheckSocialProviders = vi.fn().mockResolvedValue([]);
-vi.mock("../../src/services/setup-status.js", () => ({
+vi.mock('../../src/services/setup-status.js', () => ({
   checkSocialProviders: (...args: unknown[]) => mockCheckSocialProviders(...args),
 }));
 
-import Login from "../../src/pages/Login";
-import { getLastAuthMethod, setLastAuthMethod } from "../../src/services/last-auth-method";
+import Login from '../../src/pages/Login';
+import { getLastAuthMethod, setLastAuthMethod } from '../../src/services/last-auth-method';
 
-describe("Login", () => {
+describe('Login', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = {};
     mockSignInEmail.mockResolvedValue({});
     mockCheckSocialProviders.mockResolvedValue([]);
     localStorage.clear();
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
   });
 
-  it("renders welcome message", () => {
+  it('renders welcome message', () => {
     render(() => <Login />);
-    expect(screen.getByText("Welcome back")).toBeDefined();
+    expect(screen.getByText('Welcome back')).toBeDefined();
   });
 
-  it("renders email and password inputs", () => {
+  it('renders email and password inputs', () => {
     render(() => <Login />);
-    expect(screen.getByPlaceholderText("you@example.com")).toBeDefined();
-    expect(screen.getByPlaceholderText("Enter your password")).toBeDefined();
+    expect(screen.getByPlaceholderText('you@example.com')).toBeDefined();
+    expect(screen.getByPlaceholderText('Enter your password')).toBeDefined();
   });
 
-  it("renders sign in button", () => {
+  it('renders sign in button', () => {
     render(() => <Login />);
-    expect(screen.getByText("Sign in")).toBeDefined();
+    expect(screen.getByText('Sign in')).toBeDefined();
   });
 
-  it("has link to register", () => {
+  it('dev-only button signs in with the seed admin credentials', async () => {
+    mockSignInEmail.mockResolvedValue({ error: null });
     render(() => <Login />);
-    expect(screen.getByText("Sign up")).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /sign in as dev/i }));
+    await vi.waitFor(() => {
+      expect(mockSignInEmail).toHaveBeenCalledWith({
+        email: 'admin@manifest.build',
+        password: 'manifest',
+      });
+    });
+    expect(getLastAuthMethod()).toBe('email');
   });
 
-  it("has forgot password link", () => {
+  it('has link to register', () => {
     render(() => <Login />);
-    expect(screen.getByText("Forgot password?")).toBeDefined();
+    expect(screen.getByText('Sign up')).toBeDefined();
   });
 
-  it("shows or divider when social providers are available", async () => {
-    mockCheckSocialProviders.mockResolvedValue(["google"]);
+  it('has forgot password link', () => {
+    render(() => <Login />);
+    expect(screen.getByText('Forgot password?')).toBeDefined();
+  });
+
+  it('shows or divider when social providers are available', async () => {
+    mockCheckSocialProviders.mockResolvedValue(['google']);
     const { container } = render(() => <Login />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("or");
+      expect(container.textContent).toContain('or');
     });
   });
 
-  it("hides or divider when no social providers are available", async () => {
+  it('hides or divider when no social providers are available', async () => {
     mockCheckSocialProviders.mockResolvedValue([]);
     const { container } = render(() => <Login />);
     await vi.waitFor(() => {
-      expect(container.querySelector(".auth-divider")).toBeNull();
+      expect(container.querySelector('.auth-divider')).toBeNull();
     });
   });
 
-  it("submits login form", async () => {
+  it('submits login form', async () => {
     mockSignInEmail.mockResolvedValue({ error: null });
     const { container } = render(() => <Login />);
     const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
     const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
-    fireEvent.input(emailInput, { target: { value: "test@test.com" } });
-    fireEvent.input(passwordInput, { target: { value: "password123" } });
-    const form = container.querySelector("form")!;
+    fireEvent.input(emailInput, { target: { value: 'test@test.com' } });
+    fireEvent.input(passwordInput, { target: { value: 'password123' } });
+    const form = container.querySelector('form')!;
     fireEvent.submit(form);
     await vi.waitFor(() => {
-      expect(mockSignInEmail).toHaveBeenCalledWith({ email: "test@test.com", password: "password123" });
+      expect(mockSignInEmail).toHaveBeenCalledWith({
+        email: 'test@test.com',
+        password: 'password123',
+      });
     });
   });
 
-  it("shows error on failed login", async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: "Invalid credentials" } });
+  it('shows error on failed login', async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: 'Invalid credentials' } });
     const { container } = render(() => <Login />);
     const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
     const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
-    fireEvent.input(emailInput, { target: { value: "bad@test.com" } });
-    fireEvent.input(passwordInput, { target: { value: "wrong" } });
-    fireEvent.submit(container.querySelector("form")!);
+    fireEvent.input(emailInput, { target: { value: 'bad@test.com' } });
+    fireEvent.input(passwordInput, { target: { value: 'wrong' } });
+    fireEvent.submit(container.querySelector('form')!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Invalid credentials");
+      expect(container.textContent).toContain('Invalid credentials');
     });
   });
 
-  it("shows loading state during submission", async () => {
+  it('shows loading state during submission', async () => {
     mockSignInEmail.mockReturnValue(new Promise(() => {}));
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "t@t.com" } });
-    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
-    fireEvent.submit(container.querySelector("form")!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: 't@t.com' },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: 'pass' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
     await vi.waitFor(() => {
       const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
-      expect(btn.querySelector(".spinner")).not.toBeNull();
+      expect(btn.querySelector('.spinner')).not.toBeNull();
     });
   });
 
-  it("shows email verification prompt", async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
+  it('shows email verification prompt', async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
+    });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "t@t.com" } });
-    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
-    fireEvent.submit(container.querySelector("form")!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: 't@t.com' },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: 'pass' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("verify your email");
+      expect(container.textContent).toContain('verify your email');
     });
   });
 
-  it("shows resend verification button after email not verified", async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
+  it('shows resend verification button after email not verified', async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
+    });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "user@test.com" } });
-    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
-    fireEvent.submit(container.querySelector("form")!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: 'user@test.com' },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: 'pass' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resend verification email");
+      expect(container.textContent).toContain('Resend verification email');
     });
   });
 
-  it("calls sendVerificationEmail when resend clicked", async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
+  it('calls sendVerificationEmail when resend clicked', async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
+    });
     mockSendVerificationEmail.mockResolvedValue({ error: null });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "user@test.com" } });
-    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
-    fireEvent.submit(container.querySelector("form")!);
-    await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resend verification email");
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: 'user@test.com' },
     });
-    const resendBtn = Array.from(container.querySelectorAll("button")).find(
-      (b) => b.textContent?.includes("Resend verification email"),
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: 'pass' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Resend verification email');
+    });
+    const resendBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Resend verification email'),
     )!;
     fireEvent.click(resendBtn);
     await vi.waitFor(() => {
-      expect(mockSendVerificationEmail).toHaveBeenCalledWith({ email: "user@test.com", callbackURL: "/" });
+      expect(mockSendVerificationEmail).toHaveBeenCalledWith({
+        email: 'user@test.com',
+        callbackURL: '/',
+      });
     });
   });
 
-  it("shows default error when authError has no message", async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: "" } });
+  it('shows default error when authError has no message', async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: '' } });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "t@t.com" } });
-    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
-    fireEvent.submit(container.querySelector("form")!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: 't@t.com' },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: 'pass' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Invalid email or password");
+      expect(container.textContent).toContain('Invalid email or password');
     });
   });
 
-  it("shows error from search params on mount", async () => {
-    mockSearchParams = { error: "oauth_failed" };
+  it('shows error from search params on mount', async () => {
+    mockSearchParams = { error: 'oauth_failed' };
     const { container } = render(() => <Login />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Login failed");
+      expect(container.textContent).toContain('Login failed');
     });
   });
 
-  it("starts cooldown timer after resending verification email", async () => {
+  it('starts cooldown timer after resending verification email', async () => {
     vi.useFakeTimers();
-    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
+    mockSignInEmail.mockResolvedValue({
+      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
+    });
     mockSendVerificationEmail.mockResolvedValue({ error: null });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "user@test.com" } });
-    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
-    fireEvent.submit(container.querySelector("form")!);
-    await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resend verification email");
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: 'user@test.com' },
     });
-    const resendBtn = Array.from(container.querySelectorAll("button")).find(
-      (b) => b.textContent?.includes("Resend verification email"),
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: 'pass' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Resend verification email');
+    });
+    const resendBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Resend verification email'),
     )!;
     fireEvent.click(resendBtn);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resend in");
+      expect(container.textContent).toContain('Resend in');
     });
     // Advance timer to tick down cooldown
     vi.advanceTimersByTime(2000);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resend in");
+      expect(container.textContent).toContain('Resend in');
     });
     // Advance to expire cooldown
     vi.advanceTimersByTime(60000);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resend verification email");
+      expect(container.textContent).toContain('Resend verification email');
     });
     vi.useRealTimers();
   });
 
-  it("stores email as last auth method on successful sign-in", async () => {
+  it('stores email as last auth method on successful sign-in', async () => {
     mockSignInEmail.mockResolvedValue({ error: null });
     const { container } = render(() => <Login />);
     fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: "t@t.com" },
+      target: { value: 't@t.com' },
     });
     fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: "password123" },
+      target: { value: 'password123' },
     });
-    fireEvent.submit(container.querySelector("form")!);
+    fireEvent.submit(container.querySelector('form')!);
     await vi.waitFor(() => {
-      expect(getLastAuthMethod()).toBe("email");
+      expect(getLastAuthMethod()).toBe('email');
     });
   });
 
-  it("does not store last auth method when sign-in fails", async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: "nope" } });
+  it('does not store last auth method when sign-in fails', async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: 'nope' } });
     const { container } = render(() => <Login />);
     fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: "t@t.com" },
+      target: { value: 't@t.com' },
     });
     fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: "wrong" },
+      target: { value: 'wrong' },
     });
-    fireEvent.submit(container.querySelector("form")!);
+    fireEvent.submit(container.querySelector('form')!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("nope");
+      expect(container.textContent).toContain('nope');
     });
     expect(getLastAuthMethod()).toBeNull();
   });
 
-  it("forwards lastUsed to SocialButtons when previous method was a provider", async () => {
-    mockCheckSocialProviders.mockResolvedValue(["github"]);
-    setLastAuthMethod("github");
+  it('forwards lastUsed to SocialButtons when previous method was a provider', async () => {
+    mockCheckSocialProviders.mockResolvedValue(['github']);
+    setLastAuthMethod('github');
     const { container } = render(() => <Login />);
     await vi.waitFor(() => {
-      const githubBtn = container.querySelector(".auth-social-btn--github");
+      const githubBtn = container.querySelector('.auth-social-btn--github');
       expect(githubBtn).not.toBeNull();
-      expect(githubBtn!.querySelector(".auth-last-used")).not.toBeNull();
+      expect(githubBtn!.querySelector('.auth-last-used')).not.toBeNull();
     });
   });
 
-  it("shows resend error when sendVerificationEmail fails", async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
-    mockSendVerificationEmail.mockResolvedValue({ error: { message: "Rate limited" } });
-    const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "user@test.com" } });
-    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
-    fireEvent.submit(container.querySelector("form")!);
-    await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resend verification email");
+  it('shows resend error when sendVerificationEmail fails', async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
     });
-    const resendBtn = Array.from(container.querySelectorAll("button")).find(
-      (b) => b.textContent?.includes("Resend verification email"),
+    mockSendVerificationEmail.mockResolvedValue({ error: { message: 'Rate limited' } });
+    const { container } = render(() => <Login />);
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: 'user@test.com' },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: 'pass' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Resend verification email');
+    });
+    const resendBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Resend verification email'),
     )!;
     fireEvent.click(resendBtn);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Rate limited");
+      expect(container.textContent).toContain('Rate limited');
     });
   });
 
-  it("clears the cooldown interval on unmount", async () => {
-    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+  it('clears the cooldown interval on unmount', async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
     mockSignInEmail.mockResolvedValue({
-      error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" },
+      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
     });
     mockSendVerificationEmail.mockResolvedValue({ error: null });
     const { container, unmount } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "u@t.com" } });
-    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
-    fireEvent.submit(container.querySelector("form")!);
-    await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resend verification email");
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: 'u@t.com' },
     });
-    const resendBtn = Array.from(container.querySelectorAll("button")).find(
-      (b) => b.textContent?.includes("Resend verification email"),
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: 'pass' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Resend verification email');
+    });
+    const resendBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Resend verification email'),
     )!;
     fireEvent.click(resendBtn);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Resend in");
+      expect(container.textContent).toContain('Resend in');
     });
     unmount();
     expect(clearIntervalSpy).toHaveBeenCalled();

--- a/packages/frontend/tests/pages/Login.test.tsx
+++ b/packages/frontend/tests/pages/Login.test.tsx
@@ -1,367 +1,315 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@solidjs/testing-library';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
 
 const mockSignInEmail = vi.fn().mockResolvedValue({});
 const mockSendVerificationEmail = vi.fn().mockResolvedValue({});
 
 let mockSearchParams: Record<string, string> = {};
-vi.mock('@solidjs/router', () => ({
-  A: (props: any) => (
-    <a href={props.href} class={props.class}>
-      {props.children}
-    </a>
-  ),
+vi.mock("@solidjs/router", () => ({
+  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
   useNavigate: () => vi.fn(),
   useSearchParams: () => [mockSearchParams],
 }));
 
-vi.mock('@solidjs/meta', () => ({
+vi.mock("@solidjs/meta", () => ({
   Title: (props: any) => <title>{props.children}</title>,
   Meta: () => null,
 }));
 
-vi.mock('../../src/services/auth-client.js', () => ({
+vi.mock("../../src/services/auth-client.js", () => ({
   authClient: {
     signIn: { email: (...args: unknown[]) => mockSignInEmail(...args), social: vi.fn() },
     sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
   },
 }));
 
-vi.mock('../../src/services/toast-store.js', () => ({
+vi.mock("../../src/services/toast-store.js", () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
 const mockCheckSocialProviders = vi.fn().mockResolvedValue([]);
-vi.mock('../../src/services/setup-status.js', () => ({
+vi.mock("../../src/services/setup-status.js", () => ({
   checkSocialProviders: (...args: unknown[]) => mockCheckSocialProviders(...args),
 }));
 
-import Login from '../../src/pages/Login';
-import { getLastAuthMethod, setLastAuthMethod } from '../../src/services/last-auth-method';
+import Login from "../../src/pages/Login";
+import { getLastAuthMethod, setLastAuthMethod } from "../../src/services/last-auth-method";
 
-describe('Login', () => {
+describe("Login", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = {};
     mockSignInEmail.mockResolvedValue({});
     mockCheckSocialProviders.mockResolvedValue([]);
     localStorage.clear();
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
   });
 
-  it('renders welcome message', () => {
+  it("renders welcome message", () => {
     render(() => <Login />);
-    expect(screen.getByText('Welcome back')).toBeDefined();
+    expect(screen.getByText("Welcome back")).toBeDefined();
   });
 
-  it('renders email and password inputs', () => {
+  it("renders email and password inputs", () => {
     render(() => <Login />);
-    expect(screen.getByPlaceholderText('you@example.com')).toBeDefined();
-    expect(screen.getByPlaceholderText('Enter your password')).toBeDefined();
+    expect(screen.getByPlaceholderText("you@example.com")).toBeDefined();
+    expect(screen.getByPlaceholderText("Enter your password")).toBeDefined();
   });
 
-  it('renders sign in button', () => {
+  it("renders sign in button", () => {
     render(() => <Login />);
-    expect(screen.getByText('Sign in')).toBeDefined();
+    expect(screen.getByText("Sign in")).toBeDefined();
   });
 
-  it('dev-only button signs in with the seed admin credentials', async () => {
+  it("dev-only button signs in with the seed admin credentials", async () => {
     mockSignInEmail.mockResolvedValue({ error: null });
     render(() => <Login />);
-    fireEvent.click(screen.getByRole('button', { name: /sign in as dev/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sign in as dev/i }));
     await vi.waitFor(() => {
       expect(mockSignInEmail).toHaveBeenCalledWith({
-        email: 'admin@manifest.build',
-        password: 'manifest',
+        email: "admin@manifest.build",
+        password: "manifest",
       });
     });
-    expect(getLastAuthMethod()).toBe('email');
+    expect(getLastAuthMethod()).toBe("email");
   });
 
-  it('has link to register', () => {
+  it("has link to register", () => {
     render(() => <Login />);
-    expect(screen.getByText('Sign up')).toBeDefined();
+    expect(screen.getByText("Sign up")).toBeDefined();
   });
 
-  it('has forgot password link', () => {
+  it("has forgot password link", () => {
     render(() => <Login />);
-    expect(screen.getByText('Forgot password?')).toBeDefined();
+    expect(screen.getByText("Forgot password?")).toBeDefined();
   });
 
-  it('shows or divider when social providers are available', async () => {
-    mockCheckSocialProviders.mockResolvedValue(['google']);
+  it("shows or divider when social providers are available", async () => {
+    mockCheckSocialProviders.mockResolvedValue(["google"]);
     const { container } = render(() => <Login />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('or');
+      expect(container.textContent).toContain("or");
     });
   });
 
-  it('hides or divider when no social providers are available', async () => {
+  it("hides or divider when no social providers are available", async () => {
     mockCheckSocialProviders.mockResolvedValue([]);
     const { container } = render(() => <Login />);
     await vi.waitFor(() => {
-      expect(container.querySelector('.auth-divider')).toBeNull();
+      expect(container.querySelector(".auth-divider")).toBeNull();
     });
   });
 
-  it('submits login form', async () => {
+  it("submits login form", async () => {
     mockSignInEmail.mockResolvedValue({ error: null });
     const { container } = render(() => <Login />);
     const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
     const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
-    fireEvent.input(emailInput, { target: { value: 'test@test.com' } });
-    fireEvent.input(passwordInput, { target: { value: 'password123' } });
-    const form = container.querySelector('form')!;
+    fireEvent.input(emailInput, { target: { value: "test@test.com" } });
+    fireEvent.input(passwordInput, { target: { value: "password123" } });
+    const form = container.querySelector("form")!;
     fireEvent.submit(form);
     await vi.waitFor(() => {
-      expect(mockSignInEmail).toHaveBeenCalledWith({
-        email: 'test@test.com',
-        password: 'password123',
-      });
+      expect(mockSignInEmail).toHaveBeenCalledWith({ email: "test@test.com", password: "password123" });
     });
   });
 
-  it('shows error on failed login', async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: 'Invalid credentials' } });
+  it("shows error on failed login", async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: "Invalid credentials" } });
     const { container } = render(() => <Login />);
     const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
     const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
-    fireEvent.input(emailInput, { target: { value: 'bad@test.com' } });
-    fireEvent.input(passwordInput, { target: { value: 'wrong' } });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.input(emailInput, { target: { value: "bad@test.com" } });
+    fireEvent.input(passwordInput, { target: { value: "wrong" } });
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Invalid credentials');
+      expect(container.textContent).toContain("Invalid credentials");
     });
   });
 
-  it('shows loading state during submission', async () => {
+  it("shows loading state during submission", async () => {
     mockSignInEmail.mockReturnValue(new Promise(() => {}));
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 't@t.com' },
-    });
-    fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'pass' },
-    });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "t@t.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
       const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
-      expect(btn.querySelector('.spinner')).not.toBeNull();
+      expect(btn.querySelector(".spinner")).not.toBeNull();
     });
   });
 
-  it('shows email verification prompt', async () => {
-    mockSignInEmail.mockResolvedValue({
-      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
-    });
+  it("shows email verification prompt", async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 't@t.com' },
-    });
-    fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'pass' },
-    });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "t@t.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('verify your email');
+      expect(container.textContent).toContain("verify your email");
     });
   });
 
-  it('shows resend verification button after email not verified', async () => {
-    mockSignInEmail.mockResolvedValue({
-      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
-    });
+  it("shows resend verification button after email not verified", async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 'user@test.com' },
-    });
-    fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'pass' },
-    });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "user@test.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Resend verification email');
+      expect(container.textContent).toContain("Resend verification email");
     });
   });
 
-  it('calls sendVerificationEmail when resend clicked', async () => {
-    mockSignInEmail.mockResolvedValue({
-      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
-    });
+  it("calls sendVerificationEmail when resend clicked", async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
     mockSendVerificationEmail.mockResolvedValue({ error: null });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 'user@test.com' },
-    });
-    fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'pass' },
-    });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "user@test.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Resend verification email');
+      expect(container.textContent).toContain("Resend verification email");
     });
-    const resendBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-      b.textContent?.includes('Resend verification email'),
+    const resendBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Resend verification email"),
     )!;
     fireEvent.click(resendBtn);
     await vi.waitFor(() => {
-      expect(mockSendVerificationEmail).toHaveBeenCalledWith({
-        email: 'user@test.com',
-        callbackURL: '/',
-      });
+      expect(mockSendVerificationEmail).toHaveBeenCalledWith({ email: "user@test.com", callbackURL: "/" });
     });
   });
 
-  it('shows default error when authError has no message', async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: '' } });
+  it("shows default error when authError has no message", async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: "" } });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 't@t.com' },
-    });
-    fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'pass' },
-    });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "t@t.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Invalid email or password');
+      expect(container.textContent).toContain("Invalid email or password");
     });
   });
 
-  it('shows error from search params on mount', async () => {
-    mockSearchParams = { error: 'oauth_failed' };
+  it("shows error from search params on mount", async () => {
+    mockSearchParams = { error: "oauth_failed" };
     const { container } = render(() => <Login />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Login failed');
+      expect(container.textContent).toContain("Login failed");
     });
   });
 
-  it('starts cooldown timer after resending verification email', async () => {
+  it("starts cooldown timer after resending verification email", async () => {
     vi.useFakeTimers();
-    mockSignInEmail.mockResolvedValue({
-      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
-    });
+    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
     mockSendVerificationEmail.mockResolvedValue({ error: null });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 'user@test.com' },
-    });
-    fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'pass' },
-    });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "user@test.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Resend verification email');
+      expect(container.textContent).toContain("Resend verification email");
     });
-    const resendBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-      b.textContent?.includes('Resend verification email'),
+    const resendBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Resend verification email"),
     )!;
     fireEvent.click(resendBtn);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Resend in');
+      expect(container.textContent).toContain("Resend in");
     });
     // Advance timer to tick down cooldown
     vi.advanceTimersByTime(2000);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Resend in');
+      expect(container.textContent).toContain("Resend in");
     });
     // Advance to expire cooldown
     vi.advanceTimersByTime(60000);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Resend verification email');
+      expect(container.textContent).toContain("Resend verification email");
     });
     vi.useRealTimers();
   });
 
-  it('stores email as last auth method on successful sign-in', async () => {
+  it("stores email as last auth method on successful sign-in", async () => {
     mockSignInEmail.mockResolvedValue({ error: null });
     const { container } = render(() => <Login />);
     fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 't@t.com' },
+      target: { value: "t@t.com" },
     });
     fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'password123' },
+      target: { value: "password123" },
     });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(getLastAuthMethod()).toBe('email');
+      expect(getLastAuthMethod()).toBe("email");
     });
   });
 
-  it('does not store last auth method when sign-in fails', async () => {
-    mockSignInEmail.mockResolvedValue({ error: { message: 'nope' } });
+  it("does not store last auth method when sign-in fails", async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: "nope" } });
     const { container } = render(() => <Login />);
     fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 't@t.com' },
+      target: { value: "t@t.com" },
     });
     fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'wrong' },
+      target: { value: "wrong" },
     });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('nope');
+      expect(container.textContent).toContain("nope");
     });
     expect(getLastAuthMethod()).toBeNull();
   });
 
-  it('forwards lastUsed to SocialButtons when previous method was a provider', async () => {
-    mockCheckSocialProviders.mockResolvedValue(['github']);
-    setLastAuthMethod('github');
+  it("forwards lastUsed to SocialButtons when previous method was a provider", async () => {
+    mockCheckSocialProviders.mockResolvedValue(["github"]);
+    setLastAuthMethod("github");
     const { container } = render(() => <Login />);
     await vi.waitFor(() => {
-      const githubBtn = container.querySelector('.auth-social-btn--github');
+      const githubBtn = container.querySelector(".auth-social-btn--github");
       expect(githubBtn).not.toBeNull();
-      expect(githubBtn!.querySelector('.auth-last-used')).not.toBeNull();
+      expect(githubBtn!.querySelector(".auth-last-used")).not.toBeNull();
     });
   });
 
-  it('shows resend error when sendVerificationEmail fails', async () => {
-    mockSignInEmail.mockResolvedValue({
-      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
-    });
-    mockSendVerificationEmail.mockResolvedValue({ error: { message: 'Rate limited' } });
+  it("shows resend error when sendVerificationEmail fails", async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" } });
+    mockSendVerificationEmail.mockResolvedValue({ error: { message: "Rate limited" } });
     const { container } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 'user@test.com' },
-    });
-    fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'pass' },
-    });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "user@test.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Resend verification email');
+      expect(container.textContent).toContain("Resend verification email");
     });
-    const resendBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-      b.textContent?.includes('Resend verification email'),
+    const resendBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Resend verification email"),
     )!;
     fireEvent.click(resendBtn);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Rate limited');
+      expect(container.textContent).toContain("Rate limited");
     });
   });
 
-  it('clears the cooldown interval on unmount', async () => {
-    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+  it("clears the cooldown interval on unmount", async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
     mockSignInEmail.mockResolvedValue({
-      error: { message: 'Email is not verified', code: 'EMAIL_NOT_VERIFIED' },
+      error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" },
     });
     mockSendVerificationEmail.mockResolvedValue({ error: null });
     const { container, unmount } = render(() => <Login />);
-    fireEvent.input(container.querySelector('input[type="email"]')!, {
-      target: { value: 'u@t.com' },
-    });
-    fireEvent.input(container.querySelector('input[type="password"]')!, {
-      target: { value: 'pass' },
-    });
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "u@t.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
+    fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Resend verification email');
+      expect(container.textContent).toContain("Resend verification email");
     });
-    const resendBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-      b.textContent?.includes('Resend verification email'),
+    const resendBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Resend verification email"),
     )!;
     fireEvent.click(resendBtn);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Resend in');
+      expect(container.textContent).toContain("Resend in");
     });
     unmount();
     expect(clearIntervalSpy).toHaveBeenCalled();


### PR DESCRIPTION
### 💭 Why
Local dev meant typing the seeded admin credentials on every fresh serve.

### ✨ What changed
- Login page shows a prominent dev-only "Sign in as dev" button that submits the SEED_DATA admin (`admin@manifest.build` / `manifest`).
- Docs: CLAUDE.md seeding note.

### 👤 For users
Nothing in production. `import.meta.env.DEV` strips the button and the credential literals from prod builds, and no password rides in a URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dev‑only one‑click sign‑in button on the dashboard login that auto‑fills and submits the seeded admin (`admin@manifest.build` / `manifest`). Gated by `import.meta.env.DEV` so it never ships to production and no password appears in URLs; adds tests for success and error paths, a note in `CLAUDE.md`, and restores the login test file’s original style.

<sup>Written for commit 31c51acb33194b61b9b48b5b7cb1ac3b0fb0540e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

