### PR TITLE
feat(subscription): sync Anthropic catalog to July 2026

### DIFF
--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1502,11 +1502,16 @@ describe('ModelDiscoveryService', () => {
       );
 
       expect(fetcher.fetch).not.toHaveBeenCalled();
-      expect(result.map((m) => m.id)).toEqual([
+      // Curated list now includes the July 2026 Anthropic ids alongside
+      // the original family-prefix entries.
+      expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
-        'claude-opus-4',
-        'claude-sonnet-4',
         'claude-haiku-4',
+        'claude-haiku-4-5',
+        'claude-opus-4',
+        'claude-opus-4-6',
+        'claude-sonnet-4',
+        'claude-sonnet-5',
       ]);
     });
 
@@ -1819,14 +1824,19 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Should only include models matching knownModels prefixes (claude-opus-4, claude-sonnet-4, claude-haiku-4)
-      // and NOT claude-2.1 or openai models. claude-fable-5 has no OpenRouter
-      // pricing entry, so it is appended directly as a zero-cost known model.
-      expect(result).toHaveLength(4);
+      // and NOT claude-2.1 or openai models. claude-fable-5, claude-sonnet-5,
+      // claude-opus-4-6, and claude-haiku-4-5 have no OpenRouter pricing
+      // entry in this fixture, so they are appended directly as zero-cost
+      // known models from the curated list.
+      expect(result).toHaveLength(7);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
         'claude-haiku-4-20260301',
+        'claude-haiku-4-5',
         'claude-opus-4-20260301',
+        'claude-opus-4-6',
         'claude-sonnet-4-20260301',
+        'claude-sonnet-5',
       ]);
       // All should be stamped as subscription
       for (const m of result) {
@@ -2020,13 +2030,19 @@ describe('ModelDiscoveryService', () => {
         }),
       );
 
-      // Even without pricingSync, knownModels are returned directly
-      expect(result).toHaveLength(4);
+      // Even without pricingSync, knownModels are returned directly. The
+      // curated list now includes the July 2026 Anthropic ids
+      // (claude-sonnet-5, claude-opus-4-6, claude-haiku-4-5) in
+      // addition to the original family-prefix entries.
+      expect(result).toHaveLength(7);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
         'claude-haiku-4',
+        'claude-haiku-4-5',
         'claude-opus-4',
+        'claude-opus-4-6',
         'claude-sonnet-4',
+        'claude-sonnet-5',
       ]);
       for (const m of result) {
         expect(m.authType).toBe('subscription');
@@ -2400,13 +2416,18 @@ describe('ModelDiscoveryService', () => {
     it('should return knownModels directly when pricingSync is null', () => {
       const result = buildSubscriptionFallbackModels(null as never, 'anthropic');
 
-      // No OpenRouter data, but knownModels are added directly
-      expect(result).toHaveLength(4);
+      // No OpenRouter data, but knownModels are added directly. The
+      // curated list now includes the July 2026 Anthropic ids in
+      // addition to the original family-prefix entries.
+      expect(result).toHaveLength(7);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
         'claude-haiku-4',
+        'claude-haiku-4-5',
         'claude-opus-4',
+        'claude-opus-4-6',
         'claude-sonnet-4',
+        'claude-sonnet-5',
       ]);
       expect(result[0].inputPricePerToken).toBe(0);
     });
@@ -2443,11 +2464,15 @@ describe('ModelDiscoveryService', () => {
       mockPricingSync.getAll.mockReturnValue(orMap);
 
       const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
-      const opusModels = result.filter((m) => m.id.startsWith('claude-opus-4'));
+      // Filter on the EXACT id, not a prefix — the curated list now
+      // includes claude-opus-4-6 as a separate top-level entry (see
+      // packages/shared/src/subscription/configs.ts), so a prefix
+      // filter would also catch it and confuse the de-dup assertion.
+      const opusFour = result.filter((m) => m.id === 'claude-opus-4');
 
       // Only one claude-opus-4 entry (from OpenRouter), not duplicated
-      expect(opusModels).toHaveLength(1);
-      expect(opusModels[0].displayName).toBe('Opus 4');
+      expect(opusFour).toHaveLength(1);
+      expect(opusFour[0].displayName).toBe('Opus 4');
     });
 
     it('should use default context window when entry has none', () => {

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -477,8 +477,15 @@ describe('getSubscriptionKnownModelsMatch', () => {
 });
 
 describe('getSubscriptionExcludedModels', () => {
-  it('returns the -fast exclusion for anthropic', () => {
-    expect(getSubscriptionExcludedModels('anthropic')).toEqual(['-fast']);
+  it('returns the -fast and -20250514 exclusions for anthropic', () => {
+    // `-fast` drops the OpenRouter pricing-cache entries that 404 at
+    // api.anthropic.com. `-20250514` drops the retired
+    // claude-sonnet-4-20250514 / claude-opus-4-20250514 snapshots
+    // (retired 2026-06-15) if the pricing cache still surfaces them.
+    expect(getSubscriptionExcludedModels('anthropic')).toEqual([
+      '-fast',
+      '-20250514',
+    ]);
   });
 
   it('returns an empty array for providers with no exclusion configured', () => {

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -337,7 +337,8 @@ describe('getSubscriptionKnownModels', () => {
     // ensures the prefix-match walker never leaks them through even if
     // the pricing cache still surfaces them.
     const models = getSubscriptionKnownModels('anthropic');
-    for (const m of models) {
+    expect(models).not.toBeNull();
+    for (const m of models ?? []) {
       expect(m).not.toContain('-20250514');
     }
   });

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -320,6 +320,28 @@ describe('getSubscriptionKnownModels', () => {
     expect(models).toContain('claude-sonnet-4');
   });
 
+  it('includes July 2026 Anthropic models for subscription auth', () => {
+    // claude-sonnet-5 (2026-06-30), claude-opus-4-6 (2026-06-29),
+    // claude-haiku-4-5 (2025-10-01). All three are reachable under
+    // auth_type=subscription but absent from the previous family-prefix-
+    // only curated list.
+    const models = getSubscriptionKnownModels('anthropic');
+    expect(models).toContain('claude-sonnet-5');
+    expect(models).toContain('claude-opus-4-6');
+    expect(models).toContain('claude-haiku-4-5');
+  });
+
+  it('excludes the retired 20250514 Anthropic snapshots', () => {
+    // claude-sonnet-4-20250514 and claude-opus-4-20250514 were retired
+    // on 2026-06-15. The knownModelsExclude sentinel `-20250514`
+    // ensures the prefix-match walker never leaks them through even if
+    // the pricing cache still surfaces them.
+    const models = getSubscriptionKnownModels('anthropic');
+    for (const m of models) {
+      expect(m).not.toContain('-20250514');
+    }
+  });
+
   it('returns known models for copilot', () => {
     const models = getSubscriptionKnownModels('copilot');
     expect(models).toContain('copilot/claude-opus-4.6');

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -15,15 +15,26 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       'claude-opus-4',
       'claude-sonnet-4',
       'claude-haiku-4',
+      // July 2026 Anthropic additions. The family-prefix matchMode
+      // (default 'prefix') keeps existing variants working, so we only
+      // need to add the new top-level ids.
+      'claude-sonnet-5',
+      'claude-opus-4-6',
+      'claude-haiku-4-5',
     ]),
     // `claude-*-fast` ids exist in the OpenRouter pricing cache but 404 at
     // api.anthropic.com — fast mode is an `anthropic-beta` header on the base
     // Opus model, not a distinct model id. Keep them out of the catalog.
-    knownModelsExclude: Object.freeze(['-fast']),
+    //
+    // `*-20250514` snapshots were retired on 2026-06-15. The prefix-match
+    // walker would otherwise leak them through if they survived in the
+    // pricing cache. Block them explicitly.
+    knownModelsExclude: Object.freeze(['-fast', '-20250514']),
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
       modelContextWindows: Object.freeze({
         'claude-opus-4-8': 1000000,
+        'claude-sonnet-5': 1000000,
       }),
       supportsPromptCaching: true,
       supportsBatching: false,


### PR DESCRIPTION
## Summary

Syncs the curated Anthropic subscription catalog () to reflect the July 2026 Anthropic model surface.

## Why

Anthropic shipped several changes between June 15 and July 1, 2026 that the curated catalog did not reflect:

- **claude-sonnet-5** launched 2026-06-30 (new tokenizer, sampling-parameter changes, removed extended thinking). 1M context window.
- **claude-opus-4-6** launched 2026-06-29. 200K context window.
- **claude-haiku-4-5** was missing from the curated list.
- **claude-sonnet-4-20250514** and **claude-opus-4-20250514** were retired 2026-06-15 but had no explicit exclusion in .

Users on **Claude Max / Pro subscription** () were the only surface affected —  auth already gets the live  response from Anthropic, which has been correct since the model shipped. This means subscription users had no way to use the new models in the dashboard.

## Diff

```
 knownModels:
   + claude-sonnet-5
   + claude-opus-4-6
   + claude-haiku-4-5

 knownModelsExclude:
   + -20250514      # drop retired snapshots if they linger in pricing cache

 modelContextWindows:
   + claude-sonnet-5: 1000000
```

2 files changed, 34 insertions(+), 1 deletion(-).

## Test

Extends `packages/shared/__tests__/subscription.spec.ts` with two new assertions:
- `includes July 2026 Anthropic models for subscription auth` — the three new ids appear in `getSubscriptionKnownModels('anthropic')`.
- `excludes the retired 20250514 Anthropic snapshots` — no `*-20250514` id leaks through the curated catalog.

## Compatibility note

`matchMode` defaults to `prefix`, so adding the new top-level ids without removing the family prefixes keeps every existing variant working. The new `-20250514` exclusion ensures the prefix-match walker can never leak a stale snapshot through the pricing cache (same mechanism as the existing `-fast` exclusion for Anthropic's OpenRouter pricing-cache entries that 404 at api.anthropic.com).

## Related

The companion plugin in [JosiahSiegel/manifest-plugins](https://github.com/JosiahSiegel/manifest-plugins) (`anthropic-models-fix`) currently patches this same gap for downstream operators. With this PR merged, that plugin can be retired once downstream Manifest builds roll out.

Closes #2210-style drift on subscription auth for Claude 5 series.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the Anthropic subscription catalog to the July 2026 lineup so subscription users can access new models and avoid retired snapshots.

- **New Features**
  - Add `claude-sonnet-5` (1M context), `claude-opus-4-6`, and `claude-haiku-4-5`.

- **Bug Fixes**
  - Exclude `*-20250514` retired snapshots; update tests to expect 7 curated Anthropic rows, use exact-id filtering for `claude-opus-4`, and handle a possibly-null model list.
  - Update the exclusion test to expect `-fast` and `-20250514`.

<sup>Written for commit 80988e09e2266e2b921ce33afe1a12f0adee4b9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

