### PR TITLE
fix: Auto-fix now triggers for default agents

### DIFF
--- a/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
@@ -504,15 +504,19 @@ describe('AutofixService', () => {
       expect(result).toBeNull();
     });
 
-    it('queries the agent scoped by id + tenant with the minimal column set', async () => {
+    it('queries the agent scoped by id + tenant, selecting the PK so a NULL flag row is still found', async () => {
       const { repo, findOne } = makeAgentRepo(() => null);
       const service = makeService({ repo });
 
       await service.maybeHeal(makeParams({ agentId: 'a-9', tenantId: 't-9' }));
 
+      // `id` must stay in the select: TypeORM returns null for a row whose only
+      // selected column is NULL, so selecting the nullable `autofix_enabled`
+      // alone makes every default (NULL-flag) agent look not-found. See the
+      // real-DB regression in test/autofix-null-flag.e2e-spec.ts.
       expect(findOne).toHaveBeenCalledWith({
         where: { id: 'a-9', tenant_id: 't-9' },
-        select: ['autofix_enabled'],
+        select: ['id', 'autofix_enabled'],
       });
     });
   });

--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -480,7 +480,13 @@ export class AutofixService {
 
     const agent = await this.agentRepo.findOne({
       where: { id: agentId, tenant_id: tenantId },
-      select: ['autofix_enabled'],
+      // Select the PK alongside the flag. TypeORM's entity transformer treats a
+      // row whose only selected column is NULL as "no entity" and returns null,
+      // so `select: ['autofix_enabled']` alone makes every NULL-flag agent (the
+      // default "inherit the mode default" state) look not-found — which then
+      // resolves to `enabled: false` below and silently disables Auto-fix for it.
+      // The always-present `id` keeps the row materialized so the NULL flag is read.
+      select: ['id', 'autofix_enabled'],
     });
     // Unknown agent → off. Known agent → its explicit flag, or the mode default
     // when unset (NULL).

--- a/packages/backend/test/autofix-null-flag.e2e-spec.ts
+++ b/packages/backend/test/autofix-null-flag.e2e-spec.ts
@@ -1,0 +1,57 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { createTestApp, TEST_TENANT_ID } from './helpers';
+import { Agent } from '../src/entities/agent.entity';
+
+/**
+ * Regression for the prod bug where Auto-fix silently never ran for any agent
+ * that had never toggled it — i.e. `autofix_enabled = NULL`, the default state
+ * that is supposed to inherit the deployment-mode default (ON in cloud).
+ *
+ * `AutofixService.loadAgentConfig` looked the agent up with
+ * `findOne({ where: { id, tenant_id }, select: ['autofix_enabled'] })`. TypeORM's
+ * entity transformer treats a row whose only selected column is NULL as "no
+ * entity" and returns null, so every NULL-flag agent looked not-found and
+ * resolved to `enabled: false`. The mocked unit tests missed it because the mock
+ * returns a truthy object; only a real datasource reproduces it. The fix adds
+ * the always-present primary key to the select.
+ */
+let app: INestApplication;
+let ds: DataSource;
+
+beforeAll(async () => {
+  app = await createTestApp();
+  ds = app.get(DataSource);
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('Auto-fix NULL-flag agent lookup (real TypeORM)', () => {
+  it('materialises a NULL autofix_enabled agent only when the PK is selected', async () => {
+    const agentRepo = ds.getRepository(Agent);
+    await agentRepo.save({
+      id: 'nullflag-agent',
+      name: 'nullflag-agent',
+      tenant_id: TEST_TENANT_ID,
+      autofix_enabled: null,
+    });
+
+    // The fix: selecting the PK alongside the NULL flag keeps the row.
+    const withId = await agentRepo.findOne({
+      where: { id: 'nullflag-agent', tenant_id: TEST_TENANT_ID },
+      select: ['id', 'autofix_enabled'],
+    });
+    expect(withId).not.toBeNull();
+    expect(withId!.autofix_enabled).toBeNull();
+
+    // The footgun the fix works around: selecting only the NULL column drops the
+    // whole row, which is what silently disabled Auto-fix for default agents.
+    const flagOnly = await agentRepo.findOne({
+      where: { id: 'nullflag-agent', tenant_id: TEST_TENANT_ID },
+      select: ['autofix_enabled'],
+    });
+    expect(flagOnly).toBeNull();
+  });
+});


### PR DESCRIPTION
### 💭 Why
Auto-fix never ran for any agent that had not explicitly toggled it. The per-agent flag defaults to NULL ("inherit the mode default", which is ON in cloud), but the agent lookup dropped NULL-flag rows and treated them as disabled. So the feature was silently off for most agents, across every tenant.

### ✨ What changed
- `loadAgentConfig` selects the primary key alongside `autofix_enabled`, so a NULL-flag row is materialised instead of read as "not found".
- Adds a real-DB regression test (`test/autofix-null-flag.e2e-spec.ts`).

### 👤 For users
Auto-fix now heals repairable 4xx for agents left on the default setting, not just ones that manually re-toggled it.

### 📝 Notes
Root cause: TypeORM `findOne` returns null when the only selected column is NULL, so `select: ['autofix_enabled']` alone drops the row. Mocked unit tests could not catch it (the mock returns a truthy object), hence the real-DB test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-fix now runs for agents left on the default setting (NULL flag). Fixes a lookup bug that treated these agents as missing and silently disabled Auto-fix.

- **Bug Fixes**
  - In `loadAgentConfig`, select `id` with `autofix_enabled` so NULL-flag rows are found.
  - Added real DB regression test `packages/backend/test/autofix-null-flag.e2e-spec.ts`.
  - Updated unit test to assert the select includes `id`.

<sup>Written for commit e97d820d1d85ffa7ea61f6bdc1075b6a051c4868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

