### PR TITLE
chore: sync modelparams to 0.0.15

### DIFF
--- a/.changeset/sync-modelparams-0-0-15.md
+++ b/.changeset/sync-modelparams-0-0-15.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Sync the model parameter catalog to `modelparams@0.0.15`. Adds 24 new model routes (including a new `xiaomi` provider) with no schema changes — the param types, groups, and auth types are unchanged, so the bump is purely additive.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15114,7 +15114,7 @@
         "express-rate-limit": "^8.5.1",
         "helmet": "^8.1.0",
         "manifest-shared": "*",
-        "modelparams": "^0.0.13",
+        "modelparams": "^0.0.15",
         "pg": "^8.13.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -15184,9 +15184,9 @@
       }
     },
     "packages/backend/node_modules/modelparams": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/modelparams/-/modelparams-0.0.13.tgz",
-      "integrity": "sha512-zFbEdS+J4WURhKe+dUI/sSp9P8xxLzFShlzOncpeZaYIVP7Bn/gHp3ttLUziEFdLFTOpJf/KpPHGHqaPhpqQtQ==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/modelparams/-/modelparams-0.0.15.tgz",
+      "integrity": "sha512-WNEdVGhzZvXam2rggIUAbB6O0lJmiRfl9WzrG29JBxA15wOD+k9Mbabe7HHAPYdFuGEycL8OMVFmvjbE/WAUIg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -45,7 +45,7 @@
     "express-rate-limit": "^8.5.1",
     "helmet": "^8.1.0",
     "manifest-shared": "*",
-    "modelparams": "^0.0.13",
+    "modelparams": "^0.0.15",
     "pg": "^8.13.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
Bump the runtime model-parameter catalog `modelparams` from **0.0.3 → 0.0.15**. The pin was 12 patch releases behind — the caret on `0.0.x` is patch-locked, so it only moves on an explicit bump.

## Change

Purely additive: **191 → 215 model routes** (+24, including a new `xiaomi` provider), with identical param types, groups, and auth types and an unchanged generated `data.js` shape. A `manifest` changeset is included so it ships on the next release.

## Safety

CI loads the catalog through `ProviderParamSpecService` (which regex-parses the package's generated `data.js`), so an upstream release that changed that shape fails the check rather than shipping a backend that can't boot. Verified locally that 0.0.15 parses cleanly (215 entries) and every model the `provider-param-spec.service` spec asserts still resolves with the expected params.