### PR TITLE
feat: add DigitalOcean deploy template

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,50 @@
+spec:
+  name: manifest
+  region: nyc
+  services:
+    - name: manifest
+      image:
+        registry_type: DOCKER_HUB
+        registry: manifestdotbuild
+        repository: manifest
+        tag: "6"
+      instance_count: 1
+      instance_size_slug: apps-s-1vcpu-1gb
+      http_port: 2099
+      health_check:
+        http_path: /api/v1/health
+        port: 2099
+        initial_delay_seconds: 30
+        period_seconds: 10
+        timeout_seconds: 5
+        success_threshold: 1
+        failure_threshold: 6
+      envs:
+        - key: BIND_ADDRESS
+          scope: RUN_TIME
+          value: 0.0.0.0
+        - key: MANIFEST_MODE
+          scope: RUN_TIME
+          value: selfhosted
+        - key: DATABASE_URL
+          scope: RUN_TIME
+          value: "${manifest-db.DATABASE_URL}&uselibpqcompat=true"
+        - key: BETTER_AUTH_URL
+          scope: RUN_TIME
+          value: "${APP_URL}"
+        - key: BETTER_AUTH_SECRET
+          scope: RUN_TIME
+          type: SECRET
+        - key: MANIFEST_ENCRYPTION_KEY
+          scope: RUN_TIME
+          type: SECRET
+        - key: DB_POOL_MAX
+          scope: RUN_TIME
+          value: "10"
+        - key: AUTH_DB_POOL_MAX
+          scope: RUN_TIME
+          value: "5"
+  databases:
+    - name: manifest-db
+      engine: PG
+      version: "16"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Plug your AI agents into any provider
   <a href="https://railway.com/deploy/wild-wild" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Railway-0B0D0E?style=for-the-badge&amp;logo=railway&amp;logoColor=white" alt="Deploy on Railway" /></a>
   <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?stackName=manifest&amp;templateURL=https%3A%2F%2Fmnfst-manifest-deploy-templates.s3.us-east-1.amazonaws.com%2Fmanifest.yaml" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-AWS-232F3E?style=for-the-badge&amp;logo=amazonwebservices&amp;logoColor=white" alt="Deploy on AWS" /></a>
   <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fmnfst%2Fmanifest&amp;cloudshell_workspace=deploy%2Fgcp&amp;cloudshell_tutorial=TUTORIAL.md&amp;cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image&amp;shellonly=true" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-GCP-4285F4?style=for-the-badge&amp;logo=googlecloud&amp;logoColor=white" alt="Deploy on GCP" /></a>
+  <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/mnfst/manifest/tree/main" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-DigitalOcean-0080FF?style=for-the-badge&amp;logo=digitalocean&amp;logoColor=white" alt="Deploy on DigitalOcean" /></a>
 </p>
 
 <p align="center">
@@ -73,6 +74,7 @@ Managed deployment options:
 | [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Manifest web service plus Render PostgreSQL from [render.yaml](render.yaml). |
 | [AWS](deploy/aws/TUTORIAL.md) | ECS Fargate, Application Load Balancer, RDS PostgreSQL, and Secrets Manager via CloudFormation. |
 | [GCP](deploy/gcp/TUTORIAL.md) | Cloud Run, Cloud SQL for PostgreSQL, and Secret Manager via the Cloud Shell tutorial. |
+| [DigitalOcean](deploy/digitalocean/TUTORIAL.md) | App Platform service plus Dev PostgreSQL from [.do/deploy.template.yaml](.do/deploy.template.yaml). |
 
 > The legacy `manifest` npm package is deprecated and no longer published.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Plug your AI agents into any provider
   <a href="https://railway.com/deploy/wild-wild" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Railway-0B0D0E?style=for-the-badge&amp;logo=railway&amp;logoColor=white" alt="Deploy on Railway" /></a>
   <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?stackName=manifest&amp;templateURL=https%3A%2F%2Fmnfst-manifest-deploy-templates.s3.us-east-1.amazonaws.com%2Fmanifest.yaml" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-AWS-232F3E?style=for-the-badge&amp;logo=amazonwebservices&amp;logoColor=white" alt="Deploy on AWS" /></a>
   <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fmnfst%2Fmanifest&amp;cloudshell_workspace=deploy%2Fgcp&amp;cloudshell_tutorial=TUTORIAL.md&amp;cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image&amp;shellonly=true" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-GCP-4285F4?style=for-the-badge&amp;logo=googlecloud&amp;logoColor=white" alt="Deploy on GCP" /></a>
-  <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/mnfst/manifest/tree/main" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-DigitalOcean-0080FF?style=for-the-badge&amp;logo=digitalocean&amp;logoColor=white" alt="Deploy on DigitalOcean" /></a>
 </p>
 
 <p align="center">
@@ -66,15 +65,15 @@ bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/in
 
 Open [http://localhost:2099](http://localhost:2099) and sign up — the first account you create becomes the admin. Full self-hosting guide: [docker/DOCKER_README.md](docker/DOCKER_README.md).
 
-Managed deployment options:
+### Deploy with one click
 
-| Platform | What it provisions |
+| Platform | Notes |
 | --- | --- |
-| [Railway](https://railway.com/deploy/wild-wild) | Manifest plus PostgreSQL from the public Railway template. |
-| [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Manifest web service plus Render PostgreSQL from [render.yaml](render.yaml). |
-| [AWS](deploy/aws/TUTORIAL.md) | ECS Fargate, Application Load Balancer, RDS PostgreSQL, and Secrets Manager via CloudFormation. |
-| [GCP](deploy/gcp/TUTORIAL.md) | Cloud Run, Cloud SQL for PostgreSQL, and Secret Manager via the Cloud Shell tutorial. |
-| [DigitalOcean](deploy/digitalocean/TUTORIAL.md) | App Platform service plus Dev PostgreSQL from [.do/deploy.template.yaml](.do/deploy.template.yaml). |
+| [Railway](https://railway.com/deploy/wild-wild) | Best path. Template includes Manifest and PostgreSQL. |
+| [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Blueprint includes Manifest and Render PostgreSQL. |
+| [DigitalOcean](deploy/digitalocean/TUTORIAL.md) | App Platform button includes Manifest and a Dev PostgreSQL database. |
+| [AWS](deploy/aws/TUTORIAL.md) | CloudFormation quick-create for ECS, RDS, and Secrets Manager. |
+| [GCP](deploy/gcp/TUTORIAL.md) | Cloud Shell guided deploy for Cloud Run, Cloud SQL, and Secret Manager. |
 
 > The legacy `manifest` npm package is deprecated and no longer published.
 

--- a/deploy/digitalocean/TUTORIAL.md
+++ b/deploy/digitalocean/TUTORIAL.md
@@ -1,6 +1,6 @@
 # Deploy Manifest on DigitalOcean
 
-This deploys Manifest on DigitalOcean App Platform with a web service and Dev PostgreSQL database. The README badge uses DigitalOcean's Deploy to DigitalOcean flow, which reads `.do/deploy.template.yaml` from the public repository.
+This deploys Manifest on DigitalOcean App Platform with a web service and Dev PostgreSQL database. The deploy link uses DigitalOcean's Deploy to DigitalOcean flow, which reads `.do/deploy.template.yaml` from the public repository.
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@ This stack creates paid resources, including an App Platform service and Dev Pos
 
 ## Deploy
 
-Open the README badge or go directly to:
+Open the DigitalOcean deploy link:
 
 ```text
 https://cloud.digitalocean.com/apps/new?repo=https://github.com/mnfst/manifest/tree/main

--- a/deploy/digitalocean/TUTORIAL.md
+++ b/deploy/digitalocean/TUTORIAL.md
@@ -1,0 +1,48 @@
+# Deploy Manifest on DigitalOcean
+
+This deploys Manifest on DigitalOcean App Platform with a web service and Dev PostgreSQL database. The README badge uses DigitalOcean's Deploy to DigitalOcean flow, which reads `.do/deploy.template.yaml` from the public repository.
+
+## Prerequisites
+
+- A DigitalOcean account with billing enabled.
+- Access to App Platform in the selected region.
+
+This stack creates paid resources, including an App Platform service and Dev PostgreSQL database.
+
+## Deploy
+
+Open the README badge or go directly to:
+
+```text
+https://cloud.digitalocean.com/apps/new?repo=https://github.com/mnfst/manifest/tree/main
+```
+
+DigitalOcean prompts for the missing secret values before deployment. Generate and paste separate values for:
+
+```bash
+openssl rand -hex 32
+```
+
+Use one generated value for `BETTER_AUTH_SECRET` and another for `MANIFEST_ENCRYPTION_KEY`.
+
+## Open Manifest
+
+After App Platform finishes deploying, open the app URL and create the first account. The first account becomes the admin.
+
+To verify the deployment, open:
+
+```text
+https://<your-app-url>/api/v1/health
+```
+
+## Notes
+
+DigitalOcean's deploy button supports public repositories and Dev Databases. For production data, upgrade the Dev Database to a managed database from the DigitalOcean App Platform settings.
+
+The template appends `uselibpqcompat=true` to DigitalOcean's PostgreSQL URL so Node `pg` handles the platform's `sslmode=require` connection string correctly.
+
+Relevant DigitalOcean docs:
+
+- [Deploy to DigitalOcean button](https://docs.digitalocean.com/products/app-platform/how-to/add-deploy-do-button/)
+- [App Platform app spec](https://docs.digitalocean.com/products/app-platform/reference/app-spec/)
+- [Bindable environment variables](https://docs.digitalocean.com/products/app-platform/how-to/use-environment-variables/#using-bindable-variables-within-environment-variables)


### PR DESCRIPTION
### ✨ What changed
- Add a DigitalOcean App Platform deploy template.
- Rename the README table to `Deploy with one click`.
- Document DigitalOcean secret prompts and Dev Database limits.

### 💭 Why
Manifest already has deploy paths for Railway, Render, AWS, and GCP. DigitalOcean covers App Platform users with the same public Docker image.

### 👤 For users
The README now lists DigitalOcean in the deploy options table.

### 🔧 For operators
The DigitalOcean deploy form prompts for `BETTER_AUTH_SECRET` and `MANIFEST_ENCRYPTION_KEY`.