### PR TITLE
fix: send auth type to Auto-fix

### DIFF
--- a/.changeset/calm-birds-scope.md
+++ b/.changeset/calm-birds-scope.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Scope Auto-fix parameter repairs by provider authentication type.

--- a/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
@@ -89,6 +89,7 @@ function makeParams(overrides: Partial<MaybeHealParams>): MaybeHealParams {
     agentId: 'agent-1',
     tenantId: 'tenant-1',
     provider: 'anthropic',
+    authType: 'subscription',
     apiMode: 'chat_completions',
     requestBody: { model: 'gpt', max_tokens: 100 },
     url: 'https://api.example.com/v1/chat/completions',
@@ -603,6 +604,7 @@ describe('AutofixService', () => {
       expect(client.heal).toHaveBeenCalledTimes(1);
       const arg = client.heal.mock.calls[0][0] as Record<string, unknown>;
       expect(arg.provider).toBe('openai');
+      expect(arg.authType).toBe('subscription');
       expect(arg.api).toBe('chat_completions');
       expect(arg.url).toBe('u');
       expect(arg.request).toEqual(requestBody);

--- a/packages/backend/src/routing/autofix/__tests__/http-healing-client.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/http-healing-client.spec.ts
@@ -16,6 +16,7 @@ function makeHealRequest(): HealRequest {
     traceId: 'trace-1',
     tenantId: 'tenant-1',
     provider: 'openai',
+    authType: 'api_key',
     api: 'responses',
     request: { max_tokens: 100 },
     response: { statusCode: 400, error: { message: 'bad' } },

--- a/packages/backend/src/routing/autofix/__tests__/mock-healing-client.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/mock-healing-client.spec.ts
@@ -10,6 +10,7 @@ function makeRequest(error: PhoenixProviderError, request: Record<string, unknow
     traceId: 'trace-1',
     tenantId: 'tenant-1',
     provider: 'openai',
+    authType: 'api_key',
     api: 'responses',
     request,
     response: { statusCode: 400, error },

--- a/packages/backend/src/routing/autofix/__tests__/noop-healing-client.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/noop-healing-client.spec.ts
@@ -8,6 +8,7 @@ describe('NoopHealingClient', () => {
     traceId: 'trace-1',
     tenantId: 'tenant-1',
     provider: 'anthropic',
+    authType: 'subscription',
     api: 'chat_completions',
     request: { model: 'gpt', max_tokens: 100 },
     response: { statusCode: 400, error: { message: 'boom' } },

--- a/packages/backend/src/routing/autofix/__tests__/phoenix-contract.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/phoenix-contract.spec.ts
@@ -67,6 +67,7 @@ describe('Phoenix wire contract (vendored OpenAPI)', () => {
       traceId: 'trace-abc',
       tenantId: 'tenant-abc',
       provider: 'openai',
+      authType: 'api_key',
       api: 'chat_completions',
       url: 'https://api.openai.com/v1/chat/completions',
       request: { model: 'gpt-4o', max_tokens: 100 },
@@ -94,6 +95,10 @@ describe('Phoenix wire contract (vendored OpenAPI)', () => {
 
     it('rejects an `api` value outside the enum', () => {
       expect(validate({ ...valid, api: 'completions' })).toBe(false);
+    });
+
+    it('rejects an auth type outside the enum', () => {
+      expect(validate({ ...valid, authType: 'oauth' })).toBe(false);
     });
   });
 

--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -8,6 +8,7 @@ import { Tenant } from '../../entities/tenant.entity';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import type { ForwardResult } from '../proxy/provider-client';
 import type { ProxyApiMode } from '../proxy/proxy-types';
+import type { AuthType } from 'manifest-shared';
 import { HEALING_CLIENT, HealContractError, type HealingClient } from './healing-client';
 import { normalizeProviderError } from './provider-error-normalizer';
 import type { AutofixChainEntry, AutofixRecord } from './autofix.types';
@@ -18,6 +19,7 @@ export interface MaybeHealParams {
   agentId: string;
   tenantId: string;
   provider: string;
+  authType: AuthType;
   apiMode: ProxyApiMode;
   /** The request body that was actually forwarded and failed. */
   requestBody: Record<string, unknown>;
@@ -382,6 +384,7 @@ export class AutofixService {
         traceId: groupId,
         tenantId: params.tenantId,
         provider: params.provider,
+        authType: params.authType,
         api: params.apiMode,
         url: params.url,
         request: phoenixRequest,

--- a/packages/backend/src/routing/autofix/contract/phoenix-openapi.yaml
+++ b/packages/backend/src/routing/autofix/contract/phoenix-openapi.yaml
@@ -325,6 +325,10 @@ components:
             Tenant.id). Optional on the wire; recorded so a failure can be
             attributed to a tenant. Manifest always sends it on the proxy path.
         provider: { type: string, minLength: 1, example: openai }
+        authType:
+          type: string
+          enum: [api_key, subscription, local]
+          description: Provider credential route. Optional during the Manifest rollout.
         api:
           type: string
           enum: [responses, chat_completions, messages]

--- a/packages/backend/src/routing/autofix/observation-payload.spec.ts
+++ b/packages/backend/src/routing/autofix/observation-payload.spec.ts
@@ -11,6 +11,7 @@ const baseInput: ObservationInput = {
   tenantId: 'tenant-1',
   agentId: 'agent-1',
   provider: 'openai',
+  authType: 'api_key',
   apiMode: 'chat_completions',
   requestBody: { model: 'gpt-5.1', temperature: 5, messages: [{ role: 'user', content: 'hi' }] },
   status: 400,
@@ -104,6 +105,7 @@ describe('toObservation', () => {
     expect(obs!.traceId).toBe('trace-1');
     expect(obs!.tenantId).toBe('tenant-1');
     expect(obs!.provider).toBe('openai');
+    expect(obs!.authType).toBe('api_key');
     expect(obs!.api).toBe('chat_completions');
     expect(obs!.request).toMatchObject({ model: 'gpt-5.1', temperature: 5 });
     expect(obs!.response.statusCode).toBe(400);

--- a/packages/backend/src/routing/autofix/observation-payload.ts
+++ b/packages/backend/src/routing/autofix/observation-payload.ts
@@ -1,5 +1,6 @@
 import { scrubSecrets } from '../../common/utils/secret-scrub';
 import type { ProxyApiMode } from '../proxy/proxy-types';
+import type { AuthType } from 'manifest-shared';
 import { normalizeProviderError } from './provider-error-normalizer';
 import type { HealRequest } from './phoenix.types';
 
@@ -108,6 +109,7 @@ export interface ObservationInput {
    */
   agentId: string;
   provider: string;
+  authType: AuthType;
   apiMode: ProxyApiMode;
   /**
    * The forwarded body, with inline base64 images already redacted
@@ -148,6 +150,7 @@ export function toObservation(input: ObservationInput): HealRequest | null {
     traceId: input.traceId,
     tenantId: input.tenantId,
     provider: input.provider,
+    authType: input.authType,
     api: input.apiMode,
     request,
     response: { statusCode: input.status, error: normalizeProviderError(input.errorBody) },

--- a/packages/backend/src/routing/autofix/observation-reporter.spec.ts
+++ b/packages/backend/src/routing/autofix/observation-reporter.spec.ts
@@ -26,6 +26,7 @@ const input: ObservationInput = {
   tenantId: 'tenant-1',
   agentId: 'agent-1',
   provider: 'openai',
+  authType: 'api_key',
   apiMode: 'chat_completions',
   requestBody: { model: 'gpt-5.1', messages: [{ role: 'user', content: 'hi' }] },
   status: 400,

--- a/packages/backend/src/routing/autofix/phoenix.types.ts
+++ b/packages/backend/src/routing/autofix/phoenix.types.ts
@@ -1,4 +1,5 @@
 import type { ProxyApiMode } from '../proxy/proxy-types';
+import type { AuthType } from 'manifest-shared';
 
 /**
  * Wire contract for the Phoenix healing service (mnfst/phoenix). Mirrors
@@ -21,7 +22,7 @@ export interface PhoenixProviderResponse {
   error: PhoenixProviderError;
 }
 
-/** POST /api/heal request body. `provider` + `api` are the fingerprint dims. */
+/** POST /api/heal request body. Route identity scopes Phoenix's fingerprint. */
 export interface HealRequest {
   /**
    * Correlates every heal within one logical request's retry chain — Phoenix's
@@ -38,6 +39,7 @@ export interface HealRequest {
    */
   tenantId: string;
   provider: string;
+  authType: AuthType;
   api: ProxyApiMode;
   url?: string;
   request: Record<string, unknown>;

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -337,6 +337,9 @@ describe('ProxyService — orchestration', () => {
 
       expect(result.forward).toBe(healed);
       expect(result.autofix).toBe(record);
+      expect(autofixService.maybeHeal).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'openai', authType: 'api_key' }),
+      );
     });
 
     it('re-forwards the patched same-model body WITH the agent param merge re-applied (M3)', async () => {

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -253,12 +253,13 @@ export class ProxyController {
         // fallback model it is a different provider/model failing and Phoenix has
         // never seen it — skipping on `autofix` alone would hide it.
         const alreadyReportedByAutofix = Boolean(autofix) && !meta.fallbackFromModel;
-        if (!alreadyReportedByAutofix) {
+        if (!alreadyReportedByAutofix && meta.auth_type) {
           this.observationReporter.report({
             traceId: traceId ?? uuid(),
             tenantId,
             agentId: req.ingestionContext.agentId,
             provider: meta.provider,
+            authType: meta.auth_type,
             apiMode,
             requestBody: routingBody,
             resolvedModel: meta.model,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -89,7 +89,7 @@ export interface RoutingMeta {
    */
   manifest_error_code?: ManifestErrorCode;
   manifest_error_message?: string;
-  auth_type?: string;
+  auth_type?: AuthType;
   specificity_category?: string;
   header_tier_id?: string;
   header_tier_name?: string;
@@ -353,6 +353,7 @@ export class ProxyService {
       agentId,
       tenantId,
       provider: route.provider,
+      authType: route.authType,
       apiMode,
       requestBody: body,
       // Report the resolved provider model to Phoenix (the body may carry the


### PR DESCRIPTION
### What changed
- Send the resolved route authentication type with live heals and observations.
- Require authType in Manifest's Phoenix request type and cover it in contract tests.
- Skip legacy observations whose routing metadata has no authentication type.

### Why
Phoenix must distinguish API-key, subscription, and local model parameter surfaces.

### For operators
Deploy mnfst/phoenix#113 first. Phoenix remains compatible with older callers during the rollout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the resolved provider authentication type with Auto-fix heals and observations so Phoenix can scope repairs by credential route (api_key, subscription, local). We validate `authType` in the Manifest→Phoenix contract and skip legacy observations that don't have it.

- **Migration**
  - Deploy mnfst/phoenix#113 first; Phoenix stays compatible with older callers during the rollout.

<sup>Written for commit 6f1345c2c678fde6cc333f984037456a0716e295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

