### PR TITLE
feat: sync manifest subscription model lists (2026-07-12)

### DIFF
--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -213,6 +213,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionAuthMode: 'token' as const,
     subscriptionKeyPlaceholder: 'Paste your Z.ai API key',
     knownModels: Object.freeze([
+      'glm-5.2',
       'glm-5.1',
       'glm-5-turbo',
       'glm-5',


### PR DESCRIPTION
### ✨ What changed
- Adds `glm-5.2` to subscription `knownModels` in configs.ts.

### 💭 Why
Discovery found these subscription models served by the provider but missing from the curated `knownModels` list.

### 📝 Notes
- Smoke could not verify (zai): `glm-5.2` (HTTP 429: {"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}). Ids unverified by a live request.
- Not added: `grok-4.20-0309-non-reasoning`, `grok-4.3`, `grok-4.5`, `grok-4.20-0309-reasoning`, `grok-build-0.1` (already curated, dynamically fetched, or a routing artifact).
- 137 new api_key models auto-discover at runtime, not listed here.
- Pricing (models.dev) and params (modelparams.dev) out of scope.
- Draft PR, auto-generated by the modelparams agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `glm-5.2` to the Z.ai subscription `knownModels` so users can select and use this model. Aligns our curated list with the provider’s available models.

<sup>Written for commit 23f4345bca3dca383d24bd6236ed2daec25c6311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

