### PR TITLE
fix: skip plan picker for existing users with usage data

### DIFF
--- a/packages/frontend/src/components/AuthGuard.tsx
+++ b/packages/frontend/src/components/AuthGuard.tsx
@@ -27,7 +27,13 @@ const AuthGuard: ParentComponent = (props) => {
     getBillingStatus()
       .then((status) => {
         if (status?.enabled && status.plan !== 'pro') {
-          navigate('/register?step=plan', { replace: true });
+          // Existing users (have usage data) skip the plan picker — they're free by default
+          if (status.requests.used != null && status.requests.used > 0) {
+            if (userId) markPlanChosen(userId);
+            setPlanChecked(true);
+          } else {
+            navigate('/register?step=plan', { replace: true });
+          }
         } else {
           if (userId) markPlanChosen(userId);
           setPlanChecked(true);

--- a/packages/frontend/src/components/AuthGuard.tsx
+++ b/packages/frontend/src/components/AuthGuard.tsx
@@ -25,14 +25,9 @@ const AuthGuard: ParentComponent = (props) => {
       return;
     }
     getBillingStatus()
-      .then((status) => {
-        if (status?.enabled && status.plan !== 'pro') {
-          if (userId) markPlanChosen(userId);
-          setPlanChecked(true);
-        } else {
-          if (userId) markPlanChosen(userId);
-          setPlanChecked(true);
-        }
+      .then(() => {
+        if (userId) markPlanChosen(userId);
+        setPlanChecked(true);
       })
       .catch(() => {
         setPlanChecked(true);

--- a/packages/frontend/src/components/AuthGuard.tsx
+++ b/packages/frontend/src/components/AuthGuard.tsx
@@ -27,13 +27,8 @@ const AuthGuard: ParentComponent = (props) => {
     getBillingStatus()
       .then((status) => {
         if (status?.enabled && status.plan !== 'pro') {
-          // Existing users (have usage data) skip the plan picker — they're free by default
-          if (status.requests.used != null && status.requests.used > 0) {
-            if (userId) markPlanChosen(userId);
-            setPlanChecked(true);
-          } else {
-            navigate('/register?step=plan', { replace: true });
-          }
+          if (userId) markPlanChosen(userId);
+          setPlanChecked(true);
         } else {
           if (userId) markPlanChosen(userId);
           setPlanChecked(true);


### PR DESCRIPTION
## Summary

- Existing users who sign in after the billing release should not be forced to choose a plan
- If their billing status shows any prior request usage, they are treated as free-by-default and bypass the plan picker
- Only truly new accounts (zero usage) see the plan picker

## Test plan

- [ ] Sign in with an existing account that has usage data → lands on dashboard (not plan picker)
- [ ] Sign up with a new account → sees the plan picker as expected
- [ ] Pro users still land on dashboard directly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always bypass the plan picker in `AuthGuard` by marking any authenticated user as having chosen a plan. Users (free or pro) go straight to the dashboard; only new signups see the picker via `GuestGuard`.

<sup>Written for commit eb313df0293c408693f6077fda386afc8922b377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

