### PR TITLE
fix: skip disconnected automatic routes

### DIFF
--- a/.changeset/auto-route-unconfigured-provider.md
+++ b/.changeset/auto-route-unconfigured-provider.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix auto routing resolving to a provider the agent never connected. A stale legacy auto-assigned (or promoted fallback) route now reuses the gateway's provider-key lookup before it becomes primary, so an unconfigured provider is skipped without adding a separate model-discovery query. When nothing routable remains, the request returns the neutral `M101` "no providers configured" error. The proxy also treats the resolver's fallback chain as definitive so a fallback promoted to primary is not retried as its own fallback.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -9,7 +9,6 @@ import {
 import { ProxyService } from '../proxy.service';
 import type { ResolveService } from '../../resolve/resolve.service';
 import type { ProviderKeyService } from '../../routing-core/provider-key.service';
-import type { TierService } from '../../routing-core/tier.service';
 import type { OpenaiOauthService } from '../../oauth/openai/openai-oauth.service';
 import type { MinimaxOauthService } from '../../oauth/minimax/minimax-oauth.service';
 import type { AnthropicOauthService } from '../../oauth/anthropic/anthropic-oauth.service';
@@ -94,7 +93,6 @@ describe('ProxyService — orchestration', () => {
       'getProviderApiKey' | 'getProviderRegion' | 'getProviderKeyId' | 'selectProviderKey'
     >
   >;
-  let tierService: jest.Mocked<Pick<TierService, 'getTiers'>>;
   let openaiOauth: jest.Mocked<Pick<OpenaiOauthService, 'unwrapToken'>>;
   let minimaxOauth: jest.Mocked<Pick<MinimaxOauthService, 'unwrapToken'>>;
   let anthropicOauth: jest.Mocked<Pick<AnthropicOauthService, 'unwrapToken'>>;
@@ -146,7 +144,6 @@ describe('ProxyService — orchestration', () => {
         priority: 0,
       }),
     };
-    tierService = { getTiers: jest.fn().mockResolvedValue([]) };
     openaiOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
     minimaxOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
     anthropicOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
@@ -191,7 +188,6 @@ describe('ProxyService — orchestration', () => {
       resolveService as unknown as ResolveService,
       modelDiscovery as unknown as ModelDiscoveryService,
       providerKeyService as unknown as ProviderKeyService,
-      tierService as unknown as TierService,
       openaiOauth as unknown as OpenaiOauthService,
       minimaxOauth as unknown as MinimaxOauthService,
       anthropicOauth as unknown as AnthropicOauthService,
@@ -1660,7 +1656,6 @@ describe('ProxyService — orchestration', () => {
     });
 
     it('falls through to the resolver-provided fallback_routes', async () => {
-      // resolved.fallback_routes is non-null — tier service should NOT be consulted.
       fallbackService.tryForwardToProvider.mockResolvedValue({
         response: new Response('boom', { status: 500 }),
         isGoogle: false,
@@ -1683,7 +1678,7 @@ describe('ProxyService — orchestration', () => {
       } as never);
 
       await svc.proxyRequest(baseOpts());
-      expect(tierService.getTiers).not.toHaveBeenCalled();
+      expect(fallbackService.tryFallbacks).toHaveBeenCalled();
     });
 
     it('skips non-stream fallback routes when response mode is stream', async () => {
@@ -1727,12 +1722,6 @@ describe('ProxyService — orchestration', () => {
         score: 5,
         reason: 'scored',
       });
-      tierService.getTiers.mockResolvedValue([
-        {
-          tier: 'standard',
-          fallback_routes: [route('anthropic', 'api_key', 'claude')],
-        } as never,
-      ]);
       fallbackService.tryForwardToProvider.mockResolvedValue({
         response: new Response('boom', { status: 500 }),
         isGoogle: false,
@@ -1746,37 +1735,29 @@ describe('ProxyService — orchestration', () => {
       expect(result.forward.response.status).toBe(500);
     });
 
-    it('looks up tier fallbacks when the resolver returned null', async () => {
+    it('does not reload persisted fallbacks when the resolver returned null', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
-        route: route('openai', 'api_key', 'gpt-4o'),
+        // This route represents a configured fallback promoted to primary.
+        route: route('anthropic', 'api_key', 'claude'),
         fallback_routes: null,
         confidence: 0.9,
         score: 5,
         reason: 'scored',
       });
-      tierService.getTiers.mockResolvedValue([
-        {
-          tier: 'standard',
-          fallback_routes: [route('anthropic', 'api_key', 'claude')],
-        } as never,
-      ]);
       fallbackService.tryForwardToProvider.mockResolvedValue({
         response: new Response('boom', { status: 500 }),
         isGoogle: false,
         isAnthropic: false,
         isChatGpt: false,
       });
-      fallbackService.tryFallbacks.mockResolvedValue({
-        success: null,
-        failures: [],
-      } as never);
 
-      await svc.proxyRequest(baseOpts());
-      expect(tierService.getTiers).toHaveBeenCalledWith('agent-1');
+      const result = await svc.proxyRequest(baseOpts());
+      expect(fallbackService.tryFallbacks).not.toHaveBeenCalled();
+      expect(result.forward.response.status).toBe(500);
     });
 
-    it('returns null fallback chain when neither resolver nor tier provides routes', async () => {
+    it('returns the primary error when the resolver provides no fallback routes', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         route: route('openai', 'api_key', 'gpt-4o'),
@@ -1785,7 +1766,6 @@ describe('ProxyService — orchestration', () => {
         score: 5,
         reason: 'scored',
       });
-      tierService.getTiers.mockResolvedValue([]);
       fallbackService.tryForwardToProvider.mockResolvedValue({
         response: new Response('boom', { status: 500 }),
         isGoogle: false,
@@ -1882,7 +1862,6 @@ describe('ProxyService — orchestration', () => {
         score: 5,
         reason: 'scored',
       });
-      tierService.getTiers.mockResolvedValue([]);
       const streamRes = new Response(new ReadableStream(), {
         status: 200,
         headers: { 'content-type': 'text/event-stream' },
@@ -1933,7 +1912,6 @@ describe('ProxyService — orchestration', () => {
         score: 5,
         reason: 'scored',
       });
-      tierService.getTiers.mockResolvedValue([]);
       const streamRes = new Response(new ReadableStream(), {
         status: 200,
         headers: { 'content-type': 'text/event-stream' },

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -6,7 +6,6 @@ import {
   ProviderKeyService,
   SYNTHETIC_OLLAMA_PROVIDER_ID,
 } from '../routing-core/provider-key.service';
-import { TierService } from '../routing-core/tier.service';
 import { OpenaiOauthService } from '../oauth/openai/openai-oauth.service';
 import { MinimaxOauthService } from '../oauth/minimax/minimax-oauth.service';
 import { AnthropicOauthService } from '../oauth/anthropic/anthropic-oauth.service';
@@ -183,7 +182,6 @@ export class ProxyService {
     private readonly resolveService: ResolveService,
     private readonly modelDiscovery: ModelDiscoveryService,
     private readonly providerKeyService: ProviderKeyService,
-    private readonly tierService: TierService,
     private readonly openaiOauth: OpenaiOauthService,
     private readonly minimaxOauth: MinimaxOauthService,
     private readonly anthropicOauth: AnthropicOauthService,
@@ -847,15 +845,12 @@ export class ProxyService {
       signal,
       apiMode,
     } = args;
-    // Prefer the resolver's fallback_routes (which already contains the right
-    // tier's routes); fall back to a fresh tier lookup if the resolver returned
-    // null (e.g. the tier itself was missing).
+    // The resolver owns the effective route chain. Null is a definitive
+    // "nothing remains", including when the only configured fallback was
+    // promoted to primary. Reloading the persisted tier here would retry that
+    // promoted route as its own fallback and could resurrect routes the
+    // resolver deliberately skipped.
     let fallbackRoutes = resolved.fallback_routes ?? null;
-    if (!fallbackRoutes) {
-      const tiers = await this.tierService.getTiers(agentId);
-      const assignment = tiers.find((t) => t.tier === resolved.tier);
-      fallbackRoutes = assignment?.fallback_routes ?? null;
-    }
     if ((resolved.response_mode ?? DEFAULT_RESPONSE_MODE) === 'stream') {
       const effectiveRoutes = effectiveRoutesForResponseMode(
         resolved.response_mode,

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
@@ -85,6 +85,7 @@ describe('ResolveService — edge cases', () => {
       | 'hasActiveProvider'
       | 'getAuthType'
       | 'getDefaultKeyLabel'
+      | 'hasRouteCredentials'
     >
   >;
   let specificityService: jest.Mocked<Pick<SpecificityService, 'getActiveAssignments'>>;
@@ -106,6 +107,7 @@ describe('ResolveService — edge cases', () => {
       hasActiveProvider: jest.fn().mockResolvedValue(true),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       getDefaultKeyLabel: jest.fn().mockResolvedValue(undefined),
+      hasRouteCredentials: jest.fn().mockResolvedValue(true),
     };
     specificityService = { getActiveAssignments: jest.fn().mockResolvedValue([]) };
     pricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -54,6 +54,7 @@ describe('ResolveService', () => {
       | 'hasActiveProvider'
       | 'getAuthType'
       | 'getDefaultKeyLabel'
+      | 'hasRouteCredentials'
     >
   >;
   let specificityService: jest.Mocked<Pick<SpecificityService, 'getActiveAssignments'>>;
@@ -79,6 +80,7 @@ describe('ResolveService', () => {
       // test explicitly sets one — keeps assertions on legacy route shapes
       // (no keyLabel) passing.
       getDefaultKeyLabel: jest.fn().mockResolvedValue(undefined),
+      hasRouteCredentials: jest.fn().mockResolvedValue(true),
     };
     specificityService = { getActiveAssignments: jest.fn().mockResolvedValue([]) };
     pricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
@@ -551,6 +553,86 @@ describe('ResolveService', () => {
       expect(result.reason).toBe('default');
       expect(result.route).toEqual(route('openai', 'api_key', 'gpt-4o-mini'));
     });
+
+    // #2494: a legacy auto_assigned_route pointing at a provider the agent no
+    // longer has connected must not resolve. The proxy would otherwise emit an
+    // M100 naming that unconfigured provider; a null route yields the neutral
+    // "no providers configured" (M101) instead.
+    it('drops an unavailable auto_assigned_route so no route is returned', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: false });
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: null,
+          auto_assigned_route: route('opencode-go', 'api_key', 'glm-5.2'),
+          fallback_routes: null,
+        } as TierAssignment,
+      ]);
+      providerKeyService.hasRouteCredentials.mockResolvedValue(false);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.tier).toBe('default');
+      expect(result.route).toBeNull();
+      expect(result.fallback_routes).toBeNull();
+      expect(providerKeyService.isRouteAvailable).not.toHaveBeenCalled();
+    });
+
+    // A configured fallback provider stays eligible when the auto-assigned
+    // route's provider is not connected.
+    it('promotes an available fallback when the auto_assigned_route is unavailable', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: false });
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: null,
+          auto_assigned_route: route('opencode-go', 'api_key', 'glm-5.2'),
+          fallback_routes: [route('anthropic', 'subscription', 'claude-opus-4-8')],
+        } as unknown as TierAssignment,
+      ]);
+      providerKeyService.hasRouteCredentials.mockImplementation(
+        async (_tenant, r: ModelRoute) => r.provider !== 'opencode-go',
+      );
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual(route('anthropic', 'subscription', 'claude-opus-4-8'));
+      expect(result.fallback_routes).toBeNull();
+    });
+
+    it('keeps an available auto route without a model-discovery availability check', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: false });
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: null,
+          auto_assigned_route: route('openai', 'api_key', 'gpt-4o-mini'),
+          fallback_routes: null,
+        } as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+
+      expect(result.route).toEqual(route('openai', 'api_key', 'gpt-4o-mini'));
+      expect(providerKeyService.hasRouteCredentials).toHaveBeenCalledTimes(1);
+      expect(providerKeyService.isRouteAvailable).not.toHaveBeenCalled();
+    });
+
+    // No override and no auto-assigned route: an available configured fallback
+    // is still promoted to primary.
+    it('promotes an available fallback when there is no override or auto route', async () => {
+      agentRepo.findOne.mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: false });
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: null,
+          auto_assigned_route: null,
+          fallback_routes: [route('openai', 'api_key', 'gpt-4o-mini')],
+        } as unknown as TierAssignment,
+      ]);
+
+      const result = await svc.resolve('agent-1', 'user-1', messages);
+      expect(result.route).toEqual(route('openai', 'api_key', 'gpt-4o-mini'));
+      expect(result.fallback_routes).toBeNull();
+    });
   });
 
   describe('resolve — specificity routing', () => {
@@ -814,7 +896,10 @@ describe('ResolveService', () => {
         } as unknown as TierAssignment,
       ]);
       providerKeyService.isModelAvailable.mockResolvedValue(false);
-      providerKeyService.isRouteAvailable.mockResolvedValue(false);
+      // Only the orphaned override is unavailable; the fallback is connected.
+      providerKeyService.isRouteAvailable.mockImplementation(
+        async (_tenant, r: ModelRoute) => r.model !== 'orphaned',
+      );
 
       const result = await svc.resolve('agent-1', 'user-1', messages);
       expect(result.tier).toBe('standard');
@@ -841,7 +926,10 @@ describe('ResolveService', () => {
         } as unknown as TierAssignment,
       ]);
       providerKeyService.isModelAvailable.mockResolvedValue(false);
-      providerKeyService.isRouteAvailable.mockResolvedValue(false);
+      // Only the orphaned override is unavailable; the fallbacks are connected.
+      providerKeyService.isRouteAvailable.mockImplementation(
+        async (_tenant, r: ModelRoute) => r.model !== 'orphaned',
+      );
 
       const result = await svc.resolve('agent-1', 'user-1', messages);
       expect(result.route).toEqual(route('anthropic', 'api_key', 'fallback-1'));

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -391,10 +391,13 @@ export class ResolveService {
   }
 
   /**
-   * Build the resolved route chain for a tier assignment. Validates the
-   * override still points to an available model; when an override is orphaned,
-   * walk configured fallbacks before trying the auto-assigned route. Enriches
-   * routes with the default key label when no explicit pin is present.
+   * Build the resolved route chain for a tier assignment. Explicit overrides
+   * retain the full model-aware availability check. Automatic and fallback
+   * candidates use the provider-key cache instead: the proxy needs the same
+   * key before forwarding, so this prevents stale disconnected providers from
+   * becoming primary without adding a separate model-discovery query to the
+   * gateway path. When nothing has usable credentials, the proxy gets a null
+   * route and returns the neutral M101 instead of M100 (#2494).
    */
   private async buildResolvedRouteChain(
     agentId: string,
@@ -407,32 +410,35 @@ export class ResolveService {
     // honored when override is empty" semantics stay in lockstep with
     // TierService.hasRoutableTier / effectiveRoute (see route-helpers.ts).
     const autoAssigned = readAutoAssignedRoute(assignment);
+
+    if (override && (await this.providerKeyService.isRouteAvailable(tenantId, override, agentId))) {
+      return {
+        primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, override),
+        fallbackRoutes,
+      };
+    }
     if (override) {
-      if (await this.providerKeyService.isRouteAvailable(tenantId, override, agentId)) {
-        return {
-          primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, override),
-          fallbackRoutes,
-        };
-      }
       this.logger.warn(
         `Override ${override.model} unavailable for agent=${agentId} — ` +
           `falling back to configured routes`,
       );
-      const candidates = [...(fallbackRoutes ?? []), ...(autoAssigned ? [autoAssigned] : [])];
-      const [primaryRoute, ...remainingFallbacks] = candidates;
-      return {
-        primaryRoute: primaryRoute
-          ? await this.enrichRouteKeyLabel(agentId, tenantId, primaryRoute)
-          : null,
-        fallbackRoutes: remainingFallbacks.length > 0 ? remainingFallbacks : null,
-      };
     }
-    return {
-      primaryRoute: autoAssigned
-        ? await this.enrichRouteKeyLabel(agentId, tenantId, autoAssigned)
-        : null,
-      fallbackRoutes,
-    };
+
+    // An orphaned override walks its fallbacks before the legacy auto-assigned
+    // route; a tier with no override starts from the auto-assigned route.
+    const candidates = override
+      ? [...(fallbackRoutes ?? []), ...(autoAssigned ? [autoAssigned] : [])]
+      : [...(autoAssigned ? [autoAssigned] : []), ...(fallbackRoutes ?? [])];
+    for (let i = 0; i < candidates.length; i++) {
+      if (await this.providerKeyService.hasRouteCredentials(tenantId, candidates[i], agentId)) {
+        const rest = candidates.slice(i + 1);
+        return {
+          primaryRoute: await this.enrichRouteKeyLabel(agentId, tenantId, candidates[i]),
+          fallbackRoutes: rest.length > 0 ? rest : null,
+        };
+      }
+    }
+    return { primaryRoute: null, fallbackRoutes: null };
   }
 
   /**

--- a/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
@@ -662,6 +662,40 @@ describe('ProviderKeyService', () => {
     });
   });
 
+  describe('hasRouteCredentials', () => {
+    it('reuses the provider-key lookup for a pinned route', async () => {
+      const getProviderKeys = jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([
+        {
+          id: 'provider-key-1',
+          label: 'Default',
+          priority: 0,
+          apiKey: 'decrypted',
+          region: null,
+        },
+      ]);
+      const pinned = {
+        provider: 'openai',
+        authType: 'api_key',
+        model: 'gpt-4o',
+      } as const;
+
+      await expect(svc.hasRouteCredentials('tenant-1', pinned, 'agent-1')).resolves.toBe(true);
+      expect(getProviderKeys).toHaveBeenCalledWith('tenant-1', 'openai', 'api_key', 'agent-1');
+    });
+
+    it('rejects routes whose provider-key chain is empty', async () => {
+      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([]);
+
+      await expect(
+        svc.hasRouteCredentials(
+          'tenant-1',
+          { provider: 'opencode-go', authType: 'api_key', model: 'glm-5.2' },
+          'agent-1',
+        ),
+      ).resolves.toBe(false);
+    });
+  });
+
   describe('resolveProviderKeys ordering and local keys', () => {
     it('orders same-auth-type matches by priority when no auth type is preferred', async () => {
       providerRepo.find.mockResolvedValue([

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -109,6 +109,23 @@ export class ProviderKeyService {
     return keys[0];
   }
 
+  /**
+   * Cheap gateway-path check for a persisted route. This deliberately reuses
+   * the provider-key cache instead of assembling the full discovered-model
+   * list: the proxy must resolve the same key before forwarding anyway, so a
+   * successful check makes that later lookup a cache hit and adds no separate
+   * discovery query to automatic routing.
+   */
+  async hasRouteCredentials(
+    tenantId: string,
+    route: ModelRoute,
+    agentId?: string,
+  ): Promise<boolean> {
+    if (!route.provider) return false;
+    const keys = await this.getProviderKeys(tenantId, route.provider, route.authType, agentId);
+    return keys.length > 0;
+  }
+
   async getProviderApiKey(
     tenantId: string,
     provider: string,

--- a/packages/backend/test/proxy.e2e-spec.ts
+++ b/packages/backend/test/proxy.e2e-spec.ts
@@ -14,11 +14,12 @@ import { RoutingCacheService } from '../src/routing/routing-core/routing-cache.s
 import { ModelDiscoveryService } from '../src/model-discovery/model-discovery.service';
 
 let app: INestApplication;
+let ds: DataSource;
 
 beforeAll(async () => {
   app = await createTestApp();
 
-  const ds = app.get(DataSource);
+  ds = app.get(DataSource);
 
   // Populate PricingSyncService cache with gpt-4o-mini pricing (use prefixed key
   // so ModelPricingCacheService.inferProvider() resolves the correct provider name)
@@ -157,6 +158,55 @@ describe('Proxy E2E — /v1/chat/completions', () => {
 
     expect(res.body.error.type).toBe('invalid_request_error');
     expect(res.body.error.message).toContain('messages');
+  });
+
+  it('#2494 returns M101 when an auto route points at a disconnected provider', async () => {
+    const staleRoute = JSON.stringify({
+      provider: 'opencode-go',
+      authType: 'api_key',
+      model: 'glm-5.2',
+    });
+    const restoredRoute = JSON.stringify({
+      provider: 'openai',
+      authType: 'api_key',
+      model: 'gpt-4o-mini',
+    });
+    const routingCache = app.get(RoutingCacheService);
+
+    await ds.query(`UPDATE agents SET complexity_routing_enabled = false WHERE id = $1`, [
+      TEST_AGENT_ID,
+    ]);
+    await ds.query(
+      `UPDATE tier_assignments
+       SET override_route = NULL, auto_assigned_route = $1::jsonb, fallback_routes = NULL
+       WHERE agent_id = $2 AND tier = 'default'`,
+      [staleRoute, TEST_AGENT_ID],
+    );
+    routingCache.invalidateAgent(TEST_AGENT_ID);
+    routingCache.invalidateTenant(TEST_TENANT_ID);
+
+    try {
+      const res = await bearer(api().post('/v1/responses'))
+        .send({ model: 'auto', input: 'Hello', store: false })
+        .expect(200);
+      const body = JSON.stringify(res.body);
+
+      expect(body).toContain('M101');
+      expect(body).not.toContain('M100');
+      expect(body).not.toContain('opencode-go');
+    } finally {
+      await ds.query(`UPDATE agents SET complexity_routing_enabled = true WHERE id = $1`, [
+        TEST_AGENT_ID,
+      ]);
+      await ds.query(
+        `UPDATE tier_assignments
+         SET override_route = $1::jsonb, auto_assigned_route = NULL, fallback_routes = NULL
+         WHERE agent_id = $2 AND tier = 'default'`,
+        [restoredRoute, TEST_AGENT_ID],
+      );
+      routingCache.invalidateAgent(TEST_AGENT_ID);
+      routingCache.invalidateTenant(TEST_TENANT_ID);
+    }
   });
 
   it('returns HTTP 400 when messages array is empty', async () => {


### PR DESCRIPTION
### ✨ What changed
- Reuse provider-key caching when validating automatic and promoted routes.
- Treat resolved fallback chains as final after primary failures.
- Cover the stale route response through `/v1/responses` E2E tests.

### 💭 Why
Stale legacy routes could select disconnected providers and return M100. Reloading persisted fallbacks could also retry a promoted route as itself.

### 👤 For users
Auto routing now skips disconnected providers, then uses a fallback or returns M101.

### 📝 Notes
Closes #2494


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip disconnected providers during automatic routing so stale routes aren’t selected; when nothing is routable, return M101 instead of M100. Also treat the resolver’s fallback chain as final to avoid retry loops. Closes #2494.

- **Bug Fixes**
  - Validate automatic and fallback routes via provider-key cache (`hasRouteCredentials`) to skip unconnected providers without extra model discovery.
  - Promote the first available fallback to primary; if none are available, return a null route and surface M101.
  - Proxy no longer reloads persisted tier fallbacks when the resolver returns null, preventing a promoted route from being retried as its own fallback.
  - Added `/v1/responses` E2E to assert M101 for stale auto routes; updated resolve/proxy tests.

<sup>Written for commit 2cdaee6cef2d8604ba05bce173d1247ca33f15bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

