### PR TITLE
docs: add Koyeb deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Plug your AI agents into any provider
   <a href="https://railway.com/deploy/wild-wild" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Railway-0B0D0E?style=for-the-badge&amp;logo=railway&amp;logoColor=white" alt="Deploy on Railway" /></a>
   <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?stackName=manifest&amp;templateURL=https%3A%2F%2Fmnfst-manifest-deploy-templates.s3.us-east-1.amazonaws.com%2Fmanifest.yaml" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-AWS-232F3E?style=for-the-badge&amp;logo=amazonwebservices&amp;logoColor=white" alt="Deploy on AWS" /></a>
   <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fmnfst%2Fmanifest&amp;cloudshell_workspace=deploy%2Fgcp&amp;cloudshell_tutorial=TUTORIAL.md&amp;cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image&amp;shellonly=true" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-GCP-4285F4?style=for-the-badge&amp;logo=googlecloud&amp;logoColor=white" alt="Deploy on GCP" /></a>
-  <a href="https://app.koyeb.com/deploy?type=docker&amp;image=docker.io%2Fmanifestdotbuild%2Fmanifest%3A6&amp;name=manifest&amp;service_type=web&amp;ports=2099%3Bhttp%3B%2F&amp;env%5BDATABASE_URL%5D=postgres%3A%2F%2FUSER%3APASSWORD%40HOST%2FDB%3Fsslmode%3Drequire&amp;env%5BBETTER_AUTH_SECRET%5D=replace-with-openssl-rand-hex-32&amp;env%5BMANIFEST_ENCRYPTION_KEY%5D=replace-with-different-openssl-rand-hex-32&amp;env%5BBETTER_AUTH_URL%5D=https%3A%2F%2F%7B%7B+KOYEB_PUBLIC_DOMAIN+%7D%7D&amp;env%5BMANIFEST_MODE%5D=selfhosted&amp;env%5BDB_POOL_MAX%5D=8&amp;env%5BAUTH_DB_POOL_MAX%5D=4" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Koyeb-121212?style=for-the-badge&amp;logo=koyeb&amp;logoColor=white" alt="Deploy on Koyeb" /></a>
 </p>
 
 <p align="center">
@@ -66,15 +65,20 @@ bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/in
 
 Open [http://localhost:2099](http://localhost:2099) and sign up — the first account you create becomes the admin. Full self-hosting guide: [docker/DOCKER_README.md](docker/DOCKER_README.md).
 
-Managed deployment options:
+### Deploy with one click
 
-| Platform | What it provisions |
+| Platform | Notes |
 | --- | --- |
-| [Railway](https://railway.com/deploy/wild-wild) | Manifest plus PostgreSQL from the public Railway template. |
-| [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Manifest web service plus Render PostgreSQL from [render.yaml](render.yaml). |
-| [AWS](deploy/aws/TUTORIAL.md) | ECS Fargate, Application Load Balancer, RDS PostgreSQL, and Secrets Manager via CloudFormation. |
-| [GCP](deploy/gcp/TUTORIAL.md) | Cloud Run, Cloud SQL for PostgreSQL, and Secret Manager via the Cloud Shell tutorial. |
-| [Koyeb](deploy/koyeb/TUTORIAL.md) | Manifest Docker web service from the deploy button. Create a Koyeb PostgreSQL Database Service first and paste `DATABASE_URL`. |
+| [Railway](https://railway.com/deploy/wild-wild) | Best path. Template includes Manifest and PostgreSQL. |
+| [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Blueprint includes Manifest and Render PostgreSQL. |
+| [AWS](deploy/aws/TUTORIAL.md) | CloudFormation quick-create for ECS, RDS, and Secrets Manager. |
+| [GCP](deploy/gcp/TUTORIAL.md) | Cloud Shell guided deploy for Cloud Run, Cloud SQL, and Secret Manager. |
+
+### Other deployment guides
+
+| Platform | Notes |
+| --- | --- |
+| [Koyeb](deploy/koyeb/TUTORIAL.md) | Requires manual PostgreSQL and generated secrets before deploy. |
 
 > The legacy `manifest` npm package is deprecated and no longer published.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Plug your AI agents into any provider
   <a href="https://railway.com/deploy/wild-wild" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Railway-0B0D0E?style=for-the-badge&amp;logo=railway&amp;logoColor=white" alt="Deploy on Railway" /></a>
   <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?stackName=manifest&amp;templateURL=https%3A%2F%2Fmnfst-manifest-deploy-templates.s3.us-east-1.amazonaws.com%2Fmanifest.yaml" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-AWS-232F3E?style=for-the-badge&amp;logo=amazonwebservices&amp;logoColor=white" alt="Deploy on AWS" /></a>
   <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fmnfst%2Fmanifest&amp;cloudshell_workspace=deploy%2Fgcp&amp;cloudshell_tutorial=TUTORIAL.md&amp;cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image&amp;shellonly=true" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-GCP-4285F4?style=for-the-badge&amp;logo=googlecloud&amp;logoColor=white" alt="Deploy on GCP" /></a>
+  <a href="https://app.koyeb.com/deploy?type=docker&amp;image=docker.io%2Fmanifestdotbuild%2Fmanifest%3A6&amp;name=manifest&amp;service_type=web&amp;ports=2099%3Bhttp%3B%2F&amp;env%5BDATABASE_URL%5D=postgres%3A%2F%2FUSER%3APASSWORD%40HOST%2FDB%3Fsslmode%3Drequire&amp;env%5BBETTER_AUTH_SECRET%5D=replace-with-openssl-rand-hex-32&amp;env%5BMANIFEST_ENCRYPTION_KEY%5D=replace-with-different-openssl-rand-hex-32&amp;env%5BBETTER_AUTH_URL%5D=https%3A%2F%2F%7B%7B+KOYEB_PUBLIC_DOMAIN+%7D%7D&amp;env%5BMANIFEST_MODE%5D=selfhosted&amp;env%5BDB_POOL_MAX%5D=8&amp;env%5BAUTH_DB_POOL_MAX%5D=4" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/Deploy%20on-Koyeb-121212?style=for-the-badge&amp;logo=koyeb&amp;logoColor=white" alt="Deploy on Koyeb" /></a>
 </p>
 
 <p align="center">
@@ -73,6 +74,7 @@ Managed deployment options:
 | [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Manifest web service plus Render PostgreSQL from [render.yaml](render.yaml). |
 | [AWS](deploy/aws/TUTORIAL.md) | ECS Fargate, Application Load Balancer, RDS PostgreSQL, and Secrets Manager via CloudFormation. |
 | [GCP](deploy/gcp/TUTORIAL.md) | Cloud Run, Cloud SQL for PostgreSQL, and Secret Manager via the Cloud Shell tutorial. |
+| [Koyeb](deploy/koyeb/TUTORIAL.md) | Manifest Docker web service from the deploy button. Create a Koyeb PostgreSQL Database Service first and paste `DATABASE_URL`. |
 
 > The legacy `manifest` npm package is deprecated and no longer published.
 

--- a/deploy/koyeb/TUTORIAL.md
+++ b/deploy/koyeb/TUTORIAL.md
@@ -1,0 +1,57 @@
+# Deploy Manifest on Koyeb
+
+This walkthrough deploys the public Manifest Docker image to a Koyeb Web Service. The deploy button pre-fills the image, HTTP port, and runtime settings, but you must create PostgreSQL separately and replace the placeholder secrets before deploying.
+
+## Prerequisites
+
+- A Koyeb account.
+- A Koyeb PostgreSQL Database Service.
+- Two random 32+ character secrets for Manifest.
+
+This deployment creates paid resources if your selected Koyeb service or database plan is not free.
+
+## Create PostgreSQL
+
+In Koyeb, create a PostgreSQL Database Service in the same region you plan to use for Manifest. After it is ready, open the database connection details and copy the connection string.
+
+Manifest uses TLS to connect to Koyeb Postgres, so include `sslmode=require` in the connection string. If the copied URL has no query string, append `?sslmode=require`. If it already has query parameters, append `&sslmode=require`.
+
+## Generate secrets
+
+Generate separate values for session signing and at-rest provider credential encryption:
+
+```bash
+openssl rand -hex 32
+openssl rand -hex 32
+```
+
+## Deploy Manifest
+
+Open the Koyeb deploy button from the README. In the deploy form:
+
+- Replace `DATABASE_URL` with your Koyeb Postgres connection string.
+- Replace `BETTER_AUTH_SECRET` with the first generated secret.
+- Replace `MANIFEST_ENCRYPTION_KEY` with the second generated secret.
+- Leave `BETTER_AUTH_URL` as `https://{{ KOYEB_PUBLIC_DOMAIN }}`.
+- Leave `MANIFEST_MODE`, `DB_POOL_MAX`, and `AUTH_DB_POOL_MAX` unchanged for a single-instance deploy.
+
+The button deploys `docker.io/manifestdotbuild/manifest:6` and exposes port `2099` over HTTP.
+
+## Open Manifest
+
+After the deployment is live, open the public Koyeb domain and create the first account. The first account becomes the admin.
+
+To verify the deployment:
+
+```bash
+curl -sSf https://<your-koyeb-domain>/api/v1/health
+```
+
+## Tearing it down
+
+Delete both resources when you are done:
+
+- The Manifest Koyeb Web Service.
+- The Koyeb PostgreSQL Database Service.
+
+Deleting only the web service leaves the database running.

--- a/deploy/koyeb/TUTORIAL.md
+++ b/deploy/koyeb/TUTORIAL.md
@@ -27,7 +27,13 @@ openssl rand -hex 32
 
 ## Deploy Manifest
 
-Open the Koyeb deploy button from the README. In the deploy form:
+Open the Koyeb deploy link:
+
+```text
+https://app.koyeb.com/deploy?type=docker&image=docker.io%2Fmanifestdotbuild%2Fmanifest%3A6&name=manifest&service_type=web&ports=2099%3Bhttp%3B%2F&env%5BDATABASE_URL%5D=postgres%3A%2F%2FUSER%3APASSWORD%40HOST%2FDB%3Fsslmode%3Drequire&env%5BBETTER_AUTH_SECRET%5D=replace-with-openssl-rand-hex-32&env%5BMANIFEST_ENCRYPTION_KEY%5D=replace-with-different-openssl-rand-hex-32&env%5BBETTER_AUTH_URL%5D=https%3A%2F%2F%7B%7B+KOYEB_PUBLIC_DOMAIN+%7D%7D&env%5BMANIFEST_MODE%5D=selfhosted&env%5BDB_POOL_MAX%5D=8&env%5BAUTH_DB_POOL_MAX%5D=4
+```
+
+In the deploy form:
 
 - Replace `DATABASE_URL` with your Koyeb Postgres connection string.
 - Replace `BETTER_AUTH_SECRET` with the first generated secret.


### PR DESCRIPTION
### ✨ What changed
- Add a Koyeb deploy button to the README.
- Document the Koyeb setup path with the public Docker image, PostgreSQL, and required secrets.

### 💭 Why
Koyeb has an official Docker-image deploy button, so Manifest can offer another low-friction self-hosting path.

### 👤 For users
The README now includes a Koyeb deploy option. Users create Koyeb Postgres first, then paste `DATABASE_URL` and generated secrets into the deploy form.

### 🔧 For operators
The button pins `docker.io/manifestdotbuild/manifest:6`, exposes port `2099`, and pre-fills `BETTER_AUTH_URL` from `KOYEB_PUBLIC_DOMAIN`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Koyeb deploy flow with a one‑click URL and a short setup guide, and refine the README deploy section for clarity. This enables self‑hosting on Koyeb using the public Docker image and Koyeb PostgreSQL.

- **New Features**
  - README: Split deployment into “Deploy with one click” (Railway, Render, AWS, GCP) and “Other deployment guides”; link to the Koyeb guide with a note that it requires manual PostgreSQL and generated secrets.
  - Guide: `deploy/koyeb/TUTORIAL.md` provides a deploy URL that preconfigures `docker.io/manifestdotbuild/manifest:6`, exposes port `2099`, sets `BETTER_AUTH_URL` to `https://{{ KOYEB_PUBLIC_DOMAIN }}`, and instructs setting `DATABASE_URL` with `sslmode=require`, `BETTER_AUTH_SECRET`, and `MANIFEST_ENCRYPTION_KEY`, plus a health check.

<sup>Written for commit 5b65580c2c300396f4a45e1c05fa7877a9be232c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

