### PR TITLE
feat: expose provider attempt aggregates

### DIFF
--- a/.changeset/gentle-attempt-aggregates.md
+++ b/.changeset/gentle-attempt-aggregates.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Expose provider-attempt and fallback aggregate analytics.

--- a/packages/backend/src/analytics/analytics.module.ts
+++ b/packages/backend/src/analytics/analytics.module.ts
@@ -34,6 +34,8 @@ import { AgentsController } from './controllers/agents.controller';
 import { AgentAnalyticsController } from './controllers/agent-analytics.controller';
 import { ProviderAnalyticsController } from './controllers/provider-analytics.controller';
 import { ErrorsController } from './controllers/errors.controller';
+import { AttemptAnalyticsController } from './controllers/attempt-analytics.controller';
+import { AttemptStatsService } from './services/attempt-stats.service';
 import { BillingModule } from '../billing/billing.module';
 
 @Module({
@@ -66,6 +68,7 @@ import { BillingModule } from '../billing/billing.module';
     ProviderAnalyticsController,
     ProviderUsageController,
     ErrorsController,
+    AttemptAnalyticsController,
   ],
   providers: [
     AggregationService,
@@ -79,6 +82,7 @@ import { BillingModule } from '../billing/billing.module';
     SpecificityFeedbackService,
     AgentAnalyticsService,
     ProviderUsageService,
+    AttemptStatsService,
   ],
   exports: [SpecificityFeedbackService, ProviderUsageService],
 })

--- a/packages/backend/src/analytics/controllers/attempt-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/attempt-analytics.controller.spec.ts
@@ -1,0 +1,53 @@
+import { CacheModule } from '@nestjs/cache-manager';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AttemptAnalyticsController } from './attempt-analytics.controller';
+import { AttemptStatsService } from '../services/attempt-stats.service';
+
+describe('AttemptAnalyticsController', () => {
+  let controller: AttemptAnalyticsController;
+  let attemptStats: { getStats: jest.Mock; getTimeseries: jest.Mock };
+  const ctx = { tenantId: 'tenant-1', userId: 'user-1' };
+
+  beforeEach(async () => {
+    attemptStats = {
+      getStats: jest.fn().mockResolvedValue({ total_attempts: { value: 3, previous: 2 } }),
+      getTimeseries: jest.fn().mockResolvedValue({
+        range: '7d',
+        by: 'metric',
+        keys: [],
+        buckets: [],
+      }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [CacheModule.register()],
+      controllers: [AttemptAnalyticsController],
+      providers: [{ provide: AttemptStatsService, useValue: attemptStats }],
+    }).compile();
+    controller = module.get(AttemptAnalyticsController);
+  });
+
+  it('forwards stats range, agent, and tenant scope', async () => {
+    await expect(
+      controller.getStats({ range: '30d', agent_name: 'bot-1' }, ctx as never),
+    ).resolves.toEqual({ total_attempts: { value: 3, previous: 2 } });
+    expect(attemptStats.getStats).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      range: '30d',
+      agentName: 'bot-1',
+    });
+  });
+
+  it('forwards optional timeseries query values', async () => {
+    await expect(controller.getTimeseries({}, ctx as never)).resolves.toEqual({
+      range: '7d',
+      by: 'metric',
+      keys: [],
+      buckets: [],
+    });
+    expect(attemptStats.getTimeseries).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      range: undefined,
+      agentName: undefined,
+    });
+  });
+});

--- a/packages/backend/src/analytics/controllers/attempt-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/attempt-analytics.controller.ts
@@ -1,0 +1,32 @@
+import { CacheTTL } from '@nestjs/cache-manager';
+import { Controller, Get, Query, UseInterceptors } from '@nestjs/common';
+import { DASHBOARD_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
+import { RangeQueryDto } from '../../common/dto/range-query.dto';
+import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
+import { AttemptStatsService } from '../services/attempt-stats.service';
+
+@Controller('api/v1')
+@UseInterceptors(UserCacheInterceptor)
+@CacheTTL(DASHBOARD_CACHE_TTL_MS)
+export class AttemptAnalyticsController {
+  constructor(private readonly attemptStats: AttemptStatsService) {}
+
+  @Get('overview/attempt-stats')
+  async getStats(@Query() query: RangeQueryDto, @TenantCtx() ctx: TenantContext) {
+    return this.attemptStats.getStats({
+      tenantId: ctx.tenantId,
+      range: query.range,
+      agentName: query.agent_name,
+    });
+  }
+
+  @Get('overview/attempt-timeseries')
+  async getTimeseries(@Query() query: RangeQueryDto, @TenantCtx() ctx: TenantContext) {
+    return this.attemptStats.getTimeseries({
+      tenantId: ctx.tenantId,
+      range: query.range,
+      agentName: query.agent_name,
+    });
+  }
+}

--- a/packages/backend/src/analytics/services/attempt-stats.service.spec.ts
+++ b/packages/backend/src/analytics/services/attempt-stats.service.spec.ts
@@ -1,0 +1,118 @@
+import { AttemptStatsService } from './attempt-stats.service';
+import { EXCLUDE_PLAYGROUND_AGENTS_PREDICATE } from './query-helpers';
+
+function mockQueryBuilder(options: { rawOne?: unknown; rawMany?: unknown[] } = {}) {
+  const qb = {
+    select: jest.fn(),
+    addSelect: jest.fn(),
+    where: jest.fn(),
+    andWhere: jest.fn(),
+    groupBy: jest.fn(),
+    orderBy: jest.fn(),
+    getRawOne: jest.fn().mockResolvedValue(options.rawOne),
+    getRawMany: jest.fn().mockResolvedValue(options.rawMany ?? []),
+  };
+  for (const method of [
+    'select',
+    'addSelect',
+    'where',
+    'andWhere',
+    'groupBy',
+    'orderBy',
+  ] as const) {
+    qb[method].mockReturnValue(qb);
+  }
+  return qb;
+}
+
+function makeService(qbs: unknown[]) {
+  const repo = { createQueryBuilder: jest.fn().mockImplementation(() => qbs.shift()) };
+  return new AttemptStatsService(repo as never);
+}
+
+describe('AttemptStatsService', () => {
+  it('returns current and previous attempt and fallback totals', async () => {
+    const current = mockQueryBuilder({
+      rawOne: { attempts: '8', fallbacked_attempts: '3' },
+    });
+    const previous = mockQueryBuilder({
+      rawOne: { attempts: '5', fallbacked_attempts: '1' },
+    });
+    const service = makeService([current, previous]);
+
+    await expect(
+      service.getStats({ tenantId: 'tenant-1', range: '7d', agentName: 'bot-1' }),
+    ).resolves.toEqual({
+      total_attempts: { value: 8, previous: 5 },
+      fallbacked_attempts: { value: 3, previous: 1 },
+    });
+    expect(current.addSelect).toHaveBeenCalledWith(
+      'COUNT(*) FILTER (WHERE at.fallback_from_model IS NOT NULL)',
+      'fallbacked_attempts',
+    );
+    expect(previous.andWhere).toHaveBeenCalledWith('at.timestamp < :to', {
+      to: expect.any(String),
+    });
+    for (const qb of [current, previous]) {
+      expect(qb.andWhere).toHaveBeenCalledWith('at.tenant_id = :tenantId', {
+        tenantId: 'tenant-1',
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
+      expect(
+        qb.andWhere.mock.calls.some(([clause]) => String(clause).includes('liveAgentName')),
+      ).toBe(true);
+      expect(qb.addSelect.mock.calls.flat()).not.toContain('autofix_role');
+    }
+  });
+
+  it('defaults to seven days and returns zeros without a tenant', async () => {
+    const current = mockQueryBuilder();
+    const previous = mockQueryBuilder();
+    const service = makeService([current, previous]);
+
+    await expect(service.getStats({ tenantId: null })).resolves.toEqual({
+      total_attempts: { value: 0, previous: 0 },
+      fallbacked_attempts: { value: 0, previous: 0 },
+    });
+    expect(current.andWhere).toHaveBeenCalledWith('1 = 0');
+    expect(previous.andWhere).toHaveBeenCalledWith('1 = 0');
+  });
+
+  it('returns daily pivoted buckets in the #2485 timeseries shape', async () => {
+    const qb = mockQueryBuilder({
+      rawMany: [
+        { bucket: '2026-07-14', attempts: '4', fallbacked_attempts: '1' },
+        { bucket: '2026-07-15', attempts: '2', fallbacked_attempts: null },
+      ],
+    });
+    const service = makeService([qb]);
+
+    await expect(service.getTimeseries({ tenantId: 'tenant-1', range: '7d' })).resolves.toEqual({
+      range: '7d',
+      by: 'metric',
+      keys: ['total_attempts', 'fallbacked_attempts'],
+      buckets: [
+        { bucket: '2026-07-14', counts: [4, 1] },
+        { bucket: '2026-07-15', counts: [2, 0] },
+      ],
+    });
+    expect(qb.select.mock.calls[0][0]).toContain('YYYY-MM-DD');
+  });
+
+  it('uses hourly buckets and forwards live-agent scoping', async () => {
+    const qb = mockQueryBuilder();
+    const service = makeService([qb]);
+
+    const result = await service.getTimeseries({
+      tenantId: 'tenant-1',
+      range: '24h',
+      agentName: 'bot-1',
+    });
+
+    expect(result.buckets).toEqual([]);
+    expect(qb.select.mock.calls[0][0]).toContain("date_trunc('hour'");
+    expect(
+      qb.andWhere.mock.calls.some(([clause]) => String(clause).includes('liveAgentName')),
+    ).toBe(true);
+  });
+});

--- a/packages/backend/src/analytics/services/attempt-stats.service.ts
+++ b/packages/backend/src/analytics/services/attempt-stats.service.ts
@@ -1,0 +1,134 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  rangeToInterval,
+  rangeToPreviousInterval,
+  isHourlyRange,
+} from '../../common/utils/range.util';
+import { computeCutoff, sqlDateBucket, sqlHourBucket } from '../../common/utils/postgres-sql';
+import { AgentMessage } from '../../entities/agent-message.entity';
+import { addTenantFilter, excludePlaygroundAgents } from './query-helpers';
+
+export interface AttemptMetric {
+  value: number;
+  previous: number;
+}
+
+export interface AttemptStatsResponse {
+  /** All rows in `provider_attempts`. */
+  total_attempts: AttemptMetric;
+  /** Fallback destinations: attempts whose `fallback_from_model` is non-null. */
+  fallbacked_attempts: AttemptMetric;
+}
+
+export const ATTEMPT_METRIC_KEYS = ['total_attempts', 'fallbacked_attempts'] as const;
+
+export interface AttemptTimeseriesResponse {
+  range: string;
+  by: 'metric';
+  keys: string[];
+  buckets: Array<{ bucket: string; counts: number[] }>;
+}
+
+interface AttemptCounts {
+  attempts: number;
+  fallbacked_attempts: number;
+}
+
+/**
+ * Universal attempt aggregates. Request totals remain on
+ * `overview.request_reliability`; Auto-fix totals remain on the adjacent
+ * Auto-fix/error aggregates. When those surfaces are composed, the canonical
+ * Auto-fixed attempt is the successful `autofix_role='retry'` row. No cohort
+ * or eligibility predicate belongs in this service.
+ */
+@Injectable()
+export class AttemptStatsService {
+  constructor(
+    @InjectRepository(AgentMessage)
+    private readonly attemptRepo: Repository<AgentMessage>,
+  ) {}
+
+  async getStats(params: {
+    tenantId: string | null;
+    range?: string;
+    agentName?: string;
+  }): Promise<AttemptStatsResponse> {
+    const range = params.range ?? '7d';
+    const cutoff = computeCutoff(rangeToInterval(range));
+    const previousCutoff = computeCutoff(rangeToPreviousInterval(range));
+    const [current, previous] = await Promise.all([
+      this.queryWindow(cutoff, undefined, params.tenantId, params.agentName),
+      this.queryWindow(previousCutoff, cutoff, params.tenantId, params.agentName),
+    ]);
+
+    return {
+      total_attempts: { value: current.attempts, previous: previous.attempts },
+      fallbacked_attempts: {
+        value: current.fallbacked_attempts,
+        previous: previous.fallbacked_attempts,
+      },
+    };
+  }
+
+  async getTimeseries(params: {
+    tenantId: string | null;
+    range?: string;
+    agentName?: string;
+  }): Promise<AttemptTimeseriesResponse> {
+    const range = params.range ?? '7d';
+    const cutoff = computeCutoff(rangeToInterval(range));
+    const bucketExpression = isHourlyRange(range)
+      ? sqlHourBucket('at.timestamp')
+      : sqlDateBucket('at.timestamp');
+    const qb = this.attemptRepo
+      .createQueryBuilder('at')
+      .select(bucketExpression, 'bucket')
+      .addSelect('COUNT(*)', 'attempts')
+      .addSelect(
+        'COUNT(*) FILTER (WHERE at.fallback_from_model IS NOT NULL)',
+        'fallbacked_attempts',
+      )
+      .where('at.timestamp >= :cutoff', { cutoff });
+    addTenantFilter(qb, params.tenantId, params.agentName);
+    excludePlaygroundAgents(qb);
+
+    const rows = (await qb.groupBy('bucket').orderBy('bucket', 'ASC').getRawMany()) as Array<
+      Record<string, unknown>
+    >;
+    return {
+      range,
+      by: 'metric',
+      keys: [...ATTEMPT_METRIC_KEYS],
+      buckets: rows.map((row) => ({
+        bucket: String(row['bucket']),
+        counts: [Number(row['attempts'] ?? 0), Number(row['fallbacked_attempts'] ?? 0)],
+      })),
+    };
+  }
+
+  private async queryWindow(
+    from: string,
+    to: string | undefined,
+    tenantId: string | null,
+    agentName?: string,
+  ): Promise<AttemptCounts> {
+    const qb = this.attemptRepo
+      .createQueryBuilder('at')
+      .select('COUNT(*)', 'attempts')
+      .addSelect(
+        'COUNT(*) FILTER (WHERE at.fallback_from_model IS NOT NULL)',
+        'fallbacked_attempts',
+      )
+      .where('at.timestamp >= :from', { from });
+    if (to) qb.andWhere('at.timestamp < :to', { to });
+    addTenantFilter(qb, tenantId, agentName);
+    excludePlaygroundAgents(qb);
+    const row = await qb.getRawOne<Record<string, unknown>>();
+    return {
+      attempts: Number(row?.['attempts'] ?? 0),
+      fallbacked_attempts: Number(row?.['fallbacked_attempts'] ?? 0),
+    };
+  }
+}

--- a/packages/backend/test/attempt-analytics.e2e-spec.ts
+++ b/packages/backend/test/attempt-analytics.e2e-spec.ts
@@ -1,0 +1,82 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { createTestApp, TEST_AGENT_ID, TEST_API_KEY, TEST_TENANT_ID } from './helpers';
+
+let app: INestApplication;
+
+function sqlTimestamp(date: Date): string {
+  return date.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+}
+
+beforeAll(async () => {
+  app = await createTestApp();
+  const ds = app.get(DataSource);
+  const current = sqlTimestamp(new Date());
+  const previous = sqlTimestamp(new Date(Date.now() - 8 * 24 * 60 * 60 * 1000));
+
+  await ds.query(
+    `INSERT INTO agents
+       (id, name, display_name, description, is_active, complexity_routing_enabled,
+        is_playground, tenant_id, created_at, updated_at)
+     VALUES ('playground-attempt-analytics', 'Playground', 'Playground', 'Reserved', true,
+             false, true, $1, $2, $2)`,
+    [TEST_TENANT_ID, current],
+  );
+  await ds.query(
+    `INSERT INTO provider_attempts
+       (id, tenant_id, agent_id, agent_name, timestamp, status, model,
+        fallback_from_model, autofix_applied, autofix_group_id, autofix_role)
+     VALUES
+       ('attempt-direct', $1, $2, 'test-agent', $3, 'ok', 'model-a', NULL, false, NULL, NULL),
+       ('attempt-fallback-primary', $1, $2, 'test-agent', $3, 'fallback_error', 'model-a',
+        NULL, false, NULL, NULL),
+       ('attempt-fallback-destination', $1, $2, 'test-agent', $3, 'ok', 'model-b',
+        'model-a', false, NULL, NULL),
+       ('attempt-autofix-retry', $1, $2, 'test-agent', $3, 'ok', 'model-a', NULL,
+        true, 'heal-1', 'retry'),
+       ('attempt-previous-primary', $1, $2, 'test-agent', $4, 'fallback_error', 'model-a',
+        NULL, false, NULL, NULL),
+       ('attempt-previous-fallback', $1, $2, 'test-agent', $4, 'ok', 'model-b',
+        'model-a', false, NULL, NULL),
+       ('attempt-playground-fallback', $1, 'playground-attempt-analytics', 'Playground', $3,
+        'ok', 'model-b', 'model-a', false, NULL, NULL)`,
+    [TEST_TENANT_ID, TEST_AGENT_ID, current, previous],
+  );
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('Attempt analytics endpoints', () => {
+  it('returns current and previous universal attempt counts', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/v1/overview/attempt-stats?range=7d')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    expect(response.body).toEqual({
+      total_attempts: { value: 4, previous: 2 },
+      fallbacked_attempts: { value: 1, previous: 1 },
+    });
+  });
+
+  it('returns aligned attempt and fallback timeseries', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/v1/overview/attempt-timeseries?range=7d&agent_name=test-agent')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    expect(response.body).toEqual({
+      range: '7d',
+      by: 'metric',
+      keys: ['total_attempts', 'fallbacked_attempts'],
+      buckets: [{ bucket: expect.any(String), counts: [4, 1] }],
+    });
+  });
+
+  it('requires authentication', async () => {
+    await request(app.getHttpServer()).get('/api/v1/overview/attempt-stats').expect(401);
+  });
+});

--- a/packages/frontend/src/services/api/analytics.ts
+++ b/packages/frontend/src/services/api/analytics.ts
@@ -161,6 +161,39 @@ export function getOverview(range = '24h', agentName?: string) {
   return fetchJson('/overview', { range, ...(agentName ? { agent_name: agentName } : {}) });
 }
 
+export interface AttemptMetric {
+  value: number;
+  previous: number;
+}
+
+export interface AttemptStats {
+  /** All rows in `provider_attempts`. */
+  total_attempts: AttemptMetric;
+  /** Attempts whose `fallback_from_model` is non-null. */
+  fallbacked_attempts: AttemptMetric;
+}
+
+export interface AttemptTimeseries {
+  range: string;
+  by: 'metric';
+  keys: string[];
+  buckets: Array<{ bucket: string; counts: number[] }>;
+}
+
+export function getAttemptStats(range = '7d', agentName?: string): Promise<AttemptStats> {
+  return fetchJson('/overview/attempt-stats', {
+    range,
+    ...(agentName ? { agent_name: agentName } : {}),
+  }) as Promise<AttemptStats>;
+}
+
+export function getAttemptTimeseries(range = '7d', agentName?: string): Promise<AttemptTimeseries> {
+  return fetchJson('/overview/attempt-timeseries', {
+    range,
+    ...(agentName ? { agent_name: agentName } : {}),
+  }) as Promise<AttemptTimeseries>;
+}
+
 export function getHealth() {
   return fetchJson('/health');
 }

--- a/packages/frontend/tests/services/api/analytics.test.ts
+++ b/packages/frontend/tests/services/api/analytics.test.ts
@@ -42,6 +42,38 @@ describe('analytics API client', () => {
     expect(url).toContain('agent_name=demo');
   });
 
+  it('getAttemptStats uses the stats route and optional agent scope', async () => {
+    const fetchMock = setupFetch({});
+    await analytics.getAttemptStats('30d', 'demo');
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/overview/attempt-stats');
+    expect(url).toContain('range=30d');
+    expect(url).toContain('agent_name=demo');
+  });
+
+  it('getAttemptStats defaults to seven days without an agent scope', async () => {
+    const fetchMock = setupFetch({});
+    await analytics.getAttemptStats();
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('range=7d');
+    expect(url).not.toContain('agent_name=');
+  });
+
+  it('getAttemptTimeseries supports scoped and unscoped requests', async () => {
+    let fetchMock = setupFetch({});
+    await analytics.getAttemptTimeseries();
+    let url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/overview/attempt-timeseries');
+    expect(url).toContain('range=7d');
+    expect(url).not.toContain('agent_name=');
+
+    fetchMock = setupFetch({});
+    await analytics.getAttemptTimeseries('24h', 'demo');
+    url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('range=24h');
+    expect(url).toContain('agent_name=demo');
+  });
+
   it('getHealth GETs /health', async () => {
     const fetchMock = setupFetch({ ok: true });
     await analytics.getHealth();


### PR DESCRIPTION
## Summary

- add tenant-scoped stats and timeseries endpoints for provider attempts and fallback destinations
- keep the aggregation universal: no Auto-fix cohort or eligibility predicates
- expose typed frontend service methods without adding dashboard UI

## Metric definitions

- requests remain the rows counted by `overview.request_reliability.total`
- attempts are all rows in `provider_attempts`
- fallbacked attempts have `fallback_from_model IS NOT NULL`
- the canonical Auto-fixed attempt is the `autofix_role = 'retry'` row; adjacent PRs already own that aggregate, so this PR does not duplicate it

## Testing

- `cd packages/backend && npx jest --coverage`
- full backend E2E suite in cloud mode against a fresh PostgreSQL database
- full frontend coverage, lint, build, and TypeScript checks

## Stack

Base: #2503 (`guillaumegay13/nonblocking-request-backfill`). Independent sibling of #2485 and #2504.
