### PR TITLE
fix: forward xAI reasoning effort

### DIFF
--- a/.changeset/tidy-groks-reason.md
+++ b/.changeset/tidy-groks-reason.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Preserve xAI reasoning effort when forwarding Chat Completions requests.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -51,6 +51,19 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('temperature', 0.5);
     });
 
+    it('should preserve reasoning_effort for xAI', () => {
+      const result = sanitizeOpenAiBody(
+        {
+          messages: [{ role: 'user', content: 'Hi' }],
+          reasoning_effort: 'high',
+        },
+        'xai',
+        'grok-4.5',
+      );
+
+      expect(result).toHaveProperty('reasoning_effort', 'high');
+    });
+
     it('should preserve response_format for OpenAI-wire providers', () => {
       const responseFormat = {
         type: 'json_schema',

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -387,6 +387,10 @@ export function sanitizeOpenAiBody(
       cleaned[key] = value;
       continue;
     }
+    if (key === 'reasoning_effort' && endpointKey === 'xai') {
+      cleaned[key] = value;
+      continue;
+    }
     if (OPENAI_ONLY_FIELDS.has(key)) continue;
     if (key === 'thinking' && OLLAMA_ENDPOINTS.has(endpointKey.toLowerCase())) continue;
     if (key === 'max_completion_tokens') {


### PR DESCRIPTION
### ✨ What changed
- Preserve `reasoning_effort` on xAI Chat Completions requests.
- Add regression coverage for xAI request sanitization.

### 💭 Why
Manifest treated `reasoning_effort` as OpenAI-only and removed it before forwarding to xAI.

### 👤 For users
Grok reasoning settings now reach xAI for API-key and OAuth subscription routes.

### 📝 Notes
https://docs.x.ai/developers/model-capabilities/text/reasoning


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves xAI `reasoning_effort` in Chat Completions requests so Grok reasoning settings reach xAI across API-key and OAuth routes. Adds tests to cover xAI request sanitization and prevent regressions.

<sup>Written for commit 89c1757684cece4c7a6a907816aabaa00ef77a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

