### PR TITLE
feat: add Heroku deploy template

### DIFF
--- a/Dockerfile.heroku
+++ b/Dockerfile.heroku
@@ -1,0 +1,1 @@
+FROM docker.io/manifestdotbuild/manifest:6

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Plug your AI agents into any provider
   <a href="https://railway.com/deploy/wild-wild" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Railway-0B0D0E?style=for-the-badge&amp;logo=railway&amp;logoColor=white" alt="Deploy on Railway" /></a>
   <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?stackName=manifest&amp;templateURL=https%3A%2F%2Fmnfst-manifest-deploy-templates.s3.us-east-1.amazonaws.com%2Fmanifest.yaml" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-AWS-232F3E?style=for-the-badge&amp;logo=amazonwebservices&amp;logoColor=white" alt="Deploy on AWS" /></a>
   <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fmnfst%2Fmanifest&amp;cloudshell_workspace=deploy%2Fgcp&amp;cloudshell_tutorial=TUTORIAL.md&amp;cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image&amp;shellonly=true" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-GCP-4285F4?style=for-the-badge&amp;logo=googlecloud&amp;logoColor=white" alt="Deploy on GCP" /></a>
-  <a href="https://www.heroku.com/deploy?template=https://github.com/mnfst/manifest" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Heroku-430098?style=for-the-badge&amp;logo=heroku&amp;logoColor=white" alt="Deploy on Heroku" /></a>
 </p>
 
 <p align="center">
@@ -66,15 +65,15 @@ bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/in
 
 Open [http://localhost:2099](http://localhost:2099) and sign up — the first account you create becomes the admin. Full self-hosting guide: [docker/DOCKER_README.md](docker/DOCKER_README.md).
 
-Managed deployment options:
+### Deploy with one click
 
-| Platform | What it provisions |
+| Platform | Notes |
 | --- | --- |
-| [Railway](https://railway.com/deploy/wild-wild) | Manifest plus PostgreSQL from the public Railway template. |
-| [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Manifest web service plus Render PostgreSQL from [render.yaml](render.yaml). |
-| [AWS](deploy/aws/TUTORIAL.md) | ECS Fargate, Application Load Balancer, RDS PostgreSQL, and Secrets Manager via CloudFormation. |
-| [GCP](deploy/gcp/TUTORIAL.md) | Cloud Run, Cloud SQL for PostgreSQL, and Secret Manager via the Cloud Shell tutorial. |
-| [Heroku](deploy/heroku/TUTORIAL.md) | Manifest web dyno plus Heroku Postgres from [app.json](app.json) and [heroku.yml](heroku.yml). |
+| [Railway](https://railway.com/deploy/wild-wild) | Best path. Template includes Manifest and PostgreSQL. |
+| [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Blueprint includes Manifest and Render PostgreSQL. |
+| [Heroku](deploy/heroku/TUTORIAL.md) | Button includes Manifest and Heroku Postgres. Set `BETTER_AUTH_URL=https://<app-name>.herokuapp.com`. |
+| [AWS](deploy/aws/TUTORIAL.md) | CloudFormation quick-create for ECS, RDS, and Secrets Manager. |
+| [GCP](deploy/gcp/TUTORIAL.md) | Cloud Shell guided deploy for Cloud Run, Cloud SQL, and Secret Manager. |
 
 > The legacy `manifest` npm package is deprecated and no longer published.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Plug your AI agents into any provider
   <a href="https://railway.com/deploy/wild-wild" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Railway-0B0D0E?style=for-the-badge&amp;logo=railway&amp;logoColor=white" alt="Deploy on Railway" /></a>
   <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?stackName=manifest&amp;templateURL=https%3A%2F%2Fmnfst-manifest-deploy-templates.s3.us-east-1.amazonaws.com%2Fmanifest.yaml" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-AWS-232F3E?style=for-the-badge&amp;logo=amazonwebservices&amp;logoColor=white" alt="Deploy on AWS" /></a>
   <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fmnfst%2Fmanifest&amp;cloudshell_workspace=deploy%2Fgcp&amp;cloudshell_tutorial=TUTORIAL.md&amp;cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image&amp;shellonly=true" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-GCP-4285F4?style=for-the-badge&amp;logo=googlecloud&amp;logoColor=white" alt="Deploy on GCP" /></a>
+  <a href="https://www.heroku.com/deploy?template=https://github.com/mnfst/manifest" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Heroku-430098?style=for-the-badge&amp;logo=heroku&amp;logoColor=white" alt="Deploy on Heroku" /></a>
 </p>
 
 <p align="center">
@@ -73,6 +74,7 @@ Managed deployment options:
 | [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Manifest web service plus Render PostgreSQL from [render.yaml](render.yaml). |
 | [AWS](deploy/aws/TUTORIAL.md) | ECS Fargate, Application Load Balancer, RDS PostgreSQL, and Secrets Manager via CloudFormation. |
 | [GCP](deploy/gcp/TUTORIAL.md) | Cloud Run, Cloud SQL for PostgreSQL, and Secret Manager via the Cloud Shell tutorial. |
+| [Heroku](deploy/heroku/TUTORIAL.md) | Manifest web dyno plus Heroku Postgres from [app.json](app.json) and [heroku.yml](heroku.yml). |
 
 > The legacy `manifest` npm package is deprecated and no longer published.
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,66 @@
+{
+  "name": "Manifest",
+  "description": "Open-source AI model router for agents and apps. Connect your providers to one OpenAI-compatible endpoint.",
+  "repository": "https://github.com/mnfst/manifest",
+  "website": "https://manifest.build",
+  "logo": "https://raw.githubusercontent.com/mnfst/manifest/HEAD/.github/assets/logo-dark.svg",
+  "success_url": "/setup",
+  "stack": "container",
+  "keywords": [
+    "ai",
+    "llm",
+    "model-router",
+    "agents",
+    "postgres"
+  ],
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "basic"
+    }
+  },
+  "addons": [
+    {
+      "plan": "heroku-postgresql:essential-0",
+      "as": "DATABASE"
+    }
+  ],
+  "env": {
+    "BETTER_AUTH_URL": {
+      "description": "Public URL for this Heroku app, for example https://your-app-name.herokuapp.com. Use the app name you choose above.",
+      "required": true
+    },
+    "BETTER_AUTH_SECRET": {
+      "description": "Session signing secret. Heroku generates a secure value for you.",
+      "generator": "secret"
+    },
+    "MANIFEST_ENCRYPTION_KEY": {
+      "description": "Separate at-rest encryption key for provider credentials. Heroku generates a secure value for you.",
+      "generator": "secret"
+    },
+    "BIND_ADDRESS": {
+      "description": "Bind to all interfaces so Heroku can route traffic to the dyno.",
+      "value": "0.0.0.0"
+    },
+    "MANIFEST_MODE": {
+      "description": "Run Manifest in self-hosted mode.",
+      "value": "selfhosted"
+    },
+    "NODE_ENV": {
+      "description": "Run the backend with production settings.",
+      "value": "production"
+    },
+    "PGSSLMODE": {
+      "description": "Use TLS for Heroku Postgres connections.",
+      "value": "no-verify"
+    },
+    "DB_POOL_MAX": {
+      "description": "Keep the main database pool below the Essential-0 connection limit.",
+      "value": "8"
+    },
+    "AUTH_DB_POOL_MAX": {
+      "description": "Keep Better Auth's database pool below the Essential-0 connection limit.",
+      "value": "4"
+    }
+  }
+}

--- a/deploy/heroku/TUTORIAL.md
+++ b/deploy/heroku/TUTORIAL.md
@@ -1,0 +1,49 @@
+# Deploy Manifest on Heroku
+
+This template deploys Manifest to a Heroku Cedar container-stack app with one web dyno and a Heroku Postgres Essential-0 database.
+
+## Deploy
+
+Click the Heroku button from the README and choose an app name.
+
+When Heroku asks for `BETTER_AUTH_URL`, enter the public URL for the app name you chose:
+
+```text
+https://<your-app-name>.herokuapp.com
+```
+
+Heroku generates the session and encryption secrets, provisions Postgres as `DATABASE_URL`, builds `Dockerfile.heroku`, and starts the web dyno.
+
+## What Gets Provisioned
+
+- Heroku app on the `container` stack
+- One `basic` web dyno
+- Heroku Postgres `essential-0`
+- Runtime config for Manifest self-hosting, Postgres TLS, and conservative connection pools
+
+## After Deploy
+
+Open the deployed app and create the first admin account. Fresh installs redirect to `/setup`; the first account you create becomes the admin.
+
+Check health:
+
+```bash
+curl -fsS https://<your-app-name>.herokuapp.com/api/v1/health
+```
+
+View logs:
+
+```bash
+heroku logs --tail -a <your-app-name>
+```
+
+## Notes
+
+- Heroku sets `PORT` automatically, so the template does not pin a port.
+- `PGSSLMODE=no-verify` enables TLS for Heroku Postgres without editing the managed `DATABASE_URL`.
+- `DB_POOL_MAX=8` and `AUTH_DB_POOL_MAX=4` leave headroom under the Essential-0 connection limit. Increase them only after moving to a larger Postgres plan.
+- Heroku no longer has free dynos or free Postgres. Destroy the app when testing is done to stop billing:
+
+```bash
+heroku apps:destroy -a <your-app-name>
+```

--- a/deploy/heroku/TUTORIAL.md
+++ b/deploy/heroku/TUTORIAL.md
@@ -4,7 +4,11 @@ This template deploys Manifest to a Heroku Cedar container-stack app with one we
 
 ## Deploy
 
-Click the Heroku button from the README and choose an app name.
+Open the Heroku deploy link and choose an app name:
+
+```text
+https://www.heroku.com/deploy?template=https://github.com/mnfst/manifest
+```
 
 When Heroku asks for `BETTER_AUTH_URL`, enter the public URL for the app name you chose:
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile.heroku


### PR DESCRIPTION
### ✨ What changed
- Add a Heroku Button app manifest and container build wrapper.
- Add a README deploy badge and managed deployment table row.
- Document the Heroku deploy flow and runtime settings.

### 💭 Why
Manifest already has one-click paths for Railway, Render, AWS, and GCP. Heroku users should get the same managed setup path.

### 👤 For users
The README now has a Heroku deploy button.

### 🔧 For operators
The template provisions Heroku Postgres Essential-0 and prompts for `BETTER_AUTH_URL`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one‑click Heroku deploy with an app manifest, container build, and docs. Users can deploy Manifest on Heroku with a web dyno and Heroku Postgres in minutes.

- **New Features**
  - `app.json`: Heroku Button manifest with one `basic` web dyno, `heroku-postgresql:essential-0`, `success_url=/setup`, prompts for `BETTER_AUTH_URL`, and generates `BETTER_AUTH_SECRET` and `MANIFEST_ENCRYPTION_KEY`.
  - Container build: `heroku.yml` maps `web` to `Dockerfile.heroku` (base image `docker.io/manifestdotbuild/manifest:6`).
  - README: Refines “Deploy with one click” table and adds Heroku with notes; set `BETTER_AUTH_URL=https://<app-name>.herokuapp.com`.
  - Docs: `deploy/heroku/TUTORIAL.md` covers deploy flow, TLS via `PGSSLMODE=no-verify`, and safe pool sizes (`DB_POOL_MAX=8`, `AUTH_DB_POOL_MAX=4`).

<sup>Written for commit bc01053da73f1036b71839b5c0ac8d6a0eb063a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

