### PR TITLE
Replace social follow banner with paid plans announcement

### DIFF
--- a/packages/frontend/src/components/SocialFollowBanner.tsx
+++ b/packages/frontend/src/components/SocialFollowBanner.tsx
@@ -1,36 +1,6 @@
-import { For, Show, createSignal, type Component } from 'solid-js';
+import { Show, createSignal, type Component } from 'solid-js';
 
-export const SOCIAL_FOLLOW_DISMISSED_KEY = 'manifest:overview-social-follow-dismissed:v3';
-
-const SOCIAL_LINKS = [
-  {
-    label: 'X',
-    href: 'https://x.com/Manifestforai',
-    icon: () => (
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M18.244 2H21.8l-7.77 8.883L23.176 22h-7.159l-5.608-7.333L3.993 22H.435l8.31-9.497L0 2h7.34l5.07 6.701L18.244 2Zm-1.248 18.044h1.97L6.27 3.853H4.157l12.839 16.191Z" />
-      </svg>
-    ),
-  },
-  {
-    label: 'LinkedIn',
-    href: 'https://www.linkedin.com/company/manifest-for-agents/',
-    icon: () => (
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M20.45 20.45h-3.56v-5.58c0-1.33-.02-3.04-1.85-3.04-1.86 0-2.14 1.45-2.14 2.95v5.67H9.34V8.98h3.42v1.57h.05c.48-.9 1.64-1.85 3.37-1.85 3.61 0 4.27 2.37 4.27 5.46v6.29ZM5.32 7.41a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12Zm1.78 13.04H3.53V8.98H7.1v11.47ZM22.23 0H1.76C.79 0 0 .77 0 1.73v20.54C0 23.23.79 24 1.76 24h20.47c.97 0 1.77-.77 1.77-1.73V1.73C24 .77 23.2 0 22.23 0Z" />
-      </svg>
-    ),
-  },
-  {
-    label: 'YouTube',
-    href: 'https://www.youtube.com/@Manifest-for-AI',
-    icon: () => (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M23.5 6.2a3 3 0 0 0-2.12-2.12C19.51 3.58 12 3.58 12 3.58s-7.51 0-9.38.5A3 3 0 0 0 .5 6.2C0 8.07 0 12 0 12s0 3.93.5 5.8a3 3 0 0 0 2.12 2.12c1.87.5 9.38.5 9.38.5s7.51 0 9.38-.5a3 3 0 0 0 2.12-2.12c.5-1.87.5-5.8.5-5.8s0-3.93-.5-5.8ZM9.55 15.57V8.43L15.82 12l-6.27 3.57Z" />
-      </svg>
-    ),
-  },
-];
+export const SOCIAL_FOLLOW_DISMISSED_KEY = 'manifest:overview-social-follow-dismissed:v4';
 
 function readDismissed(): boolean {
   try {
@@ -58,31 +28,23 @@ const SocialFollowBanner: Component = () => {
 
   return (
     <Show when={!dismissed()}>
-      <aside class="overview-social-banner" aria-label="Manifest community links">
+      <aside class="overview-social-banner" aria-label="Manifest announcement">
         <div class="overview-social-banner__inner">
           <span class="overview-social-banner__text">
-            Follow Manifest to stay informed about the latest models and available features
+            🔥 Introducing Self-healing requests and paid plans for Manifest Cloud.{' '}
+            <a
+              href="https://manifest.build/blog/introducing-paid-plans/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="overview-social-banner__read-more"
+            >
+              Read more
+            </a>
           </span>
-          <div class="overview-social-banner__links">
-            <For each={SOCIAL_LINKS}>
-              {(link) => (
-                <a
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="overview-social-banner__link"
-                  aria-label={`Manifest on ${link.label}`}
-                  title={link.label}
-                >
-                  {link.icon()}
-                </a>
-              )}
-            </For>
-          </div>
           <button
             type="button"
             class="overview-social-banner__dismiss"
-            aria-label="Dismiss social follow banner"
+            aria-label="Dismiss banner"
             onClick={dismiss}
           >
             <svg

--- a/packages/frontend/src/styles/overview.css
+++ b/packages/frontend/src/styles/overview.css
@@ -171,11 +171,15 @@
   text-align: center;
 }
 
-.overview-social-banner__links {
-  display: flex;
-  align-items: stretch;
-  flex: 0 0 auto;
-  border-left: 1px solid hsl(var(--border));
+.overview-social-banner__read-more {
+  margin-left: 0.3em;
+  color: hsl(var(--primary));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.overview-social-banner__read-more:hover {
+  opacity: 0.8;
 }
 
 @media (max-width: 768px) {

--- a/packages/frontend/tests/components/SocialFollowBanner.test.tsx
+++ b/packages/frontend/tests/components/SocialFollowBanner.test.tsx
@@ -10,36 +10,30 @@ describe('SocialFollowBanner', () => {
     window.localStorage.clear();
   });
 
-  it('renders the compact follow message and community links', () => {
+  it('renders the paid plans announcement with a read-more link', () => {
     const { container } = render(() => <SocialFollowBanner />);
 
     expect(container.querySelector('.overview-social-banner')).not.toBeNull();
     expect(
-      screen.getByText(
-        'Follow Manifest to stay informed about the latest models and available features',
-      ),
+      screen.getByText(/Introducing Self-healing requests and paid plans for Manifest Cloud/),
     ).toBeDefined();
 
-    const x = screen.getByLabelText('Manifest on X') as HTMLAnchorElement;
-    const linkedIn = screen.getByLabelText('Manifest on LinkedIn') as HTMLAnchorElement;
-    const youtube = screen.getByLabelText('Manifest on YouTube') as HTMLAnchorElement;
-
-    expect(x.getAttribute('href')).toBe('https://x.com/Manifestforai');
-    expect(linkedIn.getAttribute('href')).toBe(
-      'https://www.linkedin.com/company/manifest-for-agents/',
+    const readMore = screen.getByText('Read more') as HTMLAnchorElement;
+    expect(readMore.getAttribute('href')).toBe(
+      'https://manifest.build/blog/introducing-paid-plans/',
     );
-    expect(youtube.getAttribute('href')).toBe('https://www.youtube.com/@Manifest-for-AI');
-    expect(x.getAttribute('target')).toBe('_blank');
-    expect(linkedIn.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(readMore.getAttribute('target')).toBe('_blank');
+    expect(readMore.getAttribute('rel')).toBe('noopener noreferrer');
+
     expect(container.querySelector('.overview-social-banner__inner')?.lastElementChild).toBe(
-      screen.getByLabelText('Dismiss social follow banner'),
+      screen.getByLabelText('Dismiss banner'),
     );
   });
 
   it('dismisses and persists the hidden state', async () => {
     const { container, unmount } = render(() => <SocialFollowBanner />);
 
-    await fireEvent.click(screen.getByLabelText('Dismiss social follow banner'));
+    await fireEvent.click(screen.getByLabelText('Dismiss banner'));
 
     expect(container.querySelector('.overview-social-banner')).toBeNull();
     expect(window.localStorage.getItem(SOCIAL_FOLLOW_DISMISSED_KEY)).toBe('true');
@@ -56,7 +50,7 @@ describe('SocialFollowBanner', () => {
 
     const { container } = render(() => <SocialFollowBanner />);
 
-    await fireEvent.click(screen.getByLabelText('Dismiss social follow banner'));
+    await fireEvent.click(screen.getByLabelText('Dismiss banner'));
 
     expect(container.querySelector('.overview-social-banner')).toBeNull();
   });


### PR DESCRIPTION
## ✨ What changed
- Dashboard banner now announces Self-healing requests and paid plans for Manifest Cloud
- "Read more" links to the blog post in a new tab
- Social media links (X, LinkedIn, YouTube) removed from the banner
- Dismissed-state key bumped so all users see the new banner fresh

## 💭 Why
The previous banner promoted social media follows. With the launch of paid plans and Self-healing requests, the banner is better used to announce these new features and direct users to the blog post.

## 👤 For users
The overview banner now reads "🔥 Introducing Self-healing requests and paid plans for Manifest Cloud. Read more" with a link to the announcement blog post. Dismissing it works the same as before.

## 🔧 For operators
No operator impact.

## 🧪 How to test
1. Open the dashboard overview page
2. Confirm the banner shows the paid plans announcement with a "Read more" link
3. Click "Read more": it should open `https://manifest.build/blog/introducing-paid-plans/` in a new tab
4. Click the dismiss (X) button: the banner should disappear and stay hidden on refresh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the dashboard social follow banner with an announcement for Self-healing requests and paid plans. Adds a "Read more" link and resets the dismiss state so everyone sees it.

- **New Features**
  - Adds "Read more" link to https://manifest.build/blog/introducing-paid-plans/ opening in a new tab.
  - Removes X, LinkedIn, and YouTube links from the banner.
  - Bumps `SOCIAL_FOLLOW_DISMISSED_KEY` to `manifest:overview-social-follow-dismissed:v4` to show the new banner.

<sup>Written for commit 808d092b5a020449617b6fbf0dc1db048c723d5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

