### PR TITLE
test(shared): backfill ClinePass subscription test coverage

### DIFF
--- a/.changeset/backfill-cline-pass-tests.md
+++ b/.changeset/backfill-cline-pass-tests.md
@@ -1,0 +1,13 @@
+---
+'manifest': patch
+---
+
+Backfill subscription test coverage for the ClinePass provider that was missed in the original `feat: add cline-pass subscription provider` PR (#2412):
+
+- Add `cline-pass` to the `contains all supported subscription provider IDs` list.
+- Add `getSubscriptionProviderConfig` test asserting the `cline-pass` config shape (`subscriptionLabel`, `subscriptionAuthMode`, `subscriptionKeyPlaceholder`, `knownModelsMatch: 'exact'`, and `subscriptionCapabilities`).
+- Replace the smoke `toContain` test in `getSubscriptionKnownModels` with an exact `toEqual` of the curated model list, matching the `moonshot`/`xai`/`xiaomi` test pattern.
+- Add `getSubscriptionKnownModelsMatch` test asserting `cline-pass` resolves to `'exact'`.
+- Add `getSubscriptionCapabilities` test asserting the `200_000` max context window and the `supportsPromptCaching: false` / `supportsBatching: false` flags.
+
+No production behavior changes; tests only.

--- a/.changeset/cline-pass-kimi-k3.md
+++ b/.changeset/cline-pass-kimi-k3.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add Kimi K3 (`cline-pass/kimi-k3`) to the ClinePass subscription's known models list so the model router can resolve the slug without a live `/v1/models` call from Cline.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -29,6 +29,7 @@ describe('SUBSCRIPTION_PROVIDER_CONFIGS', () => {
         'opencode-go',
         'gemini',
         'xai',
+        'cline-pass',
       ]),
     );
   });
@@ -199,6 +200,22 @@ describe('getSubscriptionProviderConfig', () => {
       subscriptionLabel: 'GLM Coding Plan',
       subscriptionAuthMode: 'token',
       subscriptionKeyPlaceholder: 'Paste your Z.ai API key',
+    });
+  });
+
+  it('returns config for cline-pass', () => {
+    const config = getSubscriptionProviderConfig('cline-pass');
+    expect(config).toMatchObject({
+      supportsSubscription: true,
+      subscriptionLabel: 'ClinePass subscription',
+      subscriptionAuthMode: 'token',
+      subscriptionKeyPlaceholder: 'Paste your ClinePass API key',
+      knownModelsMatch: 'exact',
+    });
+    expect(config?.subscriptionCapabilities).toMatchObject({
+      maxContextWindow: 200000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
     });
   });
 
@@ -389,11 +406,20 @@ describe('getSubscriptionKnownModels', () => {
     expect(getSubscriptionKnownModels('moonshot')).toEqual(['kimi-for-coding', 'kimi-k3']);
   });
 
-  it('returns known models for cline-pass including Kimi K3', () => {
-    const models = getSubscriptionKnownModels('cline-pass');
-    expect(models).toContain('cline-pass/kimi-k3');
-    expect(models).toContain('cline-pass/kimi-k2.7-code');
-    expect(models).toContain('cline-pass/glm-5.2');
+  it('returns the curated cline-pass models list (including Kimi K3)', () => {
+    expect(getSubscriptionKnownModels('cline-pass')).toEqual([
+      'cline-pass/glm-5.2',
+      'cline-pass/kimi-k2.7-code',
+      'cline-pass/kimi-k2.6',
+      'cline-pass/kimi-k3',
+      'cline-pass/deepseek-v4-pro',
+      'cline-pass/deepseek-v4-flash',
+      'cline-pass/mimo-v2.5',
+      'cline-pass/mimo-v2.5-pro',
+      'cline-pass/minimax-m3',
+      'cline-pass/qwen3.7-max',
+      'cline-pass/qwen3.7-plus',
+    ]);
   });
 
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {
@@ -461,6 +487,12 @@ describe('getSubscriptionKnownModelsMatch', () => {
 
   it('returns exact for moonshot Kimi Coding Plan', () => {
     expect(getSubscriptionKnownModelsMatch('moonshot')).toBe('exact');
+  });
+
+  it('returns exact for cline-pass', () => {
+    // ClinePass does not expose a traditional OpenAI-compatible /v1/models
+    // endpoint, so the catalog is curated manually and matched exactly.
+    expect(getSubscriptionKnownModelsMatch('cline-pass')).toBe('exact');
   });
 
   it('returns exact for Mistral Vibe', () => {
@@ -580,6 +612,15 @@ describe('getSubscriptionCapabilities', () => {
       supportsBatching: false,
     });
     expect(caps?.modelContextWindows?.['kimi-k3']).toBe(1048576);
+  });
+
+  it('returns capabilities for cline-pass', () => {
+    const caps = getSubscriptionCapabilities('cline-pass');
+    expect(caps).toMatchObject({
+      maxContextWindow: 200000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    });
   });
 
   it('returns capabilities for Qwen Token Plan', () => {

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -389,6 +389,13 @@ describe('getSubscriptionKnownModels', () => {
     expect(getSubscriptionKnownModels('moonshot')).toEqual(['kimi-for-coding', 'kimi-k3']);
   });
 
+  it('returns known models for cline-pass including Kimi K3', () => {
+    const models = getSubscriptionKnownModels('cline-pass');
+    expect(models).toContain('cline-pass/kimi-k3');
+    expect(models).toContain('cline-pass/kimi-k2.7-code');
+    expect(models).toContain('cline-pass/glm-5.2');
+  });
+
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {
     const models = getSubscriptionKnownModels('ollama-cloud');
     expect(models).toBeNull();

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -331,6 +331,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       'cline-pass/glm-5.2',
       'cline-pass/kimi-k2.7-code',
       'cline-pass/kimi-k2.6',
+      'cline-pass/kimi-k3',
       'cline-pass/deepseek-v4-pro',
       'cline-pass/deepseek-v4-flash',
       'cline-pass/mimo-v2.5',


### PR DESCRIPTION
## Summary

The original ClinePass provider PR (#2412) added the provider config but shipped with **zero assertions** in `packages/shared/__tests__/subscription.spec.ts`. This PR backfills the coverage that was missed, matching the patterns already used for `moonshot` / `xai` / `xiaomi`:

- Add `'cline-pass'` to the `"contains all supported subscription provider IDs"` list in the `SUBSCRIPTION_PROVIDER_CONFIGS` test.
- Add a `getSubscriptionProviderConfig` test asserting the ClinePass config shape (`subscriptionLabel`, `subscriptionAuthMode`, `subscriptionKeyPlaceholder`, `knownModelsMatch: 'exact'`, and `subscriptionCapabilities`).
- **Replace** the smoke `toContain` test in `getSubscriptionKnownModels` with an exact `toEqual` of the curated 11-model list, matching the `moonshot`/`xai`/`xiaomi` test pattern. The `kimi-k3` entry added in #2524 is included.
- Add a `getSubscriptionKnownModelsMatch` test asserting `'cline-pass'` resolves to `'exact'` (with a comment explaining why — no `/v1/models` endpoint from Cline).
- Add a `getSubscriptionCapabilities` test asserting the `200_000` max context window and the `supportsPromptCaching` / `supportsBatching` flags.

## Stack on #2524

This is a **stacked PR** on top of #2524 (`feat(shared): add Kimi K3 to ClinePass subscription known models`). The base branch is `add-cline-pass-kimi-k3` in this fork; because GitHub does not allow cross-fork PR bases that point at a fork-only branch, the base is set to `main` here, so the diff below shows the combined changes from both PRs.

**The diff you should review is `add-cline-pass-kimi-k3..backfill-cline-pass-tests`** — the backfill-only changes (5 hunks in `subscription.spec.ts`, +46/-5). The rest of the diff is #2524 (the kimi-k3 addition + its minimal `toContain` test, which is replaced by the full-list `toEqual` test in this PR).

After #2524 merges, rebase this branch onto `main` to drop the inherited #2524 commits and the diff will collapse to just the backfill changes.

## Test Plan

- [x] `packages/shared` jest suite: 356/356 pass (was 353; +3 new tests, the `getSubscriptionKnownModels` test was upgraded from `toContain` smoke checks to a full `toEqual` of the list)
- [x] `packages/backend` provider-model-fetcher spec: 147/147 pass
- [x] `npm run check:changesets`: OK — targets releasable package (`manifest`)
- [x] `npx prettier --check`: clean
- [x] `npm run lint`: 0 errors (339 pre-existing warnings, none in changed files)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills tests for the `cline-pass` subscription provider and adds `cline-pass/kimi-k3` to the known models so the router can resolve it without a live `/v1/models` call.

- **Test Coverage**
  - Added `cline-pass` to the supported provider IDs test.
  - Asserted `getSubscriptionProviderConfig('cline-pass')` shape: label, token auth, key placeholder, `knownModelsMatch: 'exact'`, and capabilities.
  - Replaced smoke checks with an exact `getSubscriptionKnownModels('cline-pass')` list (11 slugs, including `cline-pass/kimi-k3`).
  - Asserted `getSubscriptionKnownModelsMatch('cline-pass')` is `exact` (no `/v1/models` endpoint).
  - Asserted `getSubscriptionCapabilities('cline-pass')`: `maxContextWindow: 200000`, `supportsPromptCaching: false`, `supportsBatching: false`.

<sup>Written for commit a2b1f026275910cda095ca4a428f6488b8dd2c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

