### PR TITLE
fix: stop slow deploys from hanging on healthchecks

### DIFF
--- a/.changeset/olive-pears-shave.md
+++ b/.changeset/olive-pears-shave.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Open the HTTP port at boot instead of waiting for the provider model registry to load, so a slow database no longer stalls deploy healthchecks.

--- a/packages/backend/src/model-discovery/provider-model-registry.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-registry.service.spec.ts
@@ -1,13 +1,55 @@
-import { ProviderModelRegistryService } from './provider-model-registry.service';
+import {
+  CACHE_LOAD_BATCH_SIZE,
+  ProviderModelRegistryService,
+} from './provider-model-registry.service';
+
+/**
+ * Fake repository that honours the keyset pagination the loader performs:
+ * each `createQueryBuilder()` yields a builder with its own cursor/limit, and
+ * `getMany()` returns the rows after the cursor, capped at the limit.
+ */
+interface MockQueryBuilder {
+  select: jest.Mock;
+  where: jest.Mock;
+  orderBy: jest.Mock;
+  limit: jest.Mock;
+  andWhere: jest.Mock;
+  getMany: jest.Mock;
+}
 
 function makeMockRepo(providers: Array<{ provider: string; cached_models: unknown }> = []) {
+  const rows = providers.map((p, i) => ({ id: `id-${String(i).padStart(5, '0')}`, ...p }));
+
   return {
-    createQueryBuilder: jest.fn().mockReturnValue({
-      select: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      getMany: jest.fn().mockResolvedValue(providers),
+    createQueryBuilder: jest.fn((): MockQueryBuilder => {
+      let cursor: string | null = null;
+      let take = rows.length;
+
+      const qb: MockQueryBuilder = {
+        select: jest.fn(() => qb),
+        where: jest.fn(() => qb),
+        orderBy: jest.fn(() => qb),
+        limit: jest.fn((n: number) => {
+          take = n;
+          return qb;
+        }),
+        andWhere: jest.fn((_sql: string, params: { cursor: string }) => {
+          cursor = params.cursor;
+          return qb;
+        }),
+        getMany: jest.fn(() =>
+          Promise.resolve(rows.filter((r) => cursor === null || r.id > cursor).slice(0, take)),
+        ),
+      };
+      return qb;
     }),
   };
+}
+
+/** Run the bootstrap hook and wait for the background load it kicks off. */
+async function bootstrap(service: ProviderModelRegistryService): Promise<void> {
+  service.onApplicationBootstrap();
+  await service.whenLoaded();
 }
 
 describe('ProviderModelRegistryService', () => {
@@ -141,7 +183,7 @@ describe('ProviderModelRegistryService', () => {
       ];
       const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
 
-      await service.onApplicationBootstrap();
+      await bootstrap(service);
 
       expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
       expect(service.isModelConfirmed('openai', 'gpt-4-turbo')).toBe(true);
@@ -163,7 +205,7 @@ describe('ProviderModelRegistryService', () => {
       ];
       const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
 
-      await service.onApplicationBootstrap();
+      await bootstrap(service);
 
       expect(service.getModelMetadata('copilot', 'copilot/gpt-5.5')).toEqual({
         id: 'copilot/gpt-5.5',
@@ -175,7 +217,7 @@ describe('ProviderModelRegistryService', () => {
       const providers = [{ provider: 'openai', cached_models: 'not-an-array' }];
       const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
 
-      await service.onApplicationBootstrap();
+      await bootstrap(service);
 
       expect(service.getConfirmedModels('openai')).toBeNull();
     });
@@ -184,7 +226,7 @@ describe('ProviderModelRegistryService', () => {
       const providers = [{ provider: 'openai', cached_models: [] }];
       const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
 
-      await service.onApplicationBootstrap();
+      await bootstrap(service);
 
       expect(service.getConfirmedModels('openai')).toBeNull();
     });
@@ -203,7 +245,7 @@ describe('ProviderModelRegistryService', () => {
       ];
       const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
 
-      await service.onApplicationBootstrap();
+      await bootstrap(service);
 
       expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
       // null, undefined, and empty string should all be filtered out
@@ -216,12 +258,17 @@ describe('ProviderModelRegistryService', () => {
         createQueryBuilder: jest.fn().mockReturnValue({
           select: jest.fn().mockReturnThis(),
           where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
           getMany: jest.fn().mockRejectedValue(new Error('DB down')),
         }),
       };
       const service = new ProviderModelRegistryService(mockRepo as never);
 
-      await expect(service.onApplicationBootstrap()).resolves.not.toThrow();
+      service.onApplicationBootstrap();
+
+      await expect(service.whenLoaded()).resolves.toBeUndefined();
       expect(service.getConfirmedModels('openai')).toBeNull();
     });
 
@@ -238,7 +285,7 @@ describe('ProviderModelRegistryService', () => {
       ];
       const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
 
-      await service.onApplicationBootstrap();
+      await bootstrap(service);
 
       expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
       expect(service.isModelConfirmed('openai', 'gpt-4-turbo')).toBe(true);
@@ -247,9 +294,58 @@ describe('ProviderModelRegistryService', () => {
     it('should not register models when providers list is empty', async () => {
       const service = new ProviderModelRegistryService(makeMockRepo([]) as never);
 
-      await service.onApplicationBootstrap();
+      await bootstrap(service);
 
       expect(service.getConfirmedModels('openai')).toBeNull();
+    });
+
+    it('should not block boot on the cache load', () => {
+      let resolveLoad: (rows: unknown[]) => void = () => {};
+      const mockRepo = {
+        createQueryBuilder: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          getMany: jest.fn(() => new Promise((resolve) => (resolveLoad = resolve))),
+        }),
+      };
+      const service = new ProviderModelRegistryService(mockRepo as never);
+
+      // The hook returns synchronously even though the query is still pending,
+      // so Nest can open the HTTP port and answer healthchecks.
+      expect(service.onApplicationBootstrap()).toBeUndefined();
+      expect(service.getConfirmedModels('openai')).toBeNull();
+
+      resolveLoad([]);
+    });
+
+    it('should resolve whenLoaded before bootstrap has run', async () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+
+      await expect(service.whenLoaded()).resolves.toBeUndefined();
+    });
+
+    it('should page through providers beyond a single batch', async () => {
+      const providers = Array.from({ length: CACHE_LOAD_BATCH_SIZE + 1 }, (_, i) => ({
+        provider: `provider-${i}`,
+        cached_models: [{ id: `model-${i}` }],
+      }));
+      const repo = makeMockRepo(providers);
+      const service = new ProviderModelRegistryService(repo as never);
+
+      await bootstrap(service);
+
+      // One full page, then a short page that ends the loop.
+      expect(repo.createQueryBuilder).toHaveBeenCalledTimes(2);
+      expect(service.isModelConfirmed('provider-0', 'model-0')).toBe(true);
+      expect(
+        service.isModelConfirmed(
+          `provider-${CACHE_LOAD_BATCH_SIZE}`,
+          `model-${CACHE_LOAD_BATCH_SIZE}`,
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/packages/backend/src/model-discovery/provider-model-registry.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-registry.service.spec.ts
@@ -327,6 +327,64 @@ describe('ProviderModelRegistryService', () => {
       await expect(service.whenLoaded()).resolves.toBeUndefined();
     });
 
+    it('should not expose a partially loaded provider while pages are still arriving', async () => {
+      // Two pages, both carrying models for the same provider. The second is
+      // held open so we can observe the registry mid-load.
+      const page = (start: number, count: number) =>
+        Array.from({ length: count }, (_, i) => ({
+          id: `id-${String(start + i).padStart(5, '0')}`,
+          provider: 'openai',
+          cached_models: [{ id: `gpt-${start + i}` }],
+        }));
+      let releaseSecondPage!: () => void;
+      let call = 0;
+      const mockRepo = {
+        createQueryBuilder: jest.fn(() => ({
+          select: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          getMany: jest.fn(async () => {
+            call += 1;
+            if (call === 1) return page(0, CACHE_LOAD_BATCH_SIZE);
+            await new Promise<void>((resolve) => (releaseSecondPage = resolve));
+            return page(CACHE_LOAD_BATCH_SIZE, 1);
+          }),
+        })),
+      };
+      const service = new ProviderModelRegistryService(mockRepo as never);
+
+      service.onApplicationBootstrap();
+      // Let the first page land and be staged.
+      while (call < 2) await Promise.resolve();
+
+      // A real model from the unread page must not be reported as a phantom,
+      // so the provider stays absent (null) rather than partially populated.
+      expect(service.getConfirmedModels('openai')).toBeNull();
+      expect(service.isModelConfirmed('openai', 'gpt-0')).toBeNull();
+
+      releaseSecondPage();
+      await service.whenLoaded();
+
+      expect(service.isModelConfirmed('openai', 'gpt-0')).toBe(true);
+      expect(service.isModelConfirmed('openai', `gpt-${CACHE_LOAD_BATCH_SIZE}`)).toBe(true);
+    });
+
+    it('should keep models registered while the load was running', async () => {
+      const providers = [{ provider: 'openai', cached_models: [{ id: 'gpt-4o' }] }];
+      const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
+
+      // A provider connected mid-load writes straight to the live registry.
+      service.onApplicationBootstrap();
+      service.registerModels('openai', ['gpt-live']);
+      await service.whenLoaded();
+
+      // The staged cache merges into it rather than replacing it.
+      expect(service.isModelConfirmed('openai', 'gpt-live')).toBe(true);
+      expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
+    });
+
     it('should page through providers beyond a single batch', async () => {
       const providers = Array.from({ length: CACHE_LOAD_BATCH_SIZE + 1 }, (_, i) => ({
         provider: `provider-${i}`,

--- a/packages/backend/src/model-discovery/provider-model-registry.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-registry.service.ts
@@ -59,8 +59,16 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
    * Merges with any existing confirmed models for that provider.
    */
   registerModels(providerId: string, models: ProviderModelRegistration[]): void {
+    this.registerInto(this.registry, providerId, models);
+  }
+
+  private registerInto(
+    target: Map<string, Map<string, ProviderModelRegistryEntry>>,
+    providerId: string,
+    models: ProviderModelRegistration[],
+  ): void {
     const key = providerId.toLowerCase();
-    const existing = this.registry.get(key) ?? new Map<string, ProviderModelRegistryEntry>();
+    const existing = target.get(key) ?? new Map<string, ProviderModelRegistryEntry>();
     for (const model of models) {
       const entry = this.toRegistryEntry(model);
       if (!entry) continue;
@@ -72,7 +80,7 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
         supportedEndpoints: entry.supportedEndpoints ?? previous?.supportedEndpoints,
       });
     }
-    if (existing.size > 0) this.registry.set(key, existing);
+    if (existing.size > 0) target.set(key, existing);
   }
 
   /**
@@ -104,6 +112,14 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
    */
   private async loadFromCache(): Promise<void> {
     try {
+      // Pages are ordered by primary key, so one provider's rows are scattered
+      // across them. Registering page-by-page would expose a half-built set for
+      // a provider, and a partial set is worse than none: `isModelConfirmed`
+      // answers `false` for a model that simply has not been read yet, and the
+      // caller filters that real model out as a phantom. An absent provider
+      // answers `null` instead, which callers treat as "no data, don't filter".
+      // So stage the whole load and publish it once, at the end.
+      const staged = new Map<string, Map<string, ProviderModelRegistryEntry>>();
       let totalModels = 0;
       let cursor: string | null = null;
 
@@ -123,13 +139,19 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
               (m as { id?: string }).id!.length > 0,
           );
           if (models.length > 0) {
-            this.registerModels(p.provider, models);
+            this.registerInto(staged, p.provider, models);
             totalModels += models.length;
           }
         }
 
         if (page.length < CACHE_LOAD_BATCH_SIZE) break;
         cursor = page[page.length - 1].id;
+      }
+
+      // Merge rather than swap: a provider connected while the load was running
+      // registered straight into the live registry, and must survive.
+      for (const [provider, models] of staged) {
+        this.registerModels(provider, Array.from(models.values()));
       }
 
       const providerCount = this.registry.size;

--- a/packages/backend/src/model-discovery/provider-model-registry.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-registry.service.ts
@@ -13,6 +13,13 @@ type ProviderModelRegistration = string | Pick<DiscoveredModel, 'id' | 'supporte
 type CachedProviderModelRegistration = Pick<DiscoveredModel, 'id' | 'supportedEndpoints'>;
 
 /**
+ * Rows per keyset page. The full scan is ~9k rows / ~30 MB of JSON across all
+ * tenants, which as a single statement can hold a pooled connection for
+ * minutes on a loaded database.
+ */
+export const CACHE_LOAD_BATCH_SIZE = 500;
+
+/**
  * Maintains an in-memory registry of model IDs confirmed to exist
  * via provider-native APIs. Populated opportunistically when users
  * connect providers and on startup from cached data.
@@ -23,14 +30,28 @@ type CachedProviderModelRegistration = Pick<DiscoveredModel, 'id' | 'supportedEn
 export class ProviderModelRegistryService implements OnApplicationBootstrap {
   private readonly logger = new Logger(ProviderModelRegistryService.name);
   private readonly registry = new Map<string, Map<string, ProviderModelRegistryEntry>>();
+  private cacheLoad: Promise<void> = Promise.resolve();
 
   constructor(
     @InjectRepository(TenantProvider)
     private readonly providerRepo: Repository<TenantProvider>,
   ) {}
 
-  async onApplicationBootstrap(): Promise<void> {
-    await this.loadFromCache();
+  /**
+   * Nest runs bootstrap hooks inside `app.init()`, before the HTTP server
+   * starts listening. Awaiting the cache load here means a slow database keeps
+   * the port closed and the platform healthcheck hanging, so the load runs in
+   * the background instead. Until it finishes the registry is simply empty,
+   * which every caller already handles as "no native data recorded" — the same
+   * path a fresh install takes.
+   */
+  onApplicationBootstrap(): void {
+    this.cacheLoad = this.loadFromCache();
+  }
+
+  /** Resolves once the startup cache load has settled. For tests and probes. */
+  whenLoaded(): Promise<void> {
+    return this.cacheLoad;
   }
 
   /**
@@ -83,28 +104,32 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
    */
   private async loadFromCache(): Promise<void> {
     try {
-      const providers = await this.providerRepo
-        .createQueryBuilder('p')
-        .select(['p.provider', 'p.cached_models'])
-        .where('p.cached_models IS NOT NULL')
-        .getMany();
-
       let totalModels = 0;
-      for (const p of providers) {
-        if (!Array.isArray(p.cached_models)) continue;
-        const cachedModels = p.cached_models as unknown[];
-        const models = cachedModels.filter(
-          (m): m is CachedProviderModelRegistration =>
-            typeof m === 'object' &&
-            m !== null &&
-            'id' in m &&
-            typeof (m as { id?: unknown }).id === 'string' &&
-            (m as { id?: string }).id!.length > 0,
-        );
-        if (models.length > 0) {
-          this.registerModels(p.provider, models);
-          totalModels += models.length;
+      let cursor: string | null = null;
+
+      for (;;) {
+        const page: TenantProvider[] = await this.fetchPage(cursor);
+        if (page.length === 0) break;
+
+        for (const p of page) {
+          if (!Array.isArray(p.cached_models)) continue;
+          const cachedModels = p.cached_models as unknown[];
+          const models = cachedModels.filter(
+            (m): m is CachedProviderModelRegistration =>
+              typeof m === 'object' &&
+              m !== null &&
+              'id' in m &&
+              typeof (m as { id?: unknown }).id === 'string' &&
+              (m as { id?: string }).id!.length > 0,
+          );
+          if (models.length > 0) {
+            this.registerModels(p.provider, models);
+            totalModels += models.length;
+          }
         }
+
+        if (page.length < CACHE_LOAD_BATCH_SIZE) break;
+        cursor = page[page.length - 1].id;
       }
 
       const providerCount = this.registry.size;
@@ -116,6 +141,20 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
     } catch (err) {
       this.logger.warn(`Failed to load provider model registry from cache: ${err}`);
     }
+  }
+
+  /** One keyset page, ordered by the `id` primary key. */
+  private fetchPage(cursor: string | null): Promise<TenantProvider[]> {
+    const qb = this.providerRepo
+      .createQueryBuilder('p')
+      .select(['p.id', 'p.provider', 'p.cached_models'])
+      .where('p.cached_models IS NOT NULL')
+      .orderBy('p.id', 'ASC')
+      .limit(CACHE_LOAD_BATCH_SIZE);
+
+    if (cursor !== null) qb.andWhere('p.id > :cursor', { cursor });
+
+    return qb.getMany();
   }
 
   private toRegistryEntry(model: ProviderModelRegistration): ProviderModelRegistryEntry | null {


### PR DESCRIPTION
### 💭 Why
Deploys were sitting in "performing healthchecks" for 13+ minutes. The backend does not open its HTTP port until every Nest bootstrap hook resolves, and one of them waits on a full scan of `tenant_providers`. That query was measured at 256 seconds and climbing on production, against a mean of 10s and a max of 82s over the last 8 hours.

### ✨ What changed
- `ProviderModelRegistryService` no longer awaits its cache load at boot.
- The load pages through `tenant_providers` on the `id` primary key, 500 rows at a time.
- Added `whenLoaded()` so tests and probes can await the background load.

### 👤 For users
Replicas start serving as soon as they are ready. In the window before the registry fills, phantom-model filtering is skipped, which is the same state a fresh install boots into and which every caller already handles.

### 🔧 For operators
None. No migration, no env var.

### 📝 Notes
The scan reads ~9k rows / ~30 MB of JSON to build a map of 29 providers. It cannot be deduplicated to one row per provider: tenants cache genuinely different model lists (openrouter has 399 distinct lists across 1,347 rows), and the registry unions them on purpose. Paging bounds the statement instead.

This unblocks the deploy. It is not the cause of the dashboard being slow, which is dominated by cross-tenant scans of `agent_messages` from peacock. That is handled separately in mnfst/peacock.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop deploy healthchecks from hanging by opening the HTTP port immediately. The provider model registry now loads in the background with keyset pagination and publishes atomically, so replicas start serving sooner without phantom filtering.

- **Bug Fixes**
  - Don’t await the cache load in `onApplicationBootstrap`; start it in the background.
  - Page through `tenant_providers` by `id` (500 rows) to avoid long scans holding a pooled connection.
  - Publish the startup cache in one go; no partial providers between pages.
  - Merge the staged cache into the live registry so mid-load registrations survive; add `whenLoaded()` for tests and probes.

<sup>Written for commit 3cc5fd122a2392efece882e32f7be121a42ba148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

