### PR TITLE
fix: clarify unavailable explicit model errors

### DIFF
--- a/.changeset/explicit-model-unavailable-message.md
+++ b/.changeset/explicit-model-unavailable-message.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show a dedicated M302 "model not available" message when an explicit model ID is not available for the agent.

--- a/packages/backend/src/common/errors/__tests__/manifest-error.spec.ts
+++ b/packages/backend/src/common/errors/__tests__/manifest-error.spec.ts
@@ -82,6 +82,16 @@ describe('every documented error code is accounted for', () => {
     expect(error_class).toBe('invalid_request');
   });
 
+  it('puts an unavailable explicit model on the request origin, not config', () => {
+    const { error_origin, error_class } = classifyMessageError({
+      status: 'error',
+      routingReason: MANIFEST_CODE_TO_REASON.M302,
+    });
+
+    expect(error_origin).toBe('request');
+    expect(error_class).toBe('not_found');
+  });
+
   it('keeps a Manifest internal error off the provider reliability signal', () => {
     const { error_origin } = classifyMessageError({
       status: 'error',

--- a/packages/backend/src/common/errors/error-codes.ts
+++ b/packages/backend/src/common/errors/error-codes.ts
@@ -62,6 +62,11 @@ export const MANIFEST_ERRORS = {
     title: 'Missing messages array',
     template: '`messages` array is required.',
   },
+  M302: {
+    title: 'Model not available',
+    template:
+      'Model "{model}" is not available for this agent. Use GET /v1/models to list available model IDs, or make the provider available for this agent here: {dashboardUrl}',
+  },
   M500: {
     title: 'Internal server error',
     template: 'Something broke on our end. Try again in a moment.',

--- a/packages/backend/src/common/errors/manifest-error.ts
+++ b/packages/backend/src/common/errors/manifest-error.ts
@@ -17,6 +17,7 @@ export const MANIFEST_BLOCKED_REQUEST_REASONS = [
   'manifest_ip_rate_limited',
   'manifest_concurrency_limited',
   'manifest_invalid_request',
+  'model_not_available',
   'manifest_internal_error',
 ] as const;
 export type ManifestBlockedRequestReason = (typeof MANIFEST_BLOCKED_REQUEST_REASONS)[number];
@@ -52,6 +53,7 @@ export const MANIFEST_CODE_TO_REASON: Record<RecordableManifestCode, ManifestBlo
     M203: 'manifest_concurrency_limited',
     M204: 'plan_request_limit_exceeded',
     M300: 'manifest_invalid_request',
+    M302: 'model_not_available',
     M500: 'manifest_internal_error',
   };
 

--- a/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/openai-model-id.spec.ts
@@ -104,7 +104,7 @@ describe('OpenAI model ids', () => {
   });
 
   // Two connections carrying one bare id: the caller cannot know which was
-  // meant, so it falls back to configured routing rather than guessing.
+  // meant, so the route helper refuses to guess.
   it('returns null for a bare name carried by two connections', () => {
     expect(
       routeForOpenAiModelId('gpt-4o', [

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -868,10 +868,7 @@ describe('ProxyService — orchestration', () => {
       );
     });
 
-    // The regression that made every SDK sending an unrecognized `model` fail
-    // with M101 "no providers configured" — on agents whose providers were
-    // connected. An unroutable name must land on configured routing instead.
-    it('falls back to configured routing for a model no connection carries', async () => {
+    it('returns model-not-available for a model no connection carries', async () => {
       modelDiscovery.getModelsForAgent.mockResolvedValue([
         discoveredModel({ id: 'gpt-4o-mini', provider: 'openai', authType: 'api_key' }),
       ]);
@@ -883,31 +880,33 @@ describe('ProxyService — orchestration', () => {
       );
       const body = await result.forward.response.text();
 
+      expect(resolveService.resolve).not.toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      expect(body).toContain('M302');
+      expect(body).toContain('some-retired-model');
+      expect(body).toContain('not available for this agent');
       expect(body).not.toContain('M101');
-      expect(resolveService.resolve).toHaveBeenCalled();
-      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
-        expect.objectContaining({
-          provider: 'anthropic',
-          authType: 'api_key',
-          model: 'claude-sonnet-4-5',
-        }),
-      );
+      expect(result.meta).toMatchObject({
+        reason: 'model_not_available',
+        manifest_error_code: 'M302',
+      });
     });
 
-    it('falls back to configured routing when two connections carry the same bare name', async () => {
+    it('returns model-not-available when two connections carry the same bare name', async () => {
       modelDiscovery.getModelsForAgent.mockResolvedValue([
         discoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'api_key' }),
         discoveredModel({ id: 'gpt-4o', provider: 'openai', authType: 'subscription' }),
       ]);
 
-      await svc.proxyRequest(
+      const result = await svc.proxyRequest(
         baseOpts({ body: { model: 'gpt-4o', messages: [{ role: 'user', content: 'hi' }] } }),
       );
+      const body = await result.forward.response.text();
 
-      expect(resolveService.resolve).toHaveBeenCalled();
-      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: 'anthropic', model: 'claude-sonnet-4-5' }),
-      );
+      expect(resolveService.resolve).not.toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      expect(body).toContain('M302');
+      expect(body).toContain('gpt-4o');
     });
 
     // A header rule is an override the operator configured on purpose; the

--- a/packages/backend/src/routing/proxy/openai-model-id.ts
+++ b/packages/backend/src/routing/proxy/openai-model-id.ts
@@ -22,13 +22,11 @@ export function openAiModelId(model: DiscoveredModel): string {
  *
  * Matches the provider-qualified id published by `/v1/models`
  * (`openai/gpt-5.4-nano`) first, then the bare provider-native name
- * (`gpt-5.4-nano`) when it names exactly one discovered model. Most SDKs send a
- * bare name because the field is mandatory, and refusing to resolve it stranded
- * the request on an error even though the model was connected.
+ * (`gpt-5.4-nano`) when it names exactly one discovered model.
  *
  * Returns null for an unknown name, and for a bare name carried by more than
  * one connection (the same id under both an API key and a subscription) — the
- * caller cannot guess which was meant, so it falls back to configured routing.
+ * caller cannot guess which was meant.
  */
 export function routeForOpenAiModelId(
   modelId: string,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -65,6 +65,7 @@ import type { AutofixRecord } from '../autofix/autofix.types';
 
 type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>> & {
   explicit_model_override?: boolean;
+  explicit_model_unavailable?: string;
 };
 
 /**
@@ -242,6 +243,13 @@ export class ProxyService {
         `No route available for agent=${agentId}: ` +
           `tier=${resolved.tier} confidence=${resolved.confidence} reason=${resolved.reason}`,
       );
+      if (resolved.explicit_model_unavailable) {
+        return this.buildModelUnavailableResult(
+          stream,
+          agentName,
+          resolved.explicit_model_unavailable,
+        );
+      }
       return this.buildNoProviderResult(stream, agentName);
     }
 
@@ -655,6 +663,16 @@ export class ProxyService {
     if (apiMode !== 'messages' && requestedModel && requestedModel !== OPENAI_MODEL_ID_AUTO) {
       const explicit = await this.resolveExplicitModel(agentId, tenantId, requestedModel, headers);
       if (explicit) return explicit;
+      return {
+        tier: 'default' as const,
+        route: null,
+        fallback_routes: null,
+        response_mode: DEFAULT_RESPONSE_MODE,
+        confidence: 0,
+        score: 0,
+        reason: 'default' as const,
+        explicit_model_unavailable: requestedModel,
+      };
     }
 
     // Not guaranteed to be an array here: a healed body reaches this path from
@@ -693,11 +711,9 @@ export class ProxyService {
    * configured on purpose, and the SDK's `model` field is mandatory, so most
    * agents send a name they cannot change.
    *
-   * Returns null when neither applies, which lands the request on configured
-   * routing. It must never fail on its own: an unrecognized name used to
-   * resolve to no route at all, and the caller reported that as M101 "no
-   * providers configured" — on agents whose providers were connected and whose
-   * header tier would have routed the request.
+   * Returns null when neither applies. The caller turns that into M302 instead
+   * of falling back to automatic routing, because a concrete `model` is a
+   * request for that model.
    */
   private async resolveExplicitModel(
     agentId: string,
@@ -715,7 +731,7 @@ export class ProxyService {
     if (!route) {
       this.logger.warn(
         `Requested model "${requestedModel}" matches no connected model for agent=${agentId} — ` +
-          `falling back to configured routing`,
+          `returning model-not-available`,
       );
       return null;
     }
@@ -1056,6 +1072,16 @@ export class ProxyService {
     const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
     const content = formatManifestError('M101', { dashboardUrl });
     return buildFriendlyResponse(content, stream, 'no_provider', 'M101');
+  }
+
+  private buildModelUnavailableResult(
+    stream: boolean,
+    agentName: string | undefined,
+    model: string,
+  ): ProxyResult {
+    const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
+    const content = formatManifestError('M302', { model, dashboardUrl });
+    return buildFriendlyResponse(content, stream, 'model_not_available', 'M302');
   }
 }
 

--- a/packages/shared/__tests__/error-taxonomy.spec.ts
+++ b/packages/shared/__tests__/error-taxonomy.spec.ts
@@ -75,6 +75,7 @@ describe('classifyMessageError', () => {
     ['manifest_ip_rate_limited', 'policy', 'rate_limit'],
     ['manifest_concurrency_limited', 'policy', 'rate_limit'],
     ['manifest_invalid_request', 'request', 'invalid_request'],
+    ['model_not_available', 'request', 'not_found'],
     ['manifest_internal_error', 'internal', 'internal'],
     // Legacy alias, kept so rows written before the rename keep classifying.
     ['friendly_error', 'internal', 'internal'],

--- a/packages/shared/src/error-taxonomy.ts
+++ b/packages/shared/src/error-taxonomy.ts
@@ -114,6 +114,7 @@ const MANIFEST_REASON_TO_CLASSIFICATION: Record<
   manifest_ip_rate_limited: { origin: 'policy', errorClass: 'rate_limit' },
   manifest_concurrency_limited: { origin: 'policy', errorClass: 'rate_limit' },
   manifest_invalid_request: { origin: 'request', errorClass: 'invalid_request' },
+  model_not_available: { origin: 'request', errorClass: 'not_found' },
   manifest_internal_error: { origin: 'internal', errorClass: 'internal' },
   // Legacy alias of `manifest_internal_error`, kept for rows already written.
   friendly_error: { origin: 'internal', errorClass: 'internal' },


### PR DESCRIPTION
### ✨ What changed
- Added M302 for unavailable explicit model IDs.
- Return M302 before automatic routing when a concrete model is not agent-visible.
- Recorded unavailable model stubs as request/not_found.

### 💭 Why
Concrete model IDs are an explicit contract: use auto for Manifest routing, or use a model ID returned by GET /v1/models. M101 made unavailable direct model requests look like setup failures.

### 👤 For users
Unavailable direct model requests now point to /v1/models and the agent routing page.