### PR TITLE
fix: refresh MiniMax subscription endpoints

### DIFF
--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1515,7 +1515,7 @@ describe('ModelDiscoveryService', () => {
         t: 'minimax-access',
         r: 'minimax-refresh',
         e: Date.now() + 60000,
-        u: 'https://api.minimax.io/anthropic',
+        u: 'https://api.minimax.io/anthropic/v1',
       });
       mockDecrypt.mockReturnValue(blob);
 
@@ -1533,7 +1533,7 @@ describe('ModelDiscoveryService', () => {
         'minimax',
         'minimax-access',
         'subscription',
-        'https://api.minimax.io/anthropic',
+        'https://api.minimax.io/anthropic/v1',
       );
     });
 
@@ -1555,7 +1555,7 @@ describe('ModelDiscoveryService', () => {
         'minimax',
         'sk-cp-cn-token',
         'subscription',
-        'https://api.minimaxi.com/anthropic',
+        'https://api.minimaxi.com/anthropic/v1',
       );
     });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -164,7 +164,7 @@ export class ModelDiscoveryService {
         // region column so CN tokens discover models against the CN host
         // instead of incorrectly probing api.minimax.io.
         if (lowerProvider === 'minimax' && !endpointOverride && provider.region === 'cn') {
-          endpointOverride = `${MINIMAX_BASE_URLS.cn}/anthropic`;
+          endpointOverride = `${MINIMAX_BASE_URLS.cn}/anthropic/v1`;
         }
       } else if (lowerProvider === 'copilot' && this.copilotTokenService) {
         try {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1446,7 +1446,12 @@ describe('ProviderModelFetcherService', () => {
       json: async () => ({ data: [] }),
     });
 
-    await service.fetch('minimax', 'sk-test', 'subscription', 'https://api.minimaxi.com/anthropic');
+    await service.fetch(
+      'minimax',
+      'sk-test',
+      'subscription',
+      'https://api.minimaxi.com/anthropic/v1',
+    );
 
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://api.minimaxi.com/anthropic/v1/models?limit=100',

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -860,7 +860,7 @@ export class ProviderModelFetcherService {
     if (endpointOverride && configKey === 'minimax-subscription') {
       const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(endpointOverride);
       if (minimaxBaseUrl) {
-        url = `${minimaxBaseUrl}/v1/models?limit=100`;
+        url = `${minimaxBaseUrl}/models?limit=100`;
       } else {
         this.logger.warn('Ignoring invalid MiniMax subscription endpoint override');
       }

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.spec.ts
@@ -21,7 +21,7 @@ describe('minimax-oauth-helpers', () => {
   it('exposes the correct default region and base URLs', () => {
     expect(DEFAULT_REGION).toBe('global');
     expect(DEFAULT_BASE_URL).toBe('https://api.minimax.io');
-    expect(DEFAULT_RESOURCE_URL).toBe('https://api.minimax.io/anthropic');
+    expect(DEFAULT_RESOURCE_URL).toBe('https://api.minimax.io/anthropic/v1');
     expect(MINIMAX_BASE_URLS.cn).toBe('https://api.minimaxi.com');
   });
 
@@ -52,7 +52,7 @@ describe('minimax-oauth-helpers', () => {
         'https://api.minimax.io/oauth/token',
       );
       expect(buildMinimaxResourceUrl('https://api.minimax.io')).toBe(
-        'https://api.minimax.io/anthropic',
+        'https://api.minimax.io/anthropic/v1',
       );
     });
   });
@@ -65,8 +65,8 @@ describe('minimax-oauth-helpers', () => {
 
     it('normalises a resource URL through the provider-base-url helper', () => {
       // The helper is a pass-through for well-formed resource URLs.
-      expect(getMinimaxResourceUrl('https://api.minimax.io/anthropic')).toBe(
-        'https://api.minimax.io/anthropic',
+      expect(getMinimaxResourceUrl('https://api.minimax.io/anthropic/v1')).toBe(
+        'https://api.minimax.io/anthropic/v1',
       );
     });
   });
@@ -77,7 +77,7 @@ describe('minimax-oauth-helpers', () => {
     });
 
     it('returns the origin of a normalised resource URL', () => {
-      expect(getMinimaxOauthBaseUrl('https://api.minimaxi.com/anthropic')).toBe(
+      expect(getMinimaxOauthBaseUrl('https://api.minimaxi.com/anthropic/v1')).toBe(
         'https://api.minimaxi.com',
       );
     });

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.ts
@@ -13,7 +13,7 @@ export type MinimaxRegion = keyof typeof MINIMAX_BASE_URLS;
 
 export const DEFAULT_REGION: MinimaxRegion = 'global';
 export const DEFAULT_BASE_URL = MINIMAX_BASE_URLS[DEFAULT_REGION];
-export const DEFAULT_RESOURCE_URL = `${DEFAULT_BASE_URL}/anthropic`;
+export const DEFAULT_RESOURCE_URL = `${DEFAULT_BASE_URL}/anthropic/v1`;
 export const DEFAULT_POLL_INTERVAL_MS = 2000;
 
 export function isMinimaxRegion(value: string | undefined): value is MinimaxRegion {
@@ -33,7 +33,7 @@ export function buildMinimaxTokenUrl(baseUrl: string): string {
 }
 
 export function buildMinimaxResourceUrl(baseUrl: string): string {
-  return `${baseUrl}/anthropic`;
+  return `${baseUrl}/anthropic/v1`;
 }
 
 const VERIFICATION_HOST_REWRITES: Record<string, string> = {

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.coverage.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.coverage.spec.ts
@@ -258,7 +258,7 @@ describe('MinimaxOauthService', () => {
           access_token: 'at',
           refresh_token: 'rt',
           expired_in: 3600,
-          resource_url: 'https://api.minimax.io/anthropic',
+          resource_url: 'https://api.minimax.io/anthropic/v1',
         }),
       );
       const out = await svc.pollAuthorization(start.flowId, 'user-1');

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.spec.ts
@@ -111,7 +111,7 @@ describe('MinimaxOauthService', () => {
               access_token: 'access-123',
               refresh_token: 'refresh-456',
               expired_in: 3600,
-              resource_url: 'https://api.minimax.io/anthropic',
+              resource_url: 'https://api.minimax.io/anthropic/v1',
             }),
         });
 
@@ -167,7 +167,7 @@ describe('MinimaxOauthService', () => {
           t: 'old-access',
           r: 'old-refresh',
           e: now + 7200,
-          u: { host: 'https://api.minimax.io/anthropic' },
+          u: { host: 'https://api.minimax.io/anthropic/v1' },
         }),
         'agent-1',
         'user-1',
@@ -195,7 +195,7 @@ describe('MinimaxOauthService', () => {
           t: 'old-access',
           r: 'old-refresh',
           e: Date.now() - 1000,
-          u: 'https://api.minimax.io/anthropic',
+          u: 'https://api.minimax.io/anthropic/v1',
         }),
         'agent-1',
         'user-1',
@@ -205,7 +205,7 @@ describe('MinimaxOauthService', () => {
         expect.objectContaining({
           t: 'new-access',
           r: 'new-refresh',
-          u: 'https://api.minimax.io/anthropic',
+          u: 'https://api.minimax.io/anthropic/v1',
         }),
       );
       expect(providerService.upsertProvider).toHaveBeenCalled();
@@ -229,7 +229,7 @@ describe('MinimaxOauthService', () => {
           t: 'old-access',
           r: 'old-refresh',
           e: now - 1000,
-          u: 'https://api.minimaxi.com/anthropic',
+          u: 'https://api.minimaxi.com/anthropic/v1',
         }),
         'agent-1',
         'user-1',
@@ -250,7 +250,7 @@ describe('MinimaxOauthService', () => {
 
       const result = await service.refreshAccessToken(
         'refresh-token',
-        'https://api.minimax.io/anthropic',
+        'https://api.minimax.io/anthropic/v1',
       );
 
       expect(result.e).toBe(now + 7200);
@@ -274,7 +274,7 @@ describe('MinimaxOauthService', () => {
         'https://evil.example/anthropic',
       );
 
-      expect(result.u).toBe('https://api.minimax.io/anthropic');
+      expect(result.u).toBe('https://api.minimax.io/anthropic/v1');
     });
   });
 });

--- a/packages/backend/src/routing/provider-base-url.ts
+++ b/packages/backend/src/routing/provider-base-url.ts
@@ -3,8 +3,8 @@ export function normalizeProviderBaseUrl(baseUrl: string): string {
 }
 
 const MINIMAX_SUBSCRIPTION_BASE_URLS = new Set([
-  'https://api.minimax.io/anthropic',
-  'https://api.minimaxi.com/anthropic',
+  'https://api.minimax.io/anthropic/v1',
+  'https://api.minimaxi.com/anthropic/v1',
 ]);
 
 export function normalizeMinimaxSubscriptionBaseUrl(baseUrl: string): string | null {
@@ -14,7 +14,7 @@ export function normalizeMinimaxSubscriptionBaseUrl(baseUrl: string): string | n
       return null;
     }
 
-    const normalized = normalizeProviderBaseUrl(`${url.origin}${url.pathname}`);
+    const normalized = `${url.origin}${url.pathname}`.replace(/\/+$/, '');
     return MINIMAX_SUBSCRIPTION_BASE_URLS.has(normalized) ? normalized : null;
   } catch {
     return null;

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -486,9 +486,9 @@ describe('PROVIDER_ENDPOINTS', () => {
     expect(headers['user-agent']).toBe('codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown');
   });
 
-  it('minimax-subscription buildPath returns /v1/messages', () => {
+  it('minimax-subscription buildPath returns /messages', () => {
     const path = PROVIDER_ENDPOINTS['minimax-subscription'].buildPath('abab7-chat-preview');
-    expect(path).toBe('/v1/messages');
+    expect(path).toBe('/messages');
   });
 
   it('minimax-subscription uses Bearer auth with anthropic-version header', () => {
@@ -741,11 +741,14 @@ describe('PROVIDER_ENDPOINTS', () => {
 
 describe('buildEndpointOverride', () => {
   it('creates endpoint using the template for a known key', () => {
-    const ep = buildEndpointOverride('https://custom.minimax.io/anthropic', 'minimax-subscription');
+    const ep = buildEndpointOverride(
+      'https://custom.minimax.io/anthropic/v1',
+      'minimax-subscription',
+    );
 
-    expect(ep.baseUrl).toBe('https://custom.minimax.io/anthropic');
+    expect(ep.baseUrl).toBe('https://custom.minimax.io/anthropic/v1');
     expect(ep.format).toBe('anthropic');
-    expect(ep.buildPath('model-x')).toBe('/v1/messages');
+    expect(ep.buildPath('model-x')).toBe('/messages');
   });
 
   it('throws when template key does not exist', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -262,14 +262,14 @@ describe('ProxyFallbackService', () => {
           t: 'old-access-token',
           r: 'refresh-token',
           e: Date.now() + 10 * 60 * 1000,
-          u: 'https://api.minimax.io/anthropic',
+          u: 'https://api.minimax.io/anthropic/v1',
         }),
         setup: () =>
           minimaxOauth.unwrapToken.mockResolvedValue({
             t: 'fresh-minimax-token',
             r: 'refresh-token',
             e: Date.now() + 60 * 60 * 1000,
-            u: 'https://api.minimax.io/anthropic',
+            u: 'https://api.minimax.io/anthropic/v1',
           }),
         unwrap: () => minimaxOauth.unwrapToken,
         expectedApiKey: 'fresh-minimax-token',
@@ -824,7 +824,7 @@ describe('ProxyFallbackService', () => {
         stream: false,
         sessionKey: 'sess-1',
         authType: 'subscription',
-        resourceUrl: 'https://api.minimax.io/anthropic',
+        resourceUrl: 'https://api.minimax.io/anthropic/v1',
       });
 
       expect(providerClient.forward).toHaveBeenCalledWith(
@@ -835,7 +835,7 @@ describe('ProxyFallbackService', () => {
           body,
           stream: false,
           customEndpoint: expect.objectContaining({
-            baseUrl: 'https://api.minimax.io/anthropic',
+            baseUrl: 'https://api.minimax.io/anthropic/v1',
             format: 'anthropic',
           }),
           authType: 'subscription',
@@ -900,7 +900,7 @@ describe('ProxyFallbackService', () => {
       expect(providerClient.forward).toHaveBeenCalledWith(
         expect.objectContaining({
           customEndpoint: expect.objectContaining({
-            baseUrl: 'https://api.minimaxi.com/anthropic',
+            baseUrl: 'https://api.minimaxi.com/anthropic/v1',
             format: 'anthropic',
           }),
         }),

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
@@ -28,7 +28,7 @@ describe('resolveForwardEndpoint', () => {
       provider: 'minimax',
       authType: 'subscription',
       model: 'minimax/abab',
-      resourceUrl: 'https://api.minimaxi.com/anthropic',
+      resourceUrl: 'https://api.minimaxi.com/anthropic/v1',
     });
     expect(out.forwardModel).toBe('abab');
     expect(out.customEndpoint?.baseUrl).toContain('api.minimaxi.com');

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
@@ -133,7 +133,7 @@ export function resolveForwardEndpoint(
       }
     } else if (providerRegion === 'cn') {
       customEndpoint = buildEndpointOverride(
-        `${MINIMAX_BASE_URLS.cn}/anthropic`,
+        `${MINIMAX_BASE_URLS.cn}/anthropic/v1`,
         'minimax-subscription',
       );
     }

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -108,7 +108,7 @@ const CHATGPT_SUBSCRIPTION_BASE = 'https://chatgpt.com/backend-api';
 const BYTEPLUS_CODING_BASE = 'https://ark.ap-southeast.bytepluses.com/api/coding';
 const COMMAND_CODE_PROVIDER_BASE = 'https://api.commandcode.ai/provider';
 const KIMI_CODING_SUBSCRIPTION_BASE = 'https://api.kimi.com/coding';
-const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic';
+const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic/v1';
 const XIAOMI_MIMO_BASE = 'https://api.xiaomimimo.com';
 const XIAOMI_TOKEN_PLAN_BASE = getXiaomiTokenPlanBaseUrl();
 const QWEN_TOKEN_PLAN_BASE = 'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode';
@@ -275,7 +275,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   'minimax-subscription': {
     baseUrl: MINIMAX_SUBSCRIPTION_BASE,
     buildHeaders: anthropicBearerHeaders,
-    buildPath: () => '/v1/messages',
+    buildPath: () => '/messages',
     format: 'anthropic',
   },
   xiaomi: {
@@ -515,7 +515,10 @@ export function buildEndpointOverride(baseUrl: string, templateKey: string): Pro
   }
   return {
     ...template,
-    baseUrl: normalizeProviderBaseUrl(baseUrl),
+    baseUrl:
+      templateKey === 'minimax-subscription'
+        ? baseUrl.replace(/\/+$/, '')
+        : normalizeProviderBaseUrl(baseUrl),
     // The base URL came from a user-supplied source (Qwen region selector,
     // MiniMax OAuth resource URL). Treat it as an SSRF candidate and
     // re-validate before each forward.


### PR DESCRIPTION
Reason: refresh target model defaults against current official parameters

## Summary
- Align MiniMax subscription OAuth resource URLs and proxy endpoints with the official /anthropic/v1 base.
- Preserve /anthropic/v1 when validating MiniMax resource URLs and endpoint overrides.
- Update MiniMax CN discovery/proxy fallbacks and related tests for the global and CN Anthropic-compatible endpoints.

## Checks
- npm install
- npm run build --workspace manifest-shared
- git add -A -N && if git diff HEAD | grep -E "$SECRET_RE"; then echo secret_scan_failed; exit 1; fi
- git diff --check
- npx eslint packages/backend/src/routing/provider-base-url.ts packages/backend/src/model-discovery/provider-model-fetcher.service.ts packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.ts packages/backend/src/model-discovery/model-discovery.service.ts packages/backend/src/routing/proxy/forward-endpoint-resolver.ts packages/backend/src/routing/proxy/provider-endpoints.ts
- npm test -- --runInBand --silent routing/oauth/minimax/minimax-oauth-helpers.spec.ts routing/oauth/minimax/minimax-oauth.service.spec.ts routing/oauth/minimax/minimax-oauth.service.coverage.spec.ts model-discovery/provider-model-fetcher.service.spec.ts model-discovery/model-discovery.service.spec.ts routing/proxy/forward-endpoint-resolver.spec.ts routing/proxy/__tests__/proxy-fallback.service.spec.ts routing/proxy/__tests__/provider-endpoints.spec.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align MiniMax subscription OAuth, model discovery, and proxy routing with the official Anthropic-compatible base at `/anthropic/v1` for both global and CN regions. This removes path mismatches and standardizes how we build and validate MiniMax endpoints.

- **Bug Fixes**
  - Enforce MiniMax resource URLs to include `/anthropic/v1` (global and CN).
  - OAuth helpers now build and preserve `.../anthropic/v1` in `resource_url`.
  - Model discovery uses CN `https://api.minimaxi.com/anthropic/v1` when `region=cn`.
  - Proxy endpoint template base set to `.../anthropic/v1`; path builder returns `/messages` to avoid double `/v1`.
  - `buildEndpointOverride` preserves MiniMax base as provided and validates against `/anthropic/v1`.
  - Updated tests to reflect the new base and paths.

- **Migration**
  - Update any saved MiniMax subscription endpoint overrides to include `/anthropic/v1`.
  - Old URLs using `.../anthropic` (without `/v1`) will be rejected; re-auth MiniMax or update stored `resource_url`.
  - No client path changes needed; proxy now sends `/messages` against a v1 base.

<sup>Written for commit cf5df71fd51af88ab3217cc8108e84db5212f5bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

