### PR TITLE
ci: publish n8n node with public access

### DIFF
--- a/.github/workflows/publish-n8n-node.yml
+++ b/.github/workflows/publish-n8n-node.yml
@@ -39,4 +39,5 @@ jobs:
         run: npm run release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_ACCESS: public
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
### ✨ What changed
- Set npm publish access to public for the n8n community node workflow.

### 💭 Why
The first publish reached npm but failed because provenance for a new package requires public access to be explicit.

### 🔧 For operators
After this merges, move tag `n8n-nodes-manifest-v0.1.0` to the new main commit and push it again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `NPM_CONFIG_ACCESS=public` in the n8n node publish workflow to ensure publishes succeed with provenance. The previous publish failed because public access wasn’t explicitly set for a new package.

- **Migration**
  - Move tag `n8n-nodes-manifest-v0.1.0` to the latest main commit and push it.

<sup>Written for commit eb4fa2da3c7563e1e3328630b466ee72eb712827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

