### PR TITLE
chore: log why Auto-fix skips a request

### DIFF
--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -140,6 +140,16 @@ export class AutofixService {
     this.rollout = parseRollout(config.get<string>('AUTOFIX_ROLLOUT'));
     this.defaultAgentEnabled = !isSelfHosted();
     this.repairableStatuses = parseStatuses(config.get<string>('AUTOFIX_REPAIRABLE_STATUSES'));
+    // Boot-time snapshot of the resolved gates. Logged once so an operator can
+    // confirm what the process actually loaded — e.g. whether the global kill
+    // switch is off, or self-hosted detection flipped the per-agent default off
+    // — straight from the deploy logs, without shell access. This is the first
+    // thing to check when "Auto-fix never runs".
+    this.logger.log(
+      `config: globalEnabled=${this.globalEnabled} rollout=${this.rollout} ` +
+        `defaultAgentEnabled=${this.defaultAgentEnabled} ` +
+        `repairableStatuses=[${[...this.repairableStatuses].join(',')}]`,
+    );
   }
 
   /**
@@ -223,22 +233,49 @@ export class AutofixService {
 
   async maybeHeal(params: MaybeHealParams): Promise<AutofixAttempt | null> {
     const { forward } = params;
-    // Hot path: successful and non-repairable forwards never enter healing.
-    if (forward.response.ok || !this.globalEnabled) return null;
+    // Hot path: successful forwards never enter healing — return silently so we
+    // don't emit a log line on every request.
+    if (forward.response.ok) return null;
+
+    // Everything below runs ONLY for failed forwards, so these diagnostics stay
+    // low-volume. They make "why didn't Auto-fix run?" answerable from logs
+    // alone: one line per failed request stamped with the resolved gate values,
+    // then a single reason whenever a gate short-circuits the heal.
     const status = forward.response.status;
-    if (!this.isRepairable(status)) return null;
+    this.logger.log(
+      `maybeHeal: failed forward status=${status} agent=${params.agentId} ` +
+        `tenant=${params.tenantId} globalEnabled=${this.globalEnabled}`,
+    );
+    if (!this.globalEnabled) {
+      this.logger.warn(`skip status=${status}: globally disabled (AUTOFIX_GLOBAL_ENABLED=false)`);
+      return null;
+    }
+    if (!this.isRepairable(status)) {
+      this.logger.log(
+        `skip status=${status}: not in repairable set [${[...this.repairableStatuses].join(',')}]`,
+      );
+      return null;
+    }
 
     // Circuit breaker: while the healing service is tripped, skip healing
     // entirely and hand the forward back untouched, so a slow/unreachable
     // Phoenix never delays the fallback chain (the next safety net).
-    if (this.breakerOpenUntil > Date.now()) return null;
+    if (this.breakerOpenUntil > Date.now()) {
+      this.logger.warn(`skip status=${status}: circuit breaker open`);
+      return null;
+    }
 
     let cfg: AgentAutofixConfig;
     try {
       // Limited-rollout gate: only early-access (waitlist) tenants heal for now.
       // Sits above the per-agent default so a cloud tenant that hasn't joined
       // never heals, even though the mode default would enable it.
-      if (!(await this.hasAccess(params.tenantId))) return null;
+      if (!(await this.hasAccess(params.tenantId))) {
+        this.logger.log(
+          `skip status=${status}: tenant ${params.tenantId} lacks early-access (rollout=${this.rollout})`,
+        );
+        return null;
+      }
       cfg = await this.loadAgentConfig(params.agentId, params.tenantId);
     } catch (err) {
       // A gate-load failure (DB hiccup) must never turn a recoverable provider
@@ -246,7 +283,15 @@ export class AutofixService {
       this.logger.warn(`autofix gate load failed, skipping: ${(err as Error).message}`);
       return null;
     }
-    if (!cfg.enabled) return null;
+    if (!cfg.enabled) {
+      this.logger.log(
+        `skip status=${status}: agent ${params.agentId} disabled ` +
+          `(defaultAgentEnabled=${this.defaultAgentEnabled})`,
+      );
+      return null;
+    }
+
+    this.logger.log(`healing status=${status} agent=${params.agentId} provider=${params.provider}`);
 
     // Read the original error once, then rebuild it so it stays readable
     // downstream (fallback / recorder) whether or not we heal.

--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -285,13 +285,19 @@ export class AutofixService {
     }
     if (!cfg.enabled) {
       this.logger.log(
-        `skip status=${status}: agent ${params.agentId} disabled ` +
-          `(defaultAgentEnabled=${this.defaultAgentEnabled})`,
+        `skip status=${status}: agent ${params.agentId} tenant ${params.tenantId} ` +
+          `disabled (defaultAgentEnabled=${this.defaultAgentEnabled})`,
       );
       return null;
     }
 
-    this.logger.log(`healing status=${status} agent=${params.agentId} provider=${params.provider}`);
+    // Include tenant + agent so a healing event is self-contained for
+    // tenant-scoped log filtering (the entry line above can interleave across
+    // requests once the two awaited gate checks run between them).
+    this.logger.log(
+      `healing status=${status} agent=${params.agentId} ` +
+        `tenant=${params.tenantId} provider=${params.provider}`,
+    );
 
     // Read the original error once, then rebuild it so it stays readable
     // downstream (fallback / recorder) whether or not we heal.


### PR DESCRIPTION
### 💭 Why
Auto-fix never triggers for repairable 4xx in production, and `maybeHeal` returns null silently at each gate. There is no way from the logs to tell which gate blocked it (global switch off, no early-access, agent default off, etc.).

### ✨ What changed
- Log the resolved gates once at boot: `globalEnabled`, `rollout`, `defaultAgentEnabled`, `repairableStatuses`.
- On every failed forward, log one line: either `skip status=...: <reason>` or `healing ...`.
- Successful forwards stay silent, so there is no per-request noise.

### 🔧 For operators
No config, migration, or deploy-order changes. After deploy, the boot line shows the effective global switch, and each failed request logs why Auto-fix ran or skipped.

### 📝 Notes
Diagnostic only, no behavior change. Purpose is to pinpoint why Auto-fix skips invalid-parameter requests in prod.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add diagnostic logging to Auto-fix to explain why healing is skipped and show which gates are active at boot. No behavior change; each failed forward logs context and a skip/healing reason, and successful forwards stay silent.

- New Features
  - Log resolved gates once at startup: `globalEnabled`, `rollout`, `defaultAgentEnabled`, `repairableStatuses`.
  - For each failed forward, log a context line (status, agent, tenant) and then either "skip status=...: <reason>" or "healing ...".
  - Reasons include: globally disabled, not repairable, circuit breaker open, no early-access, agent disabled, or gate load failure.

<sup>Written for commit b3d62963bb0b96bcde2791d174a560fe2d0679de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

