### PR TITLE
fix: attribute public stats by recorded provider

### DIFF
--- a/.changeset/public-stats-provider-source.md
+++ b/.changeset/public-stats-provider-source.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Attribute public provider-token stats from recorded message providers before falling back to pricing metadata, so ChatGPT subscription usage is not grouped under API-key gateways that expose the same model name.

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -11,6 +11,7 @@ function mockQueryBuilder(result: unknown) {
   qb.where = jest.fn().mockReturnValue(qb);
   qb.andWhere = jest.fn().mockReturnValue(qb);
   qb.groupBy = jest.fn().mockReturnValue(qb);
+  qb.addGroupBy = jest.fn().mockReturnValue(qb);
   qb.orderBy = jest.fn().mockReturnValue(qb);
   qb.limit = jest.fn().mockReturnValue(qb);
   qb.getRawOne = jest.fn().mockResolvedValue(result);
@@ -146,6 +147,75 @@ describe('PublicStatsService', () => {
 
       expect(result.top_models).toHaveLength(1);
       expect(result.top_models[0].provider).toBe('OpenRouter');
+    });
+
+    it('uses recorded provider before pricing cache attribution', async () => {
+      setupQueries(
+        { total: '1' },
+        [{ model: 'gpt-5.5', provider: 'openai', usage_count: '1' }],
+        [{ model: 'gpt-5.5', provider: 'openai', tokens: '6000000' }],
+        [{ model: 'gpt-5.5', provider: 'openai', tokens: '5000000' }],
+        [{ model: 'gpt-5.5', provider: 'openai', tokens: '18000000' }],
+      );
+      mockPricingCache.getByModel.mockReturnValue(
+        makePricingEntry({ provider: 'OpenCode Zen' }),
+      );
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models).toHaveLength(1);
+      expect(result.top_models[0]).toEqual(
+        expect.objectContaining({
+          model: 'gpt-5.5',
+          provider: 'OpenAI',
+          tokens_7d: 6000000,
+          tokens_previous_7d: 5000000,
+          tokens_30d: 18000000,
+        }),
+      );
+    });
+
+    it('aggregates duplicate normalized provider token rows and skips unknown scoped rows', async () => {
+      setupQueries(
+        { total: '1' },
+        [
+          { model: 'gpt-5.5', provider: 'openai', usage_count: '1' },
+          { model: 'gpt-5.5', provider: 'OpenAI', usage_count: '1' },
+        ],
+        [
+          { model: 'gpt-5.5', provider: 'openai', tokens: '3000' },
+          { model: 'gpt-5.5', provider: 'OpenAI', tokens: '2000' },
+        ],
+        [
+          { model: 'gpt-5.5', provider: 'openai', tokens: '1000' },
+          { model: 'gpt-5.5', provider: 'OpenAI', tokens: '500' },
+          { model: 'gpt-5.5', provider: 'openai', tokens: null },
+          { model: 'unknown-model', provider: null, tokens: '9999' },
+        ],
+        [
+          { model: 'gpt-5.5', provider: 'openai', tokens: '5000' },
+          { model: 'gpt-5.5', provider: 'OpenAI', tokens: '2500' },
+          { model: 'gpt-5.5', provider: 'openai', tokens: null },
+          { model: 'unknown-model', provider: null, tokens: '9999' },
+        ],
+      );
+      mockPricingCache.getByModel.mockImplementation((name: string) => {
+        if (name === 'gpt-5.5') return makePricingEntry({ provider: 'OpenCode Zen' });
+        return null;
+      });
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models).toHaveLength(1);
+      expect(result.top_models[0]).toEqual(
+        expect.objectContaining({
+          model: 'gpt-5.5',
+          provider: 'OpenAI',
+          tokens_7d: 5000,
+          tokens_previous_7d: 1500,
+          tokens_30d: 7500,
+        }),
+      );
     });
 
     it('limits to 10 results', async () => {
@@ -305,6 +375,19 @@ describe('PublicStatsService', () => {
         makePricingEntry({
           model_name: 'a',
           provider: 'Unknown',
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+        }),
+      ]);
+
+      expect(service.getFreeModels(new Map([['a', 100]]))).toEqual([]);
+    });
+
+    it('excludes entries without a provider label', () => {
+      mockPricingCache.getAll.mockReturnValue([
+        makePricingEntry({
+          model_name: 'a',
+          provider: '',
           input_price_per_token: 0,
           output_price_per_token: 0,
         }),
@@ -800,6 +883,114 @@ describe('PublicStatsService', () => {
       expect(sub).toEqual({ auth_type: 'subscription', total_tokens: 2000, model_count: 1 });
       // Breakdown is sorted by token usage descending.
       expect(result[0].auth_types[0].auth_type).toBe('subscription');
+    });
+
+    it('uses recorded provider to split subscription GPT usage from OpenCode Zen', async () => {
+      setupProviderQuery([
+        {
+          model: 'gpt-5.5',
+          provider: 'openai',
+          date: '2026-04-07',
+          tokens: '6000',
+          auth_type: 'subscription',
+          cost: '0',
+        },
+        {
+          model: 'gpt-5.5',
+          provider: 'opencode-zen',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: 'api_key',
+          cost: '0.10',
+        },
+      ]);
+      mockPricingCache.getByModel.mockReturnValue(
+        makePricingEntry({ provider: 'OpenCode Zen' }),
+      );
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toHaveLength(2);
+      const openai = result.find((p) => p.provider === 'OpenAI');
+      const zen = result.find((p) => p.provider === 'OpenCode Zen');
+      expect(openai).toBeDefined();
+      expect(openai!.total_tokens).toBe(6000);
+      expect(openai!.models).toEqual([
+        expect.objectContaining({
+          model: 'gpt-5.5',
+          auth_type: 'subscription',
+          total_tokens: 6000,
+        }),
+      ]);
+      expect(openai!.auth_types).toEqual([
+        { auth_type: 'subscription', total_tokens: 6000, model_count: 1 },
+      ]);
+      expect(zen).toBeDefined();
+      expect(zen!.total_tokens).toBe(1000);
+      expect(zen!.auth_types).toEqual([
+        { auth_type: 'api_key', total_tokens: 1000, model_count: 1 },
+      ]);
+    });
+
+    it('normalizes recorded display-name providers through aliases', async () => {
+      setupProviderQuery([
+        {
+          model: 'gpt-5.5',
+          provider: 'OpenCode Zen',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: 'api_key',
+          cost: '0.10',
+        },
+      ]);
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('OpenCode Zen');
+      expect(result[0].models[0]).toEqual(
+        expect.objectContaining({ model: 'gpt-5.5', total_tokens: 1000 }),
+      );
+    });
+
+    it('collapses recorded custom provider labels to the public Custom bucket', async () => {
+      setupProviderQuery([
+        {
+          model: 'hosted-model',
+          provider: 'custom:tenant-provider',
+          date: '2026-04-07',
+          tokens: '500',
+          auth_type: 'api_key',
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('Custom');
+      expect(result[0].models[0]).toEqual(
+        expect.objectContaining({ model: 'hosted-model', total_tokens: 500 }),
+      );
+    });
+
+    it('keeps non-registry recorded provider labels instead of dropping usage', async () => {
+      setupProviderQuery([
+        {
+          model: 'experimental-model',
+          provider: 'Experimental Provider',
+          date: '2026-04-07',
+          tokens: '750',
+          auth_type: 'api_key',
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('Experimental Provider');
+      expect(mockPricingCache.getByModel).not.toHaveBeenCalled();
     });
 
     it('excludes zero-token models from auth_types model_count', async () => {

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -6,6 +6,7 @@ import {
   AGENT_PLATFORMS,
   CATEGORY_LABELS,
   PLATFORM_LABELS,
+  normalizeProviderName,
   type AgentCategory,
   type AgentPlatform,
 } from 'manifest-shared';
@@ -13,6 +14,7 @@ import { AgentMessage } from '../entities/agent-message.entity';
 import { Agent } from '../entities/agent.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { computeCutoff, sqlDateBucket } from '../common/utils/postgres-sql';
+import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 
 const MAX_RESULTS = 10;
 const EXCLUDED_PROVIDERS = new Set(['Unknown']);
@@ -109,6 +111,26 @@ function scrubCustomModel(model: string): string {
   return isCustomModel(scrubbed) ? OTHER_CUSTOM_MODELS : scrubbed;
 }
 
+function providerModelKey(provider: string, model: string): string {
+  return `${provider}\u0000${model}`;
+}
+
+function normalizePublicProvider(provider: string | null | undefined): string | null {
+  const raw = provider?.trim();
+  if (!raw) return null;
+
+  const lower = raw.toLowerCase();
+  if (lower === 'custom' || lower.startsWith('custom:')) return CUSTOM_PROVIDER_LABEL;
+
+  const direct = PROVIDER_BY_ID_OR_ALIAS.get(lower);
+  if (direct) return direct.displayName;
+
+  const normalized = PROVIDER_BY_ID_OR_ALIAS.get(normalizeProviderName(raw));
+  if (normalized) return normalized.displayName;
+
+  return raw;
+}
+
 @Injectable()
 export class PublicStatsService {
   constructor(
@@ -116,6 +138,16 @@ export class PublicStatsService {
     private readonly messageRepo: Repository<AgentMessage>,
     private readonly pricingCache: ModelPricingCacheService,
   ) {}
+
+  private publicProviderFor(modelName: string, recordedProvider?: string | null): string | null {
+    const recorded = normalizePublicProvider(recordedProvider);
+    if (recorded && !EXCLUDED_PROVIDERS.has(recorded)) return recorded;
+
+    const pricing = this.pricingCache.getByModel(modelName);
+    const fallback = normalizePublicProvider(pricing?.provider);
+    if (!fallback || EXCLUDED_PROVIDERS.has(fallback)) return null;
+    return fallback;
+  }
 
   async getUsageStats(): Promise<UsageStats> {
     const cutoff7d = computeCutoff('7 days');
@@ -127,68 +159,107 @@ export class PublicStatsService {
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
+        .addSelect('at.provider', 'provider')
         .addSelect('COUNT(*)', 'usage_count')
         .where('at.model IS NOT NULL')
         .groupBy('at.model')
+        .addGroupBy('at.provider')
         .orderBy('usage_count', 'DESC')
         .limit(MAX_MODEL_ROWS)
         .getRawMany(),
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
+        .addSelect('at.provider', 'provider')
         .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
         .where('at.model IS NOT NULL')
         .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff7d })
         .groupBy('at.model')
+        .addGroupBy('at.provider')
         .getRawMany(),
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
+        .addSelect('at.provider', 'provider')
         .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
         .where('at.model IS NOT NULL')
         .andWhere('at.timestamp >= :cutoff14d', { cutoff14d })
         .andWhere('at.timestamp < :cutoff7d', { cutoff7d })
         .groupBy('at.model')
+        .addGroupBy('at.provider')
         .getRawMany(),
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
+        .addSelect('at.provider', 'provider')
         .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
         .where('at.model IS NOT NULL')
         .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
         .groupBy('at.model')
+        .addGroupBy('at.provider')
         .getRawMany(),
     ]);
 
     const tokenMap = new Map<string, number>();
+    const tokenMapByProvider = new Map<string, number>();
     for (const r of tokenRows) {
-      tokenMap.set(r.model as string, Number(r.tokens ?? 0));
+      const modelName = r.model as string;
+      const tokens = Number(r.tokens ?? 0);
+      tokenMap.set(modelName, (tokenMap.get(modelName) ?? 0) + tokens);
+      const provider = this.publicProviderFor(modelName, r.provider as string | null);
+      if (provider) {
+        const key = providerModelKey(provider, modelName);
+        tokenMapByProvider.set(key, (tokenMapByProvider.get(key) ?? 0) + tokens);
+      }
     }
 
     const tokenMapPrev7d = new Map<string, number>();
     for (const r of tokenRowsPrev7d) {
-      tokenMapPrev7d.set(r.model as string, Number(r.tokens ?? 0));
+      const modelName = r.model as string;
+      const provider = this.publicProviderFor(modelName, r.provider as string | null);
+      if (!provider) continue;
+      const key = providerModelKey(provider, modelName);
+      tokenMapPrev7d.set(key, (tokenMapPrev7d.get(key) ?? 0) + Number(r.tokens ?? 0));
     }
 
     const tokenMap30d = new Map<string, number>();
     for (const r of tokenRows30d) {
-      tokenMap30d.set(r.model as string, Number(r.tokens ?? 0));
+      const modelName = r.model as string;
+      const provider = this.publicProviderFor(modelName, r.provider as string | null);
+      if (!provider) continue;
+      const key = providerModelKey(provider, modelName);
+      tokenMap30d.set(key, (tokenMap30d.get(key) ?? 0) + Number(r.tokens ?? 0));
     }
 
-    const eligible: TopModel[] = [];
+    const topCandidates = new Map<string, { modelName: string; provider: string }>();
     for (const r of topRows) {
       const modelName = r.model as string;
       if (isCustomModel(modelName)) continue;
+
+      const provider = this.publicProviderFor(modelName, r.provider as string | null);
+      if (!provider) continue;
+
+      const key = providerModelKey(provider, modelName);
+      if (!topCandidates.has(key)) {
+        topCandidates.set(key, {
+          modelName,
+          provider,
+        });
+      }
+    }
+
+    const eligible: TopModel[] = [];
+    for (const candidate of topCandidates.values()) {
+      const modelName = candidate.modelName;
       const pricing = this.pricingCache.getByModel(modelName);
-      const provider = pricing?.provider || 'Unknown';
-      if (EXCLUDED_PROVIDERS.has(provider)) continue;
+      const key = providerModelKey(candidate.provider, modelName);
 
       eligible.push({
         model: modelName,
-        provider,
-        tokens_7d: tokenMap.get(modelName) ?? 0,
-        tokens_previous_7d: tokenMapPrev7d.get(modelName) ?? 0,
-        tokens_30d: tokenMap30d.get(modelName) ?? 0,
+        provider: candidate.provider,
+        tokens_7d: tokenMapByProvider.get(key) ?? 0,
+        tokens_previous_7d: tokenMapPrev7d.get(key) ?? 0,
+        tokens_30d: tokenMap30d.get(key) ?? 0,
         input_price_per_million:
           pricing?.input_price_per_token != null
             ? Number(pricing.input_price_per_token) * 1_000_000
@@ -219,6 +290,7 @@ export class PublicStatsService {
     const [rows, customPairs]: [
       {
         model: string;
+        provider: string | null;
         date: string;
         tokens: string;
         auth_type: string | null;
@@ -229,6 +301,7 @@ export class PublicStatsService {
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
+        .addSelect('at.provider', 'provider')
         .addSelect(dateBucket, 'date')
         .addSelect('at.auth_type', 'auth_type')
         .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
@@ -236,6 +309,7 @@ export class PublicStatsService {
         .where('at.model IS NOT NULL')
         .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
         .groupBy('at.model')
+        .addGroupBy('at.provider')
         .addGroupBy('date')
         .addGroupBy('at.auth_type')
         .orderBy('date', 'ASC')
@@ -294,9 +368,9 @@ export class PublicStatsService {
         const scrubbed = scrubCustomModel(modelName);
         modelName = publishableCustomModels.has(scrubbed) ? scrubbed : OTHER_CUSTOM_MODELS;
       } else {
-        const pricing = this.pricingCache.getByModel(modelName);
-        provider = pricing?.provider || 'Unknown';
-        if (EXCLUDED_PROVIDERS.has(provider)) continue;
+        const publicProvider = this.publicProviderFor(modelName, r.provider);
+        if (!publicProvider) continue;
+        provider = publicProvider;
       }
 
       // Provider is part of the key: a scrubbed custom name can collide with
@@ -513,14 +587,15 @@ export class PublicStatsService {
         if ((e.input_price_per_token ?? 0) !== 0 || (e.output_price_per_token ?? 0) !== 0)
           return false;
         if (isCustomModel(e.model_name)) return false;
-        const provider = e.provider || 'Unknown';
+        const provider = e.provider;
+        if (!provider) return false;
         if (EXCLUDED_PROVIDERS.has(provider)) return false;
         return (tokenMap.get(e.model_name) ?? 0) > 0;
       })
       .map((e) => ({
         model_name: e.model_name,
-        provider: e.provider || 'Unknown',
-        tokens_7d: tokenMap.get(e.model_name) ?? 0,
+        provider: e.provider,
+        tokens_7d: tokenMap.get(e.model_name) as number,
       }))
       .sort((a, b) => b.tokens_7d - a.tokens_7d)
       .slice(0, MAX_RESULTS);

--- a/packages/backend/test/public-stats.e2e-spec.ts
+++ b/packages/backend/test/public-stats.e2e-spec.ts
@@ -29,6 +29,24 @@ beforeAll(async () => {
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
     ['ps-msg-3', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 150, 75, 'claude-opus-4-6', 'ok'],
   );
+  await ds.query(
+    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, provider, auth_type, status)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+    [
+      'ps-msg-6',
+      'test-tenant-001',
+      'test-agent-001',
+      'test-agent',
+      'test-user-001',
+      now,
+      800,
+      400,
+      'gpt-5.5',
+      'openai',
+      'subscription',
+      'ok',
+    ],
+  );
 
   // Custom-endpoint traffic: two tenant-scoped provider refs from one tenant,
   // exercising the Custom grouping + k-anonymity fold on real SQL.
@@ -116,6 +134,39 @@ describe('GET /api/v1/public/provider-tokens', () => {
     const payload = JSON.stringify(res.body);
     expect(payload).not.toContain('d0c5ce41');
     expect(payload).not.toContain('private-model');
+  });
+
+  it('attributes ChatGPT subscription GPT rows to OpenAI, not OpenCode Zen', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/public/provider-tokens')
+      .expect(200);
+
+    const openai = res.body.providers.find((p: { provider: string }) => p.provider === 'OpenAI');
+    expect(openai).toBeDefined();
+    expect(openai.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          model: 'gpt-5.5',
+          auth_type: 'subscription',
+          total_tokens: expect.any(Number),
+        }),
+      ]),
+    );
+    const gpt = openai.models.find(
+      (m: { model: string; auth_type: string | null }) =>
+        m.model === 'gpt-5.5' && m.auth_type === 'subscription',
+    );
+    expect(gpt.total_tokens).toBeGreaterThanOrEqual(1200);
+
+    const zen = res.body.providers.find(
+      (p: { provider: string }) => p.provider === 'OpenCode Zen',
+    );
+    expect(
+      zen?.models.some(
+        (m: { model: string; auth_type: string | null }) =>
+          m.model === 'gpt-5.5' && m.auth_type === 'subscription',
+      ),
+    ).not.toBe(true);
   });
 });
 


### PR DESCRIPTION
### ✨ What changed
- Public stats prefer recorded message providers before pricing fallback.
- Provider-token aggregation keeps same-model providers separate.
- Added coverage for ChatGPT subscription GPT rows.

### 💭 Why
Pricing metadata can map shared model names to an API-key gateway. That mislabeled ChatGPT subscription usage as OpenCode Zen.

### 👤 For users
The public model table shows GPT subscription usage under OpenAI instead of OpenCode Zen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes public usage stats to attribute tokens by the recorded message provider before pricing fallback. This correctly shows ChatGPT subscription GPT usage under OpenAI and keeps same-name models separate across providers.

- **Bug Fixes**
  - Prefer recorded provider; fall back to pricing only if missing (top models and provider daily tokens).
  - Group by model+provider and aggregate duplicates after normalization; skip unknown or empty providers.
  - Normalize provider names (IDs/aliases); collapse custom:* to "Custom"; keep non‑registry recorded labels; expanded unit and e2e tests including subscription GPT attribution.

<sup>Written for commit ca87016f0e4c260baad1eaf9f0caa0e76db807ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

