### PR TITLE
feat: add Apple Containers support

### DIFF
--- a/deploy/apple-containers/TUTORIAL.md
+++ b/deploy/apple-containers/TUTORIAL.md
@@ -15,6 +15,20 @@ Confirm the CLI is available:
 container --version
 ```
 
+### After upgrading Apple Containers
+
+The CLI and its persistent background services must run the same version. Homebrew or package upgrades can replace the CLI while leaving an older `container-apiserver` running. That mismatch may surface as `builtin network is not present`, decoding errors, or missing default-network state.
+
+After every Apple Containers upgrade, restart its services once:
+
+```bash
+container system stop
+container system start --enable-kernel-install
+container system version
+```
+
+The `container` and `container-apiserver` rows should report the same version. Startup also checks this and prints these recovery commands instead of continuing with mismatched components.
+
 ## Configure Manifest
 
 The script reads `docker/.env`, the same configuration file used by Docker Compose.
@@ -167,6 +181,19 @@ container volume delete mnfst-postgres-data
 Deleting the volume permanently deletes the bundled PostgreSQL database. Back up important data before removing it.
 
 ## Troubleshooting
+
+### `builtin network is not present`
+
+This usually means Apple Containers was upgraded while its older background services kept running. Compare component versions and restart the services:
+
+```bash
+container system version
+container system stop
+container system start --enable-kernel-install
+container network inspect default
+```
+
+If `container system stop` prints protocol or decoding errors, continue with `container system start --enable-kernel-install`; the stop command still unloads the old services after attempting to stop containers. The final inspect command should show the recreated builtin `default` network.
 
 ### View logs
 

--- a/deploy/apple-containers/TUTORIAL.md
+++ b/deploy/apple-containers/TUTORIAL.md
@@ -1,0 +1,227 @@
+# Run Manifest with Apple Containers
+
+This guide runs Manifest and PostgreSQL on Apple silicon using Apple's [`container`](https://github.com/apple/container) CLI. The deployment mirrors the bundled Docker Compose stack while accounting for differences in Apple Containers networking and storage.
+
+## Prerequisites
+
+- An Apple silicon Mac running a supported macOS version.
+- The Apple Containers `container` CLI installed from the [Apple Containers releases](https://github.com/apple/container/releases).
+- This Manifest repository checked out locally.
+- `curl` and OpenSSL, which are included with macOS.
+
+Confirm the CLI is available:
+
+```bash
+container --version
+```
+
+## Configure Manifest
+
+The script reads `docker/.env`, the same configuration file used by Docker Compose.
+
+Create it from the example if it does not exist:
+
+```bash
+cp docker/.env.example docker/.env
+```
+
+Generate a Better Auth secret and add it to `docker/.env`:
+
+```bash
+openssl rand -hex 32
+```
+
+```env
+BETTER_AUTH_SECRET=<paste-the-generated-value>
+```
+
+For stronger separation between session signing and encrypted provider credentials, generate another value and set:
+
+```env
+MANIFEST_ENCRYPTION_KEY=<a-different-generated-value>
+```
+
+The default dashboard URL is `http://localhost:2099`. To use another port, set `PORT` and keep `BETTER_AUTH_URL` aligned:
+
+```env
+PORT=3001
+BETTER_AUTH_URL=http://localhost:3001
+```
+
+You can use a different configuration file by exporting `MANIFEST_ENV_FILE`:
+
+```bash
+MANIFEST_ENV_FILE=/path/to/manifest.env ./deploy/apple-containers/start.sh up
+```
+
+Explicitly exported environment variables take precedence over values in the file.
+
+### Custom PostgreSQL password
+
+The default bundled database password is `manifest`. To change it, set both variables as described in `docker/.env.example`:
+
+```env
+POSTGRES_PASSWORD=change-me
+DATABASE_URL=postgresql://manifest:change-me@postgres:5432/manifest
+```
+
+The script replaces the Compose hostname `postgres` with the PostgreSQL container's current IP. Percent-encode URL-special characters in the `DATABASE_URL` password.
+
+`POSTGRES_PASSWORD` initializes a new database volume; changing it later does not rotate the password stored by PostgreSQL. If the persistent volume already exists, either keep its original password or rotate the `manifest` PostgreSQL role explicitly.
+
+## Start Manifest
+
+From the repository root, run:
+
+```bash
+./deploy/apple-containers/start.sh up
+```
+
+`up` is also the default command:
+
+```bash
+./deploy/apple-containers/start.sh
+```
+
+The script:
+
+1. Starts the Apple Containers service.
+2. Creates or reuses the `mnfst-postgres-data` named volume.
+3. Starts PostgreSQL and verifies an authenticated connection.
+4. Discovers the PostgreSQL container address.
+5. Recreates the Manifest container so it always receives the current database address.
+6. Publishes the dashboard on host loopback and waits for `/api/v1/health`.
+
+When startup succeeds, open:
+
+```text
+http://localhost:2099
+```
+
+On first boot, complete the setup wizard at `/setup` to create the admin account.
+
+## Manage the Stack
+
+Show container state and the dashboard URL:
+
+```bash
+./deploy/apple-containers/start.sh status
+```
+
+Stop and remove both containers:
+
+```bash
+./deploy/apple-containers/start.sh down
+```
+
+The PostgreSQL named volume is retained, so a later `up` restores the same database.
+
+Running `up` repeatedly is safe. A running PostgreSQL container is reused, while Manifest is recreated to pick up the current PostgreSQL IP and configuration.
+
+## Local LLM Servers
+
+Apple Containers does not provide Docker's `host.docker.internal` hostname. By default, the script uses the container network gateway for Ollama:
+
+```text
+http://<gateway-ip>:11434
+```
+
+A host LLM server must listen on an interface reachable through that gateway. A service bound only to `127.0.0.1` cannot be reached from the container.
+
+For Ollama, configure `OLLAMA_HOST` on the macOS host according to Ollama's documentation. Avoid exposing the service broadly unless your firewall and network are trusted. You can also point Manifest at another reachable endpoint through `docker/.env`:
+
+```env
+OLLAMA_HOST=http://192.168.1.50:11434
+```
+
+## Networking and VPNs
+
+The dashboard is published to `127.0.0.1`, providing a stable URL that does not depend on Apple Containers' private subnet and is less likely to conflict with VPN routes.
+
+PostgreSQL-to-Manifest traffic still uses the private address assigned by Apple Containers. The script discovers that address on every `up` and recreates Manifest accordingly. If Apple Containers cannot create or inspect its network while a VPN is active:
+
+1. Run `./deploy/apple-containers/start.sh down`.
+2. Temporarily disconnect the VPN.
+3. Run `./deploy/apple-containers/start.sh up`.
+4. Reconnect the VPN and verify `http://localhost:2099/api/v1/health`.
+
+The script prints the complete `container inspect` output if it cannot identify the required network addresses.
+
+## Persistence and Backups
+
+PostgreSQL data is stored in the Apple Containers named volume `mnfst-postgres-data`. Override the volume name before startup with:
+
+```bash
+MANIFEST_PG_VOLUME=my-manifest-data ./deploy/apple-containers/start.sh up
+```
+
+The script mounts the named volume at `/var/lib/postgresql/data` and uses `/var/lib/postgresql/data/pgdata` as `PGDATA`. The nested directory is required because a newly formatted Apple Containers volume may contain a root-level `lost+found` directory.
+
+`down` never deletes the named volume. Use Apple Containers volume commands to inspect or deliberately remove it:
+
+```bash
+container volume inspect mnfst-postgres-data
+container volume delete mnfst-postgres-data
+```
+
+Deleting the volume permanently deletes the bundled PostgreSQL database. Back up important data before removing it.
+
+## Troubleshooting
+
+### View logs
+
+```bash
+container logs mnfst-postgres
+container logs mnfst-manifest
+```
+
+### PostgreSQL stops during initialization
+
+If logs mention `lost+found`, confirm the script sets:
+
+```text
+PGDATA=/var/lib/postgresql/data/pgdata
+```
+
+If logs mention `chmod` or `chown` being denied, do not replace the named volume with a macOS bind mount. The official PostgreSQL image needs filesystem ownership changes that Apple Containers bind mounts do not provide.
+
+### PostgreSQL rejects the password
+
+The named volume was probably initialized with a different password. Restore the original `POSTGRES_PASSWORD`, or rotate the database role password inside PostgreSQL and update `DATABASE_URL` to match.
+
+### Manifest stops before becoming healthy
+
+The script prints the container logs automatically. You can inspect them again with:
+
+```bash
+container logs mnfst-manifest
+```
+
+Common causes include a mismatched database URL, a port already in use, or invalid environment values.
+
+### Port already in use
+
+Choose another port in `docker/.env`:
+
+```env
+PORT=2100
+BETTER_AUTH_URL=http://localhost:2100
+```
+
+Then rerun `up`.
+
+### Reset the deployment
+
+Stop the containers first:
+
+```bash
+./deploy/apple-containers/start.sh down
+```
+
+To also discard all database state, deliberately delete the named volume:
+
+```bash
+container volume delete mnfst-postgres-data
+```
+
+Then run `up` again. This is destructive and returns Manifest to a fresh-install state.

--- a/deploy/apple-containers/start.sh
+++ b/deploy/apple-containers/start.sh
@@ -107,6 +107,19 @@ fi
 validate_positive_integer PROVIDER_TIMEOUT_MS "$PROVIDER_TIMEOUT_MS"
 validate_positive_integer STREAM_WARMUP_MS "$STREAM_WARMUP_MS"
 
+component_version() {
+  local component="$1"
+  if [[ "$component" == "container" ]]; then
+    container system version 2>/dev/null \
+      | sed -n 's/^container[[:space:]]*\([^[:space:]]*\).*/\1/p' \
+      | head -n1
+  else
+    container system version 2>/dev/null \
+      | sed -n 's/^container-apiserver.* version \([^[:space:]]*\).*/\1/p' \
+      | head -n1
+  fi
+}
+
 require_cli() {
   if ! command -v container >/dev/null 2>&1; then
     echo "error: Apple 'container' CLI not found." >&2
@@ -114,12 +127,31 @@ require_cli() {
     exit 1
   fi
   # Idempotent: starts the API server / VM services if not already running.
-  if ! container system start >/dev/null 2>&1; then
+  if ! container system start --enable-kernel-install >/dev/null 2>&1; then
     # A healthy, already-running service may make `system start` non-zero.
     container list >/dev/null 2>&1 || {
       echo "error: Apple Containers service could not be started." >&2
       exit 1
     }
+  fi
+
+  local cli_version server_version
+  cli_version="$(component_version container)"
+  server_version="$(component_version container-apiserver)"
+  if [[ -n "$cli_version" && -n "$server_version" && "$cli_version" != "$server_version" ]]; then
+    echo "error: Apple Containers CLI ($cli_version) and services ($server_version) do not match." >&2
+    echo "After upgrading Apple Containers, restart its services:" >&2
+    echo "  container system stop" >&2
+    echo "  container system start --enable-kernel-install" >&2
+    exit 1
+  fi
+
+  if ! container network inspect default >/dev/null 2>&1; then
+    echo "error: Apple Containers builtin network is not present." >&2
+    echo "Restart the services to recreate it:" >&2
+    echo "  container system stop" >&2
+    echo "  container system start --enable-kernel-install" >&2
+    exit 1
   fi
 }
 
@@ -143,7 +175,10 @@ gateway_ip() {
 }
 
 is_running() {
-  container inspect "$1" 2>/dev/null | grep -q '"status"[[:space:]]*:[[:space:]]*"running"'
+  # 1.x nests lifecycle state under status.state; older releases exposed a
+  # top-level status string.
+  container inspect "$1" 2>/dev/null \
+    | grep -Eq '"(state|status)"[[:space:]]*:[[:space:]]*"running"'
 }
 
 cmd_up() {

--- a/deploy/apple-containers/start.sh
+++ b/deploy/apple-containers/start.sh
@@ -17,9 +17,9 @@
 #   - healthchecks / depends_on: replaced by explicit readiness polls
 #
 # Usage:
-#   ./scripts/start-apple-containers.sh up      # start the stack (default)
-#   ./scripts/start-apple-containers.sh down    # stop and remove containers (data kept)
-#   ./scripts/start-apple-containers.sh status  # show container state and URLs
+#   ./deploy/apple-containers/start.sh up      # start the stack (default)
+#   ./deploy/apple-containers/start.sh down    # stop and remove containers (data kept)
+#   ./deploy/apple-containers/start.sh status  # show container state and URLs
 #
 # Configuration comes from docker/.env (the same file as Docker Compose).
 # Override its path with MANIFEST_ENV_FILE. BETTER_AUTH_SECRET is required:
@@ -37,7 +37,7 @@ elif [[ -f "$SCRIPT_DIR/.env" ]]; then
   # Backward compatibility with early versions of this script.
   ENV_FILE="$SCRIPT_DIR/.env"
 else
-  ENV_FILE="$SCRIPT_DIR/../docker/.env"
+  ENV_FILE="$SCRIPT_DIR/../../docker/.env"
 fi
 load_env_file() {
   local line key value

--- a/scripts/start-apple-containers.sh
+++ b/scripts/start-apple-containers.sh
@@ -39,18 +39,53 @@ elif [[ -f "$SCRIPT_DIR/.env" ]]; then
 else
   ENV_FILE="$SCRIPT_DIR/../docker/.env"
 fi
+load_env_file() {
+  local line key value
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
+    if [[ ! "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      echo "error: invalid entry in $ENV_FILE: $line" >&2
+      exit 1
+    fi
+    key="${BASH_REMATCH[1]}"
+    value="${BASH_REMATCH[2]}"
+    if [[ "$value" =~ ^\"(.*)\"$ || "$value" =~ ^\'(.*)\'$ ]]; then
+      value="${BASH_REMATCH[1]}"
+    fi
+    printf -v "$key" '%s' "$value"
+    export "$key"
+  done < "$ENV_FILE"
+}
+
 if [[ -f "$ENV_FILE" ]]; then
-  set -a
-  # The bundled .env template contains shell-compatible KEY=VALUE entries.
-  # shellcheck source=/dev/null
-  source "$ENV_FILE"
-  set +a
+  # Parse dotenv assignments as data; never execute the configuration file.
+  load_env_file
 fi
 
 PORT="${PORT:-2099}"
 POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-manifest}"
 PG_VOLUME="${MANIFEST_PG_VOLUME:-mnfst-postgres-data}"
 POSTGRES_IMAGE="postgres:16-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416"
+
+if [[ "$POSTGRES_PASSWORD" != "manifest" && -z "${DATABASE_URL:-}" ]]; then
+  echo "error: DATABASE_URL must be set when POSTGRES_PASSWORD is customized." >&2
+  echo "Percent-encode special characters in its password; see docker/.env.example." >&2
+  exit 1
+fi
+
+validate_positive_integer() {
+  local name="$1" value="$2"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "error: $name must be a positive integer, got '$value'." >&2
+    exit 1
+  fi
+}
+
+PROVIDER_TIMEOUT_MS="${PROVIDER_TIMEOUT_MS:-180000}"
+STREAM_WARMUP_MS="${STREAM_WARMUP_MS:-15000}"
+validate_positive_integer PROVIDER_TIMEOUT_MS "$PROVIDER_TIMEOUT_MS"
+validate_positive_integer STREAM_WARMUP_MS "$STREAM_WARMUP_MS"
 
 require_cli() {
   if ! command -v container >/dev/null 2>&1; then
@@ -159,16 +194,9 @@ cmd_up() {
 
   # The compose file uses the service name `postgres` as the DB host; Apple
   # Containers has no inter-container DNS by default, so use the IP. Translate
-  # the bundled compose URL when present; custom URLs are left untouched. When
-  # DATABASE_URL is omitted, require a URL-safe password rather than silently
-  # producing a malformed connection string.
+  # the bundled compose URL when present; custom URLs are left untouched.
   local database_url
-  if [[ -z "${DATABASE_URL:-}" && "$POSTGRES_PASSWORD" =~ [^A-Za-z0-9._~-] ]]; then
-    echo "error: DATABASE_URL must be set when POSTGRES_PASSWORD contains URL-special characters." >&2
-    echo "Percent-encode its password; see docker/.env.example." >&2
-    exit 1
-  fi
-  database_url="${DATABASE_URL:-postgresql://manifest:${POSTGRES_PASSWORD}@${pg_ip}:5432/manifest}"
+  database_url="${DATABASE_URL:-postgresql://manifest:manifest@${pg_ip}:5432/manifest}"
   database_url="${database_url/@postgres:5432/@${pg_ip}:5432}"
 
   # The gateway reaches host services bound beyond loopback. Ollama and LM
@@ -178,10 +206,9 @@ cmd_up() {
 
   if is_running "$APP_CONTAINER"; then
     echo "manifest already running, recreating to pick up postgres address..."
-    container delete --force "$APP_CONTAINER" >/dev/null 2>&1 || true
-  else
-    container delete "$APP_CONTAINER" >/dev/null 2>&1 || true
+    container stop --time 15 "$APP_CONTAINER" >/dev/null
   fi
+  container delete "$APP_CONTAINER" >/dev/null 2>&1 || true
 
   echo "starting manifest..."
   container run --detach --name "$APP_CONTAINER" \
@@ -194,8 +221,8 @@ cmd_up() {
     --env MANIFEST_ENCRYPTION_KEY="${MANIFEST_ENCRYPTION_KEY:-}" \
     --env BETTER_AUTH_URL="${BETTER_AUTH_URL:-http://localhost:${PORT}}" \
     --env OLLAMA_HOST="$ollama_host" \
-    --env PROVIDER_TIMEOUT_MS="${PROVIDER_TIMEOUT_MS:-180000}" \
-    --env STREAM_WARMUP_MS="${STREAM_WARMUP_MS:-15000}" \
+    --env PROVIDER_TIMEOUT_MS="$PROVIDER_TIMEOUT_MS" \
+    --env STREAM_WARMUP_MS="$STREAM_WARMUP_MS" \
     --env SEED_DATA=false \
     --env NODE_ENV=production \
     --env MANIFEST_MODE="${MANIFEST_MODE:-selfhosted}" \

--- a/scripts/start-apple-containers.sh
+++ b/scripts/start-apple-containers.sh
@@ -50,11 +50,26 @@ load_env_file() {
     fi
     key="${BASH_REMATCH[1]}"
     value="${BASH_REMATCH[2]}"
-    if [[ "$value" =~ ^\"(.*)\"$ || "$value" =~ ^\'(.*)\'$ ]]; then
+
+    # Match Docker Compose dotenv semantics for the forms used by the bundled
+    # config: comments are literal inside quotes, and start after whitespace in
+    # unquoted values. A caller-exported value takes precedence over .env.
+    if [[ "$value" =~ ^[[:space:]]*\"(.*)\"[[:space:]]*(#.*)?$ ]]; then
       value="${BASH_REMATCH[1]}"
+    elif [[ "$value" =~ ^[[:space:]]*\'(.*)\'[[:space:]]*(#.*)?$ ]]; then
+      value="${BASH_REMATCH[1]}"
+    else
+      if [[ "$value" =~ ^(.*)[[:space:]]+#.*$ ]]; then
+        value="${BASH_REMATCH[1]}"
+      fi
+      value="${value#"${value%%[![:space:]]*}"}"
+      value="${value%"${value##*[![:space:]]}"}"
     fi
-    printf -v "$key" '%s' "$value"
-    export "$key"
+
+    if ! printenv "$key" >/dev/null 2>&1; then
+      printf -v "$key" '%s' "$value"
+      export "$key"
+    fi
   done < "$ENV_FILE"
 }
 
@@ -84,6 +99,11 @@ validate_positive_integer() {
 
 PROVIDER_TIMEOUT_MS="${PROVIDER_TIMEOUT_MS:-180000}"
 STREAM_WARMUP_MS="${STREAM_WARMUP_MS:-15000}"
+validate_positive_integer PORT "$PORT"
+if ((PORT > 65535)); then
+  echo "error: PORT must be at most 65535, got '$PORT'." >&2
+  exit 1
+fi
 validate_positive_integer PROVIDER_TIMEOUT_MS "$PROVIDER_TIMEOUT_MS"
 validate_positive_integer STREAM_WARMUP_MS "$STREAM_WARMUP_MS"
 

--- a/scripts/start-apple-containers.sh
+++ b/scripts/start-apple-containers.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Run the Manifest docker-compose stack with Apple Containers (`container` CLI).
+#
+# Mirrors docker/docker-compose.yml as closely as Apple Containers allows:
+#   - postgres:16-alpine with a persistent data directory
+#   - manifest app wired to postgres, with health-wait before starting
+#   - host LLM access (Ollama / LM Studio) via the container gateway IP
+#     (Apple Containers has no host.docker.internal)
+#   - dashboard published on host loopback for a stable, VPN-safe URL
+#
+# Not replicated:
+#   - cap_drop / no-new-privileges: each Apple container runs in its own
+#     lightweight VM, so isolation is stronger by default
+#   - log rotation options and pids_limit: unsupported by the `container` CLI
+#   - split frontend/internal networks: Apple Containers has no service-name
+#     DNS, so the app connects to PostgreSQL's discovered private IP
+#   - healthchecks / depends_on: replaced by explicit readiness polls
+#
+# Usage:
+#   ./scripts/start-apple-containers.sh up      # start the stack (default)
+#   ./scripts/start-apple-containers.sh down    # stop and remove containers (data kept)
+#   ./scripts/start-apple-containers.sh status  # show container state and URLs
+#
+# Configuration comes from docker/.env (the same file as Docker Compose).
+# Override its path with MANIFEST_ENV_FILE. BETTER_AUTH_SECRET is required:
+#   openssl rand -hex 32
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PG_CONTAINER="mnfst-postgres"
+APP_CONTAINER="mnfst-manifest"
+
+if [[ -n "${MANIFEST_ENV_FILE:-}" ]]; then
+  ENV_FILE="$MANIFEST_ENV_FILE"
+elif [[ -f "$SCRIPT_DIR/.env" ]]; then
+  # Backward compatibility with early versions of this script.
+  ENV_FILE="$SCRIPT_DIR/.env"
+else
+  ENV_FILE="$SCRIPT_DIR/../docker/.env"
+fi
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # The bundled .env template contains shell-compatible KEY=VALUE entries.
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +a
+fi
+
+PORT="${PORT:-2099}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-manifest}"
+PG_VOLUME="${MANIFEST_PG_VOLUME:-mnfst-postgres-data}"
+POSTGRES_IMAGE="postgres:16-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416"
+
+require_cli() {
+  if ! command -v container >/dev/null 2>&1; then
+    echo "error: Apple 'container' CLI not found." >&2
+    echo "Install it from https://github.com/apple/container/releases (macOS 15+, Apple silicon)." >&2
+    exit 1
+  fi
+  # Idempotent: starts the API server / VM services if not already running.
+  if ! container system start >/dev/null 2>&1; then
+    # A healthy, already-running service may make `system start` non-zero.
+    container list >/dev/null 2>&1 || {
+      echo "error: Apple Containers service could not be started." >&2
+      exit 1
+    }
+  fi
+}
+
+container_ip() {
+  # The CLI JSON-escapes the CIDR slash as `\/`, so stop parsing after the
+  # numeric address rather than matching the slash. Older releases used
+  # `address` instead of `ipv4Address`.
+  container inspect "$1" 2>/dev/null \
+    | sed -n \
+      -e 's/.*"ipv4Address"[[:space:]]*:[[:space:]]*"\([0-9.]*\).*/\1/p' \
+      -e 's/.*"address"[[:space:]]*:[[:space:]]*"\([0-9.]*\).*/\1/p' \
+    | head -n1
+}
+
+gateway_ip() {
+  container inspect "$1" 2>/dev/null \
+    | sed -n \
+      -e 's/.*"ipv4Gateway"[[:space:]]*:[[:space:]]*"\([0-9.]*\).*/\1/p' \
+      -e 's/.*"gateway"[[:space:]]*:[[:space:]]*"\([0-9.]*\).*/\1/p' \
+    | head -n1
+}
+
+is_running() {
+  container inspect "$1" 2>/dev/null | grep -q '"status"[[:space:]]*:[[:space:]]*"running"'
+}
+
+cmd_up() {
+  require_cli
+
+  if [[ -z "${BETTER_AUTH_SECRET:-}" ]]; then
+    echo "error: BETTER_AUTH_SECRET must be set (in $ENV_FILE or the environment)." >&2
+    echo "Generate one with: openssl rand -hex 32" >&2
+    exit 1
+  fi
+
+  # A host bind mount cannot be chown/chmod'ed by PostgreSQL under Apple
+  # Containers, so the image exits before starting. A named volume is managed
+  # inside the container VM and supports the ownership changes the image needs.
+  if ! container volume inspect "$PG_VOLUME" >/dev/null 2>&1; then
+    container volume create "$PG_VOLUME" >/dev/null
+  fi
+
+  if is_running "$PG_CONTAINER"; then
+    echo "postgres already running."
+  else
+    container delete "$PG_CONTAINER" >/dev/null 2>&1 || true
+    echo "starting postgres..."
+    container run --detach --name "$PG_CONTAINER" \
+      --env POSTGRES_USER=manifest \
+      --env POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+      --env POSTGRES_DB=manifest \
+      --env PGDATA=/var/lib/postgresql/data/pgdata \
+      --volume "$PG_VOLUME:/var/lib/postgresql/data" \
+      "$POSTGRES_IMAGE"
+  fi
+
+  echo "waiting for postgres to accept connections..."
+  local attempt=0
+  until container exec "$PG_CONTAINER" pg_isready -U manifest -d manifest >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if ! is_running "$PG_CONTAINER"; then
+      echo "error: postgres stopped before becoming ready." >&2
+      echo "Container logs:" >&2
+      container logs "$PG_CONTAINER" >&2 || true
+      exit 1
+    fi
+    if [[ $attempt -ge 30 ]]; then
+      echo "error: postgres did not become ready within 60s." >&2
+      echo "Container logs:" >&2
+      container logs "$PG_CONTAINER" >&2 || true
+      exit 1
+    fi
+    sleep 2
+  done
+  if ! container exec --env PGPASSWORD="$POSTGRES_PASSWORD" "$PG_CONTAINER" \
+    psql -h 127.0.0.1 -U manifest -d manifest -c 'SELECT 1' >/dev/null 2>&1; then
+    echo "error: postgres rejected POSTGRES_PASSWORD." >&2
+    echo "POSTGRES_PASSWORD only initializes a new volume; changing it later does not rotate the database password." >&2
+    echo "Restore the original password or explicitly rotate the manifest role in PostgreSQL." >&2
+    exit 1
+  fi
+  echo "postgres is ready."
+
+  local pg_ip gateway
+  pg_ip="$(container_ip "$PG_CONTAINER")"
+  gateway="$(gateway_ip "$PG_CONTAINER")"
+  if [[ -z "$pg_ip" || -z "$gateway" ]]; then
+    echo "error: could not determine postgres network addresses." >&2
+    container inspect "$PG_CONTAINER" >&2 || true
+    exit 1
+  fi
+
+  # The compose file uses the service name `postgres` as the DB host; Apple
+  # Containers has no inter-container DNS by default, so use the IP. Translate
+  # the bundled compose URL when present; custom URLs are left untouched. When
+  # DATABASE_URL is omitted, require a URL-safe password rather than silently
+  # producing a malformed connection string.
+  local database_url
+  if [[ -z "${DATABASE_URL:-}" && "$POSTGRES_PASSWORD" =~ [^A-Za-z0-9._~-] ]]; then
+    echo "error: DATABASE_URL must be set when POSTGRES_PASSWORD contains URL-special characters." >&2
+    echo "Percent-encode its password; see docker/.env.example." >&2
+    exit 1
+  fi
+  database_url="${DATABASE_URL:-postgresql://manifest:${POSTGRES_PASSWORD}@${pg_ip}:5432/manifest}"
+  database_url="${database_url/@postgres:5432/@${pg_ip}:5432}"
+
+  # The gateway reaches host services bound beyond loopback. Ollama and LM
+  # Studio may need to be configured to listen on the host gateway interface.
+  local ollama_host
+  ollama_host="${OLLAMA_HOST:-http://${gateway}:11434}"
+
+  if is_running "$APP_CONTAINER"; then
+    echo "manifest already running, recreating to pick up postgres address..."
+    container delete --force "$APP_CONTAINER" >/dev/null 2>&1 || true
+  else
+    container delete "$APP_CONTAINER" >/dev/null 2>&1 || true
+  fi
+
+  echo "starting manifest..."
+  container run --detach --name "$APP_CONTAINER" \
+    --memory 1g \
+    --publish "127.0.0.1:${PORT}:${PORT}" \
+    --env PORT="$PORT" \
+    --env BIND_ADDRESS=0.0.0.0 \
+    --env DATABASE_URL="$database_url" \
+    --env BETTER_AUTH_SECRET="$BETTER_AUTH_SECRET" \
+    --env MANIFEST_ENCRYPTION_KEY="${MANIFEST_ENCRYPTION_KEY:-}" \
+    --env BETTER_AUTH_URL="${BETTER_AUTH_URL:-http://localhost:${PORT}}" \
+    --env OLLAMA_HOST="$ollama_host" \
+    --env PROVIDER_TIMEOUT_MS="${PROVIDER_TIMEOUT_MS:-180000}" \
+    --env STREAM_WARMUP_MS="${STREAM_WARMUP_MS:-15000}" \
+    --env SEED_DATA=false \
+    --env NODE_ENV=production \
+    --env MANIFEST_MODE="${MANIFEST_MODE:-selfhosted}" \
+    --env EMAIL_PROVIDER="${EMAIL_PROVIDER:-}" \
+    --env EMAIL_API_KEY="${EMAIL_API_KEY:-}" \
+    --env EMAIL_DOMAIN="${EMAIL_DOMAIN:-}" \
+    --env EMAIL_FROM="${EMAIL_FROM:-}" \
+    --env GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID:-}" \
+    --env GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET:-}" \
+    --env GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-}" \
+    --env GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-}" \
+    --env DISCORD_CLIENT_ID="${DISCORD_CLIENT_ID:-}" \
+    --env DISCORD_CLIENT_SECRET="${DISCORD_CLIENT_SECRET:-}" \
+    --env MANIFEST_TELEMETRY_DISABLED="${MANIFEST_TELEMETRY_DISABLED:-0}" \
+    manifestdotbuild/manifest:latest
+
+  echo "waiting for manifest to become healthy..."
+  attempt=0
+  # Mirrors the compose healthcheck: 90s start grace + retries.
+  until curl -fsS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if ! is_running "$APP_CONTAINER"; then
+      echo "error: manifest stopped before becoming healthy." >&2
+      echo "Container logs:" >&2
+      container logs "$APP_CONTAINER" >&2 || true
+      exit 1
+    fi
+    if [[ $attempt -ge 40 ]]; then
+      echo "error: manifest did not become healthy within 120s." >&2
+      echo "Container logs:" >&2
+      container logs "$APP_CONTAINER" >&2 || true
+      exit 1
+    fi
+    sleep 3
+  done
+
+  echo ""
+  echo "Manifest is up: http://localhost:${PORT}"
+  echo "First boot: visit the URL above and complete the setup wizard at /setup."
+}
+
+cmd_down() {
+  require_cli
+  echo "stopping containers (postgres data in volume $PG_VOLUME is kept)..."
+  container stop --time 15 "$APP_CONTAINER" >/dev/null 2>&1 || true
+  container stop --time 15 "$PG_CONTAINER" >/dev/null 2>&1 || true
+  container delete "$APP_CONTAINER" >/dev/null 2>&1 || true
+  container delete "$PG_CONTAINER" >/dev/null 2>&1 || true
+  echo "done."
+}
+
+cmd_status() {
+  require_cli
+  for name in "$PG_CONTAINER" "$APP_CONTAINER"; do
+    if is_running "$name"; then
+      echo "$name: running at $(container_ip "$name")"
+    else
+      echo "$name: not running"
+    fi
+  done
+  if is_running "$APP_CONTAINER"; then
+    echo "app URL: http://localhost:${PORT}"
+  fi
+}
+
+case "${1:-up}" in
+  up) cmd_up ;;
+  down) cmd_down ;;
+  status) cmd_status ;;
+  *)
+    echo "usage: $0 [up|down|status]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- add an Apple Containers deployment under `deploy/apple-containers/`
- run Manifest and PostgreSQL with persistent named storage and fail-closed readiness checks
- publish Manifest on host loopback for a stable, VPN-safe URL
- add a full setup, networking, persistence, local-LLM, and troubleshooting tutorial
- reuse Docker Compose environment configuration and image pinning where applicable

## Testing

- exercised PostgreSQL startup and authenticated readiness against Apple Containers
- confirmed live container IPv4 and gateway parsing
- confirmed localhost port publishing and the Manifest health endpoint
- confirmed repeated `up` and `status` after moving the script
- tested Compose-style dotenv comments, environment precedence, malformed timeout rejection, and non-execution of shell substitutions

## Notes

- Apple Containers does not provide service-name DNS on the default network, so the script discovers PostgreSQL’s private IP and recreates Manifest on each `up`
- host LLM servers must listen on an interface reachable through the Apple Containers gateway
- unrelated generated `bun.lock` was intentionally excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
