### PR TITLE
ci: trigger website changelog rebuild on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,21 @@ jobs:
             --notes "${BODY:-No changelog}" \
             --verify-tag
 
+      # Nudge the marketing site to rebuild so its /changelog/ page (generated
+      # from these GitHub releases) picks up this version within ~1 min. Kept in
+      # this job on purpose: the release is created with the default
+      # GITHUB_TOKEN, which does NOT trigger `release: published` workflows, so a
+      # standalone workflow would never fire. No-op if the secret is unset.
+      - name: Trigger website changelog rebuild
+        env:
+          HOOK: ${{ secrets.WEBSITE_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "WEBSITE_DEPLOY_HOOK not set; skipping website rebuild."
+            exit 0
+          fi
+          curl -fsS -X POST "$HOOK"
+
   publish-docker:
     needs: release
     if: needs.release.outputs.should_publish == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,11 @@ jobs:
       # GITHUB_TOKEN, which does NOT trigger `release: published` workflows, so a
       # standalone workflow would never fire. No-op if the secret is unset.
       - name: Trigger website changelog rebuild
+        # Best-effort: the release, tag, and Docker publish already succeeded by
+        # this point, so a transient hook or network error must not fail the job
+        # (a red status after a good release is misleading). The site also
+        # rebuilds on the next release or any push to the website repo.
+        continue-on-error: true
         env:
           HOOK: ${{ secrets.WEBSITE_DEPLOY_HOOK }}
         run: |


### PR DESCRIPTION
## What

Adds one step to the end of the existing `github-release` job: after a `manifest@x.y.z` release is published, POST to the website's Vercel deploy hook (`secrets.WEBSITE_DEPLOY_HOOK`).

## Why

The marketing site is adding an auto-generated **/changelog/** page built from this repo's GitHub releases. The page only refreshes when the site rebuilds, and the site lives in a separate repo (`mnfst/website`), so releases here need to nudge it.

## Why in this job (not a standalone `on: release: published` workflow)

Releases are created with the default `GITHUB_TOKEN`, and GitHub does **not** fire `release: published` workflows for releases created by that token (recursive-run guard). A standalone workflow would silently never run. Putting the ping in the same job that creates the release sidesteps that entirely and guarantees ordering (it runs *after* the release exists).

## Safety

- Gated by the job's existing `should_publish == 'true'` condition — only fires on a real version bump.
- **No-op if `WEBSITE_DEPLOY_HOOK` is unset** (checks the env var and exits 0), so it can't break the release/tag/Docker pipeline.
- Runs last, after the release + tag already exist.

Pairs with the changelog PR on `mnfst/website`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger the marketing site rebuild after a `manifest@x.y.z` release by POSTing to its Vercel deploy hook from the `github-release` job, so /changelog/ updates quickly. Runs last, only when `should_publish == 'true'`, no-op if `WEBSITE_DEPLOY_HOOK` is unset, marked best-effort (`continue-on-error`), and kept in this job because `release: published` won’t fire with the default `GITHUB_TOKEN`.

<sup>Written for commit c122cc7fded17576d878b48cb4feccc049ad69e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

