### PR TITLE
feat(shared): add Kimi K3 to ClinePass subscription known models

### DIFF
--- a/.changeset/cline-pass-kimi-k3.md
+++ b/.changeset/cline-pass-kimi-k3.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add Kimi K3 (`cline-pass/kimi-k3`) to the ClinePass subscription's known models list so the model router can resolve the slug without a live `/v1/models` call from Cline.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -371,6 +371,13 @@ describe('getSubscriptionKnownModels', () => {
     expect(getSubscriptionKnownModels('moonshot')).toEqual(['kimi-for-coding']);
   });
 
+  it('returns known models for cline-pass including Kimi K3', () => {
+    const models = getSubscriptionKnownModels('cline-pass');
+    expect(models).toContain('cline-pass/kimi-k3');
+    expect(models).toContain('cline-pass/kimi-k2.7-code');
+    expect(models).toContain('cline-pass/glm-5.2');
+  });
+
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {
     const models = getSubscriptionKnownModels('ollama-cloud');
     expect(models).toBeNull();

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -294,6 +294,31 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       supportsBatching: false,
     }),
   }),
+  'cline-pass': Object.freeze({
+    supportsSubscription: true as const,
+    subscriptionLabel: 'ClinePass subscription',
+    subscriptionAuthMode: 'token' as const,
+    subscriptionKeyPlaceholder: 'Paste your ClinePass API key',
+    knownModels: Object.freeze([
+      'cline-pass/glm-5.2',
+      'cline-pass/kimi-k2.7-code',
+      'cline-pass/kimi-k2.6',
+      'cline-pass/kimi-k3',
+      'cline-pass/deepseek-v4-pro',
+      'cline-pass/deepseek-v4-flash',
+      'cline-pass/mimo-v2.5',
+      'cline-pass/mimo-v2.5-pro',
+      'cline-pass/minimax-m3',
+      'cline-pass/qwen3.7-max',
+      'cline-pass/qwen3.7-plus',
+    ]),
+    knownModelsMatch: 'exact' as const,
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 200000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
 });
 
 export const SUPPORTED_SUBSCRIPTION_PROVIDER_IDS: readonly string[] = Object.freeze(


### PR DESCRIPTION
## Summary

- Adds Moonshot's **Kimi K3** (released 2026-07-16, 1M context) to the ClinePass subscription's \`knownModels\` list in \`packages/shared/src/subscription/configs.ts\`.
- Adds a regression test in \`packages/shared/__tests__/subscription.spec.ts\` so the new slug is exercised by the existing \`getSubscriptionKnownModels\` test suite.
- Adds a \`.changeset/cline-pass-kimi-k3.md\` (patch bump to \`manifest\`) so the change ships in the next npm release.

## Why

ClinePass now serves Kimi K3 but does not expose a traditional OpenAI-compatible \`/v1/models\` endpoint, so the manifest router needs the slug curated manually. Without this entry the router can't resolve \`cline-pass/kimi-k3\` for users on the ClinePass subscription. (A follow-up PR will add support for the non-standard endpoint.)

The slug \`kimi-k3\` matches:
- Moonshot's upstream OpenRouter listing (\`moonshotai/kimi-k3\`)
- The \`moonshot\` provider's existing entry in this same file
- Cline's own catalog (\`kimi-k3\`, contextWindow 1,048,576, releaseDate 2026-07-16)

## Test Plan

- [x] \`packages/shared\` jest suite: 353/353 pass (was 352; +1 new test)
- [x] \`packages/backend\` provider-model-fetcher spec: 147/147 pass
- [x] \`npm run check:changesets\`: OK — targets releasable package
- [x] \`npx prettier --check\`: clean
- [x] \`npm run lint\`: 0 errors (339 pre-existing warnings, none in changed files)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Moonshot’s Kimi K3 to the ClinePass subscription known models so the router can resolve `cline-pass/kimi-k3` without a `/v1/models` endpoint. Users on ClinePass can now access Kimi K3 (1M context, released 2026-07-16).

- **New Features**
  - Added `cline-pass/kimi-k3` to `knownModels` in `packages/shared/src/subscription/configs.ts`.
  - Updated `getSubscriptionKnownModels` test in `packages/shared/__tests__/subscription.spec.ts` to cover the new slug.
  - Added a changeset (patch) for `manifest` to ship the update.

<sup>Written for commit 06596bc212dacc2f540e4d837433beb46d1d9c8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

