### PR TITLE
fix: show plan picker for all users without a plan (existing + OAuth)

### DIFF
--- a/packages/frontend/src/components/AuthGuard.tsx
+++ b/packages/frontend/src/components/AuthGuard.tsx
@@ -27,7 +27,7 @@ const AuthGuard: ParentComponent = (props) => {
     getBillingStatus()
       .then((status) => {
         if (status?.enabled && status.plan !== 'pro') {
-          navigate('/register?step=plan', { replace: true });
+          navigate('/register?step=plan&context=login', { replace: true });
         } else {
           if (userId) markPlanChosen(userId);
           setPlanChecked(true);

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -330,14 +330,22 @@ const Register: Component = () => {
           }
         >
           <div class="auth-header">
-            <h1 class="auth-header__title">Create an account</h1>
-            <p class="auth-header__subtitle">Monitor your AI harnesses' costs and usage</p>
+            <h1 class="auth-header__title">
+              {searchParams.context === 'login' ? 'Choose your plan' : 'Create an account'}
+            </h1>
+            <p class="auth-header__subtitle">
+              {searchParams.context === 'login'
+                ? 'Manifest now offers Free and Pro plans. Select the one that fits your needs.'
+                : 'Monitor your AI harnesses\' costs and usage'}
+            </p>
           </div>
 
-          <div class="plan-picker__section-header">
-            <h2 class="plan-picker__section-title">Choose your plan</h2>
-            <p class="plan-picker__section-subtitle">You can change your plan anytime</p>
-          </div>
+          <Show when={searchParams.context !== 'login'}>
+            <div class="plan-picker__section-header">
+              <h2 class="plan-picker__section-title">Choose your plan</h2>
+              <p class="plan-picker__section-subtitle">You can change your plan anytime</p>
+            </div>
+          </Show>
 
           <PlanPicker proPrice={proPrice()} onSelect={handlePlanSelect} busy={planBusy()} />
         </Show>

--- a/packages/frontend/tests/components/AuthGuard.test.tsx
+++ b/packages/frontend/tests/components/AuthGuard.test.tsx
@@ -68,7 +68,7 @@ describe('AuthGuard', () => {
     ));
 
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/register?step=plan', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/register?step=plan&context=login', { replace: true });
     });
   });
 

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -457,6 +457,35 @@ describe('Register', () => {
     });
   });
 
+  it('shows "Choose your plan" title when context=login (existing/OAuth user)', async () => {
+    mockSearchParams = { step: 'plan', context: 'login' };
+    mockGetBillingStatus.mockResolvedValue({
+      enabled: true,
+      plan: 'free',
+      priceMonthly: { amount: 20, currency: 'USD', interval: 'month' },
+    });
+
+    render(() => <Register />);
+    await vi.waitFor(() => {
+      expect(screen.getByText('Choose your plan')).toBeDefined();
+    });
+    expect(screen.getByText(/Manifest now offers Free and Pro plans/)).toBeDefined();
+  });
+
+  it('shows "Create an account" title without context=login (email signup)', async () => {
+    mockSearchParams = { step: 'plan' };
+    mockGetBillingStatus.mockResolvedValue({
+      enabled: true,
+      plan: 'free',
+      priceMonthly: { amount: 20, currency: 'USD', interval: 'month' },
+    });
+
+    render(() => <Register />);
+    await vi.waitFor(() => {
+      expect(screen.getByText('Create an account')).toBeDefined();
+    });
+  });
+
   it('clears the cooldown interval on unmount', async () => {
     const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
     mockSignUpEmail.mockResolvedValue({ error: null });


### PR DESCRIPTION
## Summary

- Existing users (pre-billing-release) and new OAuth signups see the plan picker on first login
- Title adapts to context: "Choose your plan" for returning users, "Create an account" for email signups
- Users who already chose a plan (Free or Pro) never see the plan picker again

## Context

After the billing release, existing users who log in have never selected a plan. This PR ensures they see the plan picker once, with adapted wording explaining that Manifest now offers plans.

New OAuth signups (Google, GitHub, Discord) also need to choose a plan since they bypass the email registration flow.

## Test plan

- [ ] Log in with an existing account (no plan chosen) → plan picker with "Choose your plan" title
- [ ] Sign up with email → plan picker with "Create an account" title
- [ ] Sign up with OAuth → plan picker with "Choose your plan" title
- [ ] After choosing a plan, never see the plan picker again
- [ ] Pro users skip the plan picker entirely

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the plan picker to any logged-in user without a plan, including existing users and new OAuth signups. Titles and copy adapt to the context, and users who already picked Free or Pro skip it.

- **Bug Fixes**
  - Redirect unauthenticated-plan users via AuthGuard to /register?step=plan&context=login.
  - In login context, show "Choose your plan" with a short explanation; email signups keep "Create an account".
  - Hide the duplicate plan-picker section header in login context.
  - Add tests for the redirect param and title variants (context=login vs email signup).

<sup>Written for commit de66a9d41dec76c57e83d972da6b4e095361f461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

