### PR TITLE
feat: add claude-sonnet-5 to Claude Max / Pro subscription knownModels (anthropic)

### DIFF
--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1505,6 +1505,7 @@ describe('ModelDiscoveryService', () => {
       expect(result.map((m) => m.id)).toEqual([
         'claude-fable-5',
         'claude-opus-4',
+        'claude-sonnet-5',
         'claude-sonnet-4',
         'claude-haiku-4',
       ]);
@@ -1818,15 +1819,16 @@ describe('ModelDiscoveryService', () => {
         }),
       );
 
-      // Should only include models matching knownModels prefixes (claude-opus-4, claude-sonnet-4, claude-haiku-4)
+      // Should only include models matching knownModels prefixes (claude-opus-4, claude-sonnet-5, claude-sonnet-4, claude-haiku-4)
       // and NOT claude-2.1 or openai models. claude-fable-5 has no OpenRouter
       // pricing entry, so it is appended directly as a zero-cost known model.
-      expect(result).toHaveLength(4);
+      expect(result).toHaveLength(5);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
         'claude-haiku-4-20260301',
         'claude-opus-4-20260301',
         'claude-sonnet-4-20260301',
+        'claude-sonnet-5',
       ]);
       // All should be stamped as subscription
       for (const m of result) {
@@ -2021,12 +2023,13 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Even without pricingSync, knownModels are returned directly
-      expect(result).toHaveLength(4);
+      expect(result).toHaveLength(5);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
         'claude-haiku-4',
         'claude-opus-4',
         'claude-sonnet-4',
+        'claude-sonnet-5',
       ]);
       for (const m of result) {
         expect(m.authType).toBe('subscription');
@@ -2401,12 +2404,13 @@ describe('ModelDiscoveryService', () => {
       const result = buildSubscriptionFallbackModels(null as never, 'anthropic');
 
       // No OpenRouter data, but knownModels are added directly
-      expect(result).toHaveLength(4);
+      expect(result).toHaveLength(5);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
         'claude-haiku-4',
         'claude-opus-4',
         'claude-sonnet-4',
+        'claude-sonnet-5',
       ]);
       expect(result[0].inputPricePerToken).toBe(0);
     });

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -317,6 +317,7 @@ describe('getSubscriptionKnownModels', () => {
     const models = getSubscriptionKnownModels('anthropic');
     expect(models).toContain('claude-fable-5');
     expect(models).toContain('claude-opus-4');
+    expect(models).toContain('claude-sonnet-5');
     expect(models).toContain('claude-sonnet-4');
   });
 
@@ -475,6 +476,7 @@ describe('getSubscriptionCapabilities', () => {
       supportsPromptCaching: true,
       supportsBatching: false,
     });
+    expect(caps?.modelContextWindows?.['claude-sonnet-5']).toBe(1048576);
     expect(caps?.modelContextWindows?.['claude-opus-4-8']).toBe(1000000);
   });
 

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -13,6 +13,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModels: Object.freeze([
       'claude-fable-5',
       'claude-opus-4',
+      'claude-sonnet-5',
       'claude-sonnet-4',
       'claude-haiku-4',
     ]),
@@ -23,6 +24,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
       modelContextWindows: Object.freeze({
+        'claude-sonnet-5': 1048576,
         'claude-opus-4-8': 1000000,
       }),
       supportsPromptCaching: true,


### PR DESCRIPTION
### ✨ What changed
- Adds `claude-sonnet-5` to the Claude Max / Pro subscription `knownModels` in configs.ts, with a 1M `modelContextWindows` override.
- Updates the hard-coded Anthropic fallback expectations in `model-discovery.service.spec.ts` (caught by the automated review pass; 351 shared + 145 backend tests green).

### 💭 Why
Anthropic released Claude Sonnet 5 on June 30 2026 (default model on free/Pro since July 1). The curated subscription list stops at `claude-sonnet-4` (prefix match misses `-5`), so plan users cannot route to it.

### 📝 Notes
- Verification: `claude-sonnet-5` listed on OpenRouter as `anthropic/claude-sonnet-5` (ctx 1,000,000) · present in Manifest discovery via openrouter:api_key, opencode-zen:api_key, copilot:subscription, anthropic:api_key, commandcode:subscription · 1-token probe answered live (served as `claude-sonnet-5-20260630`). Direct Claude-plan smoke skipped (no plan token on the test stack) — one manual request through a Claude plan confirms.
- Authored by Codex and approved by an independent Codex review pass (after one remediation cycle).
- https://www.anthropic.com/claude/sonnet
- https://releasebot.io/updates/anthropic
- Draft PR, auto-generated by manifest-model-watch. Pricing (models.dev) and params (modelparams.dev) out of scope.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `claude-sonnet-5` to Anthropic Claude Max/Pro subscription `knownModels` and set a `modelContextWindows` override of 1,048,576 tokens. This enables plan users to route to Sonnet 5 and updates fallback discovery/tests to include it.

<sup>Written for commit 4e3dcf260913625867233bcf1168c378b9c3bada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

