### PR TITLE
feat(shared): add Kimi K3 to ClinePass subscription known models

### DIFF
--- a/.changeset/cline-pass-kimi-k3.md
+++ b/.changeset/cline-pass-kimi-k3.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Add Kimi K3 (`cline-pass/kimi-k3`) to the ClinePass subscription's known models list so the model router can resolve the slug without a live `/v1/models` call from Cline.
+Add Kimi K3 (`cline-pass/kimi-k3`) to the ClinePass subscription's known models list. 

--- a/.changeset/cline-pass-kimi-k3.md
+++ b/.changeset/cline-pass-kimi-k3.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add Kimi K3 (`cline-pass/kimi-k3`) to the ClinePass subscription's known models list so the model router can resolve the slug without a live `/v1/models` call from Cline.

--- a/.changeset/cline-pass-kimi-k3.md
+++ b/.changeset/cline-pass-kimi-k3.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Add Kimi K3 (`cline-pass/kimi-k3`) to the ClinePass subscription's known models list. 
+Add Kimi K3 (`cline-pass/kimi-k3`) to the ClinePass subscription's known models list.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -392,8 +392,6 @@ describe('getSubscriptionKnownModels', () => {
   it('returns known models for cline-pass including Kimi K3', () => {
     const models = getSubscriptionKnownModels('cline-pass');
     expect(models).toContain('cline-pass/kimi-k3');
-    expect(models).toContain('cline-pass/kimi-k2.7-code');
-    expect(models).toContain('cline-pass/glm-5.2');
   });
 
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -389,6 +389,13 @@ describe('getSubscriptionKnownModels', () => {
     expect(getSubscriptionKnownModels('moonshot')).toEqual(['kimi-for-coding', 'kimi-k3']);
   });
 
+  it('returns known models for cline-pass including Kimi K3', () => {
+    const models = getSubscriptionKnownModels('cline-pass');
+    expect(models).toContain('cline-pass/kimi-k3');
+    expect(models).toContain('cline-pass/kimi-k2.7-code');
+    expect(models).toContain('cline-pass/glm-5.2');
+  });
+
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {
     const models = getSubscriptionKnownModels('ollama-cloud');
     expect(models).toBeNull();

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -331,6 +331,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       'cline-pass/glm-5.2',
       'cline-pass/kimi-k2.7-code',
       'cline-pass/kimi-k2.6',
+      'cline-pass/kimi-k3',
       'cline-pass/deepseek-v4-pro',
       'cline-pass/deepseek-v4-flash',
       'cline-pass/mimo-v2.5',


### PR DESCRIPTION
## Summary

- Adds Moonshot's **Kimi K3** (released 2026-07-16, 1M context) to the ClinePass subscription's `knownModels` list in `packages/shared/src/subscription/configs.ts`.
- Adds a regression test in `packages/shared/__tests__/subscription.spec.ts` so the new slug is exercised by the existing `getSubscriptionKnownModels` test suite.
- Adds a `.changeset/cline-pass-kimi-k3.md` (patch bump to `manifest`) so the change ships in the next npm release.

## Why

ClinePass now serves Kimi K3 but does not expose a traditional OpenAI-compatible `/v1/models` endpoint, so the manifest router needs the slug curated manually. Without this entry the router can't resolve `cline-pass/kimi-k3` for users on the ClinePass subscription. (A follow-up PR will add support for the non-standard endpoint.)

The slug `kimi-k3` matches:
- Moonshot's upstream OpenRouter listing (`moonshotai/kimi-k3`)
- The `moonshot` provider's existing entry in this same file
- Cline's own catalog (`kimi-k3`, contextWindow 1,048,576, releaseDate 2026-07-16)

## Test Plan

- [x] `packages/shared` jest suite: 353/353 pass (was 352; +1 new test)
- [x] `packages/backend` provider-model-fetcher spec: 147/147 pass
- [x] `npm run check:changesets`: OK — targets releasable package
- [x] `npx prettier --check`: clean
- [x] `npm run lint`: 0 errors (339 pre-existing warnings, none in changed files)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Kimi K3 to the ClinePass subscription’s known models so the router can resolve `cline-pass/kimi-k3` without a live `/v1/models` call. Enables users on ClinePass to select Kimi K3 directly.

- **New Features**
  - Added `cline-pass/kimi-k3` to `packages/shared/src/subscription/configs.ts`.
  - Added a test to ensure `getSubscriptionKnownModels('cline-pass')` includes Kimi K3.
  - Added a changeset (patch) for `manifest`; updated release notes and changelog.

<sup>Written for commit dcfe17f00d7e2ae32378bdf02f60b33bd2bff1d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

