### PR TITLE
fix: reset request quota rollout window

### DIFF
--- a/.changeset/request-quota-rollout-reset.md
+++ b/.changeset/request-quota-rollout-reset.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Reset the request quota window for the billing rollout.

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -106,3 +106,6 @@ BETTER_AUTH_URL=http://localhost:3001
 # Optional request-limit tuning (defaults: free 10000 req, pro unlimited)
 # PLAN_LIMIT_FREE_REQUESTS=10000
 # PLAN_LIMIT_PRO_REQUESTS=
+# Requests before this ISO timestamp are ignored by monthly plan quota counters.
+# Use only for hosted billing rollouts or emergency usage resets; message history remains intact.
+# PLAN_REQUEST_QUOTA_RESET_AT=2026-07-09T09:06:52Z

--- a/packages/backend/src/billing/plan.service.spec.ts
+++ b/packages/backend/src/billing/plan.service.spec.ts
@@ -287,13 +287,14 @@ describe('PlanService', () => {
 
   describe('countRequestsSince', () => {
     const START = Date.UTC(2026, 6, 1); // 2026-07-01 UTC
+    const ROLLOUT_RESET = Date.parse('2026-07-09T09:06:52Z');
 
     it('returns 0 for a null tenantId without querying', async () => {
       expect(await service.countRequestsSince(null, START)).toBe(0);
       expect(mockQuery).not.toHaveBeenCalled();
     });
 
-    it('counts via SQL, excluding Manifest-side blocks, and passes the tenant + month-start params', async () => {
+    it('counts via SQL, excluding Manifest-side blocks, and applies the rollout reset window', async () => {
       mockQuery.mockResolvedValue([{ n: 7 }]);
       expect(await service.countRequestsSince('t1', START)).toBe(7);
       const [sql, params] = mockQuery.mock.calls[0];
@@ -301,7 +302,18 @@ describe('PlanService', () => {
         "m.error_origin IS NULL OR m.error_origin NOT IN ('config', 'policy', 'internal')",
       );
       expect(params[0]).toBe('t1');
-      expect(params[1]).toBe(toLocalSqlTimestamp(new Date(START)));
+      expect(params[1]).toBe(toLocalSqlTimestamp(new Date(ROLLOUT_RESET)));
+    });
+
+    it('allows the quota reset window to be moved by env override', async () => {
+      process.env['PLAN_REQUEST_QUOTA_RESET_AT'] = '2026-07-10T12:34:56Z';
+      mockQuery.mockResolvedValue([{ n: 4 }]);
+
+      expect(await service.countRequestsSince('t1', START)).toBe(4);
+
+      expect(mockQuery.mock.calls[0][1][1]).toBe(
+        toLocalSqlTimestamp(new Date('2026-07-10T12:34:56Z')),
+      );
     });
 
     it('caches within the TTL — a second call does not re-query', async () => {
@@ -354,11 +366,27 @@ describe('PlanService', () => {
     });
 
     it('countRequestsThisMonth derives the current UTC month window', async () => {
-      mockQuery.mockResolvedValue([{ n: 2 }]);
-      expect(await service.countRequestsThisMonth('t1')).toBe(2);
-      const monthStart = new Date(mockQuery.mock.calls[0][1][1]);
-      expect(monthStart.getUTCDate()).toBe(1);
-      expect(monthStart.getUTCHours()).toBe(0);
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-15T10:00:00Z'));
+      try {
+        mockQuery.mockResolvedValue([{ n: 2 }]);
+        expect(await service.countRequestsThisMonth('t1')).toBe(2);
+        expect(mockQuery.mock.calls[0][1][1]).toBe(
+          toLocalSqlTimestamp(new Date(Date.UTC(2026, 7, 1))),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('countRequestsThisMonth starts at the rollout reset during the rollout month', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-07-10T10:00:00Z'));
+      try {
+        mockQuery.mockResolvedValue([{ n: 2 }]);
+        expect(await service.countRequestsThisMonth('t1')).toBe(2);
+        expect(mockQuery.mock.calls[0][1][1]).toBe(toLocalSqlTimestamp(new Date(ROLLOUT_RESET)));
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('invalidateRequestCountCache forces the next count to re-query', async () => {

--- a/packages/backend/src/billing/plan.service.ts
+++ b/packages/backend/src/billing/plan.service.ts
@@ -32,6 +32,8 @@ const BILLING_PRICE_UNAVAILABLE: BillingPrice = Object.freeze({
 // letting a few extra requests through, never toward false blocks.
 const REQUEST_COUNT_CACHE_TTL_MS = 30 * 1000;
 const MAX_REQUEST_COUNT_CACHE_SIZE = 10_000;
+const DEFAULT_REQUEST_QUOTA_RESET_AT = '2026-07-09T09:06:52Z';
+const REQUEST_QUOTA_RESET_AT_ENV = 'PLAN_REQUEST_QUOTA_RESET_AT';
 const MANIFEST_ERROR_ORIGIN_SQL_LIST = MANIFEST_ERROR_ORIGINS.map((origin) => `'${origin}'`).join(
   ', ',
 );
@@ -53,12 +55,18 @@ function envLimit(name: string): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
-/** Cached monthly request count for one tenant. Keyed by the UTC month it
- * covers so a month rollover invalidates naturally instead of serving last
- * month's total under this month's periodEnd. `pending` coalesces concurrent
+function requestQuotaResetAtMs(): number {
+  const raw = process.env[REQUEST_QUOTA_RESET_AT_ENV]?.trim() || DEFAULT_REQUEST_QUOTA_RESET_AT;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : Date.parse(DEFAULT_REQUEST_QUOTA_RESET_AT);
+}
+
+/** Cached monthly request count for one tenant. Keyed by the effective quota
+ * window start so a month rollover invalidates naturally instead of serving
+ * last month's total under this month's periodEnd. `pending` coalesces concurrent
  * misses (single-flight) so a burst can't stampede the DB with COUNT(*). */
 interface RequestCountEntry {
-  monthStartMs: number;
+  windowStartMs: number;
   count?: number;
   fetchedAt?: number;
   pending?: Promise<number>;
@@ -184,9 +192,13 @@ export class PlanService {
     return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
   }
 
+  private requestQuotaWindowStartMs(monthStartMs: number): number {
+    return Math.max(monthStartMs, requestQuotaResetAtMs());
+  }
+
   /**
-   * Routed requests recorded for the tenant since `monthStartMs`, cached per
-   * tenant+month with single-flight coalescing. "Routed request" = one
+   * Routed requests recorded for the tenant since the effective quota window
+   * start, cached per tenant+window with single-flight coalescing. "Routed request" = one
    * non-superseded `agent_messages` row that does not belong to the tenant's
    * Playground agent:
    *  - `superseded = false` drops intermediate fallback attempts, which the
@@ -199,9 +211,10 @@ export class PlanService {
    */
   async countRequestsSince(tenantId: string | null, monthStartMs: number): Promise<number> {
     if (!tenantId) return 0;
+    const windowStartMs = this.requestQuotaWindowStartMs(monthStartMs);
 
     const cached = this.requestCountCache.get(tenantId);
-    if (cached && cached.monthStartMs === monthStartMs) {
+    if (cached && cached.windowStartMs === windowStartMs) {
       if (cached.pending) return cached.pending;
       if (cached.count !== undefined && cached.fetchedAt !== undefined) {
         if (Date.now() - cached.fetchedAt < REQUEST_COUNT_CACHE_TTL_MS) return cached.count;
@@ -220,11 +233,11 @@ export class PlanService {
               SELECT 1 FROM agents pa
                WHERE pa.id = m.agent_id AND pa.is_playground = true
             )`,
-        [tenantId, toLocalSqlTimestamp(new Date(monthStartMs))],
+        [tenantId, toLocalSqlTimestamp(new Date(windowStartMs))],
       )
       .then((rows: Array<{ n: number }>) => {
         const count = rows[0]?.n ?? 0;
-        this.requestCountCache.set(tenantId, { monthStartMs, count, fetchedAt: Date.now() });
+        this.requestCountCache.set(tenantId, { windowStartMs, count, fetchedAt: Date.now() });
         this.evictRequestCountCache();
         return count;
       })
@@ -237,7 +250,7 @@ export class PlanService {
         throw err;
       });
 
-    this.requestCountCache.set(tenantId, { monthStartMs, pending });
+    this.requestCountCache.set(tenantId, { windowStartMs, pending });
     return pending;
   }
 


### PR DESCRIPTION
### ✨ What changed
- Request quota counts start at the billing rollout timestamp for July.
- `PLAN_REQUEST_QUOTA_RESET_AT` can move the reset without code changes.

### 💭 Why
July traffic from before the billing rollout was counted toward Free quotas, so existing workspaces could appear near or over 10,000 requests immediately after deploy.

### 👤 For users
Free request usage resets for the rollout window while message history stays intact.

### 🔧 For operators
Set `PLAN_REQUEST_QUOTA_RESET_AT` to a later ISO timestamp for an emergency reset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset monthly request quotas to start at the July billing rollout so pre-rollout traffic is ignored. Added `PLAN_REQUEST_QUOTA_RESET_AT` (default `2026-07-09T09:06:52Z`) so operators can move the reset without code changes.

- **Bug Fixes**
  - Quota counting now starts at the effective window (rollout reset or month start), preventing Free workspaces from appearing near/over 10k right after deploy.
  - Request-count cache keys by the window start to avoid stale counts after a reset.

<sup>Written for commit 9514558baa69db6f6d6bad5993fa3064feecc160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

