### PR TITLE
feat(analytics): add auto_fixed count to errors/breakdown

### DIFF
--- a/.changeset/autofix-count-errors-breakdown.md
+++ b/.changeset/autofix-count-errors-breakdown.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add an `auto_fixed` count to the `GET /api/v1/errors/breakdown` response (number of requests healed by Auto-fix in the window), plus a typed `getErrorBreakdown()` frontend API wrapper — so a dashboard can surface auto-fixed alongside errors.

--- a/packages/backend/src/analytics/services/error-breakdown.service.spec.ts
+++ b/packages/backend/src/analytics/services/error-breakdown.service.spec.ts
@@ -8,7 +8,7 @@ interface GroupRow {
   count: string;
 }
 
-function makeQb(groups: GroupRow[], successful: number) {
+function makeQb(groups: GroupRow[], successful: number, autoFixed: number) {
   return {
     select: jest.fn().mockReturnThis(),
     addSelect: jest.fn().mockReturnThis(),
@@ -17,12 +17,16 @@ function makeQb(groups: GroupRow[], successful: number) {
     groupBy: jest.fn().mockReturnThis(),
     addGroupBy: jest.fn().mockReturnThis(),
     getRawMany: jest.fn().mockResolvedValue(groups),
-    getRawOne: jest.fn().mockResolvedValue({ count: String(successful) }),
+    // querySuccessful resolves first, queryAutoFixed second (Promise.all order).
+    getRawOne: jest
+      .fn()
+      .mockResolvedValueOnce({ count: String(successful) })
+      .mockResolvedValue({ count: String(autoFixed) }),
   };
 }
 
-function makeService(groups: GroupRow[], successful: number) {
-  const qb = makeQb(groups, successful);
+function makeService(groups: GroupRow[], successful: number, autoFixed = 0) {
+  const qb = makeQb(groups, successful, autoFixed);
   const repo = {
     createQueryBuilder: jest.fn().mockReturnValue(qb),
   } as unknown as Repository<AgentMessage>;
@@ -90,6 +94,28 @@ describe('ErrorBreakdownService', () => {
     // Before the `request` origin existed these 9 rows were recorded as provider
     // 400s and dragged the reliability number down with them.
     expect(result.provider_error_rate).toBeCloseTo(3 / 10, 10);
+  });
+
+  it('counts healed requests via status=auto_fixed, independent of the error groups', async () => {
+    const { service, qb } = makeService(GROUPS, 81, 7);
+    const result = await service.getBreakdown({ tenantId: 't1', range: '7d' });
+
+    expect(result.auto_fixed).toBe(7);
+    // The heal count must not inflate the error totals — it is a view over rows
+    // already inside total_errors, not a new bucket.
+    expect(result.total_errors).toBe(21);
+    // The dedicated count query filters on status='auto_fixed'.
+    const filtersAutoFixed = (qb.andWhere as jest.Mock).mock.calls.some(
+      ([clause, params]) =>
+        clause === 'at.status = :autoFixedStatus' && params?.autoFixedStatus === 'auto_fixed',
+    );
+    expect(filtersAutoFixed).toBe(true);
+  });
+
+  it('reports auto_fixed as 0 when nothing was healed', async () => {
+    const { service } = makeService(GROUPS, 81);
+    const result = await service.getBreakdown({ tenantId: 't1' });
+    expect(result.auto_fixed).toBe(0);
   });
 
   it('defaults the range to 30d when none is supplied', async () => {

--- a/packages/backend/src/analytics/services/error-breakdown.service.ts
+++ b/packages/backend/src/analytics/services/error-breakdown.service.ts
@@ -19,6 +19,14 @@ export interface ErrorBreakdownResponse {
   transport_errors: number;
   /** Manifest's OWN config/policy/internal rejections — NOT a provider failure. */
   manifest_errors: number;
+  /**
+   * Requests healed by Auto-fix in the window — one per healed request, counted
+   * from the failed-original row (`status='auto_fixed'`). NOT additive with
+   * `total_errors`: the healed original is a superseded attempt that is already
+   * included in `total_errors`/`by_origin`, so treat this as "of those errors,
+   * this many were auto-fixed", never as a separate error bucket to sum.
+   */
+  auto_fixed: number;
   by_origin: Record<string, number>;
   by_class: Record<string, number>;
   /** provider_errors / (provider_errors + successful), 0..1. */
@@ -46,12 +54,13 @@ export class ErrorBreakdownService {
     const range = params.range ?? '30d';
     const cutoff = computeCutoff(rangeToInterval(range));
 
-    const [groups, successful] = await Promise.all([
+    const [groups, successful, autoFixed] = await Promise.all([
       this.queryErrorGroups(cutoff, params.tenantId, params.agentName),
       this.querySuccessful(cutoff, params.tenantId, params.agentName),
+      this.queryAutoFixed(cutoff, params.tenantId, params.agentName),
     ]);
 
-    return this.assemble(range, groups, successful);
+    return this.assemble(range, groups, successful, autoFixed);
   }
 
   private async queryErrorGroups(
@@ -97,10 +106,32 @@ export class ErrorBreakdownService {
     return Number(row?.count ?? 0);
   }
 
+  /**
+   * Count of requests healed by Auto-fix. The failed original of a healed pair
+   * carries `status='auto_fixed'` (its successful retry is a separate `ok` row),
+   * so one `auto_fixed` row == one healed request — no double-counting.
+   */
+  private async queryAutoFixed(
+    cutoff: string,
+    tenantId: string | null,
+    agentName?: string,
+  ): Promise<number> {
+    const qb = this.messageRepo
+      .createQueryBuilder('at')
+      .select('COUNT(*)', 'count')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.status = :autoFixedStatus', { autoFixedStatus: 'auto_fixed' });
+    addTenantFilter(qb, tenantId, agentName);
+    excludePlaygroundAgents(qb);
+    const row = await qb.getRawOne<{ count: string }>();
+    return Number(row?.count ?? 0);
+  }
+
   private assemble(
     range: string,
     groups: ErrorGroupRow[],
     successful: number,
+    autoFixed: number,
   ): ErrorBreakdownResponse {
     const by_origin: Record<string, number> = Object.fromEntries(ERROR_ORIGINS.map((o) => [o, 0]));
     const by_class: Record<string, number> = {};
@@ -120,6 +151,7 @@ export class ErrorBreakdownService {
       provider_errors: provider,
       transport_errors: by_origin['transport'] ?? 0,
       manifest_errors: manifest,
+      auto_fixed: autoFixed,
       by_origin,
       by_class,
       provider_error_rate: denom > 0 ? provider / denom : 0,

--- a/packages/frontend/src/services/api/analytics.ts
+++ b/packages/frontend/src/services/api/analytics.ts
@@ -161,6 +161,45 @@ export function getOverview(range = '24h', agentName?: string) {
   return fetchJson('/overview', { range, ...(agentName ? { agent_name: agentName } : {}) });
 }
 
+/** Response shape of `GET /api/v1/errors/breakdown`. Mirrors the backend `ErrorBreakdownResponse`. */
+export interface ErrorBreakdownResponse {
+  range: string;
+  /** Real (successful) messages in the window — the provider-error-rate denominator. */
+  successful: number;
+  /** All classified error rows (every origin). */
+  total_errors: number;
+  /** Errors a provider actually threw (the reliability signal). */
+  provider_errors: number;
+  /** Network/timeout failures reaching a provider. */
+  transport_errors: number;
+  /** Manifest's OWN config/policy/internal rejections — NOT a provider failure. */
+  manifest_errors: number;
+  /**
+   * Requests healed by Auto-fix — one per healed request. NOT additive with
+   * `total_errors`: the healed original is a superseded attempt already counted
+   * there, so read this as "of those errors, this many were auto-fixed".
+   */
+  auto_fixed: number;
+  by_origin: Record<string, number>;
+  by_class: Record<string, number>;
+  /** provider_errors / (provider_errors + successful), 0..1. */
+  provider_error_rate: number;
+}
+
+/**
+ * Error + Auto-fix breakdown for the window. `range` is one of the standard
+ * analytics presets (1h/6h/24h/7d/30d/90d/365d); pass the page's range signal.
+ */
+export function getErrorBreakdown(
+  range = '24h',
+  agentName?: string,
+): Promise<ErrorBreakdownResponse> {
+  return fetchJson('/errors/breakdown', {
+    range,
+    ...(agentName ? { agent_name: agentName } : {}),
+  }) as Promise<ErrorBreakdownResponse>;
+}
+
 export function getHealth() {
   return fetchJson('/health');
 }

--- a/packages/frontend/tests/services/api/analytics.test.ts
+++ b/packages/frontend/tests/services/api/analytics.test.ts
@@ -42,6 +42,24 @@ describe('analytics API client', () => {
     expect(url).toContain('agent_name=demo');
   });
 
+  it('getErrorBreakdown defaults range to 24h and omits agent_name when absent', async () => {
+    const fetchMock = setupFetch({ auto_fixed: 0 });
+    await analytics.getErrorBreakdown();
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/errors/breakdown');
+    expect(url).toContain('range=24h');
+    expect(url).not.toContain('agent_name=');
+  });
+
+  it('getErrorBreakdown forwards range and agent_name when provided', async () => {
+    const fetchMock = setupFetch({ auto_fixed: 3 });
+    const out = await analytics.getErrorBreakdown('30d', 'demo');
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('range=30d');
+    expect(url).toContain('agent_name=demo');
+    expect(out.auto_fixed).toBe(3);
+  });
+
   it('getHealth GETs /health', async () => {
     const fetchMock = setupFetch({ ok: true });
     await analytics.getHealth();


### PR DESCRIPTION
## ✨ What changed
- Added an `auto_fixed` field to the `GET /api/v1/errors/breakdown` response — the number of requests healed by Auto-fix in the selected window.
- Counted from the failed-original row (`status='auto_fixed'`), so it is exactly **one per healed request** (the paired `ok` retry is a separate row) — no double-counting.
- Added a typed `getErrorBreakdown(range, agentName?)` + `ErrorBreakdownResponse` to the frontend analytics API client so a dashboard can consume it in one import.
- No UI, no new endpoint, no DTO change — the existing dynamic `range` (1h/6h/24h/7d/30d/90d/365d), tenant scoping, and caching all carry over unchanged.

## 💭 Why
Auto-fix (self-healing) already stores healed requests as a linked pair of `agent_messages` rows, but nothing aggregates them for the dashboard. Surfacing the heal count next to the existing error breakdown lets someone build the Auto-fix dashboard on top without inventing a new query path.

Counting can't be done client-side: `autofix_applied` is `true` on **both** rows of a healed pair, so a naive `WHERE autofix_applied` doubles the number; and tenant isolation must stay server-side. The correct, deduplicated `COUNT(*) FILTER (status='auto_fixed')` belongs in the backend so every surface agrees.

**Important:** `auto_fixed` is **not additive** with `total_errors`. The healed original is classified with an `error_origin` and marked `superseded`, so it is already inside `total_errors`/`by_origin`. Read `auto_fixed` as "of those errors, this many were auto-fixed", never as a separate bucket to sum. This is documented on the field in both the backend and frontend types.

## 👤 For users
No visible change yet — this is the data foundation for an Auto-fix dashboard.

## 🔧 For operators
No operator impact. No migration, no config, no new route.

## 🧪 How to test
1. `cd packages/backend && npx jest src/analytics/services/error-breakdown.service.spec.ts` — 10 passing, 100% line coverage on the service.
2. `cd packages/frontend && npx vitest run tests/services/api/analytics.test.ts` — 15 passing (includes `getErrorBreakdown`).
3. Call `GET /api/v1/errors/breakdown?range=7d` and confirm the response now includes `auto_fixed`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose an `auto_fixed` count on `GET /api/v1/errors/breakdown` so dashboards can show how many errors were healed by Auto-fix in the selected window. Also adds a typed `getErrorBreakdown()` to the frontend for easy consumption.

- **New Features**
  - Added `auto_fixed` to the breakdown response; counted from the failed-original row (`status='auto_fixed'`) for exactly one per healed request; not additive with `total_errors`.
  - Reused existing range presets, tenant scoping, and caching; no new route.
  - Frontend: added `getErrorBreakdown(range, agentName?)` and `ErrorBreakdownResponse` in the `analytics` API client.

<sup>Written for commit 3a3c8d58b8e2a8d2ef32967978898b018fd9115c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

