### PR TITLE
feat: add change-password to Account page (self-hosted + cloud)

### DIFF
--- a/packages/frontend/src/pages/Account.tsx
+++ b/packages/frontend/src/pages/Account.tsx
@@ -258,17 +258,15 @@ const Account: Component = () => {
         <Show when={hasCredentialAccount()}>
           <h2 class="settings-section__title">Security</h2>
 
-          <div class="settings-card">
-            <form class="auth-form" onSubmit={handleChangePassword}>
-              {pwError() && (
-                <div class="auth-form__error" role="alert">
-                  {pwError()}
-                </div>
-              )}
-              <label class="auth-form__label">
-                Current password
+          <form class="settings-card" onSubmit={handleChangePassword}>
+            <div class="settings-card__row">
+              <div class="settings-card__label">
+                <span class="settings-card__label-title">Current password</span>
+                <span class="settings-card__label-desc">Confirm the password you use today.</span>
+              </div>
+              <div class="settings-card__control">
                 <input
-                  class="auth-form__input"
+                  class="settings-card__input"
                   type="password"
                   autocomplete="current-password"
                   aria-label="Current password"
@@ -276,11 +274,16 @@ const Account: Component = () => {
                   onInput={(e) => setCurrentPassword(e.currentTarget.value)}
                   required
                 />
-              </label>
-              <label class="auth-form__label">
-                New password
+              </div>
+            </div>
+            <div class="settings-card__row">
+              <div class="settings-card__label">
+                <span class="settings-card__label-title">New password</span>
+                <span class="settings-card__label-desc">At least 8 characters.</span>
+              </div>
+              <div class="settings-card__control">
                 <input
-                  class="auth-form__input"
+                  class="settings-card__input"
                   type="password"
                   autocomplete="new-password"
                   aria-label="New password"
@@ -289,11 +292,16 @@ const Account: Component = () => {
                   required
                   minLength={8}
                 />
-              </label>
-              <label class="auth-form__label">
-                Confirm new password
+              </div>
+            </div>
+            <div class="settings-card__row">
+              <div class="settings-card__label">
+                <span class="settings-card__label-title">Confirm new password</span>
+                <span class="settings-card__label-desc">Re-enter the new password to confirm.</span>
+              </div>
+              <div class="settings-card__control">
                 <input
-                  class="auth-form__input"
+                  class="settings-card__input"
                   type="password"
                   autocomplete="new-password"
                   aria-label="Confirm new password"
@@ -302,12 +310,17 @@ const Account: Component = () => {
                   required
                   minLength={8}
                 />
-              </label>
+              </div>
+            </div>
+            <div class="settings-card__footer account-security-footer">
+              <span class="account-security-error" role="alert">
+                {pwError()}
+              </span>
               <button class="btn btn--primary btn--sm" type="submit" disabled={pwBusy()}>
                 {pwBusy() ? <span class="spinner" /> : 'Change password'}
               </button>
-            </form>
-          </div>
+            </div>
+          </form>
         </Show>
 
         {/* Workspace ID */}

--- a/packages/frontend/src/pages/Account.tsx
+++ b/packages/frontend/src/pages/Account.tsx
@@ -21,7 +21,19 @@ const Account: Component = () => {
   const session = authClient.useSession();
   const [copied, setCopied] = createSignal(false);
   const [theme, setTheme] = createSignal<'light' | 'dark' | 'system'>('system');
+  const [currentPassword, setCurrentPassword] = createSignal('');
+  const [newPassword, setNewPassword] = createSignal('');
+  const [confirmPassword, setConfirmPassword] = createSignal('');
+  const [pwError, setPwError] = createSignal('');
+  const [pwBusy, setPwBusy] = createSignal(false);
+
+  const handleChangePassword = async (e: Event) => {
+    e.preventDefault();
+  };
   const [billing, { refetch: refetchBilling }] = createResource(() => getBillingStatus());
+  const [accounts] = createResource(() => authClient.listAccounts());
+  const hasCredentialAccount = () =>
+    (accounts()?.data ?? []).some((a) => a.providerId === 'credential');
   const [searchParams, setSearchParams] = useSearchParams();
   const [billingBusy, setBillingBusy] = createSignal(false);
   const [emailPrefsBusy, setEmailPrefsBusy] = createSignal(false);
@@ -201,6 +213,62 @@ const Account: Component = () => {
             </span>
           </div>
         </div>
+
+        {/* Security */}
+        <Show when={hasCredentialAccount()}>
+          <h2 class="settings-section__title">Security</h2>
+
+          <div class="settings-card">
+            <form class="auth-form" onSubmit={handleChangePassword}>
+              {pwError() && (
+                <div class="auth-form__error" role="alert">
+                  {pwError()}
+                </div>
+              )}
+              <label class="auth-form__label">
+                Current password
+                <input
+                  class="auth-form__input"
+                  type="password"
+                  autocomplete="current-password"
+                  aria-label="Current password"
+                  value={currentPassword()}
+                  onInput={(e) => setCurrentPassword(e.currentTarget.value)}
+                  required
+                />
+              </label>
+              <label class="auth-form__label">
+                New password
+                <input
+                  class="auth-form__input"
+                  type="password"
+                  autocomplete="new-password"
+                  aria-label="New password"
+                  value={newPassword()}
+                  onInput={(e) => setNewPassword(e.currentTarget.value)}
+                  required
+                  minLength={8}
+                />
+              </label>
+              <label class="auth-form__label">
+                Confirm new password
+                <input
+                  class="auth-form__input"
+                  type="password"
+                  autocomplete="new-password"
+                  aria-label="Confirm new password"
+                  value={confirmPassword()}
+                  onInput={(e) => setConfirmPassword(e.currentTarget.value)}
+                  required
+                  minLength={8}
+                />
+              </label>
+              <button class="btn btn--primary btn--sm" type="submit" disabled={pwBusy()}>
+                {pwBusy() ? <span class="spinner" /> : 'Change password'}
+              </button>
+            </form>
+          </div>
+        </Show>
 
         {/* Workspace ID */}
         <h2 class="settings-section__title">Workspace</h2>

--- a/packages/frontend/src/pages/Account.tsx
+++ b/packages/frontend/src/pages/Account.tsx
@@ -48,22 +48,27 @@ const Account: Component = () => {
     }
 
     setPwBusy(true);
-    const { error } = await authClient.changePassword({
-      currentPassword: current,
-      newPassword: next,
-      revokeOtherSessions: true,
-    });
-    setPwBusy(false);
+    try {
+      const { error } = await authClient.changePassword({
+        currentPassword: current,
+        newPassword: next,
+        revokeOtherSessions: true,
+      });
 
-    if (error) {
-      setPwError(error.message ?? 'Failed to change password');
-      return;
+      if (error) {
+        setPwError(error.message ?? 'Failed to change password');
+        return;
+      }
+
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      toast.success('Password changed. Other devices have been signed out.');
+    } catch {
+      setPwError('Failed to change password');
+    } finally {
+      setPwBusy(false);
     }
-
-    setCurrentPassword('');
-    setNewPassword('');
-    setConfirmPassword('');
-    toast.success('Password changed. Other devices have been signed out.');
   };
   const [billing, { refetch: refetchBilling }] = createResource(() => getBillingStatus());
   const [accounts] = createResource(() => authClient.listAccounts());

--- a/packages/frontend/src/pages/Account.tsx
+++ b/packages/frontend/src/pages/Account.tsx
@@ -29,6 +29,41 @@ const Account: Component = () => {
 
   const handleChangePassword = async (e: Event) => {
     e.preventDefault();
+    setPwError('');
+
+    const current = currentPassword();
+    const next = newPassword();
+
+    if (next !== confirmPassword()) {
+      setPwError('New passwords do not match');
+      return;
+    }
+    if (next.length < 8) {
+      setPwError('New password must be at least 8 characters');
+      return;
+    }
+    if (next === current) {
+      setPwError('New password must differ from the current password');
+      return;
+    }
+
+    setPwBusy(true);
+    const { error } = await authClient.changePassword({
+      currentPassword: current,
+      newPassword: next,
+      revokeOtherSessions: true,
+    });
+    setPwBusy(false);
+
+    if (error) {
+      setPwError(error.message ?? 'Failed to change password');
+      return;
+    }
+
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    toast.success('Password changed. Other devices have been signed out.');
   };
   const [billing, { refetch: refetchBilling }] = createResource(() => getBillingStatus());
   const [accounts] = createResource(() => authClient.listAccounts());

--- a/packages/frontend/src/styles/agents.css
+++ b/packages/frontend/src/styles/agents.css
@@ -349,6 +349,17 @@
   color: hsl(var(--muted-foreground));
 }
 
+.account-security-footer {
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--gap-lg);
+}
+
+.account-security-error {
+  font-size: var(--font-size-xs);
+  color: hsl(var(--destructive));
+}
+
 @media (max-width: 640px) {
   .billing-stats {
     flex-direction: column;

--- a/packages/frontend/tests/pages/Account.test.tsx
+++ b/packages/frontend/tests/pages/Account.test.tsx
@@ -192,6 +192,84 @@ describe('Account', () => {
     expect(screen.queryByText('Security')).toBeNull();
   });
 
+  const fillPw = (current: string, next: string, confirm: string) => {
+    fireEvent.input(screen.getByLabelText('Current password'), { target: { value: current } });
+    fireEvent.input(screen.getByLabelText('New password'), { target: { value: next } });
+    fireEvent.input(screen.getByLabelText('Confirm new password'), { target: { value: confirm } });
+  };
+
+  it('rejects when new and confirm do not match', async () => {
+    render(() => <Account />);
+    await screen.findByText('Security');
+    fillPw('oldpass1', 'newpass12', 'different12');
+    fireEvent.click(screen.getByText('Change password'));
+    expect(await screen.findByText('New passwords do not match')).toBeDefined();
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it('rejects a new password shorter than 8 characters', async () => {
+    render(() => <Account />);
+    await screen.findByText('Security');
+    fillPw('oldpass1', 'short', 'short');
+    fireEvent.click(screen.getByText('Change password'));
+    expect(await screen.findByText('New password must be at least 8 characters')).toBeDefined();
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the new password equals the current password', async () => {
+    render(() => <Account />);
+    await screen.findByText('Security');
+    fillPw('samepass1', 'samepass1', 'samepass1');
+    fireEvent.click(screen.getByText('Change password'));
+    expect(
+      await screen.findByText('New password must differ from the current password'),
+    ).toBeDefined();
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it('changes the password and revokes other sessions on success', async () => {
+    render(() => <Account />);
+    await screen.findByText('Security');
+    fillPw('oldpass1', 'newpass12', 'newpass12');
+    fireEvent.click(screen.getByText('Change password'));
+    await waitFor(() =>
+      expect(mockChangePassword).toHaveBeenCalledWith({
+        currentPassword: 'oldpass1',
+        newPassword: 'newpass12',
+        revokeOtherSessions: true,
+      }),
+    );
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        'Password changed. Other devices have been signed out.',
+      ),
+    );
+    expect((screen.getByLabelText('Current password') as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText('New password') as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText('Confirm new password') as HTMLInputElement).value).toBe('');
+  });
+
+  it('shows an inline error when changePassword fails', async () => {
+    mockChangePassword.mockResolvedValue({ data: null, error: { message: 'Invalid password' } });
+    render(() => <Account />);
+    await screen.findByText('Security');
+    fillPw('wrongpass1', 'newpass12', 'newpass12');
+    fireEvent.click(screen.getByText('Change password'));
+    expect(await screen.findByText('Invalid password')).toBeDefined();
+    expect(mockToastSuccess).not.toHaveBeenCalledWith(
+      'Password changed. Other devices have been signed out.',
+    );
+  });
+
+  it('falls back to a generic error message when changePassword error has no message', async () => {
+    mockChangePassword.mockResolvedValue({ data: null, error: {} });
+    render(() => <Account />);
+    await screen.findByText('Security');
+    fillPw('wrongpass1', 'newpass12', 'newpass12');
+    fireEvent.click(screen.getByText('Change password'));
+    expect(await screen.findByText('Failed to change password')).toBeDefined();
+  });
+
   it('shows appearance section', () => {
     render(() => <Account />);
     expect(screen.getByText('Appearance')).toBeDefined();

--- a/packages/frontend/tests/pages/Account.test.tsx
+++ b/packages/frontend/tests/pages/Account.test.tsx
@@ -270,6 +270,17 @@ describe('Account', () => {
     expect(await screen.findByText('Failed to change password')).toBeDefined();
   });
 
+  it('recovers and re-enables the button when changePassword rejects', async () => {
+    mockChangePassword.mockRejectedValue(new Error('network down'));
+    render(() => <Account />);
+    await screen.findByText('Security');
+    fillPw('oldpass1', 'newpass12', 'newpass12');
+    const button = screen.getByText('Change password') as HTMLButtonElement;
+    fireEvent.click(button);
+    expect(await screen.findByText('Failed to change password')).toBeDefined();
+    await waitFor(() => expect(button.disabled).toBe(false));
+  });
+
   it('shows appearance section', () => {
     render(() => <Account />);
     expect(screen.getByText('Appearance')).toBeDefined();

--- a/packages/frontend/tests/pages/Account.test.tsx
+++ b/packages/frontend/tests/pages/Account.test.tsx
@@ -23,6 +23,8 @@ vi.mock('@solidjs/meta', () => ({
 
 const mockUpgrade = vi.fn();
 const mockBillingPortal = vi.fn();
+const mockListAccounts = vi.fn();
+const mockChangePassword = vi.fn();
 
 vi.mock('../../src/services/auth-client.js', () => ({
   authClient: {
@@ -34,6 +36,8 @@ vi.mock('../../src/services/auth-client.js', () => ({
       upgrade: (...a: unknown[]) => mockUpgrade(...a),
       billingPortal: (...a: unknown[]) => mockBillingPortal(...a),
     },
+    listAccounts: (...a: unknown[]) => mockListAccounts(...a),
+    changePassword: (...a: unknown[]) => mockChangePassword(...a),
   },
 }));
 
@@ -120,6 +124,8 @@ describe('Account', () => {
     mockUpdateBillingEmailPreferences.mockResolvedValue({ usageAlerts: true });
     mockUpgrade.mockResolvedValue(undefined);
     mockBillingPortal.mockResolvedValue({ data: { url: 'https://billing.stripe.com/session' } });
+    mockListAccounts.mockResolvedValue({ data: [{ providerId: 'credential' }], error: null });
+    mockChangePassword.mockResolvedValue({ data: {}, error: null });
     fakeTab = { location: { href: '' }, opener: {}, close: vi.fn() };
     vi.spyOn(window, 'open').mockImplementation(() => fakeTab as unknown as Window);
   });
@@ -161,6 +167,29 @@ describe('Account', () => {
   it('shows profile information section', () => {
     render(() => <Account />);
     expect(screen.getByText('Profile information')).toBeDefined();
+  });
+
+  it('shows Security section for a credential account', async () => {
+    mockListAccounts.mockResolvedValue({ data: [{ providerId: 'credential' }], error: null });
+    render(() => <Account />);
+    expect(await screen.findByText('Security')).toBeDefined();
+    expect(screen.getByLabelText('Current password')).toBeDefined();
+    expect(screen.getByLabelText('New password')).toBeDefined();
+    expect(screen.getByLabelText('Confirm new password')).toBeDefined();
+  });
+
+  it('hides Security section for an OAuth-only account', async () => {
+    mockListAccounts.mockResolvedValue({ data: [{ providerId: 'google' }], error: null });
+    render(() => <Account />);
+    await screen.findByText('Profile information');
+    expect(screen.queryByText('Security')).toBeNull();
+  });
+
+  it('hides Security section when listAccounts returns no data', async () => {
+    mockListAccounts.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    render(() => <Account />);
+    await screen.findByText('Profile information');
+    expect(screen.queryByText('Security')).toBeNull();
   });
 
   it('shows appearance section', () => {


### PR DESCRIPTION
Adds an authenticated "Change password" control, which Manifest previously lacked — the only password flow was the email-dependent reset, useless on self-hosted installs without SMTP.

A new **Security** section on the Account page renders a current/new/confirm form, shown only for users who have a password (a `credential` account, detected via Better Auth's `listAccounts()`) so OAuth-only users see nothing. Submitting validates client-side (required, ≥8 chars, new===confirm, new≠current) and calls the existing `authClient.changePassword({ ..., revokeOtherSessions: true })` endpoint — no backend changes. On success it clears the fields and toasts that other devices were signed out; on failure it shows an inline error. Frontend-only, 100% line coverage on the changed file, full frontend suite green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Change password control on the Account page for users with password logins. Works in self‑hosted and cloud; no email/SMTP needed.

- **New Features**
  - Adds a Security section shown only for credential accounts (via listAccounts).
  - Validates inputs: required, ≥8 chars, confirm matches, and new ≠ current.
  - Calls changePassword with revokeOtherSessions: true; clears fields and shows a success toast.
  - Matches the settings-card layout and adds inline error styling.

- **Bug Fixes**
  - Handles rejected changePassword calls: shows an inline error, resets the busy state, and re-enables the button; tests cover this flow.

<sup>Written for commit e6365c522088f0d28b0d4f60128fc52312d4c168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

