### PR TITLE
fix: refresh MiniMax subscription endpoints

### DIFF
--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1518,7 +1518,7 @@ describe('ModelDiscoveryService', () => {
         t: 'minimax-access',
         r: 'minimax-refresh',
         e: Date.now() + 60000,
-        u: 'https://api.minimax.io/anthropic/v1',
+        u: 'https://api.minimax.io/anthropic',
       });
       mockDecrypt.mockReturnValue(blob);
 
@@ -1536,7 +1536,7 @@ describe('ModelDiscoveryService', () => {
         'minimax',
         'minimax-access',
         'subscription',
-        'https://api.minimax.io/anthropic/v1',
+        'https://api.minimax.io/anthropic',
       );
     });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1518,7 +1518,7 @@ describe('ModelDiscoveryService', () => {
         t: 'minimax-access',
         r: 'minimax-refresh',
         e: Date.now() + 60000,
-        u: 'https://api.minimax.io/anthropic',
+        u: 'https://api.minimax.io/anthropic/v1',
       });
       mockDecrypt.mockReturnValue(blob);
 
@@ -1536,7 +1536,7 @@ describe('ModelDiscoveryService', () => {
         'minimax',
         'minimax-access',
         'subscription',
-        'https://api.minimax.io/anthropic',
+        'https://api.minimax.io/anthropic/v1',
       );
     });
 
@@ -1558,7 +1558,7 @@ describe('ModelDiscoveryService', () => {
         'minimax',
         'sk-cp-cn-token',
         'subscription',
-        'https://api.minimaxi.com/anthropic',
+        'https://api.minimaxi.com/anthropic/v1',
       );
     });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -164,7 +164,7 @@ export class ModelDiscoveryService {
         // region column so CN tokens discover models against the CN host
         // instead of incorrectly probing api.minimax.io.
         if (lowerProvider === 'minimax' && !endpointOverride && provider.region === 'cn') {
-          endpointOverride = `${MINIMAX_BASE_URLS.cn}/anthropic`;
+          endpointOverride = `${MINIMAX_BASE_URLS.cn}/anthropic/v1`;
         }
       } else if (lowerProvider === 'copilot' && this.copilotTokenService) {
         try {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1446,7 +1446,12 @@ describe('ProviderModelFetcherService', () => {
       json: async () => ({ data: [] }),
     });
 
-    await service.fetch('minimax', 'sk-test', 'subscription', 'https://api.minimaxi.com/anthropic');
+    await service.fetch(
+      'minimax',
+      'sk-test',
+      'subscription',
+      'https://api.minimaxi.com/anthropic/v1',
+    );
 
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://api.minimaxi.com/anthropic/v1/models?limit=100',

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1446,12 +1446,7 @@ describe('ProviderModelFetcherService', () => {
       json: async () => ({ data: [] }),
     });
 
-    await service.fetch(
-      'minimax',
-      'sk-test',
-      'subscription',
-      'https://api.minimaxi.com/anthropic/v1',
-    );
+    await service.fetch('minimax', 'sk-test', 'subscription', 'https://api.minimaxi.com/anthropic');
 
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://api.minimaxi.com/anthropic/v1/models?limit=100',

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -860,7 +860,7 @@ export class ProviderModelFetcherService {
     if (endpointOverride && configKey === 'minimax-subscription') {
       const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(endpointOverride);
       if (minimaxBaseUrl) {
-        url = `${minimaxBaseUrl}/v1/models?limit=100`;
+        url = `${minimaxBaseUrl}/models?limit=100`;
       } else {
         this.logger.warn('Ignoring invalid MiniMax subscription endpoint override');
       }

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -343,7 +343,9 @@ describe('PlaygroundService.runStream', () => {
     const call = mocks.providerClient.forward.mock.calls[0][0] as Record<string, unknown>;
     expect(call.apiKey).toBe('mm-access');
     expect(call.customEndpoint).toBeDefined();
-    expect((call.customEndpoint as { baseUrl?: string }).baseUrl).toContain('api.minimaxi.com');
+    expect((call.customEndpoint as { baseUrl?: string }).baseUrl).toBe(
+      'https://api.minimaxi.com/anthropic/v1',
+    );
     // Custom endpoint forwards the model verbatim, so the `minimax/` prefix
     // must be stripped or the subscription endpoint 404s.
     expect(call.model).toBe('abab');

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.spec.ts
@@ -21,7 +21,7 @@ describe('minimax-oauth-helpers', () => {
   it('exposes the correct default region and base URLs', () => {
     expect(DEFAULT_REGION).toBe('global');
     expect(DEFAULT_BASE_URL).toBe('https://api.minimax.io');
-    expect(DEFAULT_RESOURCE_URL).toBe('https://api.minimax.io/anthropic');
+    expect(DEFAULT_RESOURCE_URL).toBe('https://api.minimax.io/anthropic/v1');
     expect(MINIMAX_BASE_URLS.cn).toBe('https://api.minimaxi.com');
   });
 
@@ -52,7 +52,7 @@ describe('minimax-oauth-helpers', () => {
         'https://api.minimax.io/oauth/token',
       );
       expect(buildMinimaxResourceUrl('https://api.minimax.io')).toBe(
-        'https://api.minimax.io/anthropic',
+        'https://api.minimax.io/anthropic/v1',
       );
     });
   });
@@ -65,8 +65,8 @@ describe('minimax-oauth-helpers', () => {
 
     it('normalises a resource URL through the provider-base-url helper', () => {
       // The helper is a pass-through for well-formed resource URLs.
-      expect(getMinimaxResourceUrl('https://api.minimax.io/anthropic')).toBe(
-        'https://api.minimax.io/anthropic',
+      expect(getMinimaxResourceUrl('https://api.minimax.io/anthropic/v1')).toBe(
+        'https://api.minimax.io/anthropic/v1',
       );
     });
   });
@@ -77,7 +77,7 @@ describe('minimax-oauth-helpers', () => {
     });
 
     it('returns the origin of a normalised resource URL', () => {
-      expect(getMinimaxOauthBaseUrl('https://api.minimaxi.com/anthropic')).toBe(
+      expect(getMinimaxOauthBaseUrl('https://api.minimaxi.com/anthropic/v1')).toBe(
         'https://api.minimaxi.com',
       );
     });

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.spec.ts
@@ -63,11 +63,29 @@ describe('minimax-oauth-helpers', () => {
       expect(getMinimaxResourceUrl('')).toBeNull();
     });
 
-    it('normalises a resource URL through the provider-base-url helper', () => {
-      // The helper is a pass-through for well-formed resource URLs.
-      expect(getMinimaxResourceUrl('https://api.minimax.io/anthropic/v1')).toBe(
+    it.each([
+      [
+        'current global URL',
         'https://api.minimax.io/anthropic/v1',
-      );
+        'https://api.minimax.io/anthropic/v1',
+      ],
+      [
+        'legacy global URL',
+        'https://api.minimax.io/anthropic',
+        'https://api.minimax.io/anthropic/v1',
+      ],
+      [
+        'current CN URL',
+        'https://api.minimaxi.com/anthropic/v1',
+        'https://api.minimaxi.com/anthropic/v1',
+      ],
+      [
+        'legacy CN URL',
+        'https://api.minimaxi.com/anthropic',
+        'https://api.minimaxi.com/anthropic/v1',
+      ],
+    ])('normalises a %s through the provider-base-url helper', (_label, resourceUrl, expected) => {
+      expect(getMinimaxResourceUrl(resourceUrl)).toBe(expected);
     });
   });
 
@@ -76,8 +94,8 @@ describe('minimax-oauth-helpers', () => {
       expect(getMinimaxOauthBaseUrl(undefined)).toBe(DEFAULT_BASE_URL);
     });
 
-    it('returns the origin of a normalised resource URL', () => {
-      expect(getMinimaxOauthBaseUrl('https://api.minimaxi.com/anthropic/v1')).toBe(
+    it('returns the CN origin for a legacy resource URL', () => {
+      expect(getMinimaxOauthBaseUrl('https://api.minimaxi.com/anthropic')).toBe(
         'https://api.minimaxi.com',
       );
     });

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth-helpers.ts
@@ -13,7 +13,7 @@ export type MinimaxRegion = keyof typeof MINIMAX_BASE_URLS;
 
 export const DEFAULT_REGION: MinimaxRegion = 'global';
 export const DEFAULT_BASE_URL = MINIMAX_BASE_URLS[DEFAULT_REGION];
-export const DEFAULT_RESOURCE_URL = `${DEFAULT_BASE_URL}/anthropic`;
+export const DEFAULT_RESOURCE_URL = `${DEFAULT_BASE_URL}/anthropic/v1`;
 export const DEFAULT_POLL_INTERVAL_MS = 2000;
 
 export function isMinimaxRegion(value: string | undefined): value is MinimaxRegion {
@@ -33,7 +33,7 @@ export function buildMinimaxTokenUrl(baseUrl: string): string {
 }
 
 export function buildMinimaxResourceUrl(baseUrl: string): string {
-  return `${baseUrl}/anthropic`;
+  return `${baseUrl}/anthropic/v1`;
 }
 
 const VERIFICATION_HOST_REWRITES: Record<string, string> = {

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.coverage.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.coverage.spec.ts
@@ -258,7 +258,7 @@ describe('MinimaxOauthService', () => {
           access_token: 'at',
           refresh_token: 'rt',
           expired_in: 3600,
-          resource_url: 'https://api.minimax.io/anthropic',
+          resource_url: 'https://api.minimax.io/anthropic/v1',
         }),
       );
       const out = await svc.pollAuthorization(start.flowId, 'user-1');

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.spec.ts
@@ -229,7 +229,7 @@ describe('MinimaxOauthService', () => {
           t: 'old-access',
           r: 'old-refresh',
           e: now - 1000,
-          u: 'https://api.minimaxi.com/anthropic/v1',
+          u: 'https://api.minimaxi.com/anthropic',
         }),
         'agent-1',
         'user-1',

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.spec.ts
@@ -111,7 +111,7 @@ describe('MinimaxOauthService', () => {
               access_token: 'access-123',
               refresh_token: 'refresh-456',
               expired_in: 3600,
-              resource_url: 'https://api.minimax.io/anthropic',
+              resource_url: 'https://api.minimax.io/anthropic/v1',
             }),
         });
 
@@ -167,7 +167,7 @@ describe('MinimaxOauthService', () => {
           t: 'old-access',
           r: 'old-refresh',
           e: now + 7200,
-          u: { host: 'https://api.minimax.io/anthropic' },
+          u: { host: 'https://api.minimax.io/anthropic/v1' },
         }),
         'agent-1',
         'user-1',
@@ -195,7 +195,7 @@ describe('MinimaxOauthService', () => {
           t: 'old-access',
           r: 'old-refresh',
           e: Date.now() - 1000,
-          u: 'https://api.minimax.io/anthropic',
+          u: 'https://api.minimax.io/anthropic/v1',
         }),
         'agent-1',
         'user-1',
@@ -205,7 +205,7 @@ describe('MinimaxOauthService', () => {
         expect.objectContaining({
           t: 'new-access',
           r: 'new-refresh',
-          u: 'https://api.minimax.io/anthropic',
+          u: 'https://api.minimax.io/anthropic/v1',
         }),
       );
       expect(providerService.upsertProvider).toHaveBeenCalled();
@@ -229,7 +229,7 @@ describe('MinimaxOauthService', () => {
           t: 'old-access',
           r: 'old-refresh',
           e: now - 1000,
-          u: 'https://api.minimaxi.com/anthropic',
+          u: 'https://api.minimaxi.com/anthropic/v1',
         }),
         'agent-1',
         'user-1',
@@ -250,7 +250,7 @@ describe('MinimaxOauthService', () => {
 
       const result = await service.refreshAccessToken(
         'refresh-token',
-        'https://api.minimax.io/anthropic',
+        'https://api.minimax.io/anthropic/v1',
       );
 
       expect(result.e).toBe(now + 7200);
@@ -274,7 +274,7 @@ describe('MinimaxOauthService', () => {
         'https://evil.example/anthropic',
       );
 
-      expect(result.u).toBe('https://api.minimax.io/anthropic');
+      expect(result.u).toBe('https://api.minimax.io/anthropic/v1');
     });
   });
 });

--- a/packages/backend/src/routing/provider-base-url.ts
+++ b/packages/backend/src/routing/provider-base-url.ts
@@ -3,8 +3,8 @@ export function normalizeProviderBaseUrl(baseUrl: string): string {
 }
 
 const MINIMAX_SUBSCRIPTION_BASE_URLS = new Set([
-  'https://api.minimax.io/anthropic',
-  'https://api.minimaxi.com/anthropic',
+  'https://api.minimax.io/anthropic/v1',
+  'https://api.minimaxi.com/anthropic/v1',
 ]);
 
 export function normalizeMinimaxSubscriptionBaseUrl(baseUrl: string): string | null {
@@ -14,7 +14,7 @@ export function normalizeMinimaxSubscriptionBaseUrl(baseUrl: string): string | n
       return null;
     }
 
-    const normalized = normalizeProviderBaseUrl(`${url.origin}${url.pathname}`);
+    const normalized = `${url.origin}${url.pathname}`.replace(/\/+$/, '');
     return MINIMAX_SUBSCRIPTION_BASE_URLS.has(normalized) ? normalized : null;
   } catch {
     return null;

--- a/packages/backend/src/routing/provider-base-url.ts
+++ b/packages/backend/src/routing/provider-base-url.ts
@@ -2,9 +2,11 @@ export function normalizeProviderBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
 }
 
-const MINIMAX_SUBSCRIPTION_BASE_URLS = new Set([
-  'https://api.minimax.io/anthropic/v1',
-  'https://api.minimaxi.com/anthropic/v1',
+const MINIMAX_SUBSCRIPTION_BASE_URLS = new Map([
+  ['https://api.minimax.io/anthropic', 'https://api.minimax.io/anthropic/v1'],
+  ['https://api.minimax.io/anthropic/v1', 'https://api.minimax.io/anthropic/v1'],
+  ['https://api.minimaxi.com/anthropic', 'https://api.minimaxi.com/anthropic/v1'],
+  ['https://api.minimaxi.com/anthropic/v1', 'https://api.minimaxi.com/anthropic/v1'],
 ]);
 
 export function normalizeMinimaxSubscriptionBaseUrl(baseUrl: string): string | null {
@@ -15,7 +17,7 @@ export function normalizeMinimaxSubscriptionBaseUrl(baseUrl: string): string | n
     }
 
     const normalized = `${url.origin}${url.pathname}`.replace(/\/+$/, '');
-    return MINIMAX_SUBSCRIPTION_BASE_URLS.has(normalized) ? normalized : null;
+    return MINIMAX_SUBSCRIPTION_BASE_URLS.get(normalized) ?? null;
   } catch {
     return null;
   }

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -486,9 +486,9 @@ describe('PROVIDER_ENDPOINTS', () => {
     expect(headers['user-agent']).toBe('codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown');
   });
 
-  it('minimax-subscription buildPath returns /v1/messages', () => {
+  it('minimax-subscription buildPath returns /messages', () => {
     const path = PROVIDER_ENDPOINTS['minimax-subscription'].buildPath('abab7-chat-preview');
-    expect(path).toBe('/v1/messages');
+    expect(path).toBe('/messages');
   });
 
   it('minimax-subscription uses Bearer auth with anthropic-version header', () => {
@@ -741,11 +741,14 @@ describe('PROVIDER_ENDPOINTS', () => {
 
 describe('buildEndpointOverride', () => {
   it('creates endpoint using the template for a known key', () => {
-    const ep = buildEndpointOverride('https://custom.minimax.io/anthropic', 'minimax-subscription');
+    const ep = buildEndpointOverride(
+      'https://custom.minimax.io/anthropic/v1',
+      'minimax-subscription',
+    );
 
-    expect(ep.baseUrl).toBe('https://custom.minimax.io/anthropic');
+    expect(ep.baseUrl).toBe('https://custom.minimax.io/anthropic/v1');
     expect(ep.format).toBe('anthropic');
-    expect(ep.buildPath('model-x')).toBe('/v1/messages');
+    expect(ep.buildPath('model-x')).toBe('/messages');
   });
 
   it('throws when template key does not exist', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -262,14 +262,14 @@ describe('ProxyFallbackService', () => {
           t: 'old-access-token',
           r: 'refresh-token',
           e: Date.now() + 10 * 60 * 1000,
-          u: 'https://api.minimax.io/anthropic',
+          u: 'https://api.minimax.io/anthropic/v1',
         }),
         setup: () =>
           minimaxOauth.unwrapToken.mockResolvedValue({
             t: 'fresh-minimax-token',
             r: 'refresh-token',
             e: Date.now() + 60 * 60 * 1000,
-            u: 'https://api.minimax.io/anthropic',
+            u: 'https://api.minimax.io/anthropic/v1',
           }),
         unwrap: () => minimaxOauth.unwrapToken,
         expectedApiKey: 'fresh-minimax-token',
@@ -824,7 +824,7 @@ describe('ProxyFallbackService', () => {
         stream: false,
         sessionKey: 'sess-1',
         authType: 'subscription',
-        resourceUrl: 'https://api.minimax.io/anthropic',
+        resourceUrl: 'https://api.minimax.io/anthropic/v1',
       });
 
       expect(providerClient.forward).toHaveBeenCalledWith(
@@ -835,7 +835,7 @@ describe('ProxyFallbackService', () => {
           body,
           stream: false,
           customEndpoint: expect.objectContaining({
-            baseUrl: 'https://api.minimax.io/anthropic',
+            baseUrl: 'https://api.minimax.io/anthropic/v1',
             format: 'anthropic',
           }),
           authType: 'subscription',
@@ -900,7 +900,7 @@ describe('ProxyFallbackService', () => {
       expect(providerClient.forward).toHaveBeenCalledWith(
         expect.objectContaining({
           customEndpoint: expect.objectContaining({
-            baseUrl: 'https://api.minimaxi.com/anthropic',
+            baseUrl: 'https://api.minimaxi.com/anthropic/v1',
             format: 'anthropic',
           }),
         }),

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
@@ -28,7 +28,7 @@ describe('resolveForwardEndpoint', () => {
       provider: 'minimax',
       authType: 'subscription',
       model: 'minimax/abab',
-      resourceUrl: 'https://api.minimaxi.com/anthropic',
+      resourceUrl: 'https://api.minimaxi.com/anthropic/v1',
     });
     expect(out.forwardModel).toBe('abab');
     expect(out.customEndpoint?.baseUrl).toContain('api.minimaxi.com');

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
@@ -23,15 +23,15 @@ describe('resolveForwardEndpoint', () => {
     expect(out.customEndpoint).toBeUndefined();
   });
 
-  it('builds the minimax region endpoint from a valid resource_url and strips the prefix', () => {
+  it('normalises a legacy MiniMax resource_url before building the region endpoint', () => {
     const out = resolveForwardEndpoint({
       provider: 'minimax',
       authType: 'subscription',
       model: 'minimax/abab',
-      resourceUrl: 'https://api.minimaxi.com/anthropic/v1',
+      resourceUrl: 'https://api.minimaxi.com/anthropic',
     });
     expect(out.forwardModel).toBe('abab');
-    expect(out.customEndpoint?.baseUrl).toContain('api.minimaxi.com');
+    expect(out.customEndpoint?.baseUrl).toBe('https://api.minimaxi.com/anthropic/v1');
   });
 
   it('warns and builds no endpoint for an invalid minimax resource_url (still strips prefix)', () => {

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
@@ -133,7 +133,7 @@ export function resolveForwardEndpoint(
       }
     } else if (providerRegion === 'cn') {
       customEndpoint = buildEndpointOverride(
-        `${MINIMAX_BASE_URLS.cn}/anthropic`,
+        `${MINIMAX_BASE_URLS.cn}/anthropic/v1`,
         'minimax-subscription',
       );
     }

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -108,7 +108,7 @@ const CHATGPT_SUBSCRIPTION_BASE = 'https://chatgpt.com/backend-api';
 const BYTEPLUS_CODING_BASE = 'https://ark.ap-southeast.bytepluses.com/api/coding';
 const COMMAND_CODE_PROVIDER_BASE = 'https://api.commandcode.ai/provider';
 const KIMI_CODING_SUBSCRIPTION_BASE = 'https://api.kimi.com/coding';
-const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic';
+const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic/v1';
 const XIAOMI_MIMO_BASE = 'https://api.xiaomimimo.com';
 const XIAOMI_TOKEN_PLAN_BASE = getXiaomiTokenPlanBaseUrl();
 const QWEN_TOKEN_PLAN_BASE = 'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode';
@@ -275,7 +275,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   'minimax-subscription': {
     baseUrl: MINIMAX_SUBSCRIPTION_BASE,
     buildHeaders: anthropicBearerHeaders,
-    buildPath: () => '/v1/messages',
+    buildPath: () => '/messages',
     format: 'anthropic',
   },
   xiaomi: {
@@ -515,7 +515,10 @@ export function buildEndpointOverride(baseUrl: string, templateKey: string): Pro
   }
   return {
     ...template,
-    baseUrl: normalizeProviderBaseUrl(baseUrl),
+    baseUrl:
+      templateKey === 'minimax-subscription'
+        ? baseUrl.replace(/\/+$/, '')
+        : normalizeProviderBaseUrl(baseUrl),
     // The base URL came from a user-supplied source (Qwen region selector,
     // MiniMax OAuth resource URL). Treat it as an SSRF candidate and
     // re-validate before each forward.


### PR DESCRIPTION
### ✨ What changed
- Move MiniMax subscription requests to `/anthropic/v1`.
- Normalize legacy OAuth resource URLs to the canonical endpoint.
- Add regional compatibility regression coverage.

### 💭 Why
Existing MiniMax OAuth records use `/anthropic`. Without normalization, old CN connections fall back to the global host.

### 📝 Notes
Supersedes #2453.
Original endpoint work is credited to @octo-patch in the commit history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch MiniMax subscription to the official `/anthropic/v1` base and normalize legacy `/anthropic` URLs so global and CN routing works consistently.

- **Bug Fixes**
  - Normalize MiniMax resource URLs (global and CN) to `/anthropic/v1`.
  - Update `minimax-subscription` to use `/messages` with base `/anthropic/v1`.
  - Use CN `/anthropic/v1` for discovery and forwarding when region is `cn`.
  - Add tests covering legacy/current URLs and regional routing.

<sup>Written for commit 37be2787f11cb662a3bb6711fde987a71fd5b676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

