### PR TITLE
fix: record actual autofix retries

### DIFF
--- a/.changeset/honest-ravens-retry.md
+++ b/.changeset/honest-ravens-retry.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix Auto-fix attempt recording so no-patch consultations remain plain provider failures and failed patched retries keep their own outcome.

--- a/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
@@ -779,11 +779,11 @@ describe('AutofixService', () => {
   // maybeHeal — single attempt (no retry budget)
   // -------------------------------------------------------------------------
   describe('maybeHeal single attempt', () => {
-    it('applies the patch once; if the retry still fails, reports it and gives up as unfixable', async () => {
+    it('preserves a failed patched retry as the terminal exhausted attempt', async () => {
       const client = makeHealingClient();
       client.heal.mockResolvedValue(patchedHeal());
       // The patched retry still fails with a repairable 400 — Auto-fix does NOT
-      // re-heal; it reports the retry outcome to Phoenix and returns the original.
+      // re-heal; it reports and returns the retry as the terminal attempt.
       const reforward = reforwardMock('{"error":{"message":"still-broken","code":"dup"}}', 400);
       const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
       const service = makeService({ client: client as unknown as HealingClient, repo });
@@ -793,7 +793,7 @@ describe('AutofixService', () => {
         makeParams({ forward: makeForward(originalBody, 400), reforward }),
       );
 
-      expect(result!.record.outcome).toBe('unfixable');
+      expect(result!.record.outcome).toBe('exhausted');
       // Exactly one heal + one reforward — there is no retry budget.
       expect(client.heal).toHaveBeenCalledTimes(1);
       expect(reforward).toHaveBeenCalledTimes(1);
@@ -804,14 +804,22 @@ describe('AutofixService', () => {
         error: { message: 'still-broken', type: null, param: null, code: 'dup' },
       });
 
-      // The original entry is marked with the patch that didn't work; no terminal
-      // success entry is appended.
-      expect(result!.record.chain).toHaveLength(1);
+      // The original is linked to the distinct failed retry that Phoenix produced.
+      expect(result!.record.chain).toHaveLength(2);
       expect(result!.record.chain[0].patch_worked).toBe(false);
+      expect(result!.record.chain[1]).toEqual({
+        attempt: 1,
+        origin: 'autofix',
+        request: { model: 'gpt', max_output_tokens: 100 },
+        http_status: 400,
+        error: { message: 'still-broken', type: null, param: null, code: 'dup' },
+      });
 
-      // Falls back to the rebuilt original error, still readable.
+      // Continues with the rebuilt retry error, still readable downstream.
       expect(result!.forward.response.status).toBe(400);
-      await expect(result!.forward.response.text()).resolves.toBe(originalBody);
+      await expect(result!.forward.response.text()).resolves.toBe(
+        '{"error":{"message":"still-broken","code":"dup"}}',
+      );
     });
   });
 

--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -38,7 +38,7 @@ export interface MaybeHealParams {
 }
 
 export interface AutofixAttempt {
-  /** Forward to continue with: a healed 200, or the original error rebuilt. */
+  /** Forward to continue with: the latest provider response, rebuilt if consumed. */
   forward: ForwardResult;
   record: AutofixRecord;
 }
@@ -483,16 +483,25 @@ export class AutofixService {
       };
     }
 
-    // The patch didn't clear the error. Report the retry outcome to Phoenix and
-    // give up — a single attempt, no re-heal.
+    // The patch didn't clear the error. Preserve that retry as its own provider
+    // attempt, report it to Phoenix, and continue with its rebuilt response so
+    // fallback and terminal recording see what actually happened last.
     const retryText = await next.response.text();
+    const retryError = normalizeProviderError(retryText);
+    chain.push({
+      attempt: 1,
+      origin: 'autofix',
+      request: bodyToReforward,
+      http_status: next.response.status,
+      error: retryError,
+    });
     this.reportOutcome(healAttemptId, {
       retryStatusCode: next.response.status,
-      error: normalizeProviderError(retryText),
+      error: retryError,
     });
     return {
-      forward: originalForward,
-      record: { groupId, outcome: 'unfixable', original_http_status: status, chain },
+      forward: rebuildForward(next, retryText, next.response.status),
+      record: { groupId, outcome: 'exhausted', original_http_status: status, chain },
     };
   }
 

--- a/packages/backend/src/routing/autofix/autofix.types.ts
+++ b/packages/backend/src/routing/autofix/autofix.types.ts
@@ -11,8 +11,9 @@ import type {
  * - `unfixable`  — Phoenix had no patch (`no_patch`) or returned an empty one.
  * - `resolving`  — Phoenix is still authoring a patch (novel error); nothing to
  *                  resend this time. A later request for the same issue may heal.
- * - `exhausted`  — the healing service was unreachable or the attempt threw
- *                  before completing.
+ * - `exhausted`  — a patched retry failed, or the healing flow aborted before
+ *                  it could complete. Inspect `chain` to tell whether a retry
+ *                  was actually sent.
  */
 export type AutofixOutcome = 'healed' | 'unfixable' | 'resolving' | 'exhausted';
 
@@ -41,14 +42,20 @@ export interface AutofixChainEntry {
 }
 
 /**
- * The full Auto-fix story. A healed request is recorded as two linked
- * `agent_messages` rows (failed original + successful retry) sharing `groupId`;
- * `chain` carries the per-attempt detail the recorder splits into those rows.
+ * The full Auto-fix story. An `autofix` chain entry exists if and only if a
+ * patched request was actually sent to the provider. The recorder uses that
+ * invariant—not Phoenix consultation alone—to decide whether Auto-fix was
+ * applied and whether linked original/retry rows must be written.
  */
 export interface AutofixRecord {
-  /** Shared id linking the failed-original and successful-retry rows. */
+  /** Shared id linking the failed-original and retry rows, when a retry exists. */
   groupId: string;
   outcome: AutofixOutcome;
   original_http_status: number;
   chain: AutofixChainEntry[];
+}
+
+/** The patched provider attempt, when Manifest actually sent one. */
+export function getAutofixRetry(autofix: AutofixRecord | undefined): AutofixChainEntry | undefined {
+  return autofix?.chain.find((entry) => entry.origin === 'autofix');
 }

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -866,10 +866,7 @@ describe('ProxyMessageRecorder', () => {
       expect(insertMock.mock.calls[0][0].routing_reason).toBe('header-match');
     });
 
-    it('stamps the Auto-fix audit onto the superseded row when heal-then-fallback ran', async () => {
-      // Heal failed, a fallback then succeeded: the primary failure is recorded
-      // exactly once here (as fallback_error) carrying the Auto-fix stamp — no
-      // separate auto_fixed row is emitted, so the failure is never double-counted.
+    it('records the superseded patched retry when heal-then-fallback ran', async () => {
       await recorder.recordPrimaryFailure(
         ctx,
         'standard',
@@ -877,13 +874,14 @@ describe('ProxyMessageRecorder', () => {
         'Unknown parameter',
         '2025-01-01T00:00:00.000Z',
         'api_key',
-        { provider: 'openai', autofix: sampleAutofix },
+        { provider: 'openai', autofix: sampleAutofix, httpStatus: 400 },
       );
       const row = insertMock.mock.calls[0][0];
       expect(row.status).toBe('fallback_error');
       expect(row.autofix_applied).toBe(true);
       expect(row.autofix_group_id).toBe('grp-1');
-      expect(row.autofix_role).toBe('original');
+      expect(row.autofix_role).toBe('retry');
+      expect(row.error_http_status).toBe(400);
       expect(row.autofix_operations).toEqual([
         { type: 'rename_param', from: 'max_tokens', to: 'max_output_tokens' },
       ]);
@@ -1419,14 +1417,82 @@ describe('ProxyMessageRecorder', () => {
 
   describe('autofix persistence', () => {
     const operations = [{ type: 'rename_param', from: 'max_tokens', to: 'max_output_tokens' }];
+    const failedRetryAutofix: AutofixRecord = {
+      ...sampleAutofix,
+      outcome: 'exhausted',
+      chain: [
+        sampleAutofix.chain[0],
+        {
+          attempt: 1,
+          origin: 'autofix',
+          request: { max_output_tokens: 5 },
+          http_status: 400,
+          error: { message: 'Retry also failed' },
+        },
+      ],
+    };
 
-    it('recordProviderError tags an exhausted attempt as the original', async () => {
-      await recorder.recordProviderError(ctx, 400, 'Unknown parameter', { autofix: sampleAutofix });
+    it('recordProviderError records a failed patched request as the retry', async () => {
+      await recorder.recordProviderError(ctx, 400, 'Retry also failed', {
+        autofix: failedRetryAutofix,
+      });
       const row = insertMock.mock.calls.at(-1)![0];
       expect(row.autofix_applied).toBe(true);
       expect(row.autofix_group_id).toBe('grp-1');
-      expect(row.autofix_role).toBe('original');
+      expect(row.autofix_role).toBe('retry');
       expect(row.autofix_operations).toEqual(operations);
+    });
+
+    it('recordProviderError keeps a no-patch Phoenix audit without claiming Auto-fix', async () => {
+      const noPatch: AutofixRecord = {
+        groupId: 'grp-no-patch',
+        outcome: 'unfixable',
+        original_http_status: 400,
+        chain: [
+          {
+            attempt: 0,
+            origin: 'original',
+            request: {},
+            http_status: 400,
+            error: { message: 'Unknown parameter' },
+            issue_id: 'issue-no-patch',
+            patch_id: null,
+            heal_attempt_id: null,
+          },
+        ],
+      };
+
+      await recorder.recordProviderError(ctx, 400, 'Unknown parameter', { autofix: noPatch });
+
+      const row = insertMock.mock.calls.at(-1)![0];
+      expect(row.autofix_applied).toBeUndefined();
+      expect(row.autofix_group_id).toBeUndefined();
+      expect(row.autofix_role).toBeUndefined();
+      expect(row.autofix_phoenix).toEqual({
+        issueId: 'issue-no-patch',
+        patchId: null,
+        healAttemptId: null,
+        explanation: null,
+      });
+    });
+
+    it('recordPrimaryFailure keeps a failed retry identity through fallback', async () => {
+      await recorder.recordPrimaryFailure(
+        ctx,
+        'standard',
+        'gpt-4o',
+        'Retry also failed',
+        '2026-07-15T12:00:00.000Z',
+        'api_key',
+        { autofix: failedRetryAutofix, httpStatus: 400 },
+      );
+
+      const row = insertMock.mock.calls.at(-1)![0];
+      expect(row.status).toBe('fallback_error');
+      expect(row.error_http_status).toBe(400);
+      expect(row.autofix_applied).toBe(true);
+      expect(row.autofix_role).toBe('retry');
+      expect(row.autofix_group_id).toBe('grp-1');
     });
 
     it('recordProviderError leaves autofix columns unset when omitted', async () => {
@@ -1436,20 +1502,19 @@ describe('ProxyMessageRecorder', () => {
       expect(row.autofix_group_id).toBeUndefined();
     });
 
-    it('recordAutofixOriginals writes a linked auto_fixed original row', async () => {
-      await recorder.recordAutofixOriginals(ctx, 'gpt-4o', 'default', sampleAutofix, {
+    it('recordAutofixOriginal writes a linked auto_fixed original row', async () => {
+      await recorder.recordAutofixOriginal(ctx, 'gpt-4o', 'default', sampleAutofix, {
         provider: 'openai',
         reason: 'default',
         authType: 'api_key',
         traceId: 'trace-af',
       });
-      const rows = insertMock.mock.calls.at(-1)![0] as Array<Record<string, unknown>>;
-      expect(rows).toHaveLength(1);
-      expect(rows[0].status).toBe('auto_fixed');
-      expect(rows[0].error_http_status).toBe(400);
+      const row = insertMock.mock.calls.at(-1)![0] as Record<string, unknown>;
+      expect(row.status).toBe('auto_fixed');
+      expect(row.error_http_status).toBe(400);
       // The full provider envelope, like every other error row. Storing the bare message
       // would drop type/param/code — the dimensions that identify the error downstream.
-      expect(JSON.parse(rows[0].error_message as string)).toEqual({
+      expect(JSON.parse(row.error_message as string)).toEqual({
         error: {
           message: 'Unknown parameter',
           type: 'invalid_request_error',
@@ -1457,14 +1522,14 @@ describe('ProxyMessageRecorder', () => {
           code: 'unknown_parameter',
         },
       });
-      expect(rows[0].autofix_applied).toBe(true);
-      expect(rows[0].autofix_group_id).toBe('grp-1');
-      expect(rows[0].autofix_role).toBe('original');
-      expect(rows[0].autofix_operations).toEqual(operations);
+      expect(row.autofix_applied).toBe(true);
+      expect(row.autofix_group_id).toBe('grp-1');
+      expect(row.autofix_role).toBe('original');
+      expect(row.autofix_operations).toEqual(operations);
       // Persist Phoenix's own identifiers for the heal decision. sampleAutofix's
       // failed entry carries only heal_attempt_id, so issueId/patchId fall to
       // null while healAttemptId is preserved (covers the non-null branch).
-      expect(rows[0].autofix_phoenix).toEqual({
+      expect(row.autofix_phoenix).toEqual({
         issueId: null,
         patchId: null,
         healAttemptId: 'heal-1',
@@ -1472,10 +1537,10 @@ describe('ProxyMessageRecorder', () => {
       });
     });
 
-    it('recordAutofixOriginals falls each absent Phoenix id to null while keeping the present one', async () => {
+    it('recordAutofixOriginal falls each absent Phoenix id to null while keeping the present one', async () => {
       // The ternary is entered via patch_id alone, so issueId + healAttemptId
       // exercise the `?? null` fallback (covers the null side of each field).
-      await recorder.recordAutofixOriginals(ctx, 'gpt-4o', 'default', {
+      await recorder.recordAutofixOriginal(ctx, 'gpt-4o', 'default', {
         ...sampleAutofix,
         chain: [
           {
@@ -1489,8 +1554,8 @@ describe('ProxyMessageRecorder', () => {
           { attempt: 1, origin: 'autofix', request: { max_output_tokens: 5 }, http_status: 200 },
         ],
       });
-      const rows = insertMock.mock.calls.at(-1)![0] as Array<Record<string, unknown>>;
-      expect(rows[0].autofix_phoenix).toEqual({
+      const row = insertMock.mock.calls.at(-1)![0] as Record<string, unknown>;
+      expect(row.autofix_phoenix).toEqual({
         issueId: null,
         patchId: 'patch-xyz',
         healAttemptId: null,
@@ -1498,7 +1563,7 @@ describe('ProxyMessageRecorder', () => {
       });
     });
 
-    it('recordAutofixOriginals carries the Phoenix explanation onto autofix_phoenix', async () => {
+    it('recordAutofixOriginal carries the Phoenix explanation onto autofix_phoenix', async () => {
       // Phoenix's human-readable "why" is persisted alongside the ids so the
       // dashboard Auto-fix card can render it (not re-derive it locally).
       const explanation = {
@@ -1511,7 +1576,7 @@ describe('ProxyMessageRecorder', () => {
         ],
         source: 'deterministic' as const,
       };
-      await recorder.recordAutofixOriginals(ctx, 'gpt-4o', 'default', {
+      await recorder.recordAutofixOriginal(ctx, 'gpt-4o', 'default', {
         ...sampleAutofix,
         chain: [
           {
@@ -1527,8 +1592,8 @@ describe('ProxyMessageRecorder', () => {
           { attempt: 1, origin: 'autofix', request: { max_output_tokens: 5 }, http_status: 200 },
         ],
       });
-      const rows = insertMock.mock.calls.at(-1)![0] as Array<Record<string, unknown>>;
-      expect(rows[0].autofix_phoenix).toEqual({
+      const row = insertMock.mock.calls.at(-1)![0] as Record<string, unknown>;
+      expect(row.autofix_phoenix).toEqual({
         issueId: 'issue-9',
         patchId: null,
         healAttemptId: 'heal-9',
@@ -1536,10 +1601,10 @@ describe('ProxyMessageRecorder', () => {
       });
     });
 
-    it('recordAutofixOriginals sets autofix_phoenix to null when the failed entry has no Phoenix ids', async () => {
+    it('recordAutofixOriginal sets autofix_phoenix to null when the failed entry has no Phoenix ids', async () => {
       // A failed chain entry with none of issue_id/patch_id/heal_attempt_id must
       // leave autofix_phoenix null (covers the `: null` branch of the ternary).
-      await recorder.recordAutofixOriginals(ctx, 'gpt-4o', 'default', {
+      await recorder.recordAutofixOriginal(ctx, 'gpt-4o', 'default', {
         ...sampleAutofix,
         chain: [
           {
@@ -1552,15 +1617,23 @@ describe('ProxyMessageRecorder', () => {
           { attempt: 1, origin: 'autofix', request: { max_output_tokens: 5 }, http_status: 200 },
         ],
       });
-      const rows = insertMock.mock.calls.at(-1)![0] as Array<Record<string, unknown>>;
-      expect(rows).toHaveLength(1);
-      expect(rows[0].autofix_phoenix).toBeNull();
+      const row = insertMock.mock.calls.at(-1)![0] as Record<string, unknown>;
+      expect(row.autofix_phoenix).toBeNull();
     });
 
-    it('recordAutofixOriginals is a no-op when the chain has no failed entries', async () => {
-      await recorder.recordAutofixOriginals(ctx, 'gpt-4o', 'default', {
+    it('recordAutofixOriginal is a no-op when the chain has no failed original', async () => {
+      await recorder.recordAutofixOriginal(ctx, 'gpt-4o', 'default', {
         ...sampleAutofix,
         chain: [{ attempt: 1, origin: 'autofix', request: {}, http_status: 200 }],
+      });
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+
+    it('recordAutofixOriginal is a no-op when Phoenix supplied no patch', async () => {
+      await recorder.recordAutofixOriginal(ctx, 'gpt-4o', 'default', {
+        ...sampleAutofix,
+        outcome: 'unfixable',
+        chain: [sampleAutofix.chain[0]],
       });
       expect(insertMock).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -662,6 +662,27 @@ describe('proxy-response-handler', () => {
       );
     });
 
+    it('does not attribute the Auto-fix original to the fallback provider', () => {
+      const recorder = mockRecorder();
+      const meta = makeMeta({
+        fallbackFromModel: 'gpt-4o',
+        primaryProvider: undefined,
+        provider: 'anthropic',
+        model: 'claude-sonnet',
+      });
+      const autofix = failedAutofixRetry();
+
+      recordFallbackFailures(testCtx, meta, undefined, recorder as any, null, null, autofix);
+
+      expect(recorder.recordAutofixOriginal).toHaveBeenCalledWith(
+        testCtx,
+        'gpt-4o',
+        'standard',
+        autofix,
+        expect.objectContaining({ provider: undefined }),
+      );
+    });
+
     it('should not record failed fallbacks when array is empty', () => {
       const recorder = mockRecorder();
       const meta = makeMeta({ fallbackFromModel: 'gpt-4o' });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -55,7 +55,34 @@ function mockRecorder() {
     recordPrimaryFailure: jest.fn().mockResolvedValue(undefined),
     recordFallbackSuccess: jest.fn().mockResolvedValue(undefined),
     recordSuccessMessage: jest.fn().mockResolvedValue(undefined),
-    recordAutofixOriginals: jest.fn().mockResolvedValue(undefined),
+    recordAutofixOriginal: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function failedAutofixRetry(): AutofixRecord {
+  return {
+    groupId: 'grp-failed-retry',
+    outcome: 'exhausted',
+    original_http_status: 400,
+    chain: [
+      {
+        attempt: 0,
+        origin: 'original',
+        request: { max_tokens: 5 },
+        http_status: 400,
+        error: { message: 'Unknown parameter' },
+        issue_id: 'issue-1',
+        patch_id: 'patch-1',
+        heal_attempt_id: 'heal-1',
+      },
+      {
+        attempt: 1,
+        origin: 'autofix',
+        request: { max_output_tokens: 5 },
+        http_status: 422,
+        error: { message: 'Retry also failed' },
+      },
+    ],
   };
 }
 
@@ -192,6 +219,42 @@ describe('proxy-response-handler', () => {
       );
     });
 
+    it('records the original and terminal retry when a patched request fails', async () => {
+      const { res } = mockResponse();
+      const recorder = mockRecorder();
+      const meta = makeMeta();
+      const autofix = failedAutofixRetry();
+
+      await handleProviderError(
+        res as any,
+        testCtx,
+        meta,
+        buildMetaHeaders(meta),
+        422,
+        'Retry also failed',
+        undefined,
+        recorder as any,
+        'trace-retry',
+        null,
+        { 'x-request': '1' },
+        autofix,
+      );
+
+      expect(recorder.recordAutofixOriginal).toHaveBeenCalledWith(
+        testCtx,
+        'gpt-4o',
+        'standard',
+        autofix,
+        expect.objectContaining({ traceId: 'trace-retry', provider: 'openai' }),
+      );
+      expect(recorder.recordProviderError).toHaveBeenCalledWith(
+        testCtx,
+        422,
+        'Retry also failed',
+        expect.objectContaining({ autofix }),
+      );
+    });
+
     it('should handle fallback exhausted when failedFallbacks present and no fallbackFromModel', async () => {
       const { res, headers } = mockResponse();
       const recorder = mockRecorder();
@@ -234,9 +297,7 @@ describe('proxy-response-handler', () => {
       );
     });
 
-    it('stamps the Auto-fix audit onto the primary row when the fallback chain exhausted', async () => {
-      // Heal ran but neither it nor any fallback cleared the error: the primary
-      // failure is recorded once (here) and must carry the Auto-fix stamp.
+    it('keeps a no-patch audit unlinked when the fallback chain exhausted', async () => {
       const { res } = mockResponse();
       const recorder = mockRecorder();
       const meta = makeMeta();
@@ -281,8 +342,9 @@ describe('proxy-response-handler', () => {
         expect.any(String),
         expect.any(String),
         undefined,
-        expect.objectContaining({ autofix }),
+        expect.objectContaining({ autofix, httpStatus: 400 }),
       );
+      expect(recorder.recordAutofixOriginal).not.toHaveBeenCalled();
     });
 
     it('preserves provider context overflow code when fallback chain is exhausted', async () => {
@@ -530,10 +592,7 @@ describe('proxy-response-handler', () => {
       expect(recorder.recordFailedFallbacks).toHaveBeenCalled();
     });
 
-    it('stamps the Auto-fix audit onto the primary-failure row when heal-then-fallback ran', () => {
-      // Heal failed → fallback succeeded: the Auto-fix record must ride along to
-      // recordPrimaryFailure so the single fallback_error row carries the stamp,
-      // instead of a duplicate auto_fixed row being written elsewhere.
+    it('passes a no-patch audit to the plain primary failure', () => {
       const recorder = mockRecorder();
       const meta = makeMeta({ fallbackFromModel: 'gpt-4o', primaryErrorStatus: 400 });
       const autofix: AutofixRecord = {
@@ -561,6 +620,45 @@ describe('proxy-response-handler', () => {
         expect.any(String),
         undefined,
         expect.objectContaining({ autofix }),
+      );
+      expect(recorder.recordAutofixOriginal).not.toHaveBeenCalled();
+    });
+
+    it('records the original and failed Auto-fix retry before a successful fallback', () => {
+      const recorder = mockRecorder();
+      const meta = makeMeta({
+        fallbackFromModel: 'gpt-4o',
+        primaryErrorBody: 'Retry also failed',
+        primaryErrorStatus: 422,
+        primaryProvider: 'openai',
+        primaryAuthType: 'api_key',
+        primaryTenantProviderId: 'primary-key',
+        provider: 'anthropic',
+        model: 'claude-sonnet',
+      });
+      const autofix = failedAutofixRetry();
+
+      recordFallbackFailures(testCtx, meta, undefined, recorder as any, null, null, autofix);
+
+      expect(recorder.recordAutofixOriginal).toHaveBeenCalledWith(
+        testCtx,
+        'gpt-4o',
+        'standard',
+        autofix,
+        expect.objectContaining({
+          provider: 'openai',
+          authType: 'api_key',
+          tenantProviderId: 'primary-key',
+        }),
+      );
+      expect(recorder.recordPrimaryFailure).toHaveBeenCalledWith(
+        testCtx,
+        expect.anything(),
+        'gpt-4o',
+        'Retry also failed',
+        expect.any(String),
+        'api_key',
+        expect.objectContaining({ autofix, httpStatus: 422 }),
       );
     });
 
@@ -595,7 +693,12 @@ describe('proxy-response-handler', () => {
         'Provider returned HTTP 503',
         expect.any(String),
         undefined,
-        { provider: 'anthropic', reason: 'auto', callerAttribution: undefined },
+        expect.objectContaining({
+          provider: 'anthropic',
+          reason: 'auto',
+          callerAttribution: undefined,
+          httpStatus: 503,
+        }),
       );
     });
 
@@ -2188,7 +2291,7 @@ describe('proxy-response-handler', () => {
         healedAutofix,
       );
 
-      expect(recorder.recordAutofixOriginals).toHaveBeenCalledWith(
+      expect(recorder.recordAutofixOriginal).toHaveBeenCalledWith(
         testCtx,
         'gpt-4o',
         'standard',
@@ -2220,7 +2323,7 @@ describe('proxy-response-handler', () => {
       );
 
       expect(recorder.recordFallbackSuccess).toHaveBeenCalled();
-      expect(recorder.recordAutofixOriginals).not.toHaveBeenCalled();
+      expect(recorder.recordAutofixOriginal).not.toHaveBeenCalled();
     });
 
     it('does NOT record a separate auto_fixed original when healing EXHAUSTED but a fallback then succeeded', () => {
@@ -2265,12 +2368,12 @@ describe('proxy-response-handler', () => {
       expect(recorder.recordFallbackSuccess).toHaveBeenCalled();
       expect(recorder.recordSuccessMessage).not.toHaveBeenCalled();
       // …and no duplicate auto_fixed row is written for the failed primary.
-      expect(recorder.recordAutofixOriginals).not.toHaveBeenCalled();
+      expect(recorder.recordAutofixOriginal).not.toHaveBeenCalled();
     });
 
     it('does not record Auto-fix originals when healing did not heal (outcome !== healed)', () => {
       // An Auto-fix record that did not heal must not trigger
-      // recordAutofixOriginals — the guard is `outcome === 'healed'`.
+      // recordAutofixOriginal — the guard is the presence of a real retry.
       const recorder = mockRecorder();
       const meta = makeMeta();
       const emptyChainAutofix: AutofixRecord = {
@@ -2294,7 +2397,7 @@ describe('proxy-response-handler', () => {
         emptyChainAutofix,
       );
 
-      expect(recorder.recordAutofixOriginals).not.toHaveBeenCalled();
+      expect(recorder.recordAutofixOriginal).not.toHaveBeenCalled();
     });
 
     it('does not record Auto-fix originals when autofix is absent', () => {
@@ -2310,7 +2413,7 @@ describe('proxy-response-handler', () => {
         recorder as any,
       );
 
-      expect(recorder.recordAutofixOriginals).not.toHaveBeenCalled();
+      expect(recorder.recordAutofixOriginal).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -18,7 +18,11 @@ import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-cata
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
 import type { ManifestErrorCode } from '../../common/errors/error-codes';
 import type { ManifestBlockedRequestReason } from '../../common/errors/manifest-error';
-import type { AutofixChainEntry, AutofixRecord } from '../autofix/autofix.types';
+import {
+  getAutofixRetry,
+  type AutofixChainEntry,
+  type AutofixRecord,
+} from '../autofix/autofix.types';
 import { serializeProviderError } from '../autofix/provider-error-normalizer';
 
 /**
@@ -42,7 +46,10 @@ function buildAutofixPhoenix(entry: AutofixChainEntry | undefined): object | nul
   };
 }
 
-/** Auto-fix columns for one row of a healed pair (or an exhausted attempt). */
+/**
+ * Auto-fix audit for every Phoenix decision, plus linked-flow columns only when
+ * Manifest actually sent a patched retry.
+ */
 function autofixColumns(
   autofix: AutofixRecord | undefined,
   role: 'original' | 'retry',
@@ -56,6 +63,10 @@ function autofixColumns(
       e.heal_attempt_id != null ||
       e.explanation != null,
   );
+  const phoenixAudit = buildAutofixPhoenix(healEntry);
+  if (!getAutofixRetry(autofix)) {
+    return phoenixAudit ? { autofix_phoenix: phoenixAudit } : {};
+  }
   return {
     autofix_applied: true,
     autofix_group_id: autofix.groupId,
@@ -63,6 +74,10 @@ function autofixColumns(
     autofix_operations: (healEntry?.operations as object | null) ?? null,
     autofix_phoenix: buildAutofixPhoenix(healEntry),
   };
+}
+
+function terminalAutofixRole(autofix: AutofixRecord | undefined): 'original' | 'retry' {
+  return getAutofixRetry(autofix) ? 'retry' : 'original';
 }
 
 export interface HeaderTierRef {
@@ -300,7 +315,11 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       autofix,
     } = opts ?? {};
 
-    if (httpStatus === 429 && this.shouldSkipRateLimitRecord(ctx)) return;
+    // A real Auto-fix retry must never disappear behind the generic 429
+    // deduplication window; it is required to complete the linked attempt story.
+    if (httpStatus === 429 && !getAutofixRetry(autofix) && this.shouldSkipRateLimitRecord(ctx)) {
+      return;
+    }
 
     const messageStatus = httpStatus === 429 ? 'rate_limited' : 'error';
 
@@ -317,7 +336,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         status: messageStatus,
         error_message: scrubSecrets(errorMessage).slice(0, 2000),
         error_http_status: httpStatus,
-        ...autofixColumns(autofix, 'original'),
+        ...autofixColumns(autofix, terminalAutofixRole(autofix)),
         model: canonical.model,
         provider: canonical.provider,
         routing_tier: tier ?? null,
@@ -519,6 +538,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       headerTierId?: string | null;
       headerTierName?: string | null;
       headerTierColor?: string | null;
+      /** Provider status for the superseded primary or failed Auto-fix retry. */
+      httpStatus?: number | null;
       /**
        * Auto-fix audit when this superseded primary was also an Auto-fix
        * attempt. Stamped onto THIS row (not a separate `auto_fixed` row) so a
@@ -536,8 +557,9 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       buildMessageRow(ctx, {
         timestamp,
         status: 'fallback_error',
-        ...autofixColumns(opts?.autofix, 'original'),
+        ...autofixColumns(opts?.autofix, terminalAutofixRole(opts?.autofix)),
         error_message: scrubSecrets(errorBody).slice(0, 2000),
+        error_http_status: opts?.httpStatus ?? null,
         model: canonical.model,
         provider: canonical.provider,
         routing_tier: tier,
@@ -792,59 +814,55 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
   }
 
   /**
-   * Record the failed original request(s) of a healed Auto-fix flow as their
-   * own rows (`status='auto_fixed'`, `autofix_role='original'`), linked to the
-   * successful retry row via `autofix.groupId`. Timestamped just before the
-   * retry so they sort adjacently, with the retry directly above.
+   * Record the failed original request of an Auto-fix flow as its own row,
+   * linked to the successful or failed retry via `autofix.groupId`.
    */
-  async recordAutofixOriginals(
+  async recordAutofixOriginal(
     ctx: IngestionContext,
     model: string,
     tier: string,
     autofix: AutofixRecord,
     opts?: AutofixOriginalOpts,
   ): Promise<void> {
-    const failed = autofix.chain.filter((e) => e.error);
-    if (failed.length === 0) return;
+    if (!getAutofixRetry(autofix)) return;
+    const original = autofix.chain.find((entry) => entry.origin === 'original' && entry.error);
+    if (!original?.error) return;
 
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
       ctx.tenantId,
       opts?.provider,
       model,
     );
-    const nowMs = Date.now();
-    const rows = failed.map((entry, i) =>
-      buildMessageRow(ctx, {
-        trace_id: opts?.traceId ?? null,
-        timestamp: new Date(nowMs - (failed.length - i) * 1000).toISOString(),
-        status: 'auto_fixed',
-        // The full `{"error":{…}}` envelope, like every other error row — storing the
-        // bare message would drop the `type`/`param`/`code` that identify the error
-        // downstream (see serializeProviderError).
-        error_message: serializeProviderError(entry.error!),
-        error_http_status: entry.http_status,
-        model: canonical.model,
-        provider: canonical.provider,
-        routing_tier: tier ?? null,
-        routing_reason: opts?.reason ?? null,
-        auth_type: opts?.authType ?? null,
-        specificity_category: opts?.specificityCategory ?? null,
-        provider_key_label: opts?.providerKeyLabel ?? null,
-        tenant_provider_id: opts?.tenantProviderId ?? null,
-        caller_attribution: opts?.callerAttribution ?? null,
-        request_headers: opts?.requestHeaders ?? null,
-        request_params: opts?.requestParams ?? null,
-        header_tier_id: opts?.headerTierId ?? null,
-        header_tier_name: opts?.headerTierName ?? null,
-        header_tier_color: opts?.headerTierColor ?? null,
-        autofix_applied: true,
-        autofix_group_id: autofix.groupId,
-        autofix_role: 'original',
-        autofix_operations: (entry.operations as object | null) ?? null,
-        autofix_phoenix: buildAutofixPhoenix(entry),
-      }),
-    );
-    await this.messageRepo.insert(rows);
+    const row = buildMessageRow(ctx, {
+      trace_id: opts?.traceId ?? null,
+      timestamp: new Date(Date.now() - 1000).toISOString(),
+      status: 'auto_fixed',
+      // The full `{"error":{…}}` envelope, like every other error row — storing the
+      // bare message would drop the `type`/`param`/`code` that identify the error
+      // downstream (see serializeProviderError).
+      error_message: serializeProviderError(original.error),
+      error_http_status: original.http_status,
+      model: canonical.model,
+      provider: canonical.provider,
+      routing_tier: tier ?? null,
+      routing_reason: opts?.reason ?? null,
+      auth_type: opts?.authType ?? null,
+      specificity_category: opts?.specificityCategory ?? null,
+      provider_key_label: opts?.providerKeyLabel ?? null,
+      tenant_provider_id: opts?.tenantProviderId ?? null,
+      caller_attribution: opts?.callerAttribution ?? null,
+      request_headers: opts?.requestHeaders ?? null,
+      request_params: opts?.requestParams ?? null,
+      header_tier_id: opts?.headerTierId ?? null,
+      header_tier_name: opts?.headerTierName ?? null,
+      header_tier_color: opts?.headerTierColor ?? null,
+      autofix_applied: true,
+      autofix_group_id: autofix.groupId,
+      autofix_role: 'original',
+      autofix_operations: (original.operations as object | null) ?? null,
+      autofix_phoenix: buildAutofixPhoenix(original),
+    });
+    await this.messageRepo.insert(row);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }
 

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -2,7 +2,7 @@ import { Logger } from '@nestjs/common';
 import { Response as ExpressResponse } from 'express';
 import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interface';
 import { RoutingMeta } from './proxy.service';
-import type { AutofixRecord } from '../autofix/autofix.types';
+import { getAutofixRetry, type AutofixRecord } from '../autofix/autofix.types';
 import { FailedFallback } from './proxy-fallback.service';
 import { ForwardResult } from './provider-client';
 import { ProxyMessageRecorder } from './proxy-message-recorder';
@@ -52,6 +52,43 @@ const logger = new Logger('ProxyResponseHandler');
 
 function recordSafely(promise: Promise<unknown>, label: string): void {
   promise.catch((e) => logger.warn(`Failed to record ${label}: ${e}`));
+}
+
+function recordAutofixOriginalIfRetried(
+  ctx: IngestionContext,
+  meta: RoutingMeta,
+  recorder: ProxyMessageRecorder,
+  autofix: AutofixRecord | undefined,
+  traceId?: string,
+  callerAttribution?: CallerAttribution | null,
+  requestHeaders?: Record<string, string> | null,
+  route?: {
+    model?: string;
+    provider?: string;
+    authType?: string;
+    tenantProviderId?: string | null;
+  },
+): void {
+  if (!autofix || !getAutofixRetry(autofix)) return;
+  recordSafely(
+    recorder.recordAutofixOriginal(ctx, route?.model ?? meta.model, meta.tier, autofix, {
+      provider: route?.provider ?? meta.provider,
+      reason: meta.reason,
+      authType: route?.authType ?? meta.auth_type,
+      traceId,
+      callerAttribution,
+      requestHeaders,
+      requestParams: meta.request_params,
+      specificityCategory: meta.specificity_category,
+      providerKeyLabel: meta.provider_key_label,
+      tenantProviderId:
+        route?.tenantProviderId === undefined ? meta.tenantProviderId : route.tenantProviderId,
+      headerTierId: meta.header_tier_id,
+      headerTierName: meta.header_tier_name,
+      headerTierColor: meta.header_tier_color,
+    }),
+    'autofix original',
+  );
 }
 
 function thinkingRouteContext(meta: RoutingMeta): ThinkingBlockRouteContext {
@@ -127,6 +164,16 @@ export async function handleProviderError(
   requestHeaders?: Record<string, string> | null,
   autofix?: AutofixRecord,
 ): Promise<void> {
+  recordAutofixOriginalIfRetried(
+    ctx,
+    meta,
+    recorder,
+    autofix,
+    traceId,
+    callerAttribution,
+    requestHeaders,
+  );
+
   if (failedFallbacks && failedFallbacks.length > 0 && !meta.fallbackFromModel) {
     await handleFallbackExhausted(
       res,
@@ -236,8 +283,9 @@ function handleFallbackExhausted(
         headerTierId: meta.header_tier_id,
         headerTierName: meta.header_tier_name,
         headerTierColor: meta.header_tier_color,
-        // Auto-fix ran on this primary before the chain exhausted — stamp its
-        // audit onto the single primary-failure row (no separate `auto_fixed`).
+        httpStatus: errorStatus,
+        // When a patched retry exists this row is that retry; otherwise it is
+        // the plain original failure carrying only Phoenix's audit.
         autofix,
       },
     ),
@@ -286,6 +334,21 @@ export function recordFallbackFailures(
   // (see RoutingMeta.primaryAuthType / #1173). Older meta shapes only carry
   // `auth_type`, so fall back to it when primaryAuthType is absent.
   const primaryAuthType = meta.primaryAuthType ?? meta.auth_type;
+  recordAutofixOriginalIfRetried(
+    ctx,
+    meta,
+    recorder,
+    autofix,
+    undefined,
+    callerAttribution,
+    requestHeaders,
+    {
+      model: meta.fallbackFromModel,
+      provider: meta.primaryProvider,
+      authType: primaryAuthType,
+      tenantProviderId: meta.primaryTenantProviderId,
+    },
+  );
   recordSafely(
     recorder.recordPrimaryFailure(
       ctx,
@@ -314,9 +377,9 @@ export function recordFallbackFailures(
         headerTierId: meta.header_tier_id,
         headerTierName: meta.header_tier_name,
         headerTierColor: meta.header_tier_color,
-        // Heal-then-fallback: stamp the Auto-fix audit onto the single primary
-        // row here; `recordAutofixOriginals` is guarded on outcome==='healed'
-        // so it no longer emits a duplicate `auto_fixed` row for this failure.
+        httpStatus: meta.primaryErrorStatus,
+        // A failed patched retry is the primary failure that triggered fallback.
+        // No-patch consultations remain an unmarked original with audit only.
         autofix,
       },
     ),
@@ -683,35 +746,17 @@ export function recordSuccess(
     );
   }
 
-  // Record the failed original as its own `auto_fixed` row ONLY when healing
-  // actually succeeded — that row is linked to the retry above via groupId and
-  // is the sole record of the pre-heal failure. When healing did NOT heal, the
-  // primary failure is already recorded exactly once elsewhere (the terminal
-  // error row, or the `fallback_error` row when a fallback took over), both of
-  // which carry the Auto-fix stamp — so emitting an `auto_fixed` row here too
-  // would double-count the same failure (and under the wrong, fallback model).
-  // `!meta.fallbackFromModel`: if a fallback took over after the heal, `meta.model`
-  // here is the fallback route, and the fallback path already stamps the pre-heal
-  // failure with the Auto-fix audit — so recording a standalone `auto_fixed` row
-  // now would double-count it under the wrong model.
-  if (autofix && autofix.outcome === 'healed' && !meta.fallbackFromModel) {
-    recordSafely(
-      recorder.recordAutofixOriginals(ctx, meta.model, meta.tier, autofix, {
-        provider: meta.provider,
-        reason: meta.reason,
-        authType: meta.auth_type,
-        traceId,
-        callerAttribution,
-        requestHeaders,
-        requestParams: meta.request_params,
-        specificityCategory: meta.specificity_category,
-        providerKeyLabel: meta.provider_key_label,
-        tenantProviderId: meta.tenantProviderId,
-        headerTierId: meta.header_tier_id,
-        headerTierName: meta.header_tier_name,
-        headerTierColor: meta.header_tier_color,
-      }),
-      'autofix originals',
+  // Fallback-success flows recorded the original and failed retry above in
+  // recordFallbackFailures. A direct Auto-fix success records its original here.
+  if (!meta.fallbackFromModel) {
+    recordAutofixOriginalIfRetried(
+      ctx,
+      meta,
+      recorder,
+      autofix,
+      traceId,
+      callerAttribution,
+      requestHeaders,
     );
   }
 }

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -72,7 +72,7 @@ function recordAutofixOriginalIfRetried(
   if (!autofix || !getAutofixRetry(autofix)) return;
   recordSafely(
     recorder.recordAutofixOriginal(ctx, route?.model ?? meta.model, meta.tier, autofix, {
-      provider: route?.provider ?? meta.provider,
+      provider: route ? route.provider : meta.provider,
       reason: meta.reason,
       authType: route?.authType ?? meta.auth_type,
       traceId,


### PR DESCRIPTION
### ✨ What changed
- Mark Auto-fix applied only when a patched retry was sent.
- Preserve failed retry responses as linked provider attempts through fallback.
- Add regression coverage and a patch changeset.

### 💭 Why
No-patch Phoenix consultations appeared as successful Auto-fixes, while failed patched retries were discarded.

### 📝 Notes
Closes #2509

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Auto-fix auditing to record real provider retries, preserve primary provider attribution, and stop marking no‑patch consultations as applied. Failed patched retries are now persisted and linked across the flow. Closes #2509.

- **Bug Fixes**
  - Only set `autofix_applied`/`autofix_group_id` when a patched retry was actually sent; no‑patch Phoenix consultations remain plain provider errors.
  - Persist failed patched retries as `autofix_role=retry` with `error_http_status`, including through fallback and terminal rows.
  - Return the retry’s rebuilt response and mark the terminal outcome as `exhausted` when a patched retry fails.
  - Record the failed original once via `recordAutofixOriginal` when a real retry exists; prevent 429 dedup from hiding real retries.
  - Add `getAutofixRetry`, preserve primary provider/auth attribution in fallback paths, update tests, and include a patch changeset.

<sup>Written for commit 34cad7412fad279d2213f38eb3c2e9151022c4c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

