### PR TITLE
feat: report the Manifest tenant id to Phoenix on heal requests

### DIFF
--- a/.changeset/heal-tenant-attribution.md
+++ b/.changeset/heal-tenant-attribution.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Report the Manifest tenant id to Phoenix on auto-fix heal requests, so failures are attributed to the tenant that hit them.

--- a/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
@@ -591,6 +591,7 @@ describe('AutofixService', () => {
       expect(arg.url).toBe('u');
       expect(arg.request).toEqual(requestBody);
       expect(typeof arg.traceId).toBe('string');
+      expect(arg.tenantId).toBe('tenant-1');
       expect(arg.response).toEqual({
         statusCode: 400,
         error: { message: 'boom', type: null, param: null, code: null },

--- a/packages/backend/src/routing/autofix/__tests__/http-healing-client.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/http-healing-client.spec.ts
@@ -14,6 +14,7 @@ function fakeResponse(ok: boolean, status: number, body: unknown): Response {
 function makeHealRequest(): HealRequest {
   return {
     traceId: 'trace-1',
+    tenantId: 'tenant-1',
     provider: 'openai',
     api: 'responses',
     request: { max_tokens: 100 },

--- a/packages/backend/src/routing/autofix/__tests__/mock-healing-client.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/mock-healing-client.spec.ts
@@ -8,6 +8,7 @@ import type { HealRequest, PhoenixProviderError } from '../phoenix.types';
 function makeRequest(error: PhoenixProviderError, request: Record<string, unknown>): HealRequest {
   return {
     traceId: 'trace-1',
+    tenantId: 'tenant-1',
     provider: 'openai',
     api: 'responses',
     request,

--- a/packages/backend/src/routing/autofix/__tests__/noop-healing-client.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/noop-healing-client.spec.ts
@@ -6,6 +6,7 @@ describe('NoopHealingClient', () => {
 
   const sampleRequest: HealRequest = {
     traceId: 'trace-1',
+    tenantId: 'tenant-1',
     provider: 'anthropic',
     api: 'chat_completions',
     request: { model: 'gpt', max_tokens: 100 },

--- a/packages/backend/src/routing/autofix/__tests__/phoenix-contract.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/phoenix-contract.spec.ts
@@ -65,6 +65,7 @@ describe('Phoenix wire contract (vendored OpenAPI)', () => {
     // Mirrors the heal() call in AutofixService.runHealOnce — keep them aligned.
     const valid = {
       traceId: 'trace-abc',
+      tenantId: 'tenant-abc',
       provider: 'openai',
       api: 'chat_completions',
       url: 'https://api.openai.com/v1/chat/completions',

--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -308,6 +308,7 @@ export class AutofixService {
     try {
       heal = await this.client.heal({
         traceId: groupId,
+        tenantId: params.tenantId,
         provider: params.provider,
         api: params.apiMode,
         url: params.url,

--- a/packages/backend/src/routing/autofix/contract/phoenix-openapi.yaml
+++ b/packages/backend/src/routing/autofix/contract/phoenix-openapi.yaml
@@ -317,6 +317,13 @@ components:
             same value on every heal of that request's retry chain (not the
             provider's per-call request id) — it groups the attempts into one
             trace.
+        tenantId:
+          type: string
+          minLength: 1
+          description: >
+            Opaque id of the gateway tenant this request belongs to (Manifest's
+            Tenant.id). Optional on the wire; recorded so a failure can be
+            attributed to a tenant. Manifest always sends it on the proxy path.
         provider: { type: string, minLength: 1, example: openai }
         api:
           type: string

--- a/packages/backend/src/routing/autofix/phoenix.types.ts
+++ b/packages/backend/src/routing/autofix/phoenix.types.ts
@@ -29,6 +29,14 @@ export interface HealRequest {
    * rejects a heal request without it (`400`).
    */
   traceId: string;
+  /**
+   * The Manifest tenant this request belongs to (`Tenant.id`). Attributes the
+   * failure to a customer so Phoenix can report affected tenants per issue and
+   * browse a tenant's failures. Always available on the proxy heal path (the
+   * agent key resolves a tenant), so we always send it; Phoenix treats it as an
+   * optional, opaque label.
+   */
+  tenantId: string;
   provider: string;
   api: ProxyApiMode;
   url?: string;


### PR DESCRIPTION
## What & why

When the auto-fix loop reports a failing provider call to Phoenix (`POST /api/heal`), it now includes the **tenant** that made the request. This lets Phoenix attribute failures to a customer — answering *"how many tenants are affected by this error"* and letting operators browse a single tenant's failures — instead of only counting raw occurrences.

The tenant id is our canonical `Tenant.id`, so the two systems connect the dots.

## Changes

- **`HealRequest`** (`phoenix.types.ts`) gains a required `tenantId: string`.
- **`AutofixService.runHealOnce`** forwards `params.tenantId` in the heal body. It's already in scope on the proxy heal path (the agent-key guard resolves a tenant), so no new threading — one line.
- **Vendored `contract/phoenix-openapi.yaml`** documents `tenantId` as an optional `HealRequest` property, matching Phoenix's own spec (Phoenix backfills `null` when absent; we always send it).
- Test fixtures updated in lockstep (`phoenix-contract`, `http-healing-client`, `mock-`/`noop-healing-client`, `autofix.service` — the last asserts the tenant is forwarded).
- Changeset added (`manifest: minor`).

`PATCH /api/heal-attempts/:id` is unchanged — Phoenix already has the tenant from the originating `/heal` call.

## Testing

- All **8 autofix suites pass (116 tests)** incl. the contract spec; backend `tsc --noEmit` clean.

## Companion PR

Phoenix side (stores + surfaces the tenant): **mnfst/phoenix#58** — *"attribute healed failures to gateway tenants"*. Deploy order is safe either way: an old Phoenix ignores the extra field; an old gateway just leaves `tenant_id` null.

> Targets `feat/autofix-healing` because the Phoenix heal client only exists on that branch (not `main`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-fix heal requests now include the Manifest tenant id, so Phoenix can attribute failures to a specific tenant and report how many tenants are affected.

- **New Features**
  - Added `tenantId` to `HealRequest` (required in types; optional in vendored OpenAPI, but we always send it).
  - `AutofixService.runHealOnce` forwards `params.tenantId` in the heal body.
  - Updated tests and `contract/phoenix-openapi.yaml`; remains backward compatible (older Phoenix ignores the extra field, older gateway leaves `tenant_id` null).

<sup>Written for commit 64422244b41e12dceb64075869dce408b1d175cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

