### PR TITLE
perf: drop 1 GB of unused indexes from the messages table

### DIFF
--- a/.changeset/lucky-hoops-drift.md
+++ b/.changeset/lucky-hoops-drift.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Drop two unused indexes on `agent_messages`, reclaiming about 1 GB and removing an index write from every message insert.

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -28,6 +28,7 @@ import { WaitlistClaim } from '../entities/waitlist-claim.entity';
 import { RenameWaitlistClaimsTable1800000000000 } from './migrations/1800000000000-RenameWaitlistClaimsTable';
 import { ReclassifyPlanRequestLimitMessages1800100000000 } from './migrations/1800100000000-ReclassifyPlanRequestLimitMessages';
 import { AddMessageErrorCode1800200000000 } from './migrations/1800200000000-AddMessageErrorCode';
+import { DropUnusedAgentMessageIndexes1800300000000 } from './migrations/1800300000000-DropUnusedAgentMessageIndexes';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -290,4 +291,5 @@ export const migrations = [
   RenameWaitlistClaimsTable1800000000000,
   ReclassifyPlanRequestLimitMessages1800100000000,
   AddMessageErrorCode1800200000000,
+  DropUnusedAgentMessageIndexes1800300000000,
 ];

--- a/packages/backend/src/database/migrations/1800300000000-DropUnusedAgentMessageIndexes.spec.ts
+++ b/packages/backend/src/database/migrations/1800300000000-DropUnusedAgentMessageIndexes.spec.ts
@@ -1,0 +1,51 @@
+import { DropUnusedAgentMessageIndexes1800300000000 } from './1800300000000-DropUnusedAgentMessageIndexes';
+
+describe('DropUnusedAgentMessageIndexes1800300000000', () => {
+  const migration = new DropUnusedAgentMessageIndexes1800300000000();
+  let queries: string[];
+
+  const mockQueryRunner = {
+    query: jest.fn().mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve();
+    }),
+  } as never;
+
+  beforeEach(() => {
+    queries = [];
+    jest.clearAllMocks();
+  });
+
+  it('exposes the expected migration name', () => {
+    expect(migration.name).toBe('DropUnusedAgentMessageIndexes1800300000000');
+  });
+
+  it('runs outside a transaction so the drops can be CONCURRENT', () => {
+    expect(migration.transaction).toBe(false);
+  });
+
+  it('drops both unused indexes concurrently', async () => {
+    await migration.up(mockQueryRunner);
+
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_user_id_timestamp"',
+    );
+    expect(queries[1]).toContain('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_errors"');
+    // The timestamp-leading twin does the cross-tenant work and must survive.
+    for (const sql of queries) expect(sql).not.toContain('IDX_agent_messages_errors_timestamp');
+  });
+
+  it('recreates both indexes on rollback, matching their original definitions', async () => {
+    await migration.down(mockQueryRunner);
+
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
+    expect(queries[0]).toContain('"IDX_agent_messages_user_id_timestamp"');
+    expect(queries[0]).toContain('ON "agent_messages" ("user_id", "timestamp")');
+
+    expect(queries[1]).toContain('"IDX_agent_messages_errors"');
+    expect(queries[1]).toContain('ON "agent_messages" ("tenant_id", "timestamp")');
+    expect(queries[1]).toContain(`WHERE "status" IN ('error', 'fallback_error', 'rate_limited')`);
+  });
+});

--- a/packages/backend/src/database/migrations/1800300000000-DropUnusedAgentMessageIndexes.spec.ts
+++ b/packages/backend/src/database/migrations/1800300000000-DropUnusedAgentMessageIndexes.spec.ts
@@ -39,13 +39,24 @@ describe('DropUnusedAgentMessageIndexes1800300000000', () => {
   it('recreates both indexes on rollback, matching their original definitions', async () => {
     await migration.down(mockQueryRunner);
 
-    expect(queries).toHaveLength(2);
-    expect(queries[0]).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
-    expect(queries[0]).toContain('"IDX_agent_messages_user_id_timestamp"');
-    expect(queries[0]).toContain('ON "agent_messages" ("user_id", "timestamp")');
+    expect(queries).toHaveLength(4);
+    expect(queries[1]).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
+    expect(queries[1]).toContain('"IDX_agent_messages_user_id_timestamp"');
+    expect(queries[1]).toContain('ON "agent_messages" ("user_id", "timestamp")');
 
-    expect(queries[1]).toContain('"IDX_agent_messages_errors"');
-    expect(queries[1]).toContain('ON "agent_messages" ("tenant_id", "timestamp")');
-    expect(queries[1]).toContain(`WHERE "status" IN ('error', 'fallback_error', 'rate_limited')`);
+    expect(queries[3]).toContain('"IDX_agent_messages_errors"');
+    expect(queries[3]).toContain('ON "agent_messages" ("tenant_id", "timestamp")');
+    expect(queries[3]).toContain(`WHERE "status" IN ('error', 'fallback_error', 'rate_limited')`);
+  });
+
+  it('clears an invalid leftover before each concurrent rebuild', async () => {
+    await migration.down(mockQueryRunner);
+
+    // `CREATE ... IF NOT EXISTS` matches on name and would skip an INVALID
+    // index left by an interrupted CONCURRENTLY build, wedging it forever.
+    expect(queries[0]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_user_id_timestamp"',
+    );
+    expect(queries[2]).toContain('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_errors"');
   });
 });

--- a/packages/backend/src/database/migrations/1800300000000-DropUnusedAgentMessageIndexes.ts
+++ b/packages/backend/src/database/migrations/1800300000000-DropUnusedAgentMessageIndexes.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Drops two indexes on `agent_messages` that no query uses.
+ *
+ * The table's indexes had grown to 8.3 GB against a 7.0 GB heap — 17 of them,
+ * every one written on every insert, and every one rebuilt by VACUUM. Two carry
+ * that cost and serve nothing:
+ *
+ * `IDX_agent_messages_user_id_timestamp` (715 MB, non-partial, so it is written
+ * on EVERY row) indexes `user_id`, which is the deprecated attribution-only
+ * column. Both this codebase and the control plane state it is never scoped on
+ * — see `query-helpers.ts` ("the informational `at.user_id` column is never
+ * consulted") — and neither queries it. Production confirms: 215 index scans
+ * over the table's whole lifetime, against 238k on the (tenant, agent, ts)
+ * index.
+ *
+ * `IDX_agent_messages_errors` (302 MB) is `(tenant_id, timestamp) WHERE status
+ * IN (errors)`. Migration 1795100000000 added the timestamp-leading twin for
+ * cross-tenant scans and kept this one "for the dashboard's tenant-scoped error
+ * views". That never happened: the tenant-scoped views resolve through
+ * `IDX_agent_messages_tenant_timestamp` and `IDX_agent_messages_tenant_agent_status`,
+ * and this index has 3 scans over its lifetime. The cross-tenant twin
+ * (`IDX_agent_messages_errors_timestamp`, 106 MB) is the one doing the work.
+ *
+ * Both are recreatable from the statements in `down()` if a plan regresses.
+ *
+ * Dropped CONCURRENTLY (so `transaction = false`) to avoid the ACCESS EXCLUSIVE
+ * lock against live writes during a deploy.
+ */
+export class DropUnusedAgentMessageIndexes1800300000000 implements MigrationInterface {
+  name = 'DropUnusedAgentMessageIndexes1800300000000';
+  transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_user_id_timestamp"`,
+    );
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_errors"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_user_id_timestamp" ON "agent_messages" ("user_id", "timestamp")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_errors" ON "agent_messages" ("tenant_id", "timestamp") WHERE "status" IN ('error', 'fallback_error', 'rate_limited')`,
+    );
+  }
+}

--- a/packages/backend/src/database/migrations/1800300000000-DropUnusedAgentMessageIndexes.ts
+++ b/packages/backend/src/database/migrations/1800300000000-DropUnusedAgentMessageIndexes.ts
@@ -27,6 +27,15 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *
  * Dropped CONCURRENTLY (so `transaction = false`) to avoid the ACCESS EXCLUSIVE
  * lock against live writes during a deploy.
+ *
+ * `npm run migration:revert` CANNOT run the `down()` below, and this is true of
+ * every CONCURRENTLY migration here (1795100000000 included). TypeORM honours a
+ * migration's `transaction = false` in `executePendingMigrations`, but
+ * `undoLastMigration` consults only the DataSource-level setting, so it opens a
+ * transaction and Postgres rejects `CREATE/DROP INDEX CONCURRENTLY` with
+ * `PreventInTransactionBlock`. To roll back, run the `down()` statements
+ * directly against the database, then delete this migration's row from
+ * `migrations`.
  */
 export class DropUnusedAgentMessageIndexes1800300000000 implements MigrationInterface {
   name = 'DropUnusedAgentMessageIndexes1800300000000';
@@ -40,9 +49,18 @@ export class DropUnusedAgentMessageIndexes1800300000000 implements MigrationInte
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    // Clear any invalid leftover from an interrupted CONCURRENTLY build first:
+    // `CREATE ... IF NOT EXISTS` matches on name, so it would skip over an
+    // invalid index and leave it permanently unusable. Same guard migration
+    // 1795100000000 applies before its concurrent build.
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_user_id_timestamp"`,
+    );
     await queryRunner.query(
       `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_user_id_timestamp" ON "agent_messages" ("user_id", "timestamp")`,
     );
+
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_errors"`);
     await queryRunner.query(
       `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_errors" ON "agent_messages" ("tenant_id", "timestamp") WHERE "status" IN ('error', 'fallback_error', 'rate_limited')`,
     );

--- a/packages/backend/src/entities/agent-message.entity.ts
+++ b/packages/backend/src/entities/agent-message.entity.ts
@@ -4,7 +4,9 @@ import type { CallerAttribution } from '../routing/proxy/caller-classifier';
 
 @Entity('agent_messages')
 @Index(['tenant_id', 'agent_id', 'timestamp'])
-@Index(['user_id', 'timestamp'])
+// No index on `user_id`: it is deprecated attribution-only metadata, never
+// scoped or filtered on (see query-helpers.ts). Its index cost 715 MB and was
+// dropped in migration 1800300000000.
 @Index(['tenant_id', 'agent_name', 'timestamp'])
 @Index(['tenant_id', 'timestamp'])
 @Index(['tenant_id', 'trace_id'])


### PR DESCRIPTION
### 💭 Why
`agent_messages` carries 8.3 GB of indexes against a 7.0 GB heap. Seventeen of them, each written on every insert and rebuilt by every vacuum. Two serve no query at all.

`IDX_agent_messages_user_id_timestamp` (715 MB, non-partial, so it is written on **every** row) indexes `user_id`. That column is deprecated attribution-only metadata. `query-helpers.ts` says it "is never consulted", the control plane says the same, and neither queries it. Production agrees: **215 index scans over the table's entire lifetime**, against 238k on the (tenant, agent, timestamp) index.

`IDX_agent_messages_errors` (302 MB) was kept by migration 1795100000000 "for the dashboard's tenant-scoped error views". That never materialised. Those views resolve through `IDX_agent_messages_tenant_timestamp` and `IDX_agent_messages_tenant_agent_status`, and this index has **3 lifetime scans**. Its timestamp-leading twin (`IDX_agent_messages_errors_timestamp`, 106 MB), which does the cross-tenant work, stays.

### ✨ What changed
- Migration drops both indexes `CONCURRENTLY`. `down()` recreates them.
- Removed the matching `@Index(['user_id','timestamp'])` from the entity so a future `migration:generate` does not resurrect it.

### 👤 For users
Slightly faster message ingestion: one less index write per row.

### 🔧 For operators
Reclaims ~1 GB. The drops run `CONCURRENTLY` (`transaction = false`), so no ACCESS EXCLUSIVE lock against live writes during deploy, matching migration 1795100000000.

### 📝 Notes
Verified by running the migration against a real database: it is recorded, both indexes are gone, and `IDX_agent_messages_errors_timestamp` survives.

Separate and not addressed here: the remaining indexes are roughly 1.4-1.6x bloated, largely from two one-off backfill migrations that updated ~674k rows at 3.1% HOT. VACUUM does not shrink indexes, so reclaiming that needs a `REINDEX INDEX CONCURRENTLY` pass in a maintenance window. And `shared_buffers` is still 128 MB against a 15 GB table.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops two unused indexes from `agent_messages` to reclaim ~1 GB and remove an index write on every insert. This speeds up ingestion and reduces vacuum work.

- **Migration**
  - Drops `IDX_agent_messages_user_id_timestamp` and `IDX_agent_messages_errors` CONCURRENTLY (`transaction = false`).
  - Keeps `IDX_agent_messages_errors_timestamp`; removes the `@Index(['user_id','timestamp'])` from the entity.
  - `down()` first drops any invalid leftovers, then recreates both indexes CONCURRENTLY.
  - Note: `migration:revert` cannot run this `down()` (CONCURRENTLY requires no transaction); run the SQL directly if rollback is needed.

<sup>Written for commit 6dc0d6609f790a54102f139bcac6c7e066f05106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

