### PR TITLE
feat: warn on reset-password page when no email provider is configured

### DIFF
--- a/.changeset/reset-password-email-notice.md
+++ b/.changeset/reset-password-email-notice.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+The password reset page now detects when no email provider is configured and shows a clear notice (pointing to the authenticated Change Password flow) instead of silently pretending a reset link was sent. Self-hosted installs without an `EMAIL_PROVIDER` no longer dead-end here.

--- a/packages/backend/src/notifications/services/email-providers/send-email.spec.ts
+++ b/packages/backend/src/notifications/services/email-providers/send-email.spec.ts
@@ -2,8 +2,45 @@ jest.mock('./resolve-provider', () => ({
   createProvider: jest.fn(),
 }));
 
-import { sendEmail } from './send-email';
+import { sendEmail, isEmailConfigured } from './send-email';
 import { createProvider } from './resolve-provider';
+
+describe('isEmailConfigured', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env['EMAIL_PROVIDER'];
+    delete process.env['EMAIL_API_KEY'];
+    delete process.env['EMAIL_DOMAIN'];
+    delete process.env['MAILGUN_API_KEY'];
+    delete process.env['MAILGUN_DOMAIN'];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns false when no provider is configured', () => {
+    expect(isEmailConfigured()).toBe(false);
+  });
+
+  it('returns true for the unified EMAIL_* scheme', () => {
+    process.env['EMAIL_PROVIDER'] = 'resend';
+    process.env['EMAIL_API_KEY'] = 're_key';
+    expect(isEmailConfigured()).toBe(true);
+  });
+
+  it('returns false for mailgun without a domain', () => {
+    process.env['EMAIL_PROVIDER'] = 'mailgun';
+    process.env['EMAIL_API_KEY'] = 'key';
+    expect(isEmailConfigured()).toBe(false);
+  });
+
+  it('honors an explicit env override argument', () => {
+    expect(isEmailConfigured({ emailProvider: 'resend', emailApiKey: 're_key' })).toBe(true);
+  });
+});
 
 describe('sendEmail', () => {
   const originalEnv = process.env;

--- a/packages/backend/src/notifications/services/email-providers/send-email.ts
+++ b/packages/backend/src/notifications/services/email-providers/send-email.ts
@@ -63,6 +63,17 @@ function resolveConfig(env?: SendEmailEnvConfig): EmailProviderConfig | null {
   return null;
 }
 
+/**
+ * True when a transactional email provider is fully configured, i.e. a call to
+ * `sendEmail` would actually dispatch rather than no-op. This is the single
+ * source of truth for "can we send email?" — the setup status endpoint reads it
+ * so the password-reset UI can warn instead of silently pretending a reset link
+ * was sent on installs with no provider wired in.
+ */
+export function isEmailConfigured(env?: SendEmailEnvConfig): boolean {
+  return resolveConfig(env) !== null;
+}
+
 export async function sendEmail(
   opts: SendEmailOptions,
   env?: SendEmailEnvConfig,

--- a/packages/backend/src/setup/setup.controller.spec.ts
+++ b/packages/backend/src/setup/setup.controller.spec.ts
@@ -14,6 +14,7 @@ describe('SetupController', () => {
   let mockIsSelfHosted: jest.Mock;
   let mockIsOllamaAvailable: jest.Mock;
   let mockGetLocalLlmHost: jest.Mock;
+  let mockIsEmailConfigured: jest.Mock;
 
   beforeEach(async () => {
     mockNeedsSetup = jest.fn();
@@ -22,6 +23,7 @@ describe('SetupController', () => {
     mockIsSelfHosted = jest.fn().mockReturnValue(false);
     mockIsOllamaAvailable = jest.fn().mockResolvedValue(false);
     mockGetLocalLlmHost = jest.fn().mockReturnValue('localhost');
+    mockIsEmailConfigured = jest.fn().mockReturnValue(true);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SetupController],
@@ -35,6 +37,7 @@ describe('SetupController', () => {
             isSelfHosted: mockIsSelfHosted,
             isOllamaAvailable: mockIsOllamaAvailable,
             getLocalLlmHost: mockGetLocalLlmHost,
+            isEmailConfigured: mockIsEmailConfigured,
           },
         },
       ],
@@ -53,6 +56,7 @@ describe('SetupController', () => {
         isSelfHosted: false,
         ollamaAvailable: false,
         localLlmHost: 'localhost',
+        emailConfigured: true,
       });
     });
 
@@ -65,6 +69,7 @@ describe('SetupController', () => {
         isSelfHosted: false,
         ollamaAvailable: false,
         localLlmHost: 'localhost',
+        emailConfigured: true,
       });
     });
 
@@ -78,6 +83,7 @@ describe('SetupController', () => {
         isSelfHosted: false,
         ollamaAvailable: false,
         localLlmHost: 'localhost',
+        emailConfigured: true,
       });
     });
 
@@ -92,6 +98,7 @@ describe('SetupController', () => {
         isSelfHosted: true,
         ollamaAvailable: false,
         localLlmHost: 'localhost',
+        emailConfigured: true,
       });
     });
 
@@ -106,6 +113,7 @@ describe('SetupController', () => {
         isSelfHosted: true,
         ollamaAvailable: true,
         localLlmHost: 'localhost',
+        emailConfigured: true,
       });
     });
 
@@ -115,6 +123,13 @@ describe('SetupController', () => {
       mockGetLocalLlmHost.mockReturnValue('host.docker.internal');
       const result = await controller.getStatus();
       expect(result.localLlmHost).toBe('host.docker.internal');
+    });
+
+    it('reports emailConfigured=false when no email provider is set', async () => {
+      mockNeedsSetup.mockResolvedValue(false);
+      mockIsEmailConfigured.mockReturnValue(false);
+      const result = await controller.getStatus();
+      expect(result.emailConfigured).toBe(false);
     });
 
     it('skips Ollama check in cloud mode (always false)', async () => {

--- a/packages/backend/src/setup/setup.controller.ts
+++ b/packages/backend/src/setup/setup.controller.ts
@@ -15,6 +15,7 @@ export class SetupController {
     isSelfHosted: boolean;
     ollamaAvailable: boolean;
     localLlmHost: string;
+    emailConfigured: boolean;
   }> {
     const selfHosted = this.setupService.isSelfHosted();
     const ollamaAvailable = selfHosted ? await this.setupService.isOllamaAvailable() : false;
@@ -24,6 +25,7 @@ export class SetupController {
       isSelfHosted: selfHosted,
       ollamaAvailable,
       localLlmHost: this.setupService.getLocalLlmHost(),
+      emailConfigured: this.setupService.isEmailConfigured(),
     };
   }
 

--- a/packages/backend/src/setup/setup.service.spec.ts
+++ b/packages/backend/src/setup/setup.service.spec.ts
@@ -222,6 +222,49 @@ describe('SetupService', () => {
     });
   });
 
+  describe('isEmailConfigured', () => {
+    const envKeys = [
+      'EMAIL_PROVIDER',
+      'EMAIL_API_KEY',
+      'EMAIL_DOMAIN',
+      'MAILGUN_API_KEY',
+      'MAILGUN_DOMAIN',
+    ];
+
+    let savedEnv: Record<string, string | undefined>;
+
+    beforeEach(() => {
+      savedEnv = {};
+      for (const k of envKeys) {
+        savedEnv[k] = process.env[k];
+        delete process.env[k];
+      }
+    });
+
+    afterEach(() => {
+      for (const k of envKeys) {
+        if (savedEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = savedEnv[k];
+      }
+    });
+
+    it('returns false when no email provider is configured', () => {
+      expect(service.isEmailConfigured()).toBe(false);
+    });
+
+    it('returns true when the unified EMAIL_* scheme is configured', () => {
+      process.env['EMAIL_PROVIDER'] = 'resend';
+      process.env['EMAIL_API_KEY'] = 're_key';
+      expect(service.isEmailConfigured()).toBe(true);
+    });
+
+    it('returns true when legacy Mailgun env vars are configured', () => {
+      process.env['MAILGUN_API_KEY'] = 'key';
+      process.env['MAILGUN_DOMAIN'] = 'mg.example.com';
+      expect(service.isEmailConfigured()).toBe(true);
+    });
+  });
+
   describe('needsSetup', () => {
     it('returns true when user table is empty', async () => {
       ds.query.mockResolvedValueOnce([{ count: '0' }]);

--- a/packages/backend/src/setup/setup.service.ts
+++ b/packages/backend/src/setup/setup.service.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 import { CreateAdminDto } from './dto/create-admin.dto';
 import { OLLAMA_HOST } from '../common/constants/ollama';
 import { getContainerHostAlias, isSelfHosted } from '../common/utils/detect-self-hosted';
+import { isEmailConfigured } from '../notifications/services/email-providers/send-email';
 
 /**
  * Postgres advisory lock key reserved for the first-run setup wizard.
@@ -48,6 +49,16 @@ export class SetupService {
     if (process.env['DISCORD_CLIENT_ID'] && process.env['DISCORD_CLIENT_SECRET'])
       providers.push('discord');
     return providers;
+  }
+
+  /**
+   * Returns true when a transactional email provider is configured, meaning the
+   * email-based password reset flow can actually deliver a link. The reset page
+   * reads this to warn (and point to Change Password) instead of silently
+   * pretending an email was sent on installs with no provider wired in.
+   */
+  isEmailConfigured(): boolean {
+    return isEmailConfigured();
   }
 
   /**

--- a/packages/backend/test/setup.e2e-spec.ts
+++ b/packages/backend/test/setup.e2e-spec.ts
@@ -41,6 +41,7 @@ describe('First-run setup wizard', () => {
       expect(res.body).toHaveProperty('isSelfHosted');
       expect(res.body).toHaveProperty('localLlmHost');
       expect(res.body).toHaveProperty('ollamaAvailable');
+      expect(res.body).toHaveProperty('emailConfigured');
     });
 
     it('returns needsSetup=false after a user has been inserted', async () => {

--- a/packages/frontend/src/pages/ResetPassword.tsx
+++ b/packages/frontend/src/pages/ResetPassword.tsx
@@ -1,15 +1,24 @@
 import { A, useSearchParams } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
-import { type Component, createSignal, createUniqueId, Show } from 'solid-js';
+import { type Component, createSignal, createUniqueId, onMount, Show } from 'solid-js';
 import { authClient } from '../services/auth-client.js';
+import { checkEmailConfigured } from '../services/setup-status.js';
 
 const RequestResetForm: Component = () => {
   const [email, setEmail] = createSignal('');
   const [sent, setSent] = createSignal(false);
   const [error, setError] = createSignal('');
   const [loading, setLoading] = createSignal(false);
+  // Assume email works until the status check says otherwise, so the form
+  // renders immediately and only flips to the notice on a confirmed no-provider
+  // install (typically self-hosted without EMAIL_PROVIDER set).
+  const [emailConfigured, setEmailConfigured] = createSignal(true);
   const emailId = createUniqueId();
   const errorId = createUniqueId();
+
+  onMount(() => {
+    void checkEmailConfigured().then(setEmailConfigured);
+  });
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -36,13 +45,28 @@ const RequestResetForm: Component = () => {
       <div class="auth-header">
         <h1 class="auth-header__title">Reset your password</h1>
         <p class="auth-header__subtitle">
-          {sent()
-            ? 'Check your email for a reset link'
-            : 'Enter your email to receive a reset link'}
+          {!emailConfigured()
+            ? "Email isn't set up on this server"
+            : sent()
+              ? 'Check your email for a reset link'
+              : 'Enter your email to receive a reset link'}
         </p>
       </div>
 
-      <Show when={!sent()}>
+      <Show when={!emailConfigured()}>
+        <div class="auth-form">
+          <div class="auth-form__notice" role="status">
+            Password reset by email isn't available on this install. Ask an admin to reset your
+            password, or sign in and update it from your{' '}
+            <A href="/account" class="auth-form__notice-link">
+              Account
+            </A>{' '}
+            page.
+          </div>
+        </div>
+      </Show>
+
+      <Show when={emailConfigured() && !sent()}>
         <form class="auth-form" onSubmit={handleSubmit}>
           {error() && (
             <div id={errorId} class="auth-form__error" role="alert">

--- a/packages/frontend/src/services/setup-status.ts
+++ b/packages/frontend/src/services/setup-status.ts
@@ -9,6 +9,7 @@ interface SetupStatusResponse {
   isSelfHosted?: boolean;
   ollamaAvailable?: boolean;
   localLlmHost?: string;
+  emailConfigured?: boolean;
 }
 
 interface SetupStatusResult {
@@ -17,6 +18,7 @@ interface SetupStatusResult {
   isSelfHosted: boolean;
   ollamaAvailable: boolean;
   localLlmHost: string;
+  emailConfigured: boolean;
 }
 
 let cachedPromise: Promise<SetupStatusResult> | null = null;
@@ -34,6 +36,7 @@ async function fetchSetupStatus(): Promise<SetupStatusResult> {
         isSelfHosted: false,
         ollamaAvailable: false,
         localLlmHost: 'localhost',
+        emailConfigured: true,
       };
     const data = (await res.json()) as SetupStatusResponse;
     return {
@@ -42,6 +45,9 @@ async function fetchSetupStatus(): Promise<SetupStatusResult> {
       isSelfHosted: data.isSelfHosted === true,
       ollamaAvailable: data.ollamaAvailable === true,
       localLlmHost: data.localLlmHost || 'localhost',
+      // Assume available unless the backend explicitly says otherwise, so a
+      // transient status glitch never hides the email reset form.
+      emailConfigured: data.emailConfigured !== false,
     };
   } catch {
     return {
@@ -50,6 +56,7 @@ async function fetchSetupStatus(): Promise<SetupStatusResult> {
       isSelfHosted: false,
       ollamaAvailable: false,
       localLlmHost: 'localhost',
+      emailConfigured: true,
     };
   }
 }
@@ -79,6 +86,10 @@ export async function checkIsOllamaAvailable(): Promise<boolean> {
 
 export async function checkLocalLlmHost(): Promise<string> {
   return (await getSetupStatus()).localLlmHost;
+}
+
+export async function checkEmailConfigured(): Promise<boolean> {
+  return (await getSetupStatus()).emailConfigured;
 }
 
 /** Invalidate the cached status. Call this after a successful setup. */

--- a/packages/frontend/src/styles/auth.css
+++ b/packages/frontend/src/styles/auth.css
@@ -173,6 +173,22 @@
   line-height: 1.5;
 }
 
+.auth-form__notice {
+  padding: var(--gap-sm) var(--gap-md);
+  background: hsl(var(--muted) / 0.5);
+  color: hsl(var(--muted-foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+}
+
+.auth-form__notice-link {
+  color: hsl(var(--primary));
+  font-weight: 600;
+  text-decoration: underline;
+}
+
 .auth-form__link-btn {
   background: none;
   border: none;
@@ -345,7 +361,9 @@
   cursor: pointer;
   text-align: left;
   font-family: var(--font-family);
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 
 .plan-picker__card:hover {
@@ -402,8 +420,8 @@
 .plan-picker__badge {
   padding: 3px 5px;
   border-radius: 2px;
-  background: #2632EF;
-  color: #FFFFFF;
+  background: #2632ef;
+  color: #ffffff;
   font-size: 9px;
   font-weight: 600;
   text-transform: uppercase;

--- a/packages/frontend/tests/pages/ResetPassword.test.tsx
+++ b/packages/frontend/tests/pages/ResetPassword.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from "@solidjs/testing-library";
 let mockSearchParamsValue: Record<string, string> = {};
 const mockRequestPasswordReset = vi.fn();
 const mockResetPassword = vi.fn();
+const mockCheckEmailConfigured = vi.fn().mockResolvedValue(true);
 
 vi.mock("@solidjs/router", () => ({
   A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
@@ -22,11 +23,16 @@ vi.mock("../../src/services/auth-client.js", () => ({
   },
 }));
 
+vi.mock("../../src/services/setup-status.js", () => ({
+  checkEmailConfigured: (...args: unknown[]) => mockCheckEmailConfigured(...args),
+}));
+
 import ResetPassword from "../../src/pages/ResetPassword";
 
 describe("ResetPassword - Request form (no token)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCheckEmailConfigured.mockResolvedValue(true);
     mockSearchParamsValue = {};
   });
 
@@ -102,9 +108,43 @@ describe("ResetPassword - Request form (no token)", () => {
   });
 });
 
+describe("ResetPassword - Request form (no email provider)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckEmailConfigured.mockResolvedValue(false);
+    mockSearchParamsValue = {};
+  });
+
+  it("shows the unavailable notice instead of the form", async () => {
+    const { container } = render(() => <ResetPassword />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain(
+        "Password reset by email isn't available on this install",
+      );
+    });
+    expect(container.querySelector("form")).toBeNull();
+    expect(container.querySelector('input[type="email"]')).toBeNull();
+  });
+
+  it("swaps the subtitle to explain email is not set up", async () => {
+    const { container } = render(() => <ResetPassword />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Email isn't set up on this server");
+    });
+  });
+
+  it("links to the Account page for a signed-in change-password path", async () => {
+    const { container } = render(() => <ResetPassword />);
+    await vi.waitFor(() => {
+      expect(container.querySelector('a[href="/account"]')).not.toBeNull();
+    });
+  });
+});
+
 describe("ResetPassword - Set new password form (with token)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCheckEmailConfigured.mockResolvedValue(true);
     mockSearchParamsValue = { token: "test-token-123" };
   });
 

--- a/packages/frontend/tests/services/setup-status.test.ts
+++ b/packages/frontend/tests/services/setup-status.test.ts
@@ -5,6 +5,7 @@ import {
   checkIsSelfHosted,
   checkIsOllamaAvailable,
   checkLocalLlmHost,
+  checkEmailConfigured,
   resetSetupStatus,
   createFirstAdmin,
 } from '../../src/services/setup-status';
@@ -252,6 +253,51 @@ describe('setup-status service', () => {
     it("defaults to 'localhost' when the backend returns a non-ok response", async () => {
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
       expect(await checkLocalLlmHost()).toBe('localhost');
+    });
+  });
+
+  describe('checkEmailConfigured', () => {
+    it('returns true when backend reports emailConfigured=true', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ needsSetup: false, emailConfigured: true }),
+        }),
+      );
+      expect(await checkEmailConfigured()).toBe(true);
+    });
+
+    it('returns false when backend reports emailConfigured=false', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ needsSetup: false, emailConfigured: false }),
+        }),
+      );
+      expect(await checkEmailConfigured()).toBe(false);
+    });
+
+    it('defaults to true when backend omits emailConfigured', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ needsSetup: false }),
+        }),
+      );
+      expect(await checkEmailConfigured()).toBe(true);
+    });
+
+    it('defaults to true on a non-ok response', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+      expect(await checkEmailConfigured()).toBe(true);
+    });
+
+    it('defaults to true on fetch failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+      expect(await checkEmailConfigured()).toBe(true);
     });
   });
 


### PR DESCRIPTION
## What

On the password reset request page, detect when the server has **no email provider configured** and show a clear notice pointing to the authenticated Change Password flow, instead of the misleading "check your email" success that fires even when nothing was sent.

## Why (context: #2516)

Issue #2516 reports the reset flow as "broken" on self-hosted. Most of that report is a wrong endpoint path (`/api/auth/forgot-password` doesn't exist; the real routes are `/api/auth/request-password-reset` and `/api/auth/forget-password`), and email reset already works once `EMAIL_PROVIDER` + `EMAIL_API_KEY` are set.

The one genuine gap: when **no** email provider is configured, `sendEmail()` silently no-ops (logs a warning, returns `false`), so `requestPasswordReset` succeeds with a generic 200 and the reset page tells the user to "check your email" — but no email was ever sent. Better Auth calls `sendResetPassword` through `runInBackgroundOrAwait`, which swallows any throw, so a backend-side error can't surface here. The clean fix is a frontend notice driven by server config.

This pairs with #2514 (authenticated Change Password on the Account page), which is the recovery path this notice points users to.

## Changes

- **Backend**
  - `send-email.ts`: new `isEmailConfigured()` — the single source of truth for "will a reset email actually send" (`resolveConfig() !== null`).
  - `setup.service.ts`: `isEmailConfigured()` delegates to it.
  - `setup.controller.ts`: public `/api/v1/setup/status` now returns `emailConfigured`.
- **Frontend**
  - `setup-status.ts`: `checkEmailConfigured()` helper; **defaults to `true`** so a transient status fetch never hides the form — only an explicit `false` flips to the notice.
  - `ResetPassword.tsx`: request form reads the flag on mount and renders the notice (linking to `/account`) when email isn't configured.
  - `auth.css`: neutral `.auth-form__notice` styling.

## Tests

- Backend: `isEmailConfigured` unit tests (service + send-email), controller `emailConfigured` assertions, e2e contract check. 
- Frontend: `checkEmailConfigured` service tests + reset-page notice/subtitle/account-link tests.
- Full frontend suite (203 files) green; changed files at 100% line coverage; typecheck + lint clean.

Closes #2516

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warn users on the Reset Password page when no email provider is configured, and point them to the Account page to change their password. Prevents the misleading “check your email” message on self-hosted installs without an email provider (addresses #2516).

- **New Features**
  - Backend: expose `emailConfigured` on `/api/v1/setup/status`, powered by a new `isEmailConfigured()` helper.
  - Frontend: `ResetPassword` calls `checkEmailConfigured()` on mount and shows a notice (with a link to `/account`) instead of the form when false.
  - UX: default to true when the backend omits the flag or on fetch errors, so transient issues don’t hide the form.

<sup>Written for commit a1320713795dd1ddbc2e1482127f25d90b1d688d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

