### PR TITLE
fix: handle Anthropic thinking on OpenRouter

### DIFF
--- a/.changeset/fix-openrouter-anthropic-thinking.md
+++ b/.changeset/fix-openrouter-anthropic-thinking.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix OpenRouter routes for Anthropic thinking requests.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -3822,6 +3822,47 @@ describe('ProviderClient', () => {
       expect(sentBody.stream_options).toEqual({ include_usage: true });
     });
 
+    it('drops Anthropic thinking only for OpenRouter Messages requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'openrouter',
+        apiKey: 'sk-or',
+        model: 'nvidia/nemotron-3-ultra-550b-a55b',
+        body: {
+          messages: [{ role: 'user', content: 'Hello' }],
+          thinking: { type: 'enabled', budget_tokens: 1024 },
+        },
+        chatBody: {
+          messages: [{ role: 'user', content: 'Hello' }],
+          thinking: { type: 'enabled', budget_tokens: 1024 },
+          reasoning: { effort: 'high' },
+        },
+        stream: false,
+        apiMode: 'messages',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody).not.toHaveProperty('thinking');
+      expect(sentBody).toHaveProperty('reasoning', { effort: 'high' });
+    });
+
+    it('preserves direct OpenRouter thinking params', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'openrouter',
+        apiKey: 'sk-or',
+        model: 'openai/gpt-4o',
+        body: {
+          messages: [{ role: 'user', content: 'Hello' }],
+          thinking: { type: 'enabled', budget_tokens: 1024 },
+        },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody).toHaveProperty('thinking', { type: 'enabled', budget_tokens: 1024 });
+    });
+
     it('injects stream_options.include_usage for Ollama streaming requests', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -588,9 +588,20 @@ export class ProviderClient {
       };
     }
 
+    // OpenRouter accepts model-specific OpenAI-compatible parameters. An Anthropic
+    // Messages request, however, has been translated to this shape and its
+    // `thinking` object is not valid on OpenRouter's API.
+    const openAiRequestSource =
+      endpointKey === 'openrouter' && ctx.apiMode === 'messages'
+        ? { ...requestSource }
+        : requestSource;
+    if (openAiRequestSource !== requestSource) {
+      delete openAiRequestSource.thinking;
+    }
+
     // OpenAI-compatible path (default)
     const sanitized = sanitizeOpenAiBody(
-      requestSource,
+      openAiRequestSource,
       endpointKey,
       ctx.model,
       ctx.reasoningContentLookup,


### PR DESCRIPTION
### ✨ What changed
- Drop Anthropic `thinking` only for Messages requests routed through OpenRouter.
- Preserve direct OpenRouter model-specific parameters.

### 💭 Why
OpenRouter rejects the Anthropic-only object on affected routes.

### 📝 Notes
Fixes #2464

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenRouter Messages request failures by removing Anthropic-only `thinking` from translated Anthropic requests, while keeping OpenRouter-native params intact.

- **Bug Fixes**
  - Drop `thinking` only when routing Anthropic Messages through OpenRouter; keep `reasoning`.
  - Preserve direct OpenRouter model-specific `thinking` params.
  - Added tests covering both behaviors.

<sup>Written for commit 0d6a222d7e5ccf48d20cd3b92a85ead46788645f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

