### PR TITLE
feat: add managed deploy buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Plug your AI agents into any provider
 ![manifest-gh](https://github.com/user-attachments/assets/7dd74fc2-f7d6-4558-a95a-014ed754a125)
 
 <p align="center">
+  <a href="https://render.com/deploy?repo=https://github.com/mnfst/manifest" target="_blank" rel="nofollow"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height="40" /></a>
+  <a href="https://railway.com/deploy/wild-wild" target="_blank" rel="nofollow"><img src="https://railway.com/button.svg" alt="Deploy on Railway" height="40" /></a>
+  <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?stackName=manifest&amp;templateURL=https%3A%2F%2Fmnfst-manifest-deploy-templates.s3.us-east-1.amazonaws.com%2Fmanifest.yaml" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-AWS-232F3E?style=for-the-badge&amp;logo=amazonwebservices&amp;logoColor=white" alt="Deploy on AWS" height="40" /></a>
+  <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fmnfst%2Fmanifest&amp;cloudshell_workspace=deploy%2Fgcp&amp;cloudshell_tutorial=TUTORIAL.md&amp;cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image&amp;shellonly=true" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-GCP-4285F4?style=for-the-badge&amp;logo=googlecloud&amp;logoColor=white" alt="Deploy on GCP" height="40" /></a>
+</p>
+
+<p align="center">
   <span><img src="https://img.shields.io/badge/status-beta-yellow" alt="beta" /></span>
   &nbsp;
   <a href="https://github.com/mnfst/manifest/stargazers"><img src="https://img.shields.io/github/stars/mnfst/manifest?style=flat" alt="GitHub stars" /></a>
@@ -57,6 +64,15 @@ bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/in
 ```
 
 Open [http://localhost:2099](http://localhost:2099) and sign up — the first account you create becomes the admin. Full self-hosting guide: [docker/DOCKER_README.md](docker/DOCKER_README.md).
+
+Managed deployment options:
+
+| Platform | What it provisions |
+| --- | --- |
+| [Railway](https://railway.com/deploy/wild-wild) | Manifest plus PostgreSQL from the public Railway template. |
+| [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Manifest web service plus Render PostgreSQL from [render.yaml](render.yaml). |
+| [AWS](deploy/aws/TUTORIAL.md) | ECS Fargate, Application Load Balancer, RDS PostgreSQL, and Secrets Manager via CloudFormation. |
+| [GCP](deploy/gcp/TUTORIAL.md) | Cloud Run, Cloud SQL for PostgreSQL, and Secret Manager via the Cloud Shell tutorial. |
 
 > The legacy `manifest` npm package is deprecated and no longer published.
 

--- a/deploy/aws/TUTORIAL.md
+++ b/deploy/aws/TUTORIAL.md
@@ -1,0 +1,96 @@
+# Deploy Manifest on AWS
+
+This walkthrough deploys Manifest on AWS with ECS Fargate, RDS PostgreSQL, Secrets Manager, and an Application Load Balancer. The stack uses public ECS tasks behind the load balancer and private RDS subnets, so it does not create a NAT gateway.
+
+## Prerequisites
+
+- An AWS account with billing enabled.
+- Permission to create CloudFormation stacks, IAM roles, VPC resources, ECS, RDS, Elastic Load Balancing, CloudWatch Logs, and Secrets Manager secrets.
+- AWS CloudShell or a local shell with `aws` and `git` installed.
+
+This stack creates paid resources, including an Application Load Balancer, ECS Fargate tasks, and RDS PostgreSQL.
+
+## Open AWS CloudShell
+
+Open [AWS CloudShell](https://console.aws.amazon.com/cloudshell/home), choose the region you want to deploy into, then run:
+
+```bash
+git clone https://github.com/mnfst/manifest.git
+cd manifest
+AWS_REGION=us-east-1 ./deploy/aws/deploy.sh
+```
+
+Change `AWS_REGION` if you deploy outside `us-east-1`.
+
+The first deploy usually takes 10-15 minutes because RDS needs time to provision.
+
+## Configuration
+
+The deploy script exposes the common settings as environment variables:
+
+```bash
+STACK_NAME=manifest \
+SERVICE_NAME=manifest \
+AWS_REGION=us-east-1 \
+IMAGE_URL=docker.io/manifestdotbuild/manifest:6 \
+DATABASE_INSTANCE_CLASS=db.t4g.micro \
+DESIRED_COUNT=1 \
+./deploy/aws/deploy.sh
+```
+
+The CloudFormation template generates these runtime values in Secrets Manager:
+
+- `DATABASE_URL`
+- `BETTER_AUTH_SECRET`
+- `MANIFEST_ENCRYPTION_KEY`
+
+Manifest runs with:
+
+- `PORT=2099`
+- `BIND_ADDRESS=0.0.0.0`
+- `MANIFEST_MODE=selfhosted`
+- `BETTER_AUTH_URL=http://<load-balancer-dns-name>`
+
+## Open Manifest
+
+After deployment, the script prints `ServiceUrl` and `HealthCheckUrl`.
+
+To fetch them again:
+
+```bash
+aws cloudformation describe-stacks \
+  --region us-east-1 \
+  --stack-name manifest \
+  --query "Stacks[0].Outputs[?OutputKey=='ServiceUrl' || OutputKey=='HealthCheckUrl'].[OutputKey,OutputValue]" \
+  --output table
+```
+
+Open `ServiceUrl` and create the first account. The first account becomes the admin.
+
+To verify the deployment:
+
+```bash
+HEALTH_URL="$(aws cloudformation describe-stacks \
+  --region us-east-1 \
+  --stack-name manifest \
+  --query "Stacks[0].Outputs[?OutputKey=='HealthCheckUrl'].OutputValue" \
+  --output text)"
+
+curl -sSf "$HEALTH_URL"
+```
+
+## Tearing it down
+
+```bash
+aws cloudformation delete-stack --region us-east-1 --stack-name manifest
+aws cloudformation wait stack-delete-complete --region us-east-1 --stack-name manifest
+```
+
+If you deployed with `DATABASE_DELETION_PROTECTION=true`, redeploy with `DATABASE_DELETION_PROTECTION=false` before deleting the stack.
+
+## Quick-create button
+
+The README badge opens AWS CloudFormation quick-create with the published template:
+
+- Template URL: `https://mnfst-manifest-deploy-templates.s3.us-east-1.amazonaws.com/manifest.yaml`
+- Quick-create URL: `https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?stackName=manifest&templateURL=https%3A%2F%2Fmnfst-manifest-deploy-templates.s3.us-east-1.amazonaws.com%2Fmanifest.yaml`

--- a/deploy/aws/TUTORIAL.md
+++ b/deploy/aws/TUTORIAL.md
@@ -10,6 +10,8 @@ This walkthrough deploys Manifest on AWS with ECS Fargate, RDS PostgreSQL, Secre
 
 This stack creates paid resources, including an Application Load Balancer, ECS Fargate tasks, and RDS PostgreSQL.
 
+The default template exposes Manifest over HTTP on the generated load balancer DNS name. Configure TLS with your own domain and ACM certificate before using the deployment for production authentication traffic.
+
 ## Open AWS CloudShell
 
 Open [AWS CloudShell](https://console.aws.amazon.com/cloudshell/home), choose the region you want to deploy into, then run:

--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+STACK_NAME="${STACK_NAME:-manifest}"
+SERVICE_NAME="${SERVICE_NAME:-manifest}"
+IMAGE_URL="${IMAGE_URL:-docker.io/manifestdotbuild/manifest:6}"
+DESIRED_COUNT="${DESIRED_COUNT:-1}"
+DATABASE_INSTANCE_CLASS="${DATABASE_INSTANCE_CLASS:-db.t4g.micro}"
+DATABASE_DELETION_PROTECTION="${DATABASE_DELETION_PROTECTION:-false}"
+TEMPLATE_FILE="${TEMPLATE_FILE:-$SCRIPT_DIR/manifest.yaml}"
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+
+if [[ -z "$REGION" ]]; then
+  REGION="$(aws configure get region 2>/dev/null || true)"
+fi
+
+if [[ -z "$REGION" ]]; then
+  echo "Set AWS_REGION or configure a default AWS CLI region." >&2
+  exit 1
+fi
+
+aws cloudformation deploy \
+  --region "$REGION" \
+  --stack-name "$STACK_NAME" \
+  --template-file "$TEMPLATE_FILE" \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+    ServiceName="$SERVICE_NAME" \
+    ImageUrl="$IMAGE_URL" \
+    DesiredCount="$DESIRED_COUNT" \
+    DatabaseInstanceClass="$DATABASE_INSTANCE_CLASS" \
+    DatabaseDeletionProtection="$DATABASE_DELETION_PROTECTION"
+
+aws cloudformation describe-stacks \
+  --region "$REGION" \
+  --stack-name "$STACK_NAME" \
+  --query "Stacks[0].Outputs[?OutputKey=='ServiceUrl' || OutputKey=='HealthCheckUrl'].[OutputKey,OutputValue]" \
+  --output table

--- a/deploy/aws/deploy.sh
+++ b/deploy/aws/deploy.sh
@@ -21,15 +21,27 @@ if [[ -z "$REGION" ]]; then
   exit 1
 fi
 
+if [[ ! "$DESIRED_COUNT" =~ ^[0-9]+$ ]]; then
+  echo "DESIRED_COUNT must be an integer from 1 to 10." >&2
+  exit 1
+fi
+
+desired_count_number=$((10#$DESIRED_COUNT))
+if ((desired_count_number < 1 || desired_count_number > 10)); then
+  echo "DESIRED_COUNT must be an integer from 1 to 10." >&2
+  exit 1
+fi
+
 aws cloudformation deploy \
   --region "$REGION" \
   --stack-name "$STACK_NAME" \
   --template-file "$TEMPLATE_FILE" \
   --capabilities CAPABILITY_IAM \
+  --no-fail-on-empty-changeset \
   --parameter-overrides \
     ServiceName="$SERVICE_NAME" \
     ImageUrl="$IMAGE_URL" \
-    DesiredCount="$DESIRED_COUNT" \
+    DesiredCount="$desired_count_number" \
     DatabaseInstanceClass="$DATABASE_INSTANCE_CLASS" \
     DatabaseDeletionProtection="$DATABASE_DELETION_PROTECTION"
 

--- a/deploy/aws/manifest.yaml
+++ b/deploy/aws/manifest.yaml
@@ -1,0 +1,443 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Deploy Manifest on AWS with ECS Fargate, RDS PostgreSQL, an Application Load Balancer, and Secrets Manager.
+
+Parameters:
+  ServiceName:
+    Type: String
+    Default: manifest
+    Description: Lowercase service name used in resource labels.
+    AllowedPattern: "^[a-z][a-z0-9-]{0,39}$"
+    ConstraintDescription: Use up to 40 lowercase letters, numbers, and hyphens, starting with a letter.
+  ImageUrl:
+    Type: String
+    Default: docker.io/manifestdotbuild/manifest:6
+    Description: Manifest container image to deploy.
+  ContainerPort:
+    Type: Number
+    Default: 2099
+    MinValue: 1
+    MaxValue: 65535
+    Description: Port exposed by the Manifest container.
+  DesiredCount:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 10
+    Description: Number of ECS tasks to run.
+  Cpu:
+    Type: String
+    Default: "512"
+    AllowedValues: ["256", "512", "1024", "2048", "4096"]
+    Description: Fargate task CPU units.
+  Memory:
+    Type: String
+    Default: "1024"
+    AllowedValues: ["512", "1024", "2048", "3072", "4096", "5120", "6144", "7168", "8192"]
+    Description: Fargate task memory in MiB.
+  DatabaseName:
+    Type: String
+    Default: manifest
+    AllowedPattern: "^[a-zA-Z][a-zA-Z0-9_]{0,62}$"
+    Description: PostgreSQL database name.
+  DatabaseUsername:
+    Type: String
+    Default: manifest
+    AllowedPattern: "^[a-zA-Z][a-zA-Z0-9_]{0,62}$"
+    Description: PostgreSQL master username.
+  DatabaseInstanceClass:
+    Type: String
+    Default: db.t4g.micro
+    Description: RDS PostgreSQL instance class.
+  DatabaseAllocatedStorage:
+    Type: Number
+    Default: 20
+    MinValue: 20
+    MaxValue: 1024
+    Description: RDS storage in GiB.
+  DatabaseDeletionProtection:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: Set to true to prevent accidental database deletion.
+  AllowedIngressCidr:
+    Type: String
+    Default: 0.0.0.0/0
+    Description: CIDR allowed to reach the public load balancer.
+  VpcCidr:
+    Type: String
+    Default: 10.80.0.0/16
+    Description: CIDR block for the VPC.
+  PublicSubnet1Cidr:
+    Type: String
+    Default: 10.80.0.0/24
+    Description: CIDR block for the first public subnet.
+  PublicSubnet2Cidr:
+    Type: String
+    Default: 10.80.1.0/24
+    Description: CIDR block for the second public subnet.
+  PrivateSubnet1Cidr:
+    Type: String
+    Default: 10.80.10.0/24
+    Description: CIDR block for the first private database subnet.
+  PrivateSubnet2Cidr:
+    Type: String
+    Default: 10.80.11.0/24
+    Description: CIDR block for the second private database subnet.
+
+Conditions:
+  EnableDatabaseDeletionProtection: !Equals [!Ref DatabaseDeletionProtection, "true"]
+
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-${ServiceName}"
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-${ServiceName}"
+
+  VpcGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref Vpc
+
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: !Ref PublicSubnet1Cidr
+      MapPublicIpOnLaunch: true
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-${ServiceName}-public-a"
+
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: !Ref PublicSubnet2Cidr
+      MapPublicIpOnLaunch: true
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-${ServiceName}-public-b"
+
+  PrivateSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: !Ref PrivateSubnet1Cidr
+      MapPublicIpOnLaunch: false
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-${ServiceName}-private-a"
+
+  PrivateSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: !Ref PrivateSubnet2Cidr
+      MapPublicIpOnLaunch: false
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-${ServiceName}-private-b"
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-${ServiceName}-public"
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VpcGatewayAttachment
+    Properties:
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet1
+
+  PublicSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet2
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow HTTP traffic to Manifest.
+      SecurityGroupIngress:
+        - CidrIp: !Ref AllowedIngressCidr
+          FromPort: 80
+          IpProtocol: tcp
+          ToPort: 80
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: -1
+      VpcId: !Ref Vpc
+
+  ServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow load balancer traffic to the Manifest ECS task.
+      SecurityGroupIngress:
+        - FromPort: !Ref ContainerPort
+          IpProtocol: tcp
+          SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+          ToPort: !Ref ContainerPort
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: -1
+      VpcId: !Ref Vpc
+
+  DatabaseSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow Manifest ECS tasks to reach PostgreSQL.
+      SecurityGroupIngress:
+        - FromPort: 5432
+          IpProtocol: tcp
+          SourceSecurityGroupId: !Ref ServiceSecurityGroup
+          ToPort: 5432
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: -1
+      VpcId: !Ref Vpc
+
+  DatabaseSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Private subnets for Manifest PostgreSQL.
+      SubnetIds:
+        - !Ref PrivateSubnet1
+        - !Ref PrivateSubnet2
+
+  DatabasePassword:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Generated PostgreSQL password for Manifest.
+      GenerateSecretString:
+        ExcludePunctuation: true
+        IncludeSpace: false
+        PasswordLength: 32
+
+  BetterAuthSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Generated Better Auth session secret for Manifest.
+      GenerateSecretString:
+        ExcludePunctuation: true
+        IncludeSpace: false
+        PasswordLength: 64
+
+  ManifestEncryptionKey:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Generated at-rest encryption key for Manifest provider credentials.
+      GenerateSecretString:
+        ExcludePunctuation: true
+        IncludeSpace: false
+        PasswordLength: 64
+
+  Database:
+    Type: AWS::RDS::DBInstance
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AllocatedStorage: !Ref DatabaseAllocatedStorage
+      BackupRetentionPeriod: 7
+      DBInstanceClass: !Ref DatabaseInstanceClass
+      DBName: !Ref DatabaseName
+      DBSubnetGroupName: !Ref DatabaseSubnetGroup
+      DeletionProtection: !If [EnableDatabaseDeletionProtection, true, false]
+      Engine: postgres
+      MasterUsername: !Ref DatabaseUsername
+      MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabasePassword}:SecretString}}"
+      MultiAZ: false
+      PubliclyAccessible: false
+      StorageEncrypted: true
+      VPCSecurityGroups:
+        - !Ref DatabaseSecurityGroup
+
+  DatabaseUrlSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: DATABASE_URL for Manifest.
+      SecretString: !Sub "postgresql://${DatabaseUsername}:{{resolve:secretsmanager:${DatabasePassword}:SecretString}}@${Database.Endpoint.Address}:${Database.Endpoint.Port}/${DatabaseName}?uselibpqcompat=true&sslmode=require"
+
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub "${AWS::StackName}-${ServiceName}"
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/ecs/${AWS::StackName}-${ServiceName}"
+      RetentionInDays: 14
+
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: ReadManifestRuntimeSecrets
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref DatabaseUrlSecret
+                  - !Ref BetterAuthSecret
+                  - !Ref ManifestEncryptionKey
+
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      SecurityGroups:
+        - !Ref LoadBalancerSecurityGroup
+      Subnets:
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
+      Type: application
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckEnabled: true
+      HealthCheckIntervalSeconds: 30
+      HealthCheckPath: /api/v1/health
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      Matcher:
+        HttpCode: "200"
+      Port: !Ref ContainerPort
+      Protocol: HTTP
+      TargetType: ip
+      UnhealthyThresholdCount: 3
+      VpcId: !Ref Vpc
+
+  Listener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref TargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Environment:
+            - Name: PORT
+              Value: !Sub "${ContainerPort}"
+            - Name: BIND_ADDRESS
+              Value: 0.0.0.0
+            - Name: MANIFEST_MODE
+              Value: selfhosted
+            - Name: DB_POOL_MAX
+              Value: "10"
+            - Name: AUTH_DB_POOL_MAX
+              Value: "5"
+            - Name: BETTER_AUTH_URL
+              Value: !Sub "http://${LoadBalancer.DNSName}"
+          Essential: true
+          Image: !Ref ImageUrl
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: manifest
+          Name: manifest
+          PortMappings:
+            - ContainerPort: !Ref ContainerPort
+              Protocol: tcp
+          Secrets:
+            - Name: DATABASE_URL
+              ValueFrom: !Ref DatabaseUrlSecret
+            - Name: BETTER_AUTH_SECRET
+              ValueFrom: !Ref BetterAuthSecret
+            - Name: MANIFEST_ENCRYPTION_KEY
+              ValueFrom: !Ref ManifestEncryptionKey
+      Cpu: !Ref Cpu
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      Family: !Sub "${AWS::StackName}-${ServiceName}"
+      Memory: !Ref Memory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - Listener
+      - DatabaseUrlSecret
+    Properties:
+      Cluster: !Ref Cluster
+      DesiredCount: !Ref DesiredCount
+      HealthCheckGracePeriodSeconds: 180
+      LaunchType: FARGATE
+      LoadBalancers:
+        - ContainerName: manifest
+          ContainerPort: !Ref ContainerPort
+          TargetGroupArn: !Ref TargetGroup
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - !Ref ServiceSecurityGroup
+          Subnets:
+            - !Ref PublicSubnet1
+            - !Ref PublicSubnet2
+      TaskDefinition: !Ref TaskDefinition
+
+Outputs:
+  ServiceUrl:
+    Description: Public Manifest URL.
+    Value: !Sub "http://${LoadBalancer.DNSName}"
+  HealthCheckUrl:
+    Description: Manifest health check URL.
+    Value: !Sub "http://${LoadBalancer.DNSName}/api/v1/health"
+  DatabaseEndpoint:
+    Description: RDS PostgreSQL endpoint.
+    Value: !GetAtt Database.Endpoint.Address
+  DatabaseUrlSecretArn:
+    Description: Secrets Manager ARN containing DATABASE_URL.
+    Value: !Ref DatabaseUrlSecret

--- a/deploy/aws/manifest.yaml
+++ b/deploy/aws/manifest.yaml
@@ -1,5 +1,9 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Deploy Manifest on AWS with ECS Fargate, RDS PostgreSQL, an Application Load Balancer, and Secrets Manager.
+Description: >-
+  Deploy Manifest on AWS with ECS Fargate, RDS PostgreSQL, an
+  Application Load Balancer, and Secrets Manager. The load balancer is
+  HTTP-only by default; configure TLS with your own domain and ACM
+  certificate before sending production auth traffic through it.
 
 Parameters:
   ServiceName:

--- a/deploy/gcp/TUTORIAL.md
+++ b/deploy/gcp/TUTORIAL.md
@@ -52,7 +52,7 @@ curl -sSf "$(terraform output -raw health_check_url)"
 deploystack uninstall
 ```
 
-If you deployed with `database_deletion_protection=true`, set it back to `false` and apply before uninstalling.
+Cloud SQL deletion protection is enabled by default. Set `database_deletion_protection=false` and apply before uninstalling.
 
 ## You're done
 

--- a/deploy/gcp/TUTORIAL.md
+++ b/deploy/gcp/TUTORIAL.md
@@ -1,0 +1,59 @@
+# Deploy Manifest on GCP
+
+<walkthrough-tutorial-duration duration="15"></walkthrough-tutorial-duration>
+
+This walkthrough deploys Manifest on Google Cloud with Cloud Run, Cloud SQL for PostgreSQL, and Secret Manager. DeployStack asks for a few settings, writes `terraform.tfvars`, and runs Terraform in the selected project.
+
+## Prerequisites
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Pick the Google Cloud project you want to deploy into and make sure billing is enabled. This stack creates paid resources, including Cloud SQL.
+
+## Enable required APIs
+
+<walkthrough-enable-apis apis="iam.googleapis.com,run.googleapis.com,sqladmin.googleapis.com,secretmanager.googleapis.com"></walkthrough-enable-apis>
+
+```bash
+gcloud services enable \
+  iam.googleapis.com \
+  run.googleapis.com \
+  sqladmin.googleapis.com \
+  secretmanager.googleapis.com
+```
+
+## Run the installer
+
+DeployStack reads `<walkthrough-editor-open-file filePath="deploy/gcp/deploystack.json">deploystack.json</walkthrough-editor-open-file>`, prompts for project, region, service name, image, and sizing, then runs Terraform.
+
+```bash
+deploystack install
+```
+
+The first deploy usually takes 10-15 minutes because Cloud SQL needs time to provision. The Terraform config also patches `BETTER_AUTH_URL` to the final Cloud Run URL after the service is created.
+
+## Open Manifest
+
+```bash
+terraform output service_url
+```
+
+Open the URL and create the first account. The first account becomes the admin.
+
+To verify the deployment:
+
+```bash
+curl -sSf "$(terraform output -raw health_check_url)"
+```
+
+## Tearing it down
+
+```bash
+deploystack uninstall
+```
+
+If you deployed with `database_deletion_protection=true`, set it back to `false` and apply before uninstalling.
+
+## You're done
+
+<walkthrough-conclusion-trophy></walkthrough-conclusion-trophy>

--- a/deploy/gcp/deploystack.json
+++ b/deploy/gcp/deploystack.json
@@ -44,7 +44,7 @@
       "name": "database_deletion_protection",
       "prompt": "Enable Cloud SQL deletion protection",
       "type": "boolean",
-      "default": false
+      "default": true
     }
   ]
 }

--- a/deploy/gcp/deploystack.json
+++ b/deploy/gcp/deploystack.json
@@ -1,0 +1,50 @@
+{
+  "title": "Manifest",
+  "description": "Deploy Manifest on Google Cloud Run with Cloud SQL for PostgreSQL.",
+  "logo": "https://raw.githubusercontent.com/mnfst/manifest/HEAD/.github/assets/logo-dark.svg",
+  "duration": 15,
+  "documentationLink": "https://manifest.build/docs",
+  "variables": [
+    {
+      "name": "project_id",
+      "prompt": "Google Cloud project ID",
+      "type": "project"
+    },
+    {
+      "name": "region",
+      "prompt": "Region",
+      "type": "string",
+      "default": "us-central1"
+    },
+    {
+      "name": "service_name",
+      "prompt": "Cloud Run service name",
+      "type": "string",
+      "default": "manifest"
+    },
+    {
+      "name": "image_url",
+      "prompt": "Manifest image",
+      "type": "string",
+      "default": "docker.io/manifestdotbuild/manifest:6"
+    },
+    {
+      "name": "database_tier",
+      "prompt": "Cloud SQL machine tier",
+      "type": "string",
+      "default": "db-f1-micro"
+    },
+    {
+      "name": "max_instances",
+      "prompt": "Maximum Cloud Run instances",
+      "type": "number",
+      "default": 1
+    },
+    {
+      "name": "database_deletion_protection",
+      "prompt": "Enable Cloud SQL deletion protection",
+      "type": "boolean",
+      "default": false
+    }
+  ]
+}

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -1,0 +1,269 @@
+locals {
+  suffix          = random_id.suffix.hex
+  name_prefix     = "${var.service_name}-${local.suffix}"
+  database_name   = "manifest"
+  database_user   = "manifest"
+  service_account = substr("${var.service_name}-${local.suffix}", 0, 30)
+  database_url    = "postgresql://${local.database_user}:${urlencode(random_password.database.result)}@/${local.database_name}?host=${urlencode("/cloudsql/${google_sql_database_instance.manifest.connection_name}")}"
+  managed_secret_ids = {
+    database_url            = "${local.name_prefix}-database-url"
+    better_auth_secret      = "${local.name_prefix}-better-auth-secret"
+    manifest_encryption_key = "${local.name_prefix}-encryption-key"
+  }
+  managed_secret_values = {
+    database_url            = local.database_url
+    better_auth_secret      = random_id.better_auth_secret.hex
+    manifest_encryption_key = random_id.manifest_encryption_key.hex
+  }
+}
+
+resource "google_project_service" "required" {
+  for_each = toset([
+    "iam.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com",
+    "sqladmin.googleapis.com",
+  ])
+
+  project            = var.project_id
+  service            = each.key
+  disable_on_destroy = false
+}
+
+resource "random_id" "suffix" {
+  byte_length = 3
+}
+
+resource "random_id" "better_auth_secret" {
+  byte_length = 32
+}
+
+resource "random_id" "manifest_encryption_key" {
+  byte_length = 32
+}
+
+resource "random_password" "database" {
+  length  = 32
+  special = false
+}
+
+resource "google_service_account" "manifest" {
+  account_id   = local.service_account
+  display_name = "Manifest Cloud Run"
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_sql_database_instance" "manifest" {
+  name                = "${var.service_name}-postgres-${local.suffix}"
+  region              = var.region
+  database_version    = "POSTGRES_16"
+  deletion_protection = var.database_deletion_protection
+
+  settings {
+    tier              = var.database_tier
+    edition           = "ENTERPRISE"
+    availability_type = "ZONAL"
+    disk_autoresize   = true
+
+    backup_configuration {
+      enabled    = true
+      start_time = "03:00"
+    }
+  }
+
+  depends_on = [google_project_service.required["sqladmin.googleapis.com"]]
+}
+
+resource "google_sql_database" "manifest" {
+  name     = local.database_name
+  instance = google_sql_database_instance.manifest.name
+}
+
+resource "google_sql_user" "manifest" {
+  name     = local.database_user
+  instance = google_sql_database_instance.manifest.name
+  password = random_password.database.result
+}
+
+resource "google_secret_manager_secret" "managed" {
+  for_each = local.managed_secret_ids
+
+  secret_id = each.value
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "managed" {
+  for_each = local.managed_secret_values
+
+  secret      = google_secret_manager_secret.managed[each.key].id
+  secret_data = each.value
+}
+
+resource "google_secret_manager_secret_iam_member" "managed" {
+  for_each = google_secret_manager_secret.managed
+
+  secret_id = each.value.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.manifest.email}"
+}
+
+resource "google_project_iam_member" "cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.manifest.email}"
+}
+
+resource "google_cloud_run_v2_service" "manifest" {
+  name                = var.service_name
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = false
+
+  template {
+    service_account                  = google_service_account.manifest.email
+    max_instance_request_concurrency = 20
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = var.max_instances
+    }
+
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.manifest.connection_name]
+      }
+    }
+
+    containers {
+      image = var.image_url
+
+      ports {
+        container_port = 2099
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "1Gi"
+        }
+      }
+
+      env {
+        name  = "BIND_ADDRESS"
+        value = "0.0.0.0"
+      }
+
+      env {
+        name  = "MANIFEST_MODE"
+        value = "selfhosted"
+      }
+
+      env {
+        name  = "DB_POOL_MAX"
+        value = "10"
+      }
+
+      env {
+        name  = "AUTH_DB_POOL_MAX"
+        value = "5"
+      }
+
+      env {
+        name = "DATABASE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.managed["database_url"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "BETTER_AUTH_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.managed["better_auth_secret"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "MANIFEST_ENCRYPTION_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.managed["manifest_encryption_key"].secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      startup_probe {
+        http_get {
+          path = "/api/v1/health"
+          port = 2099
+        }
+        initial_delay_seconds = 10
+        period_seconds        = 10
+        timeout_seconds       = 5
+        failure_threshold     = 12
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/api/v1/health"
+          port = 2099
+        }
+        period_seconds    = 30
+        timeout_seconds   = 5
+        failure_threshold = 3
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].env,
+    ]
+  }
+
+  depends_on = [
+    google_project_iam_member.cloudsql_client,
+    google_secret_manager_secret_iam_member.managed,
+    google_secret_manager_secret_version.managed,
+    google_project_service.required["run.googleapis.com"],
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "public" {
+  project  = var.project_id
+  location = google_cloud_run_v2_service.manifest.location
+  name     = google_cloud_run_v2_service.manifest.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "terraform_data" "set_better_auth_url" {
+  triggers_replace = [google_cloud_run_v2_service.manifest.uri]
+
+  provisioner "local-exec" {
+    command = "gcloud run services update ${google_cloud_run_v2_service.manifest.name} --project ${var.project_id} --region ${var.region} --update-env-vars 'BETTER_AUTH_URL=${google_cloud_run_v2_service.manifest.uri}' --quiet"
+  }
+
+  depends_on = [
+    google_cloud_run_v2_service.manifest,
+    google_cloud_run_v2_service_iam_member.public,
+  ]
+}

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -3,7 +3,7 @@ locals {
   name_prefix     = "${var.service_name}-${local.suffix}"
   database_name   = "manifest"
   database_user   = "manifest"
-  service_account = substr("${var.service_name}-${local.suffix}", 0, 30)
+  service_account = "${substr(var.service_name, 0, 23)}-${local.suffix}"
   database_url    = "postgresql://${local.database_user}:${urlencode(random_password.database.result)}@/${local.database_name}?host=${urlencode("/cloudsql/${google_sql_database_instance.manifest.connection_name}")}"
   managed_secret_ids = {
     database_url            = "${local.name_prefix}-database-url"
@@ -240,6 +240,8 @@ resource "google_cloud_run_v2_service" "manifest" {
   }
 
   depends_on = [
+    google_sql_database.manifest,
+    google_sql_user.manifest,
     google_project_iam_member.cloudsql_client,
     google_secret_manager_secret_iam_member.managed,
     google_secret_manager_secret_version.managed,

--- a/deploy/gcp/outputs.tf
+++ b/deploy/gcp/outputs.tf
@@ -1,0 +1,19 @@
+output "service_url" {
+  description = "Manifest Cloud Run URL."
+  value       = google_cloud_run_v2_service.manifest.uri
+}
+
+output "health_check_url" {
+  description = "Manifest health check URL."
+  value       = "${google_cloud_run_v2_service.manifest.uri}/api/v1/health"
+}
+
+output "database_instance" {
+  description = "Cloud SQL instance name."
+  value       = google_sql_database_instance.manifest.name
+}
+
+output "database_url_secret" {
+  description = "Secret Manager secret containing DATABASE_URL."
+  value       = google_secret_manager_secret.managed["database_url"].id
+}

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -15,8 +15,8 @@ variable "service_name" {
   default     = "manifest"
 
   validation {
-    condition     = can(regex("^[a-z][a-z0-9-]{0,39}$", var.service_name))
-    error_message = "service_name must start with a letter and contain at most 40 lowercase letters, numbers, or hyphens."
+    condition     = can(regex("^[a-z]([a-z0-9-]{0,38}[a-z0-9])?$", var.service_name))
+    error_message = "service_name must be 1-40 characters, start with a letter, end with a letter or number, and contain only lowercase letters, numbers, or hyphens."
   }
 }
 
@@ -41,5 +41,5 @@ variable "max_instances" {
 variable "database_deletion_protection" {
   description = "Protect the Cloud SQL instance from terraform destroy."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -1,0 +1,45 @@
+variable "project_id" {
+  description = "Google Cloud project ID to deploy Manifest into."
+  type        = string
+}
+
+variable "region" {
+  description = "Google Cloud region for Cloud Run and Cloud SQL."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "service_name" {
+  description = "Cloud Run service name. Use lowercase letters, numbers, and hyphens."
+  type        = string
+  default     = "manifest"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{0,39}$", var.service_name))
+    error_message = "service_name must start with a letter and contain at most 40 lowercase letters, numbers, or hyphens."
+  }
+}
+
+variable "image_url" {
+  description = "Manifest container image to deploy."
+  type        = string
+  default     = "docker.io/manifestdotbuild/manifest:6"
+}
+
+variable "database_tier" {
+  description = "Cloud SQL machine tier."
+  type        = string
+  default     = "db-f1-micro"
+}
+
+variable "max_instances" {
+  description = "Maximum number of Cloud Run instances. Keep this low for the starter deploy."
+  type        = number
+  default     = 1
+}
+
+variable "database_deletion_protection" {
+  description = "Protect the Cloud SQL instance from terraform destroy."
+  type        = bool
+  default     = false
+}

--- a/deploy/gcp/versions.tf
+++ b/deploy/gcp/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,35 @@
+services:
+  - type: web
+    name: manifest
+    runtime: image
+    image:
+      url: docker.io/manifestdotbuild/manifest:6
+    plan: free
+    numInstances: 1
+    healthCheckPath: /api/v1/health
+    autoDeployTrigger: off
+    envVars:
+      - key: PORT
+        value: 2099
+      - key: DATABASE_URL
+        fromDatabase:
+          name: manifest-postgres
+          property: connectionString
+      - key: BETTER_AUTH_SECRET
+        generateValue: true
+      - key: MANIFEST_ENCRYPTION_KEY
+        generateValue: true
+      - key: BETTER_AUTH_URL
+        fromService:
+          type: web
+          name: manifest
+          envVarKey: RENDER_EXTERNAL_URL
+      - key: MANIFEST_MODE
+        value: selfhosted
+
+databases:
+  - name: manifest-postgres
+    plan: free
+    databaseName: manifest
+    user: manifest
+    ipAllowList: []


### PR DESCRIPTION
### ✨ What changed
- Added Railway, Render, AWS, and GCP deploy buttons to README.
- Added Render, AWS, and GCP deployment templates.
- Published the AWS CloudFormation template for quick-create.

### 💭 Why
Self-hosters can start from a managed platform template instead of wiring every service by hand.

### 👤 For users
The README now links directly to managed deploy flows after the product GIF.

### 🔧 For operators
AWS provisions ECS Fargate, ALB, RDS PostgreSQL, and Secrets Manager.
GCP provisions Cloud Run, Cloud SQL PostgreSQL, and Secret Manager.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds one-click managed deploy options so self-hosters can launch Manifest fast, and incorporates template review fixes for consistent health checks, secret handling, and safer defaults.
The README now shows deploy buttons for Railway, Render, AWS, and GCP with ready-to-use templates.

- **New Features**
  - Render: `render.yaml` deploys the web service with Render PostgreSQL; generates secrets and sets `BETTER_AUTH_URL`.
  - AWS: CloudFormation (`deploy/aws/manifest.yaml`) with `deploy.sh` and `TUTORIAL.md`; provisions ECS Fargate, ALB, RDS, and Secrets Manager; quick-create uses the published template.
  - GCP: DeployStack + Terraform (`deploy/gcp/*`, `deploystack.json`, `TUTORIAL.md`); provisions Cloud Run, Cloud SQL, and Secret Manager; patches `BETTER_AUTH_URL` post-deploy.
  - README: Adds Railway, Render, AWS, and GCP deploy buttons and a table summarizing each option.

<sup>Written for commit 1fecb2ff8dce44ba9e4f4c8d4ad301a673570e05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

