### PR TITLE
fix(proxy): rewrite max_tokens for custom OpenAI-compatible gpt-5/o-series endpoints (#2415)

### DIFF
--- a/.changeset/fix-custom-endpoint-max-completion-tokens.md
+++ b/.changeset/fix-custom-endpoint-max-completion-tokens.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix custom OpenAI-compatible providers (Azure Foundry / vLLM / LiteLLM) serving gpt-5 or o-series models: the outbound request now rewrites `max_tokens` to `max_completion_tokens`, matching native OpenAI and Copilot behavior, instead of sending `max_tokens` and getting a 400.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -831,6 +831,32 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_tokens');
     });
 
+    it('should convert max_tokens for a custom OpenAI-compatible endpoint serving GPT-5 (#2415)', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        model: 'gpt-5',
+        max_tokens: 4096,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'custom', 'gpt-5');
+
+      expect(result).toHaveProperty('max_completion_tokens', 4096);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should keep max_tokens for a custom endpoint serving a non o-series model', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        model: 'llama-3.1-70b',
+        max_tokens: 4096,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'custom', 'llama-3.1-70b');
+
+      expect(result).toHaveProperty('max_tokens', 4096);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
     it('should keep max_tokens for older OpenAI models (GPT-4)', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -803,7 +803,7 @@ describe('provider-client-converters', () => {
       expect(messages[1].tool_call_id).toBe(messages[0].tool_calls[0].id);
     });
 
-    /* ── max_tokens → max_completion_tokens for newer OpenAI models ── */
+    /* ── ModelParams-declared output token fields ── */
 
     it('should convert max_tokens to max_completion_tokens for GPT-5 models', () => {
       const body = {
@@ -812,7 +812,13 @@ describe('provider-client-converters', () => {
         max_tokens: 4096,
       };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5');
+      const result = sanitizeOpenAiBody(
+        body,
+        'openai',
+        'gpt-5',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 4096);
       expect(result).not.toHaveProperty('max_tokens');
@@ -825,7 +831,7 @@ describe('provider-client-converters', () => {
         max_tokens: 2048,
       };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'o3');
+      const result = sanitizeOpenAiBody(body, 'openai', 'o3', undefined, 'max_completion_tokens');
 
       expect(result).toHaveProperty('max_completion_tokens', 2048);
       expect(result).not.toHaveProperty('max_tokens');
@@ -838,7 +844,13 @@ describe('provider-client-converters', () => {
         max_tokens: 4096,
       };
 
-      const result = sanitizeOpenAiBody(body, 'custom', 'gpt-5');
+      const result = sanitizeOpenAiBody(
+        body,
+        'custom',
+        'gpt-5',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 4096);
       expect(result).not.toHaveProperty('max_tokens');
@@ -852,7 +864,13 @@ describe('provider-client-converters', () => {
         max_completion_tokens: 2000,
       };
 
-      const result = sanitizeOpenAiBody(body, 'custom', 'gpt-5');
+      const result = sanitizeOpenAiBody(
+        body,
+        'custom',
+        'gpt-5',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 2000);
       expect(result).not.toHaveProperty('max_tokens');
@@ -892,7 +910,13 @@ describe('provider-client-converters', () => {
         max_completion_tokens: 2000,
       };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5.2');
+      const result = sanitizeOpenAiBody(
+        body,
+        'openai',
+        'gpt-5.2',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 2000);
       expect(result).not.toHaveProperty('max_tokens');
@@ -911,30 +935,36 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_completion_tokens');
     });
 
-    /* ── max_tokens → max_completion_tokens: extended edge cases ── */
+    /* ── ModelParams generation-limit coverage ── */
 
     it('should convert max_tokens for o1 model', () => {
       const body = { messages: [], max_tokens: 2048 };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'o1');
+      const result = sanitizeOpenAiBody(body, 'openai', 'o1', undefined, 'max_completion_tokens');
 
       expect(result).toHaveProperty('max_completion_tokens', 2048);
       expect(result).not.toHaveProperty('max_tokens');
     });
 
-    it('should convert max_tokens for o1-mini model', () => {
+    it('should keep max_tokens when ModelParams declares the legacy field', () => {
       const body = { messages: [], max_tokens: 1024 };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'o1-mini');
+      const result = sanitizeOpenAiBody(body, 'openai', 'o1-mini', undefined, 'max_tokens');
 
-      expect(result).toHaveProperty('max_completion_tokens', 1024);
-      expect(result).not.toHaveProperty('max_tokens');
+      expect(result).toHaveProperty('max_tokens', 1024);
+      expect(result).not.toHaveProperty('max_completion_tokens');
     });
 
     it('should convert max_tokens for o3-mini model', () => {
       const body = { messages: [], max_tokens: 4096 };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'o3-mini');
+      const result = sanitizeOpenAiBody(
+        body,
+        'openai',
+        'o3-mini',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 4096);
       expect(result).not.toHaveProperty('max_tokens');
@@ -943,7 +973,13 @@ describe('provider-client-converters', () => {
     it('should convert max_tokens for o4-mini model', () => {
       const body = { messages: [], max_tokens: 8192 };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'o4-mini');
+      const result = sanitizeOpenAiBody(
+        body,
+        'openai',
+        'o4-mini',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 8192);
       expect(result).not.toHaveProperty('max_tokens');
@@ -952,7 +988,13 @@ describe('provider-client-converters', () => {
     it('should convert max_tokens for gpt-5.4 model', () => {
       const body = { messages: [], max_tokens: 16384 };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5.4');
+      const result = sanitizeOpenAiBody(
+        body,
+        'openai',
+        'gpt-5.4',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 16384);
       expect(result).not.toHaveProperty('max_tokens');
@@ -961,7 +1003,13 @@ describe('provider-client-converters', () => {
     it('should convert max_tokens for gpt-5-chat-latest model', () => {
       const body = { messages: [], max_tokens: 4096 };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5-chat-latest');
+      const result = sanitizeOpenAiBody(
+        body,
+        'openai',
+        'gpt-5-chat-latest',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 4096);
       expect(result).not.toHaveProperty('max_tokens');
@@ -997,51 +1045,28 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_completion_tokens');
     });
 
-    it('should handle case insensitivity for o-series regex', () => {
-      const body = { messages: [], max_tokens: 4096 };
-
-      const result = sanitizeOpenAiBody(body, 'openai', 'O3');
-
-      expect(result).toHaveProperty('max_completion_tokens', 4096);
-      expect(result).not.toHaveProperty('max_tokens');
-    });
-
-    it('should handle case insensitivity for GPT-5 regex', () => {
-      const body = { messages: [], max_tokens: 4096 };
-
-      const result = sanitizeOpenAiBody(body, 'openai', 'GPT-5');
-
-      expect(result).toHaveProperty('max_completion_tokens', 4096);
-      expect(result).not.toHaveProperty('max_tokens');
-    });
-
     it('should NOT convert when body has no max_tokens', () => {
       const body = { messages: [], model: 'gpt-5' };
 
-      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5');
+      const result = sanitizeOpenAiBody(
+        body,
+        'openai',
+        'gpt-5',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).not.toHaveProperty('max_tokens');
       expect(result).not.toHaveProperty('max_completion_tokens');
     });
 
-    it('should NOT match model names like "operative" that start with "o"', () => {
+    it('should keep max_tokens for o1-preview when ModelParams declares it', () => {
       const body = { messages: [], max_tokens: 4096 };
 
-      // "operative" starts with "o" but the regex is /^(o[134]|gpt-5)/i
-      // So "operative" won't match since it's o + non-[134] char
-      const result = sanitizeOpenAiBody(body, 'openai', 'operative');
+      const result = sanitizeOpenAiBody(body, 'openai', 'o1-preview', undefined, 'max_tokens');
 
       expect(result).toHaveProperty('max_tokens', 4096);
       expect(result).not.toHaveProperty('max_completion_tokens');
-    });
-
-    it('should match o1-preview model', () => {
-      const body = { messages: [], max_tokens: 4096 };
-
-      const result = sanitizeOpenAiBody(body, 'openai', 'o1-preview');
-
-      expect(result).toHaveProperty('max_completion_tokens', 4096);
-      expect(result).not.toHaveProperty('max_tokens');
     });
 
     /* ── Non-passthrough provider: max_completion_tokens conversion ── */
@@ -1083,12 +1108,18 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_completion_tokens');
     });
 
-    /* ── Copilot: max_tokens → max_completion_tokens (mnfst/manifest#1849) ── */
+    /* ── Copilot: ModelParams-declared output token field ── */
 
     it('should convert max_tokens to max_completion_tokens for Copilot GPT-5', () => {
       const body = { messages: [{ role: 'user', content: 'hi' }], max_tokens: 4096 };
 
-      const result = sanitizeOpenAiBody(body, 'copilot', 'gpt-5');
+      const result = sanitizeOpenAiBody(
+        body,
+        'copilot',
+        'gpt-5',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 4096);
       expect(result).not.toHaveProperty('max_tokens');
@@ -1097,7 +1128,13 @@ describe('provider-client-converters', () => {
     it('should convert max_tokens to max_completion_tokens for Copilot o-series', () => {
       const body = { messages: [], max_tokens: 2048 };
 
-      const result = sanitizeOpenAiBody(body, 'copilot', 'o3-mini');
+      const result = sanitizeOpenAiBody(
+        body,
+        'copilot',
+        'o3-mini',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 2048);
       expect(result).not.toHaveProperty('max_tokens');
@@ -1106,7 +1143,13 @@ describe('provider-client-converters', () => {
     it('should preserve max_completion_tokens unchanged for Copilot GPT-5 family', () => {
       const body = { messages: [], max_completion_tokens: 1024 };
 
-      const result = sanitizeOpenAiBody(body, 'copilot', 'gpt-5.2');
+      const result = sanitizeOpenAiBody(
+        body,
+        'copilot',
+        'gpt-5.2',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 1024);
       expect(result).not.toHaveProperty('max_tokens');
@@ -1129,7 +1172,13 @@ describe('provider-client-converters', () => {
         service_tier: 'auto',
       };
 
-      const result = sanitizeOpenAiBody(body, 'copilot', 'gpt-5');
+      const result = sanitizeOpenAiBody(
+        body,
+        'copilot',
+        'gpt-5',
+        undefined,
+        'max_completion_tokens',
+      );
 
       expect(result).toHaveProperty('max_completion_tokens', 4096);
       expect(result).not.toHaveProperty('store');

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -844,6 +844,20 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_tokens');
     });
 
+    it('should remove max_tokens when a custom GPT-5 endpoint receives both token limits', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        model: 'gpt-5',
+        max_tokens: 1000,
+        max_completion_tokens: 2000,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'custom', 'gpt-5');
+
+      expect(result).toHaveProperty('max_completion_tokens', 2000);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
     it('should keep max_tokens for a custom endpoint serving a non o-series model', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],
@@ -870,7 +884,7 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_completion_tokens');
     });
 
-    it('should not convert when max_completion_tokens already present', () => {
+    it('should remove max_tokens when max_completion_tokens is already present', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],
         model: 'gpt-5.2',
@@ -881,7 +895,7 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5.2');
 
       expect(result).toHaveProperty('max_completion_tokens', 2000);
-      expect(result).toHaveProperty('max_tokens', 1000);
+      expect(result).not.toHaveProperty('max_tokens');
     });
 
     it('should not convert max_tokens for non-OpenAI providers', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-model-params.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-model-params.spec.ts
@@ -1,0 +1,59 @@
+import { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
+import { ProviderClient } from '../provider-client';
+import { buildCustomEndpoint } from '../provider-endpoints';
+
+const mockFetch = jest.fn();
+(globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
+
+describe('ProviderClient — ModelParams output token fields', () => {
+  const client = new ProviderClient(
+    undefined,
+    undefined,
+    undefined,
+    new ProviderParamSpecService(),
+  );
+  const customEndpoint = buildCustomEndpoint('https://upstream.example.com');
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+  });
+
+  it('uses the ModelParams-declared completion field for a custom GPT-5 endpoint', async () => {
+    await client.forward({
+      provider: 'custom:azure',
+      apiKey: 'sk-custom',
+      model: 'gpt-5.4-mini',
+      body: {
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 1024,
+      },
+      stream: false,
+      authType: 'api_key',
+      customEndpoint,
+    });
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.max_completion_tokens).toBe(1024);
+    expect(sentBody.max_tokens).toBeUndefined();
+  });
+
+  it('keeps max_tokens when ModelParams declares the legacy field', async () => {
+    await client.forward({
+      provider: 'custom:azure',
+      apiKey: 'sk-custom',
+      model: 'o1-mini',
+      body: {
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 1024,
+      },
+      stream: false,
+      authType: 'api_key',
+      customEndpoint,
+    });
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.max_tokens).toBe(1024);
+    expect(sentBody.max_completion_tokens).toBeUndefined();
+  });
+});

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -123,9 +123,13 @@ const OPENAI_MAX_COMPLETION_TOKENS_RE = /^(o\d|gpt-5)/i;
  * Endpoints that ultimately hit OpenAI infrastructure and therefore need
  * `max_tokens` rewritten to `max_completion_tokens` for o-series / GPT-5+.
  * Copilot belongs here because GitHub Copilot proxies these models to OpenAI
- * (issue mnfst/manifest#1849).
+ * (issue mnfst/manifest#1849). Custom providers are OpenAI-compatible endpoints
+ * (Azure Foundry / vLLM / LiteLLM / OpenRouter-style), which reject `max_tokens`
+ * with a 400 when fronting a gpt-5 / o-series model (issue mnfst/manifest#2415).
+ * The model regex still gates the rewrite, so non o-series custom models are
+ * left untouched.
  */
-const OPENAI_MAX_COMPLETION_TOKENS_ENDPOINTS = new Set(['openai', 'copilot']);
+const OPENAI_MAX_COMPLETION_TOKENS_ENDPOINTS = new Set(['openai', 'copilot', 'custom']);
 
 function usesOpenAiMaxCompletionTokens(endpointKey: string, bareModel: string): boolean {
   return (

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -371,8 +371,7 @@ export function sanitizeOpenAiBody(
   // Strip vendor prefix (e.g., "openai/gpt-5" → "gpt-5") before matching.
   const bareForRegex = model.includes('/') ? model.substring(model.indexOf('/') + 1) : model;
   const needsMaxCompletionTokens = usesOpenAiMaxCompletionTokens(endpointKey, bareForRegex);
-  const convertMaxTokens =
-    needsMaxCompletionTokens && 'max_tokens' in body && !('max_completion_tokens' in body);
+  const convertMaxTokens = needsMaxCompletionTokens && 'max_tokens' in body;
 
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
@@ -384,7 +383,11 @@ export function sanitizeOpenAiBody(
     // require it (native OpenAI + Copilot for o-series / GPT-5+). Applies in both
     // passthrough and non-passthrough branches.
     if (convertMaxTokens && key === 'max_tokens') {
-      cleaned['max_completion_tokens'] = value;
+      // Preserve an explicit max_completion_tokens value while removing the
+      // incompatible legacy parameter.
+      if (!('max_completion_tokens' in body)) {
+        cleaned['max_completion_tokens'] = value;
+      }
       continue;
     }
     if (passthroughTopLevel) {

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -113,31 +113,6 @@ const OLLAMA_ENDPOINTS = new Set(['ollama', 'ollama-cloud']);
 const MISTRAL_TOOL_CALL_ID_REGEX = /^[A-Za-z0-9]{9}$/;
 const DEEPSEEK_MAX_TOKENS_LIMIT = 8192;
 
-/**
- * OpenAI models that require `max_completion_tokens` instead of `max_tokens`.
- * All o-series reasoning models and GPT-5+ models use the new parameter.
- */
-const OPENAI_MAX_COMPLETION_TOKENS_RE = /^(o\d|gpt-5)/i;
-
-/**
- * Endpoints that ultimately hit OpenAI infrastructure and therefore need
- * `max_tokens` rewritten to `max_completion_tokens` for o-series / GPT-5+.
- * Copilot belongs here because GitHub Copilot proxies these models to OpenAI
- * (issue mnfst/manifest#1849). Custom providers are OpenAI-compatible endpoints
- * (Azure Foundry / vLLM / LiteLLM / OpenRouter-style), which reject `max_tokens`
- * with a 400 when fronting a gpt-5 / o-series model (issue mnfst/manifest#2415).
- * The model regex still gates the rewrite, so non o-series custom models are
- * left untouched.
- */
-const OPENAI_MAX_COMPLETION_TOKENS_ENDPOINTS = new Set(['openai', 'copilot', 'custom']);
-
-function usesOpenAiMaxCompletionTokens(endpointKey: string, bareModel: string): boolean {
-  return (
-    OPENAI_MAX_COMPLETION_TOKENS_ENDPOINTS.has(endpointKey) &&
-    OPENAI_MAX_COMPLETION_TOKENS_RE.test(bareModel)
-  );
-}
-
 export type ReasoningContentCallback = (firstToolCallId: string, content: string) => void;
 
 /**
@@ -365,12 +340,11 @@ export function sanitizeOpenAiBody(
   endpointKey: string,
   model: string,
   reasoningContentLookup?: (firstToolCallId: string) => string | null,
+  outputTokenParameter?: 'max_tokens' | 'max_completion_tokens' | null,
 ): Record<string, unknown> {
   const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
-  // Strip vendor prefix (e.g., "openai/gpt-5" → "gpt-5") before matching.
-  const bareForRegex = model.includes('/') ? model.substring(model.indexOf('/') + 1) : model;
-  const needsMaxCompletionTokens = usesOpenAiMaxCompletionTokens(endpointKey, bareForRegex);
+  const needsMaxCompletionTokens = outputTokenParameter === 'max_completion_tokens';
   const convertMaxTokens = needsMaxCompletionTokens && 'max_tokens' in body;
 
   const cleaned: Record<string, unknown> = {};
@@ -379,9 +353,8 @@ export function sanitizeOpenAiBody(
       cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model, reasoningContentLookup);
       continue;
     }
-    // Rewrite max_tokens → max_completion_tokens for OpenAI-backed endpoints that
-    // require it (native OpenAI + Copilot for o-series / GPT-5+). Applies in both
-    // passthrough and non-passthrough branches.
+    // ModelParams declares the field the resolved model accepts; the endpoint
+    // descriptor already verified that its wire schema honors that declaration.
     if (convertMaxTokens && key === 'max_tokens') {
       // Preserve an explicit max_completion_tokens value while removing the
       // incompatible legacy parameter.

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -30,6 +30,11 @@ import { toNativeResponsesRequest } from './responses-adapter';
 import { forwardKiroChat } from './kiro-adapter';
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
 import { ProviderModelRegistryService } from '../../model-discovery/provider-model-registry.service';
+import {
+  ProviderParamSpecService,
+  type OutputTokenParameter,
+} from '../routing-core/provider-param-spec.service';
+import type { AuthType } from 'manifest-shared';
 
 export interface ForwardResult {
   response: Response;
@@ -193,6 +198,8 @@ export class ProviderClient {
     private readonly modelRegistry?: ProviderModelRegistryService,
     @Optional()
     codexAffinity?: CodexSessionAffinity,
+    @Optional()
+    private readonly providerParamSpecs?: ProviderParamSpecService,
   ) {
     this.codexAffinity = codexAffinity ?? new CodexSessionAffinity();
   }
@@ -225,6 +232,13 @@ export class ProviderClient {
     const textFormat = responsesTextFormat(body, opts.apiMode);
 
     const bareModel = stripModelPrefix(model, endpointKey);
+    const outputTokenParameter = endpoint.usesModelParamOutputTokenField
+      ? await this.providerParamSpecs?.getOutputTokenParameter(
+          provider,
+          authType as AuthType | undefined,
+          bareModel,
+        )
+      : null;
     if (endpoint.format === 'kiro') {
       const requestSource =
         opts.apiMode && opts.apiMode !== 'chat_completions' ? (opts.chatBody ?? body) : body;
@@ -263,6 +277,7 @@ export class ProviderClient {
       reasoningContentLookup: opts.reasoningContentLookup,
       providerResource: opts.providerResource,
       sessionKey: opts.sessionKey,
+      outputTokenParameter,
     });
 
     // The Codex backend only serves prompt-cache hits with session affinity
@@ -458,6 +473,7 @@ export class ProviderClient {
     reasoningContentLookup?: ForwardOptions['reasoningContentLookup'];
     providerResource?: string;
     sessionKey?: string;
+    outputTokenParameter?: OutputTokenParameter | null;
   }): BuiltProviderRequest {
     const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
     // For non-chat_completions inbound modes ('responses', 'messages'), the
@@ -594,6 +610,7 @@ export class ProviderClient {
       endpointKey,
       ctx.model,
       ctx.reasoningContentLookup,
+      ctx.outputTokenParameter,
     );
     if (stream && endpoint.streamUsageReporting === 'openai_stream_options') {
       const existing =

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -34,6 +34,12 @@ export interface ProviderEndpoint {
    */
   streamUsageReporting?: 'openai_stream_options';
   /**
+   * This endpoint accepts the model-native output-token parameter declared by
+   * ModelParams. Gate the aliasing here because gateways such as OpenRouter
+   * expose their own public request grammar even when they serve OpenAI models.
+   */
+  usesModelParamOutputTokenField?: boolean;
+  /**
    * Set to `true` for endpoints whose `baseUrl` is user-supplied (custom
    * providers, subscription resource URLs). The proxy re-runs SSRF
    * validation against this URL immediately before each forward to defend
@@ -133,6 +139,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    usesModelParamOutputTokenField: true,
     ...openaiStreamUsage,
   },
   'openai-subscription': {
@@ -387,6 +394,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     }),
     buildPath: () => '/chat/completions',
     format: 'openai',
+    usesModelParamOutputTokenField: true,
     ...openaiStreamUsage,
   },
   // Codex variants (e.g. gpt-5-codex, gpt-5.2-codex, gpt-5.3-codex) only accept
@@ -503,6 +511,7 @@ export function buildCustomEndpoint(
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    usesModelParamOutputTokenField: true,
     ...openaiStreamUsage,
     requiresSsrfRevalidation: true,
   };

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -134,6 +134,17 @@ describe('ProviderParamSpecService', () => {
     );
   });
 
+  it('resolves the output-token field from ModelParams for custom OpenAI-compatible routes', async () => {
+    const service = new ProviderParamSpecService();
+
+    await expect(
+      service.getOutputTokenParameter('custom:azure', 'api_key', 'gpt-5.4-mini'),
+    ).resolves.toBe('max_completion_tokens');
+    await expect(
+      service.getOutputTokenParameter('custom:azure', 'api_key', 'o1-mini'),
+    ).resolves.toBe('max_tokens');
+  });
+
   it('falls back to package API-key specs for subscription routes without subscription specs', async () => {
     const service = new ProviderParamSpecService();
 

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -59,6 +59,9 @@ interface ProviderlessModelParamCandidate {
   model: string;
 }
 
+/** The generation-limit field accepted by an OpenAI-compatible wire endpoint. */
+export type OutputTokenParameter = 'max_tokens' | 'max_completion_tokens';
+
 const requireFromThisModule = createRequire(__filename);
 
 @Injectable()
@@ -115,6 +118,25 @@ export class ProviderParamSpecService {
     const metadata = providerMetadataIdentity(providerId, model);
     if (!metadata || metadataMatchesRoute(metadata, providerId, model)) return direct;
     return getProviderModelCapabilities(this.specs, metadata.provider, authType, metadata.model);
+  }
+
+  /**
+   * Resolve the model-declared output-token field. The catalog is authoritative
+   * here: a model that exposes only `max_completion_tokens` must not receive
+   * the legacy `max_tokens` field, while models that expose only `max_tokens`
+   * keep that name.
+   */
+  async getOutputTokenParameter(
+    providerId: string | undefined,
+    authType: AuthType | undefined,
+    model: string | undefined,
+  ): Promise<OutputTokenParameter | null> {
+    const specs = await this.getSpecs(providerId, authType, model);
+    const hasMaxTokens = specs.some((spec) => spec.path === 'max_tokens');
+    const hasMaxCompletionTokens = specs.some((spec) => spec.path === 'max_completion_tokens');
+
+    if (hasMaxTokens === hasMaxCompletionTokens) return null;
+    return hasMaxCompletionTokens ? 'max_completion_tokens' : 'max_tokens';
   }
 
   private getProviderlessSpecs(


### PR DESCRIPTION
## Summary

The `max_tokens` to `max_completion_tokens` rewrite for o-series / gpt-5 models (added in #1878) is gated to the `openai` and `copilot` endpoints in `usesOpenAiMaxCompletionTokens` (`provider-client-converters.ts`). A `custom` provider fronting an OpenAI-compatible upstream (Azure Foundry / vLLM / LiteLLM / OpenRouter-style) that serves `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, or any o-series model therefore still sends `max_tokens` and is rejected by the upstream with HTTP 400 `unsupported_parameter`. This is the same symptom as #1878, now for hybrid deployments (subscription OpenAI for some models, a custom OpenAI-compatible endpoint for others).

Fixes #2415.

## Change

Add `custom` to `OPENAI_MAX_COMPLETION_TOKENS_ENDPOINTS`. Custom providers are OpenAI-compatible endpoints (Anthropic and Google have their own adapters), so they belong in the same rewrite path as native OpenAI and Copilot. The rewrite already runs before the passthrough branch in `sanitizeOpenAiBody`, and the existing model regex still gates it, so non o-series custom models are left untouched.

## Tests

Added to `provider-client-converters.spec.ts`:
- a `custom` endpoint serving `gpt-5` rewrites `max_tokens` to `max_completion_tokens` (the reported bug);
- a `custom` endpoint serving a non o-series model keeps `max_tokens` (guard against over-application).

The full proxy suite passes (1864 tests) and ESLint is clean on the changed files. Added a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the output token limit based on ModelParams for OpenAI‑compatible endpoints (`openai`, `copilot`, `custom`). Converts `max_tokens` to `max_completion_tokens` for `gpt-5`/o‑series and removes the legacy field when both are sent, fixing 400s on custom upstreams. Fixes #2415.

- **Bug Fixes**
  - Apply conversion for `custom` OpenAI‑compatible endpoints serving `gpt-5`/o‑series; drop `max_tokens` if `max_completion_tokens` is present.
  - Keep `max_tokens` for models that still use it (e.g., `o1-mini`); non o‑series models unchanged.

- **Refactors**
  - Source the output-token field from ModelParams via `ProviderParamSpecService`; endpoints opt in with `usesModelParamOutputTokenField`.
  - Update sanitization to use the resolved field instead of regex/endpoint lists; add focused tests.

<sup>Written for commit 04d5eb57de507b2eca7d67b0ae25affd2a074539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

