### PR TITLE
chore: bump modelparams to 0.0.13

### DIFF
--- a/.changeset/bump-modelparams-0-0-13.md
+++ b/.changeset/bump-modelparams-0-0-13.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Bump `modelparams` to 0.0.13 to pick up the new xAI Grok model parameter specs, including `grok-4.5` and subscription entries for the Grok subscription models.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11042,15 +11042,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/modelparams": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/modelparams/-/modelparams-0.0.3.tgz",
-      "integrity": "sha512-fXnNNY76CwRdCxfZyON0WGpZ04jFRknsGeIS1zg0sR94VGk39JqxSM7csmGFOp3ErVTLYM8KUmgZMxLbLEuryA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/mri": {
       "version": "1.2.0",
       "dev": true,
@@ -14763,7 +14754,7 @@
         "express-rate-limit": "^8.5.1",
         "helmet": "^8.1.0",
         "manifest-shared": "*",
-        "modelparams": "^0.0.3",
+        "modelparams": "^0.0.13",
         "pg": "^8.13.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -14830,6 +14821,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "packages/backend/node_modules/modelparams": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/modelparams/-/modelparams-0.0.13.tgz",
+      "integrity": "sha512-zFbEdS+J4WURhKe+dUI/sSp9P8xxLzFShlzOncpeZaYIVP7Bn/gHp3ttLUziEFdLFTOpJf/KpPHGHqaPhpqQtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/frontend": {
@@ -15014,7 +15014,7 @@
       }
     },
     "packages/manifest": {
-      "version": "6.13.5"
+      "version": "6.15.1"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,6 +22,7 @@
     "backfill:message-providers:prod": "node dist/database/backfills/backfill-message-providers.cli.js"
   },
   "dependencies": {
+    "@better-auth/stripe": "1.6.11",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.0",
@@ -31,7 +32,6 @@
     "@nestjs/serve-static": "^5.0.4",
     "@nestjs/throttler": "^6.0.0",
     "@nestjs/typeorm": "^11.0.0",
-    "@better-auth/stripe": "1.6.11",
     "@react-email/components": "^1.0.7",
     "@react-email/render": "^2.0.4",
     "better-auth": "1.6.11",
@@ -44,7 +44,7 @@
     "express-rate-limit": "^8.5.1",
     "helmet": "^8.1.0",
     "manifest-shared": "*",
-    "modelparams": "^0.0.3",
+    "modelparams": "^0.0.13",
     "pg": "^8.13.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
## What

Bumps the backend's `modelparams` dependency `^0.0.3` → `^0.0.13` (rebased on latest `main`, single commit).

## Why

The old pin `^0.0.3` resolves to `>=0.0.3 <0.0.4` (caret semantics on a `0.0.x` package), so the backend was stuck on `modelparams@0.0.3` and never picked up newly published specs. `0.0.13` includes the freshly added xAI Grok params:

- `grok-4.5` (api_key) — previously missing
- `-subscription` specs for all 5 Grok subscription models: `grok-4.5`, `grok-4.3`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, `grok-build-0.1`

(from mnfst/modelparams.dev#102)

## Verification

- `npm install modelparams@0.0.13` → lockfile resolves `modelparams@0.0.13`
- installed package ships all 5 `xai/grok-*-subscription` ids + `xai/grok-4.5`
- `npx jest provider-param-spec` → 10/10 pass