### PR TITLE
ci: add npm token fallback for n8n publish

### DIFF
--- a/.github/workflows/publish-n8n-node.yml
+++ b/.github/workflows/publish-n8n-node.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Publish
         run: npm run release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
### ✨ What changed
- Pass the existing `NPM_TOKEN` secret to the n8n node publish step.
- Keep npm provenance enabled for the first npm release.

### 💭 Why
`n8n-nodes-manifest` does not exist on npm yet, so npm Trusted Publishing cannot be configured until after the bootstrap publish.

### 🔧 For operators
After this merges, push tag `n8n-nodes-manifest-v0.1.0` to publish the first package version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fallback NPM auth token to the publish workflow and keeps provenance enabled. This allows the first `n8n-nodes-manifest` release before Trusted Publishing is set up.

- **Migration**
  - After merge, push tag `n8n-nodes-manifest-v0.1.0` to publish the first version.

<sup>Written for commit 959b7d744cee46f356c75dcfcbcfd69f4579065d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

