### PR TITLE
fix: refresh harness sidebar after creation

### DIFF
--- a/.changeset/instant-harness-sidebar.md
+++ b/.changeset/instant-harness-sidebar.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show newly created harnesses in the sidebar immediately.

--- a/packages/frontend/src/components/AddAgentModal.tsx
+++ b/packages/frontend/src/components/AddAgentModal.tsx
@@ -4,6 +4,7 @@ import AgentTypeSelect from './AgentTypeSelect.jsx';
 import { createAgent, getGlobalProviders } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 import { markAgentCreated, markSetupPending } from '../services/recent-agents.js';
+import { refreshAgents } from '../services/sse.js';
 import { type AgentCategory, type AgentPlatform, PLATFORMS_BY_CATEGORY } from 'manifest-shared';
 
 /**
@@ -59,6 +60,9 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
         ...(category() ? { agent_category: category()! } : {}),
         ...(platform() ? { agent_platform: platform()! } : {}),
       });
+      // Local creates do not wait for the asynchronous server-sent event. This
+      // immediately reruns the sidebar's harness-list resource with fresh data.
+      refreshAgents();
       // The user dismissed the modal while the request was in flight — honour
       // that dismissal and skip every success side effect + the navigation.
       if (cancelled) return;

--- a/packages/frontend/src/services/sse.ts
+++ b/packages/frontend/src/services/sse.ts
@@ -12,6 +12,12 @@ const [routingPing, setRoutingPing] = createSignal(0);
 
 export { pingCount, messagePing, agentPing, routingPing };
 
+/** Refresh views derived from the harness list after a local mutation. */
+export function refreshAgents(): void {
+  invalidateGroup('agent');
+  setAgentPing((n) => n + 1);
+}
+
 export function connectSse(): () => void {
   const es = new EventSource('/api/v1/events');
 
@@ -50,8 +56,7 @@ export function connectSse(): () => void {
   });
   es.addEventListener('agent', () => {
     // Drop agent-list/per-agent GET cache before the agentPing refetch reads it.
-    invalidateGroup('agent');
-    setAgentPing((n) => n + 1);
+    refreshAgents();
     bumpPing();
   });
   es.addEventListener('routing', () => {

--- a/packages/frontend/tests/components/AddAgentModal.test.tsx
+++ b/packages/frontend/tests/components/AddAgentModal.test.tsx
@@ -24,6 +24,11 @@ vi.mock('../../src/services/recent-agents.js', () => ({
   markSetupPending: (...args: unknown[]) => mockMarkSetupPending(...args),
 }));
 
+const mockRefreshAgents = vi.fn();
+vi.mock('../../src/services/sse.js', () => ({
+  refreshAgents: (...args: unknown[]) => mockRefreshAgents(...args),
+}));
+
 vi.mock('../../src/components/AgentTypeSelect.jsx', () => ({
   default: (props: any) => (
     <div
@@ -108,6 +113,16 @@ describe('AddAgentModal', () => {
     // Persistent flag set so the setup modal survives a refresh on landing.
     expect(mockMarkSetupPending).toHaveBeenCalledWith('new-agent');
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('refreshes the harness list as soon as creation succeeds', async () => {
+    const { input, createBtn } = renderOpen();
+    fireEvent.input(input, { target: { value: 'agent-a' } });
+    fireEvent.click(createBtn);
+
+    await vi.waitFor(() => {
+      expect(mockRefreshAgents).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('adds openProviders when the tenant has no providers yet', async () => {

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -39,11 +39,6 @@ vi.mock("../../src/services/api/billing.js", () => ({
   getBillingStatus: (...args: unknown[]) => mockGetBillingStatus(...args),
 }));
 
-// The SSE ping signal drives the agents resource refetch — a stable 0 is fine.
-vi.mock("../../src/services/sse.js", () => ({
-  agentPing: () => 0,
-}));
-
 // Local providers only exist on self-hosted installs; the Sidebar hides the
 // Local nav entry in cloud. Default to self-hosted so the legacy link
 // assertions keep applying; cloud tests flip the flag.
@@ -92,6 +87,7 @@ vi.mock("../../src/components/AutofixModal.jsx", async () => {
 });
 
 import Sidebar from "../../src/components/Sidebar";
+import { refreshAgents } from "../../src/services/sse";
 
 const SAMPLE_AGENTS = [
   {
@@ -330,6 +326,24 @@ describe("Sidebar — harness switcher list", () => {
     await waitFor(() => {
       expect(container.querySelectorAll("a.sidebar__agent-item").length).toBe(2);
     });
+  });
+
+  it("refetches when a harness is created locally", async () => {
+    mockGetAgents.mockResolvedValueOnce({ agents: [] }).mockResolvedValueOnce({
+      agents: [{ agent_name: "new-harness", display_name: "New Harness" }],
+    });
+    const { container } = render(() => <Sidebar />);
+
+    await waitFor(() => {
+      expect(container.querySelector(".sidebar__agents-empty")).not.toBeNull();
+    });
+
+    refreshAgents();
+
+    await waitFor(() => {
+      expect(container.querySelector('a[href="/harnesses/new-harness"]')).not.toBeNull();
+    });
+    expect(mockGetAgents).toHaveBeenCalledTimes(2);
   });
 
   it("renders the empty state only once the resource resolves empty (not while loading)", async () => {

--- a/packages/frontend/tests/pages/Workspace-validation.test.tsx
+++ b/packages/frontend/tests/pages/Workspace-validation.test.tsx
@@ -56,6 +56,7 @@ vi.mock('../../src/services/sse.js', () => ({
   messagePing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
+  refreshAgents: vi.fn(),
 }));
 
 vi.mock('../../src/components/AgentTypeSelect.jsx', () => ({

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -79,6 +79,7 @@ vi.mock('../../src/services/sse.js', () => ({
   messagePing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
+  refreshAgents: vi.fn(),
 }));
 
 vi.mock('../../src/components/AgentTypeSelect.jsx', () => ({


### PR DESCRIPTION
### ✨ What changed
- Refresh the harness list immediately after a successful create.
- Cover the sidebar refresh path with frontend tests.

### 💭 Why
New harnesses stayed hidden in the sidebar until a page refresh because the client waited for an asynchronous event.

### 👤 For users
New harnesses appear in the sidebar as soon as they are created.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New harnesses now appear in the sidebar immediately after creation. This removes the delay caused by waiting for SSE updates.

- **Bug Fixes**
  - Added `refreshAgents()` in `packages/frontend/src/services/sse.ts` to invalidate the `agent` cache and trigger a refetch.
  - Called `refreshAgents()` after successful `createAgent` in `AddAgentModal` to update the sidebar right away.
  - Reused `refreshAgents()` for SSE `agent` events to avoid duplicate logic.
  - Added frontend tests for the modal and sidebar to cover the instant refresh behavior.

<sup>Written for commit 970ed6340c995081db43cce3325dc46f4c58f7c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

