### PR TITLE
feat: add kimi-k3 to Kimi Coding Plan knownModels (moonshot)

### DIFF
--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -385,8 +385,8 @@ describe('getSubscriptionKnownModels', () => {
     expect(getSubscriptionKnownModels('qwen')).toBeNull();
   });
 
-  it('returns the fixed model id for moonshot Kimi Coding Plan', () => {
-    expect(getSubscriptionKnownModels('moonshot')).toEqual(['kimi-for-coding']);
+  it('returns the fixed model ids for moonshot Kimi Coding Plan', () => {
+    expect(getSubscriptionKnownModels('moonshot')).toEqual(['kimi-for-coding', 'kimi-k3']);
   });
 
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {
@@ -572,6 +572,7 @@ describe('getSubscriptionCapabilities', () => {
       supportsPromptCaching: true,
       supportsBatching: false,
     });
+    expect(caps?.modelContextWindows?.['kimi-k3']).toBe(1048576);
   });
 
   it('returns capabilities for Qwen Token Plan', () => {

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -154,10 +154,13 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionLabel: 'Kimi Coding Plan',
     subscriptionAuthMode: 'token' as const,
     subscriptionKeyPlaceholder: 'Paste your Kimi Code API key',
-    knownModels: Object.freeze(['kimi-for-coding']),
+    knownModels: Object.freeze(['kimi-for-coding', 'kimi-k3']),
     knownModelsMatch: 'exact' as const,
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 262144,
+      modelContextWindows: Object.freeze({
+        'kimi-k3': 1048576,
+      }),
       supportsPromptCaching: true,
       supportsBatching: false,
     }),


### PR DESCRIPTION
### ✨ What changed
- Adds `kimi-k3` to the Kimi Coding Plan `knownModels` in configs.ts.

### 💭 Why
Moonshot AI launched this and the curated subscription list doesn't cover it yet, so Manifest users cannot route to it.

### 📝 Notes
- Verification: Manifest SDK smoke (proxy, pinned route): `kimi-k3` ✅ served end-to-end via opencode-go:subscription · `kimi-k3` listed on OpenRouter as `moonshotai/kimi-k3` (ctx 1048576, checked 2026-07-17) · `kimi-k3` in Manifest discovery via opencode-go:subscription, moonshot:api_key, openrouter:api_key, commandcode:subscription · plan smoke (through Manifest, pinned to the subscription connection): `kimi-k3` ✅ served as `kimi-k3`.
- Authored by Codex and approved by an independent Codex review pass (model-add-pr.mjs).
- https://platform.kimi.ai/docs/models
- https://www.kimi.com/blog/kimi-k3
- https://simonwillison.net/2026/Jul/16/kimi-k3/
- Auto-generated by manifest-model-watch. Pricing (models.dev) and params (modelparams.dev) out of scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `kimi-k3` to the Kimi Coding Plan (`moonshot`) `knownModels` and set its context window to 1,048,576 tokens to enable routing; updated subscription tests to cover the new model and context window.

<sup>Written for commit 74da7d3007d8910be3b6774be762ed4d7ffe75c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

