### PR TITLE
revert: public stats provider attribution

### DIFF
--- a/.changeset/public-stats-provider-source.md
+++ b/.changeset/public-stats-provider-source.md
@@ -1,5 +1,0 @@
----
-'manifest': patch
----
-
-Attribute public provider-token stats from recorded message providers before falling back to pricing metadata, so ChatGPT subscription usage is not grouped under API-key gateways that expose the same model name.

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -11,7 +11,6 @@ function mockQueryBuilder(result: unknown) {
   qb.where = jest.fn().mockReturnValue(qb);
   qb.andWhere = jest.fn().mockReturnValue(qb);
   qb.groupBy = jest.fn().mockReturnValue(qb);
-  qb.addGroupBy = jest.fn().mockReturnValue(qb);
   qb.orderBy = jest.fn().mockReturnValue(qb);
   qb.limit = jest.fn().mockReturnValue(qb);
   qb.getRawOne = jest.fn().mockResolvedValue(result);
@@ -147,75 +146,6 @@ describe('PublicStatsService', () => {
 
       expect(result.top_models).toHaveLength(1);
       expect(result.top_models[0].provider).toBe('OpenRouter');
-    });
-
-    it('uses recorded provider before pricing cache attribution', async () => {
-      setupQueries(
-        { total: '1' },
-        [{ model: 'gpt-5.5', provider: 'openai', usage_count: '1' }],
-        [{ model: 'gpt-5.5', provider: 'openai', tokens: '6000000' }],
-        [{ model: 'gpt-5.5', provider: 'openai', tokens: '5000000' }],
-        [{ model: 'gpt-5.5', provider: 'openai', tokens: '18000000' }],
-      );
-      mockPricingCache.getByModel.mockReturnValue(
-        makePricingEntry({ provider: 'OpenCode Zen' }),
-      );
-
-      const result = await service.getUsageStats();
-
-      expect(result.top_models).toHaveLength(1);
-      expect(result.top_models[0]).toEqual(
-        expect.objectContaining({
-          model: 'gpt-5.5',
-          provider: 'OpenAI',
-          tokens_7d: 6000000,
-          tokens_previous_7d: 5000000,
-          tokens_30d: 18000000,
-        }),
-      );
-    });
-
-    it('aggregates duplicate normalized provider token rows and skips unknown scoped rows', async () => {
-      setupQueries(
-        { total: '1' },
-        [
-          { model: 'gpt-5.5', provider: 'openai', usage_count: '1' },
-          { model: 'gpt-5.5', provider: 'OpenAI', usage_count: '1' },
-        ],
-        [
-          { model: 'gpt-5.5', provider: 'openai', tokens: '3000' },
-          { model: 'gpt-5.5', provider: 'OpenAI', tokens: '2000' },
-        ],
-        [
-          { model: 'gpt-5.5', provider: 'openai', tokens: '1000' },
-          { model: 'gpt-5.5', provider: 'OpenAI', tokens: '500' },
-          { model: 'gpt-5.5', provider: 'openai', tokens: null },
-          { model: 'unknown-model', provider: null, tokens: '9999' },
-        ],
-        [
-          { model: 'gpt-5.5', provider: 'openai', tokens: '5000' },
-          { model: 'gpt-5.5', provider: 'OpenAI', tokens: '2500' },
-          { model: 'gpt-5.5', provider: 'openai', tokens: null },
-          { model: 'unknown-model', provider: null, tokens: '9999' },
-        ],
-      );
-      mockPricingCache.getByModel.mockImplementation((name: string) => {
-        if (name === 'gpt-5.5') return makePricingEntry({ provider: 'OpenCode Zen' });
-        return null;
-      });
-
-      const result = await service.getUsageStats();
-
-      expect(result.top_models).toHaveLength(1);
-      expect(result.top_models[0]).toEqual(
-        expect.objectContaining({
-          model: 'gpt-5.5',
-          provider: 'OpenAI',
-          tokens_7d: 5000,
-          tokens_previous_7d: 1500,
-          tokens_30d: 7500,
-        }),
-      );
     });
 
     it('limits to 10 results', async () => {
@@ -375,19 +305,6 @@ describe('PublicStatsService', () => {
         makePricingEntry({
           model_name: 'a',
           provider: 'Unknown',
-          input_price_per_token: 0,
-          output_price_per_token: 0,
-        }),
-      ]);
-
-      expect(service.getFreeModels(new Map([['a', 100]]))).toEqual([]);
-    });
-
-    it('excludes entries without a provider label', () => {
-      mockPricingCache.getAll.mockReturnValue([
-        makePricingEntry({
-          model_name: 'a',
-          provider: '',
           input_price_per_token: 0,
           output_price_per_token: 0,
         }),
@@ -883,114 +800,6 @@ describe('PublicStatsService', () => {
       expect(sub).toEqual({ auth_type: 'subscription', total_tokens: 2000, model_count: 1 });
       // Breakdown is sorted by token usage descending.
       expect(result[0].auth_types[0].auth_type).toBe('subscription');
-    });
-
-    it('uses recorded provider to split subscription GPT usage from OpenCode Zen', async () => {
-      setupProviderQuery([
-        {
-          model: 'gpt-5.5',
-          provider: 'openai',
-          date: '2026-04-07',
-          tokens: '6000',
-          auth_type: 'subscription',
-          cost: '0',
-        },
-        {
-          model: 'gpt-5.5',
-          provider: 'opencode-zen',
-          date: '2026-04-07',
-          tokens: '1000',
-          auth_type: 'api_key',
-          cost: '0.10',
-        },
-      ]);
-      mockPricingCache.getByModel.mockReturnValue(
-        makePricingEntry({ provider: 'OpenCode Zen' }),
-      );
-
-      const result = await service.getProviderDailyTokens();
-
-      expect(result).toHaveLength(2);
-      const openai = result.find((p) => p.provider === 'OpenAI');
-      const zen = result.find((p) => p.provider === 'OpenCode Zen');
-      expect(openai).toBeDefined();
-      expect(openai!.total_tokens).toBe(6000);
-      expect(openai!.models).toEqual([
-        expect.objectContaining({
-          model: 'gpt-5.5',
-          auth_type: 'subscription',
-          total_tokens: 6000,
-        }),
-      ]);
-      expect(openai!.auth_types).toEqual([
-        { auth_type: 'subscription', total_tokens: 6000, model_count: 1 },
-      ]);
-      expect(zen).toBeDefined();
-      expect(zen!.total_tokens).toBe(1000);
-      expect(zen!.auth_types).toEqual([
-        { auth_type: 'api_key', total_tokens: 1000, model_count: 1 },
-      ]);
-    });
-
-    it('normalizes recorded display-name providers through aliases', async () => {
-      setupProviderQuery([
-        {
-          model: 'gpt-5.5',
-          provider: 'OpenCode Zen',
-          date: '2026-04-07',
-          tokens: '1000',
-          auth_type: 'api_key',
-          cost: '0.10',
-        },
-      ]);
-
-      const result = await service.getProviderDailyTokens();
-
-      expect(result).toHaveLength(1);
-      expect(result[0].provider).toBe('OpenCode Zen');
-      expect(result[0].models[0]).toEqual(
-        expect.objectContaining({ model: 'gpt-5.5', total_tokens: 1000 }),
-      );
-    });
-
-    it('collapses recorded custom provider labels to the public Custom bucket', async () => {
-      setupProviderQuery([
-        {
-          model: 'hosted-model',
-          provider: 'custom:tenant-provider',
-          date: '2026-04-07',
-          tokens: '500',
-          auth_type: 'api_key',
-          cost: null,
-        },
-      ]);
-
-      const result = await service.getProviderDailyTokens();
-
-      expect(result).toHaveLength(1);
-      expect(result[0].provider).toBe('Custom');
-      expect(result[0].models[0]).toEqual(
-        expect.objectContaining({ model: 'hosted-model', total_tokens: 500 }),
-      );
-    });
-
-    it('keeps non-registry recorded provider labels instead of dropping usage', async () => {
-      setupProviderQuery([
-        {
-          model: 'experimental-model',
-          provider: 'Experimental Provider',
-          date: '2026-04-07',
-          tokens: '750',
-          auth_type: 'api_key',
-          cost: null,
-        },
-      ]);
-
-      const result = await service.getProviderDailyTokens();
-
-      expect(result).toHaveLength(1);
-      expect(result[0].provider).toBe('Experimental Provider');
-      expect(mockPricingCache.getByModel).not.toHaveBeenCalled();
     });
 
     it('excludes zero-token models from auth_types model_count', async () => {

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -6,7 +6,6 @@ import {
   AGENT_PLATFORMS,
   CATEGORY_LABELS,
   PLATFORM_LABELS,
-  normalizeProviderName,
   type AgentCategory,
   type AgentPlatform,
 } from 'manifest-shared';
@@ -14,7 +13,6 @@ import { AgentMessage } from '../entities/agent-message.entity';
 import { Agent } from '../entities/agent.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { computeCutoff, sqlDateBucket } from '../common/utils/postgres-sql';
-import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 
 const MAX_RESULTS = 10;
 const EXCLUDED_PROVIDERS = new Set(['Unknown']);
@@ -111,26 +109,6 @@ function scrubCustomModel(model: string): string {
   return isCustomModel(scrubbed) ? OTHER_CUSTOM_MODELS : scrubbed;
 }
 
-function providerModelKey(provider: string, model: string): string {
-  return `${provider}\u0000${model}`;
-}
-
-function normalizePublicProvider(provider: string | null | undefined): string | null {
-  const raw = provider?.trim();
-  if (!raw) return null;
-
-  const lower = raw.toLowerCase();
-  if (lower === 'custom' || lower.startsWith('custom:')) return CUSTOM_PROVIDER_LABEL;
-
-  const direct = PROVIDER_BY_ID_OR_ALIAS.get(lower);
-  if (direct) return direct.displayName;
-
-  const normalized = PROVIDER_BY_ID_OR_ALIAS.get(normalizeProviderName(raw));
-  if (normalized) return normalized.displayName;
-
-  return raw;
-}
-
 @Injectable()
 export class PublicStatsService {
   constructor(
@@ -138,16 +116,6 @@ export class PublicStatsService {
     private readonly messageRepo: Repository<AgentMessage>,
     private readonly pricingCache: ModelPricingCacheService,
   ) {}
-
-  private publicProviderFor(modelName: string, recordedProvider?: string | null): string | null {
-    const recorded = normalizePublicProvider(recordedProvider);
-    if (recorded && !EXCLUDED_PROVIDERS.has(recorded)) return recorded;
-
-    const pricing = this.pricingCache.getByModel(modelName);
-    const fallback = normalizePublicProvider(pricing?.provider);
-    if (!fallback || EXCLUDED_PROVIDERS.has(fallback)) return null;
-    return fallback;
-  }
 
   async getUsageStats(): Promise<UsageStats> {
     const cutoff7d = computeCutoff('7 days');
@@ -159,107 +127,68 @@ export class PublicStatsService {
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
-        .addSelect('at.provider', 'provider')
         .addSelect('COUNT(*)', 'usage_count')
         .where('at.model IS NOT NULL')
         .groupBy('at.model')
-        .addGroupBy('at.provider')
         .orderBy('usage_count', 'DESC')
         .limit(MAX_MODEL_ROWS)
         .getRawMany(),
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
-        .addSelect('at.provider', 'provider')
         .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
         .where('at.model IS NOT NULL')
         .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff7d })
         .groupBy('at.model')
-        .addGroupBy('at.provider')
         .getRawMany(),
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
-        .addSelect('at.provider', 'provider')
         .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
         .where('at.model IS NOT NULL')
         .andWhere('at.timestamp >= :cutoff14d', { cutoff14d })
         .andWhere('at.timestamp < :cutoff7d', { cutoff7d })
         .groupBy('at.model')
-        .addGroupBy('at.provider')
         .getRawMany(),
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
-        .addSelect('at.provider', 'provider')
         .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
         .where('at.model IS NOT NULL')
         .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
         .groupBy('at.model')
-        .addGroupBy('at.provider')
         .getRawMany(),
     ]);
 
     const tokenMap = new Map<string, number>();
-    const tokenMapByProvider = new Map<string, number>();
     for (const r of tokenRows) {
-      const modelName = r.model as string;
-      const tokens = Number(r.tokens ?? 0);
-      tokenMap.set(modelName, (tokenMap.get(modelName) ?? 0) + tokens);
-      const provider = this.publicProviderFor(modelName, r.provider as string | null);
-      if (provider) {
-        const key = providerModelKey(provider, modelName);
-        tokenMapByProvider.set(key, (tokenMapByProvider.get(key) ?? 0) + tokens);
-      }
+      tokenMap.set(r.model as string, Number(r.tokens ?? 0));
     }
 
     const tokenMapPrev7d = new Map<string, number>();
     for (const r of tokenRowsPrev7d) {
-      const modelName = r.model as string;
-      const provider = this.publicProviderFor(modelName, r.provider as string | null);
-      if (!provider) continue;
-      const key = providerModelKey(provider, modelName);
-      tokenMapPrev7d.set(key, (tokenMapPrev7d.get(key) ?? 0) + Number(r.tokens ?? 0));
+      tokenMapPrev7d.set(r.model as string, Number(r.tokens ?? 0));
     }
 
     const tokenMap30d = new Map<string, number>();
     for (const r of tokenRows30d) {
-      const modelName = r.model as string;
-      const provider = this.publicProviderFor(modelName, r.provider as string | null);
-      if (!provider) continue;
-      const key = providerModelKey(provider, modelName);
-      tokenMap30d.set(key, (tokenMap30d.get(key) ?? 0) + Number(r.tokens ?? 0));
-    }
-
-    const topCandidates = new Map<string, { modelName: string; provider: string }>();
-    for (const r of topRows) {
-      const modelName = r.model as string;
-      if (isCustomModel(modelName)) continue;
-
-      const provider = this.publicProviderFor(modelName, r.provider as string | null);
-      if (!provider) continue;
-
-      const key = providerModelKey(provider, modelName);
-      if (!topCandidates.has(key)) {
-        topCandidates.set(key, {
-          modelName,
-          provider,
-        });
-      }
+      tokenMap30d.set(r.model as string, Number(r.tokens ?? 0));
     }
 
     const eligible: TopModel[] = [];
-    for (const candidate of topCandidates.values()) {
-      const modelName = candidate.modelName;
+    for (const r of topRows) {
+      const modelName = r.model as string;
+      if (isCustomModel(modelName)) continue;
       const pricing = this.pricingCache.getByModel(modelName);
-      const key = providerModelKey(candidate.provider, modelName);
+      const provider = pricing?.provider || 'Unknown';
+      if (EXCLUDED_PROVIDERS.has(provider)) continue;
 
       eligible.push({
         model: modelName,
-        provider: candidate.provider,
-        tokens_7d: tokenMapByProvider.get(key) ?? 0,
-        tokens_previous_7d: tokenMapPrev7d.get(key) ?? 0,
-        tokens_30d: tokenMap30d.get(key) ?? 0,
+        provider,
+        tokens_7d: tokenMap.get(modelName) ?? 0,
+        tokens_previous_7d: tokenMapPrev7d.get(modelName) ?? 0,
+        tokens_30d: tokenMap30d.get(modelName) ?? 0,
         input_price_per_million:
           pricing?.input_price_per_token != null
             ? Number(pricing.input_price_per_token) * 1_000_000
@@ -290,7 +219,6 @@ export class PublicStatsService {
     const [rows, customPairs]: [
       {
         model: string;
-        provider: string | null;
         date: string;
         tokens: string;
         auth_type: string | null;
@@ -301,7 +229,6 @@ export class PublicStatsService {
       this.messageRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
-        .addSelect('at.provider', 'provider')
         .addSelect(dateBucket, 'date')
         .addSelect('at.auth_type', 'auth_type')
         .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
@@ -309,7 +236,6 @@ export class PublicStatsService {
         .where('at.model IS NOT NULL')
         .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
         .groupBy('at.model')
-        .addGroupBy('at.provider')
         .addGroupBy('date')
         .addGroupBy('at.auth_type')
         .orderBy('date', 'ASC')
@@ -368,9 +294,9 @@ export class PublicStatsService {
         const scrubbed = scrubCustomModel(modelName);
         modelName = publishableCustomModels.has(scrubbed) ? scrubbed : OTHER_CUSTOM_MODELS;
       } else {
-        const publicProvider = this.publicProviderFor(modelName, r.provider);
-        if (!publicProvider) continue;
-        provider = publicProvider;
+        const pricing = this.pricingCache.getByModel(modelName);
+        provider = pricing?.provider || 'Unknown';
+        if (EXCLUDED_PROVIDERS.has(provider)) continue;
       }
 
       // Provider is part of the key: a scrubbed custom name can collide with
@@ -587,15 +513,14 @@ export class PublicStatsService {
         if ((e.input_price_per_token ?? 0) !== 0 || (e.output_price_per_token ?? 0) !== 0)
           return false;
         if (isCustomModel(e.model_name)) return false;
-        const provider = e.provider;
-        if (!provider) return false;
+        const provider = e.provider || 'Unknown';
         if (EXCLUDED_PROVIDERS.has(provider)) return false;
         return (tokenMap.get(e.model_name) ?? 0) > 0;
       })
       .map((e) => ({
         model_name: e.model_name,
-        provider: e.provider,
-        tokens_7d: tokenMap.get(e.model_name) as number,
+        provider: e.provider || 'Unknown',
+        tokens_7d: tokenMap.get(e.model_name) ?? 0,
       }))
       .sort((a, b) => b.tokens_7d - a.tokens_7d)
       .slice(0, MAX_RESULTS);

--- a/packages/backend/test/public-stats.e2e-spec.ts
+++ b/packages/backend/test/public-stats.e2e-spec.ts
@@ -29,24 +29,6 @@ beforeAll(async () => {
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
     ['ps-msg-3', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 150, 75, 'claude-opus-4-6', 'ok'],
   );
-  await ds.query(
-    `INSERT INTO agent_messages (id, tenant_id, agent_id, agent_name, user_id, timestamp, input_tokens, output_tokens, model, provider, auth_type, status)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
-    [
-      'ps-msg-6',
-      'test-tenant-001',
-      'test-agent-001',
-      'test-agent',
-      'test-user-001',
-      now,
-      800,
-      400,
-      'gpt-5.5',
-      'openai',
-      'subscription',
-      'ok',
-    ],
-  );
 
   // Custom-endpoint traffic: two tenant-scoped provider refs from one tenant,
   // exercising the Custom grouping + k-anonymity fold on real SQL.
@@ -134,39 +116,6 @@ describe('GET /api/v1/public/provider-tokens', () => {
     const payload = JSON.stringify(res.body);
     expect(payload).not.toContain('d0c5ce41');
     expect(payload).not.toContain('private-model');
-  });
-
-  it('attributes ChatGPT subscription GPT rows to OpenAI, not OpenCode Zen', async () => {
-    const res = await request(app.getHttpServer())
-      .get('/api/v1/public/provider-tokens')
-      .expect(200);
-
-    const openai = res.body.providers.find((p: { provider: string }) => p.provider === 'OpenAI');
-    expect(openai).toBeDefined();
-    expect(openai.models).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          model: 'gpt-5.5',
-          auth_type: 'subscription',
-          total_tokens: expect.any(Number),
-        }),
-      ]),
-    );
-    const gpt = openai.models.find(
-      (m: { model: string; auth_type: string | null }) =>
-        m.model === 'gpt-5.5' && m.auth_type === 'subscription',
-    );
-    expect(gpt.total_tokens).toBeGreaterThanOrEqual(1200);
-
-    const zen = res.body.providers.find(
-      (p: { provider: string }) => p.provider === 'OpenCode Zen',
-    );
-    expect(
-      zen?.models.some(
-        (m: { model: string; auth_type: string | null }) =>
-          m.model === 'gpt-5.5' && m.auth_type === 'subscription',
-      ),
-    ).not.toBe(true);
   });
 });
 


### PR DESCRIPTION
### ✨ What changed
- Reverts mnfst/manifest#2463.
- Restores the previous public stats aggregation behavior.

### 💭 Why
The merged attribution change exposed null pricing rows on the website homepage and left the model table stuck on Loading.

### 👤 For users
The homepage model leaderboard should render again after deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the public stats provider-attribution change and restores pricing-based aggregation. Fixes the homepage leaderboard (null pricing rows, stuck Loading).

- **Bug Fixes**
  - Dropped provider-based grouping/normalization in `packages/backend/src/public-stats/public-stats.service.ts`; use pricing cache provider instead and exclude `Unknown`.
  - Simplified queries to aggregate by model only; removed `provider` groupings and keys.
  - Updated `getProviderDailyTokens` to derive provider from pricing metadata.
  - Removed the related tests and the changeset for the reverted behavior.

<sup>Written for commit fe722106e310f86e2d0423dfc18307b02f87e5b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

