### PR TITLE
feat: prepare request history backfill

### DIFF
--- a/.changeset/quiet-request-history.md
+++ b/.changeset/quiet-request-history.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Prepare request history in the background before the request-level dashboard rollout.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,7 +19,9 @@
     "migration:show": "typeorm-ts-node-commonjs migration:show -d src/database/datasource.ts",
     "migration:create": "typeorm-ts-node-commonjs migration:create",
     "backfill:message-providers": "ts-node -T src/database/backfills/backfill-message-providers.cli.ts",
-    "backfill:message-providers:prod": "node dist/database/backfills/backfill-message-providers.cli.js"
+    "backfill:message-providers:prod": "node dist/database/backfills/backfill-message-providers.cli.js",
+    "backfill:requests": "ts-node -T src/database/backfills/request-backfill.cli.ts",
+    "backfill:requests:prod": "node dist/database/backfills/request-backfill.cli.js"
   },
   "dependencies": {
     "@better-auth/stripe": "1.6.11",

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
@@ -11,8 +11,10 @@ import {
   INSERT_LEGACY_FALLBACK_PAIRS_SQL,
   INSERT_LEGACY_FALLBACK_REQUESTS_SQL,
   INSERT_ATTEMPT_REQUESTS_SQL,
+  INSERT_REJECTIONS_SQL,
   LINK_ATTEMPTS_SQL,
   LINK_LEGACY_FALLBACK_ATTEMPTS_SQL,
+  MARK_REJECTIONS_SQL,
   REFRESH_ATTEMPT_REQUESTS_SQL,
   TypeOrmRequestBackfillGateway,
   REQUEST_BACKFILL_WINDOW_END_SQL,
@@ -97,6 +99,8 @@ describe('TypeOrmRequestBackfillGateway', () => {
     });
     expect(runner.query).toHaveBeenNthCalledWith(1, "SET LOCAL lock_timeout = '5000ms'");
     expect(runner.query).toHaveBeenNthCalledWith(2, "SET LOCAL statement_timeout = '60000ms'");
+    expect(runner.query).toHaveBeenNthCalledWith(3, INSERT_REJECTIONS_SQL, ['a', 'b', before]);
+    expect(runner.query).toHaveBeenNthCalledWith(4, MARK_REJECTIONS_SQL, ['a', 'b', before]);
     expect(runner.commitTransaction).toHaveBeenCalled();
     expect(runner.rollbackTransaction).not.toHaveBeenCalled();
     expect(runner.release).toHaveBeenCalled();

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
@@ -1,0 +1,302 @@
+import { DataSource } from 'typeorm';
+
+import {
+  CREATE_LEGACY_FALLBACK_STAGING_SQL,
+  CREATE_LEGACY_FALLBACK_GROUPS_SQL,
+  FALLBACK_PRIMARY_WINDOW_END_SQL,
+  FINALIZE_PENDING_REQUESTS_SQL,
+  INSERT_LEGACY_FALLBACK_DIRECT_MEMBERS_SQL,
+  INSERT_LEGACY_FALLBACK_INDEXES_SQL,
+  INSERT_LEGACY_FALLBACK_MEMBERS_SQL,
+  INSERT_LEGACY_FALLBACK_PAIRS_SQL,
+  INSERT_LEGACY_FALLBACK_REQUESTS_SQL,
+  INSERT_ATTEMPT_REQUESTS_SQL,
+  LINK_ATTEMPTS_SQL,
+  LINK_LEGACY_FALLBACK_ATTEMPTS_SQL,
+  REFRESH_ATTEMPT_REQUESTS_SQL,
+  TypeOrmRequestBackfillGateway,
+  REQUEST_BACKFILL_WINDOW_END_SQL,
+} from './backfill-requests.gateway';
+
+function mockQueryRunner() {
+  return {
+    connect: jest.fn(async () => undefined),
+    startTransaction: jest.fn(async () => undefined),
+    commitTransaction: jest.fn(async () => undefined),
+    rollbackTransaction: jest.fn(async () => undefined),
+    release: jest.fn(async () => undefined),
+    query: jest.fn(),
+  };
+}
+
+const timeouts = { lockTimeoutMs: 5_000, statementTimeoutMs: 60_000 };
+const before = '2026-01-01 00:00:00';
+
+describe('TypeOrmRequestBackfillGateway', () => {
+  it('derives every request-level Auto-fix status during historical backfill', () => {
+    const sql = `${INSERT_ATTEMPT_REQUESTS_SQL}\n${REFRESH_ATTEMPT_REQUESTS_SQL}`;
+    for (const status of [
+      'no_patch',
+      'resolving',
+      'retry_succeeded',
+      'retry_failed',
+      'service_error',
+    ]) {
+      expect(sql).toContain(`'${status}'`);
+    }
+    expect(sql).toContain("autofix_phoenix->>'status'");
+    expect(sql).toContain("autofix_phoenix->>'healAttemptId'");
+  });
+
+  it('preserves pending attempts when deriving request status', () => {
+    const sql = `${INSERT_ATTEMPT_REQUESTS_SQL}\n${REFRESH_ATTEMPT_REQUESTS_SQL}`;
+    expect(sql).toContain("WHEN terminal.status = 'pending' THEN 'pending'");
+    expect(sql).toContain("WHEN status = 'pending' THEN 'pending'");
+  });
+
+  it('precomputes legacy Auto-fix group sizes once per window', () => {
+    expect(LINK_ATTEMPTS_SQL).toContain('target_autofix_groups AS MATERIALIZED');
+    expect(LINK_ATTEMPTS_SQL).toContain('autofix_group_stats AS MATERIALIZED');
+    expect(LINK_ATTEMPTS_SQL).toContain('LEFT JOIN autofix_group_stats stats');
+    expect(LINK_ATTEMPTS_SQL).not.toMatch(/WHEN \(\s*SELECT count\(\*\)/);
+  });
+
+  it('analyzes attempts and finds keyset window ends', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([{ end_id: 'attempt-9' }])
+      .mockResolvedValueOnce([]);
+    const gateway = new TypeOrmRequestBackfillGateway({ query } as unknown as DataSource);
+
+    await gateway.analyze();
+    await expect(gateway.nextWindowEnd('attempt-0', 100, before)).resolves.toBe('attempt-9');
+    await expect(gateway.nextWindowEnd('attempt-9', 100, before)).resolves.toBeNull();
+    expect(query).toHaveBeenCalledWith('ANALYZE "agent_messages"');
+    expect(query).toHaveBeenCalledWith(REQUEST_BACKFILL_WINDOW_END_SQL, ['attempt-0', 100, before]);
+  });
+
+  it('backfills a window in one timeout-guarded transaction', async () => {
+    const runner = mockQueryRunner();
+    runner.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([{ n: 2 }])
+      .mockResolvedValueOnce([{ n: 1 }])
+      .mockResolvedValueOnce([{ n: 3 }])
+      .mockResolvedValueOnce([{ n: 4 }])
+      .mockResolvedValueOnce(undefined);
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    await expect(gateway.backfillWindow('a', 'b', before, timeouts)).resolves.toEqual({
+      requests: 5,
+      attempts: 4,
+      rejections: 1,
+    });
+    expect(runner.query).toHaveBeenNthCalledWith(1, "SET LOCAL lock_timeout = '5000ms'");
+    expect(runner.query).toHaveBeenNthCalledWith(2, "SET LOCAL statement_timeout = '60000ms'");
+    expect(runner.commitTransaction).toHaveBeenCalled();
+    expect(runner.rollbackTransaction).not.toHaveBeenCalled();
+    expect(runner.release).toHaveBeenCalled();
+  });
+
+  it('reconstructs unambiguous legacy fallback chains transactionally', async () => {
+    const runner = mockQueryRunner();
+    let primaryWindow = 0;
+    runner.query.mockImplementation(async (sql: string) => {
+      if (sql === FALLBACK_PRIMARY_WINDOW_END_SQL) {
+        primaryWindow += 1;
+        return [{ end_id: primaryWindow === 1 ? 'primary-z' : null }];
+      }
+      if (sql.includes('max(pair_seq)')) return [{ max_seq: 1 }];
+      if (sql === INSERT_LEGACY_FALLBACK_REQUESTS_SQL) return [{ n: 2 }];
+      if (sql === LINK_LEGACY_FALLBACK_ATTEMPTS_SQL) return [{ n: 5 }];
+      return undefined;
+    });
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    const pause = jest.fn().mockResolvedValue(undefined);
+    await expect(gateway.backfillFallbackGroups(100, before, timeouts, pause)).resolves.toEqual({
+      requests: 2,
+      attempts: 5,
+    });
+    expect(runner.query).toHaveBeenCalledWith(CREATE_LEGACY_FALLBACK_STAGING_SQL);
+    expect(runner.query).toHaveBeenCalledWith(INSERT_LEGACY_FALLBACK_INDEXES_SQL, [before]);
+    expect(runner.query).toHaveBeenCalledWith(INSERT_LEGACY_FALLBACK_PAIRS_SQL, [
+      '',
+      'primary-z',
+      before,
+    ]);
+    expect(runner.query).toHaveBeenCalledWith(INSERT_LEGACY_FALLBACK_MEMBERS_SQL, [0, 1]);
+    expect(runner.query).toHaveBeenCalledWith(INSERT_LEGACY_FALLBACK_DIRECT_MEMBERS_SQL, [0, 1]);
+    expect(runner.query).toHaveBeenCalledWith(CREATE_LEGACY_FALLBACK_GROUPS_SQL, [0, 1]);
+    expect(runner.query).toHaveBeenCalledWith(INSERT_LEGACY_FALLBACK_REQUESTS_SQL);
+    expect(runner.query).toHaveBeenCalledWith(LINK_LEGACY_FALLBACK_ATTEMPTS_SQL);
+    expect(pause).toHaveBeenCalledTimes(3);
+    expect(runner.commitTransaction).toHaveBeenCalled();
+  });
+
+  it('reports progress while scanning large fallback histories', async () => {
+    const runner = mockQueryRunner();
+    let primaryWindow = 0;
+    runner.query.mockImplementation(async (sql: string) => {
+      if (sql === FALLBACK_PRIMARY_WINDOW_END_SQL) {
+        primaryWindow += 1;
+        return [{ end_id: primaryWindow <= 25 ? `primary-${primaryWindow}` : null }];
+      }
+      if (sql.includes('max(pair_seq)')) return [{ max_seq: 0 }];
+      return undefined;
+    });
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+    const progress = jest.fn();
+
+    await expect(
+      gateway.backfillFallbackGroups(100, before, timeouts, jest.fn(), progress),
+    ).resolves.toEqual({ requests: 0, attempts: 0 });
+
+    expect(progress).toHaveBeenCalledWith('scanned 25 fallback-primary window(s)');
+  });
+
+  it('shrinks a timed-out fallback link batch without rebuilding staged candidates', async () => {
+    const runner = mockQueryRunner();
+    let primaryWindow = 0;
+    let linkAttempt = 0;
+    runner.query.mockImplementation(async (sql: string) => {
+      if (sql === FALLBACK_PRIMARY_WINDOW_END_SQL) {
+        primaryWindow += 1;
+        return [{ end_id: primaryWindow === 1 ? 'primary-z' : null }];
+      }
+      if (sql.includes('max(pair_seq)')) return [{ max_seq: 100 }];
+      if (sql === INSERT_LEGACY_FALLBACK_REQUESTS_SQL) return [{ n: 1 }];
+      if (sql === LINK_LEGACY_FALLBACK_ATTEMPTS_SQL) {
+        linkAttempt += 1;
+        if (linkAttempt === 1) {
+          throw new Error('canceling statement due to statement timeout');
+        }
+        return [{ n: 2 }];
+      }
+      return undefined;
+    });
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+    const progress = jest.fn();
+
+    await expect(
+      gateway.backfillFallbackGroups(100, before, timeouts, jest.fn(), progress),
+    ).resolves.toEqual({ requests: 2, attempts: 4 });
+
+    expect(runner.query).toHaveBeenCalledWith(CREATE_LEGACY_FALLBACK_STAGING_SQL);
+    expect(runner.query).toHaveBeenCalledWith(CREATE_LEGACY_FALLBACK_GROUPS_SQL, [0, 100]);
+    expect(runner.query).toHaveBeenCalledWith(CREATE_LEGACY_FALLBACK_GROUPS_SQL, [0, 50]);
+    expect(runner.query).toHaveBeenCalledWith(CREATE_LEGACY_FALLBACK_GROUPS_SQL, [50, 100]);
+    expect(runner.rollbackTransaction).toHaveBeenCalledTimes(1);
+    expect(runner.commitTransaction).toHaveBeenCalledTimes(2);
+    expect(progress).toHaveBeenCalledWith(
+      expect.stringContaining('reducing batch size from 100 to 50'),
+    );
+    expect(progress).toHaveBeenCalledWith(
+      expect.stringContaining('linked 100/100 fallback candidate chain(s)'),
+    );
+  });
+
+  it('handles empty fallback staging results and cleanup failures', async () => {
+    const runner = mockQueryRunner();
+    runner.query.mockImplementation(async (sql: string) => {
+      if (sql === FALLBACK_PRIMARY_WINDOW_END_SQL || sql.includes('max(pair_seq)')) return [];
+      if (sql.startsWith('DROP TABLE')) throw new Error('cleanup failed');
+      return undefined;
+    });
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    await expect(gateway.backfillFallbackGroups(100, before, timeouts, jest.fn())).resolves.toEqual(
+      { requests: 0, attempts: 0 },
+    );
+    expect(runner.release).toHaveBeenCalled();
+  });
+
+  it('rolls back a fallback group transaction when grouping fails', async () => {
+    const runner = mockQueryRunner();
+    const failure = new Error('grouping failed');
+    let primaryWindow = 0;
+    runner.query.mockImplementation(async (sql: string) => {
+      if (sql === FALLBACK_PRIMARY_WINDOW_END_SQL) {
+        primaryWindow += 1;
+        return [{ end_id: primaryWindow === 1 ? 'primary-z' : null }];
+      }
+      if (sql.includes('max(pair_seq)')) return [{ max_seq: 1 }];
+      if (sql === CREATE_LEGACY_FALLBACK_GROUPS_SQL) throw failure;
+      return undefined;
+    });
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    await expect(gateway.backfillFallbackGroups(100, before, timeouts, jest.fn())).rejects.toBe(
+      failure,
+    );
+    expect(runner.rollbackTransaction).toHaveBeenCalled();
+    expect(runner.commitTransaction).not.toHaveBeenCalled();
+    expect(runner.release).toHaveBeenCalled();
+  });
+
+  it('finalizes pending requests and validates the foreign key', async () => {
+    const runner = mockQueryRunner();
+    runner.query.mockResolvedValue(undefined);
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    await gateway.finalize(timeouts);
+
+    expect(runner.query).toHaveBeenCalledWith("SET LOCAL statement_timeout = '0'");
+    expect(runner.query).toHaveBeenCalledWith(
+      'ALTER TABLE "agent_messages" VALIDATE CONSTRAINT "FK_agent_messages_request"',
+    );
+    expect(runner.query).toHaveBeenCalledWith(
+      'ALTER TABLE "agent_messages" VALIDATE CONSTRAINT "CHK_agent_messages_attempt_number_positive"',
+    );
+    expect(runner.commitTransaction).toHaveBeenCalled();
+    expect(runner.release).toHaveBeenCalled();
+  });
+
+  it('finalizes pending requests without validating the foreign key', async () => {
+    const runner = mockQueryRunner();
+    runner.query.mockResolvedValue(undefined);
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    await gateway.finalizePending(timeouts);
+
+    expect(runner.query).toHaveBeenCalledWith(FINALIZE_PENDING_REQUESTS_SQL);
+    expect(runner.query).not.toHaveBeenCalledWith(expect.stringContaining('VALIDATE CONSTRAINT'));
+    expect(runner.commitTransaction).toHaveBeenCalled();
+    expect(runner.release).toHaveBeenCalled();
+  });
+
+  it('rolls back and releases when a window fails', async () => {
+    const runner = mockQueryRunner();
+    const error = new Error('deadlock');
+    runner.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+    const gateway = new TypeOrmRequestBackfillGateway({
+      createQueryRunner: jest.fn(() => runner),
+    } as unknown as DataSource);
+
+    await expect(gateway.backfillWindow('a', 'b', before, timeouts)).rejects.toBe(error);
+    expect(runner.rollbackTransaction).toHaveBeenCalled();
+    expect(runner.commitTransaction).not.toHaveBeenCalled();
+    expect(runner.release).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
@@ -248,26 +248,6 @@ describe('TypeOrmRequestBackfillGateway', () => {
     expect(runner.release).toHaveBeenCalled();
   });
 
-  it('finalizes pending requests and validates the foreign key', async () => {
-    const runner = mockQueryRunner();
-    runner.query.mockResolvedValue(undefined);
-    const gateway = new TypeOrmRequestBackfillGateway({
-      createQueryRunner: jest.fn(() => runner),
-    } as unknown as DataSource);
-
-    await gateway.finalize(timeouts);
-
-    expect(runner.query).toHaveBeenCalledWith("SET LOCAL statement_timeout = '0'");
-    expect(runner.query).toHaveBeenCalledWith(
-      'ALTER TABLE "agent_messages" VALIDATE CONSTRAINT "FK_agent_messages_request"',
-    );
-    expect(runner.query).toHaveBeenCalledWith(
-      'ALTER TABLE "agent_messages" VALIDATE CONSTRAINT "CHK_agent_messages_attempt_number_positive"',
-    );
-    expect(runner.commitTransaction).toHaveBeenCalled();
-    expect(runner.release).toHaveBeenCalled();
-  });
-
   it('finalizes pending requests without validating the foreign key', async () => {
     const runner = mockQueryRunner();
     runner.query.mockResolvedValue(undefined);
@@ -275,7 +255,7 @@ describe('TypeOrmRequestBackfillGateway', () => {
       createQueryRunner: jest.fn(() => runner),
     } as unknown as DataSource);
 
-    await gateway.finalizePending(timeouts);
+    await gateway.finalize(timeouts);
 
     expect(runner.query).toHaveBeenCalledWith(FINALIZE_PENDING_REQUESTS_SQL);
     expect(runner.query).not.toHaveBeenCalledWith(expect.stringContaining('VALIDATE CONSTRAINT'));

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.ts
@@ -806,21 +806,6 @@ export class TypeOrmRequestBackfillGateway implements RequestBackfillGateway {
   async finalize(timeouts: RequestBackfillTimeouts): Promise<void> {
     await this.inTransaction(timeouts, async (runner) => {
       await runner.query(FINALIZE_PENDING_REQUESTS_SQL);
-      // Validation scans the table under SHARE UPDATE EXCLUSIVE: reads and
-      // writes continue, unlike adding a validated FK in the deploy migration.
-      await runner.query(`SET LOCAL statement_timeout = '0'`);
-      await runner.query(
-        'ALTER TABLE "agent_messages" VALIDATE CONSTRAINT "FK_agent_messages_request"',
-      );
-      await runner.query(
-        'ALTER TABLE "agent_messages" VALIDATE CONSTRAINT "CHK_agent_messages_attempt_number_positive"',
-      );
-    });
-  }
-
-  async finalizePending(timeouts: RequestBackfillTimeouts): Promise<void> {
-    await this.inTransaction(timeouts, async (runner) => {
-      await runner.query(FINALIZE_PENDING_REQUESTS_SQL);
     });
   }
 

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.ts
@@ -1,0 +1,865 @@
+import { DataSource, QueryRunner } from 'typeorm';
+import type { RequestBackfillGateway, RequestBackfillTimeouts } from './backfill-requests';
+
+const RETRYABLE_STAGED_BATCH_ERROR = /statement timeout|lock timeout|deadlock/i;
+
+function canResizeStagedBatch(error: unknown): boolean {
+  return RETRYABLE_STAGED_BATCH_ERROR.test(error instanceof Error ? error.message : String(error));
+}
+
+export const REQUEST_BACKFILL_WINDOW_END_SQL = `
+  SELECT max(id) AS end_id
+  FROM (
+    SELECT id
+    FROM "agent_messages"
+    WHERE "request_id" IS NULL AND id > $1 AND timestamp < $3
+    ORDER BY id
+    LIMIT $2
+  ) w
+`;
+
+export const FALLBACK_PRIMARY_WINDOW_END_SQL = `
+  SELECT max(id) AS end_id
+  FROM (
+    SELECT id
+    FROM "agent_messages"
+    WHERE "request_id" IS NULL
+      AND id > $1
+      AND timestamp < $3
+      AND status = 'fallback_error'
+      AND COALESCE(superseded, false)
+      AND fallback_from_model IS NULL
+      AND model IS NOT NULL
+    ORDER BY id
+    LIMIT $2
+  ) w
+`;
+
+const REQUEST_LEVEL_ORIGINS = `'config', 'policy', 'request', 'internal'`;
+
+/**
+ * The requests this backfill materializes must use the canonical
+ * `success` / `failed` vocabulary, same as the live recorder now writes, so the
+ * `requests` table is coherent regardless of which side created a row. Historical
+ * `agent_messages.status` still holds the legacy values (`ok` / `error` /
+ * `rate_limited` / `fallback_error` / `auto_fixed`); this collapses a terminal
+ * attempt status onto the request outcome while preserving in-flight work.
+ */
+const normalizeAttemptStatusSql = (expr: string): string =>
+  `CASE WHEN ${expr} = 'pending' THEN 'pending' WHEN ${expr} IN ('ok', 'success') THEN 'success' ELSE 'failed' END`;
+
+/**
+ * Historical decisions written before this migration have no JSON `status`.
+ * With no retry evidence those rows are necessarily no-patch or resolving, but
+ * the two cannot be distinguished retrospectively; use the terminal no_patch
+ * value rather than inventing an in-progress state for old traffic.
+ */
+const autofixStatusFromAttempt = (alias: string): string => `CASE
+  WHEN ${alias}.autofix_role = 'retry' THEN
+    CASE WHEN ${alias}.status IN ('ok', 'success') THEN 'retry_succeeded' ELSE 'retry_failed' END
+  WHEN COALESCE(${alias}.autofix_applied, false)
+    AND ${alias}.autofix_phoenix->>'healAttemptId' IS NOT NULL THEN 'retry_failed'
+  WHEN ${alias}.autofix_phoenix->>'status' = 'resolving' THEN 'resolving'
+  WHEN ${alias}.autofix_phoenix->>'status' = 'no_patch' THEN 'no_patch'
+  WHEN ${alias}.autofix_phoenix IS NOT NULL THEN 'no_patch'
+  WHEN COALESCE(${alias}.autofix_applied, false) THEN 'service_error'
+  ELSE NULL
+END`;
+
+const autofixStatusFromAttempts = (alias: string): string => `CASE
+  WHEN BOOL_OR(${alias}.autofix_role = 'retry' AND ${alias}.status IN ('ok', 'success'))
+    THEN 'retry_succeeded'
+  WHEN BOOL_OR(${alias}.autofix_role = 'retry')
+    OR BOOL_OR(COALESCE(${alias}.autofix_applied, false)
+      AND ${alias}.autofix_phoenix->>'healAttemptId' IS NOT NULL)
+    THEN 'retry_failed'
+  WHEN BOOL_OR(${alias}.autofix_phoenix->>'status' = 'resolving') THEN 'resolving'
+  WHEN BOOL_OR(${alias}.autofix_phoenix->>'status' = 'no_patch') THEN 'no_patch'
+  WHEN BOOL_OR(${alias}.autofix_phoenix IS NOT NULL) THEN 'no_patch'
+  WHEN BOOL_OR(COALESCE(${alias}.autofix_applied, false)) THEN 'service_error'
+  ELSE NULL
+END`;
+
+/**
+ * The legacy recorder encoded fallback chains with exact 100 ms timestamp
+ * offsets but did not stamp a shared id. Recover only chains whose primary,
+ * terminal attempt, fallback indexes, and request metadata match that encoding.
+ * If one attempt can belong to more than one candidate chain, leave the whole
+ * chain to the generic one-attempt fallback rather than merging unrelated calls.
+ */
+export const CREATE_LEGACY_FALLBACK_STAGING_SQL = `
+  CREATE TEMP TABLE "request_backfill_fallback_indexes" (
+    fallback_index integer PRIMARY KEY
+  ) ON COMMIT PRESERVE ROWS;
+  CREATE TEMP TABLE "request_backfill_fallback_pairs" (
+    pair_seq bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    request_id varchar NOT NULL,
+    primary_id varchar NOT NULL,
+    terminal_id varchar NOT NULL,
+    primary_model varchar NOT NULL,
+    primary_timestamp timestamp NOT NULL,
+    terminal_index integer NOT NULL,
+    outcome varchar NOT NULL,
+    UNIQUE (outcome, primary_id, terminal_id)
+  ) ON COMMIT PRESERVE ROWS;
+  CREATE TEMP TABLE "request_backfill_fallback_members" (
+    request_id varchar NOT NULL,
+    attempt_id varchar NOT NULL,
+    primary_id varchar NOT NULL,
+    terminal_id varchar NOT NULL,
+    PRIMARY KEY (request_id, attempt_id)
+  ) ON COMMIT PRESERVE ROWS
+`;
+
+export const INSERT_LEGACY_FALLBACK_INDEXES_SQL = `
+  INSERT INTO "request_backfill_fallback_indexes" (fallback_index)
+  SELECT DISTINCT fallback_index
+  FROM "agent_messages"
+  WHERE "request_id" IS NULL
+    AND fallback_from_model IS NOT NULL
+    AND fallback_index IS NOT NULL
+    AND fallback_index >= 0
+    AND timestamp < $1
+`;
+
+export const INSERT_LEGACY_FALLBACK_PAIRS_SQL = `
+  INSERT INTO "request_backfill_fallback_pairs" (
+    request_id, primary_id, terminal_id, primary_model, primary_timestamp,
+    terminal_index, outcome
+  )
+  WITH recovered_pairs AS (
+    SELECT
+      'legacy-fallback-' || md5(p.id) AS request_id,
+      p.id AS primary_id,
+      t.id AS terminal_id,
+      p.model AS primary_model,
+      p.timestamp AS primary_timestamp,
+      t.fallback_index AS terminal_index,
+      'recovered'::varchar AS outcome
+    FROM "agent_messages" p
+    JOIN "request_backfill_fallback_indexes" fi ON true
+    JOIN "agent_messages" t
+      ON t."request_id" IS NULL
+     AND t.status IN ('ok', 'success')
+     AND t.fallback_from_model = p.model
+     AND t.fallback_index = fi.fallback_index
+     AND t.timestamp = p.timestamp + (fi.fallback_index + 1) * INTERVAL '100 milliseconds'
+     AND t.tenant_id IS NOT DISTINCT FROM p.tenant_id
+     AND t.agent_id IS NOT DISTINCT FROM p.agent_id
+     AND t.trace_id IS NOT DISTINCT FROM p.trace_id
+     AND t.session_key IS NOT DISTINCT FROM p.session_key
+     AND t.session_id IS NOT DISTINCT FROM p.session_id
+     AND t.caller_attribution IS NOT DISTINCT FROM p.caller_attribution
+     AND t.request_headers IS NOT DISTINCT FROM p.request_headers
+     AND t.request_params IS NOT DISTINCT FROM p.request_params
+     AND t.timestamp < $3
+    WHERE p."request_id" IS NULL
+      AND p.id > $1 AND p.id <= $2
+      AND p.timestamp < $3
+      AND p.status = 'fallback_error'
+      AND COALESCE(p.superseded, false)
+      AND p.fallback_from_model IS NULL
+      AND p.model IS NOT NULL
+  ), exhausted_pairs AS (
+    SELECT
+      'legacy-fallback-' || md5(p.id) AS request_id,
+      p.id AS primary_id,
+      t.id AS terminal_id,
+      p.model AS primary_model,
+      p.timestamp AS primary_timestamp,
+      t.fallback_index AS terminal_index,
+      'exhausted'::varchar AS outcome
+    FROM "agent_messages" p
+    JOIN "request_backfill_fallback_indexes" fi ON true
+    JOIN "agent_messages" t
+      ON t."request_id" IS NULL
+     AND t.status NOT IN ('ok', 'fallback_error', 'auto_fixed')
+     AND NOT COALESCE(t.superseded, false)
+     AND t.fallback_from_model = p.model
+     AND t.fallback_index = fi.fallback_index
+     AND t.timestamp = p.timestamp - (fi.fallback_index + 1) * INTERVAL '100 milliseconds'
+     AND t.tenant_id IS NOT DISTINCT FROM p.tenant_id
+     AND t.agent_id IS NOT DISTINCT FROM p.agent_id
+     AND t.trace_id IS NOT DISTINCT FROM p.trace_id
+     AND t.session_key IS NOT DISTINCT FROM p.session_key
+     AND t.session_id IS NOT DISTINCT FROM p.session_id
+     AND t.caller_attribution IS NOT DISTINCT FROM p.caller_attribution
+     AND t.request_headers IS NOT DISTINCT FROM p.request_headers
+     AND t.request_params IS NOT DISTINCT FROM p.request_params
+     AND t.timestamp < $3
+    WHERE p."request_id" IS NULL
+      AND p.id > $1 AND p.id <= $2
+      AND p.timestamp < $3
+      AND p.status = 'fallback_error'
+      AND COALESCE(p.superseded, false)
+      AND p.fallback_from_model IS NULL
+      AND p.model IS NOT NULL
+  )
+  SELECT request_id, primary_id, terminal_id, primary_model, primary_timestamp,
+         terminal_index, outcome
+  FROM recovered_pairs
+  UNION ALL
+  SELECT request_id, primary_id, terminal_id, primary_model, primary_timestamp,
+         terminal_index, outcome
+  FROM exhausted_pairs
+  ON CONFLICT DO NOTHING
+`;
+
+export const INDEX_LEGACY_FALLBACK_PAIRS_SQL = `
+  CREATE INDEX ON "request_backfill_fallback_pairs" (request_id);
+  CREATE INDEX ON "request_backfill_fallback_pairs" (terminal_id)
+`;
+
+export const INSERT_LEGACY_FALLBACK_DIRECT_MEMBERS_SQL = `
+  WITH groups AS (
+    SELECT *
+    FROM "request_backfill_fallback_pairs"
+    WHERE pair_seq > $1 AND pair_seq <= $2
+  )
+  INSERT INTO "request_backfill_fallback_members" (
+    request_id, attempt_id, primary_id, terminal_id
+  )
+  SELECT g.request_id, g.primary_id, g.primary_id, g.terminal_id
+  FROM groups g
+  UNION ALL
+  SELECT g.request_id, g.terminal_id, g.primary_id, g.terminal_id
+  FROM groups g
+  ON CONFLICT DO NOTHING
+`;
+
+export const INSERT_LEGACY_FALLBACK_MEMBERS_SQL = `
+  WITH groups AS (
+    SELECT *
+    FROM "request_backfill_fallback_pairs"
+    WHERE pair_seq > $1 AND pair_seq <= $2
+  ), member_candidates AS (
+    SELECT g.request_id, pa.id AS attempt_id, g.primary_id, g.terminal_id
+    FROM groups g
+    JOIN "agent_messages" primary_attempt ON primary_attempt.id = g.primary_id
+    JOIN "request_backfill_fallback_indexes" fi
+      ON fi.fallback_index >= 0 AND fi.fallback_index < g.terminal_index
+    JOIN "agent_messages" pa
+      ON pa."request_id" IS NULL
+     AND g.outcome = 'recovered'
+     AND pa.status = 'fallback_error'
+     AND COALESCE(pa.superseded, false)
+     AND pa.fallback_from_model = g.primary_model
+     AND pa.fallback_index = fi.fallback_index
+     AND pa.tenant_id IS NOT DISTINCT FROM primary_attempt.tenant_id
+     AND pa.agent_id IS NOT DISTINCT FROM primary_attempt.agent_id
+     AND pa.trace_id IS NOT DISTINCT FROM primary_attempt.trace_id
+     AND pa.session_key IS NOT DISTINCT FROM primary_attempt.session_key
+     AND pa.session_id IS NOT DISTINCT FROM primary_attempt.session_id
+     AND pa.caller_attribution IS NOT DISTINCT FROM primary_attempt.caller_attribution
+     AND pa.request_headers IS NOT DISTINCT FROM primary_attempt.request_headers
+     AND pa.request_params IS NOT DISTINCT FROM primary_attempt.request_params
+     AND pa.timestamp = g.primary_timestamp
+       + (g.terminal_index - fi.fallback_index) * INTERVAL '100 milliseconds'
+    UNION ALL
+    SELECT g.request_id, pa.id, g.primary_id, g.terminal_id
+    FROM groups g
+    JOIN "agent_messages" primary_attempt ON primary_attempt.id = g.primary_id
+    JOIN "request_backfill_fallback_indexes" fi
+      ON fi.fallback_index >= 0 AND fi.fallback_index < g.terminal_index
+    JOIN "agent_messages" pa
+      ON pa."request_id" IS NULL
+     AND g.outcome = 'exhausted'
+     AND pa.status = 'fallback_error'
+     AND COALESCE(pa.superseded, false)
+     AND pa.fallback_from_model = g.primary_model
+     AND pa.fallback_index = fi.fallback_index
+     AND pa.tenant_id IS NOT DISTINCT FROM primary_attempt.tenant_id
+     AND pa.agent_id IS NOT DISTINCT FROM primary_attempt.agent_id
+     AND pa.trace_id IS NOT DISTINCT FROM primary_attempt.trace_id
+     AND pa.session_key IS NOT DISTINCT FROM primary_attempt.session_key
+     AND pa.session_id IS NOT DISTINCT FROM primary_attempt.session_id
+     AND pa.caller_attribution IS NOT DISTINCT FROM primary_attempt.caller_attribution
+     AND pa.request_headers IS NOT DISTINCT FROM primary_attempt.request_headers
+     AND pa.request_params IS NOT DISTINCT FROM primary_attempt.request_params
+     AND pa.timestamp = g.primary_timestamp
+       - (fi.fallback_index + 1) * INTERVAL '100 milliseconds'
+  )
+  INSERT INTO "request_backfill_fallback_members" (
+    request_id, attempt_id, primary_id, terminal_id
+  )
+  SELECT request_id, attempt_id, primary_id, terminal_id
+  FROM member_candidates
+  ON CONFLICT DO NOTHING
+`;
+
+export const INDEX_LEGACY_FALLBACK_MEMBERS_SQL = `
+  CREATE INDEX ON "request_backfill_fallback_members" (attempt_id)
+`;
+
+export const CREATE_LEGACY_FALLBACK_GROUPS_SQL = `
+  CREATE TEMP TABLE "request_backfill_fallback_groups" ON COMMIT DROP AS
+  WITH groups AS (
+    SELECT p.*
+    FROM "request_backfill_fallback_pairs" p
+    WHERE p.pair_seq > $1 AND p.pair_seq <= $2
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "request_backfill_fallback_pairs" other
+        WHERE other.request_id = p.request_id AND other.pair_seq <> p.pair_seq
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "request_backfill_fallback_pairs" other
+        WHERE other.terminal_id = p.terminal_id AND other.request_id <> p.request_id
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "request_backfill_fallback_members" member
+        JOIN "request_backfill_fallback_members" other
+          ON other.attempt_id = member.attempt_id
+         AND other.request_id <> member.request_id
+        WHERE member.request_id = p.request_id
+      )
+  )
+  SELECT m.request_id, m.attempt_id, m.primary_id, m.terminal_id
+  FROM "request_backfill_fallback_members" m
+  JOIN groups g ON g.request_id = m.request_id
+`;
+
+/*
+ * Pair and member candidates are staged across bounded reads before any row is
+ * linked. That is what keeps ambiguity detection global even though no query
+ * scans and joins the whole hot table in one transaction.
+ */
+export const LEGACY_FALLBACK_STAGING_INDEX_SQL = `
+  ANALYZE "request_backfill_fallback_pairs";
+  ANALYZE "request_backfill_fallback_members"
+`;
+
+export const INSERT_LEGACY_FALLBACK_REQUESTS_SQL = `
+  WITH groups AS (
+    SELECT DISTINCT request_id, primary_id, terminal_id
+    FROM "request_backfill_fallback_groups"
+  ), totals AS (
+    SELECT g.request_id,
+           min(pa.timestamp) AS started_at,
+           sum(pa.duration_ms)::int AS duration_ms,
+           ${autofixStatusFromAttempts('pa')} AS autofix_status
+    FROM groups g
+    JOIN "request_backfill_fallback_groups" member ON member.request_id = g.request_id
+    JOIN "agent_messages" pa ON pa.id = member.attempt_id
+    GROUP BY g.request_id
+  ), ins AS (
+    INSERT INTO "requests" (
+      id, tenant_id, agent_id, user_id, agent_name, trace_id, session_key, session_id,
+      timestamp, duration_ms, status, error_message, error_http_status, error_code,
+      autofix_status, error_origin, error_class, requested_model, caller_attribution, request_headers,
+      request_params, feedback_rating, feedback_tags, feedback_details
+    )
+    SELECT
+      g.request_id, terminal.tenant_id, terminal.agent_id, terminal.user_id,
+      terminal.agent_name, terminal.trace_id, terminal.session_key, terminal.session_id,
+      totals.started_at, totals.duration_ms, ${normalizeAttemptStatusSql('terminal.status')}, terminal.error_message,
+      terminal.error_http_status, terminal.error_code, totals.autofix_status, terminal.error_origin,
+      terminal.error_class, primary_attempt.model, terminal.caller_attribution,
+      terminal.request_headers, terminal.request_params, terminal.feedback_rating,
+      terminal.feedback_tags, terminal.feedback_details
+    FROM groups g
+    JOIN totals ON totals.request_id = g.request_id
+    JOIN "agent_messages" primary_attempt ON primary_attempt.id = g.primary_id
+    JOIN "agent_messages" terminal ON terminal.id = g.terminal_id
+    ON CONFLICT (id) DO NOTHING
+    RETURNING 1
+  )
+  SELECT count(*)::int AS n FROM ins
+`;
+
+export const LINK_LEGACY_FALLBACK_ATTEMPTS_SQL = `
+  WITH updated AS (
+    UPDATE "agent_messages" pa
+    SET "request_id" = grouped.request_id,
+        "attempt_number" = CASE
+          WHEN pa.id = grouped.primary_id THEN 1
+          WHEN pa.fallback_index IS NOT NULL THEN pa.fallback_index + 2
+          ELSE NULL
+        END
+    FROM "request_backfill_fallback_groups" grouped
+    WHERE pa.id = grouped.attempt_id AND pa."request_id" IS NULL
+    RETURNING 1
+  )
+  SELECT count(*)::int AS n FROM updated
+`;
+
+// These rows predate the explicit request table but never represented a
+// provider call. Copy them to requests and remove the pseudo-attempt.
+export const INSERT_REJECTIONS_SQL = `
+  WITH batch AS (
+    SELECT * FROM "agent_messages"
+    WHERE "request_id" IS NULL AND id > $1 AND id <= $2
+      AND timestamp < $3
+      AND status NOT IN ('ok', 'success')
+      AND error_origin IN (${REQUEST_LEVEL_ORIGINS})
+  ), ins AS (
+    INSERT INTO "requests" (
+      id, tenant_id, agent_id, user_id, agent_name, trace_id, session_key, session_id,
+      timestamp, duration_ms, status, error_message, error_http_status, error_code,
+      autofix_status, error_origin, error_class, requested_model, caller_attribution, request_headers,
+      request_params, feedback_rating, feedback_tags, feedback_details
+    )
+    SELECT
+      id, tenant_id, agent_id, user_id, agent_name, trace_id, session_key, session_id,
+      timestamp, duration_ms, ${normalizeAttemptStatusSql('status')}, error_message, error_http_status, error_code,
+      ${autofixStatusFromAttempt('batch')}, error_origin, error_class, model, caller_attribution, request_headers,
+      request_params, feedback_rating, feedback_tags, feedback_details
+    FROM batch
+    ON CONFLICT (id) DO NOTHING
+    RETURNING 1
+  )
+  SELECT count(*)::int AS n FROM ins
+`;
+
+export const DELETE_REJECTIONS_SQL = `
+  WITH deleted AS (
+    DELETE FROM "agent_messages"
+    WHERE "request_id" IS NULL AND id > $1 AND id <= $2
+      AND timestamp < $3
+      AND status NOT IN ('ok', 'success')
+      AND error_origin IN (${REQUEST_LEVEL_ORIGINS})
+    RETURNING 1
+  )
+  SELECT count(*)::int AS n FROM deleted
+`;
+
+const LEGACY_REQUEST_ID = `CASE
+  WHEN autofix_group_id IS NOT NULL THEN
+    'legacy-autofix-' || md5(COALESCE(tenant_id, '') || ':' || COALESCE(agent_id, '') || ':' || autofix_group_id)
+  WHEN trace_id IS NOT NULL THEN
+    'legacy-trace-' || md5(COALESCE(tenant_id, '') || ':' || COALESCE(agent_id, '') || ':' || trace_id)
+  ELSE id
+END`;
+
+const OUTCOME_RANK = `CASE
+  WHEN status IN ('ok', 'success') THEN 3
+  WHEN NOT COALESCE(superseded, false)
+    AND status NOT IN ('fallback_error', 'auto_fixed') THEN 2
+  ELSE 1
+END`;
+
+export const INSERT_ATTEMPT_REQUESTS_SQL = `
+  WITH batch AS (
+    SELECT *, ${LEGACY_REQUEST_ID} AS legacy_request_id, ${OUTCOME_RANK} AS outcome_rank
+    FROM "agent_messages"
+    WHERE "request_id" IS NULL AND id > $1 AND id <= $2
+      AND timestamp < $3
+  ), terminal AS (
+    SELECT DISTINCT ON (legacy_request_id) *
+    FROM batch
+    ORDER BY legacy_request_id, outcome_rank DESC, timestamp DESC, id DESC
+  ), ins AS (
+    INSERT INTO "requests" (
+      id, tenant_id, agent_id, user_id, agent_name, trace_id, session_key, session_id,
+      timestamp, duration_ms, status, error_message, error_http_status, error_code,
+      autofix_status, error_origin, error_class, requested_model, caller_attribution, request_headers,
+      request_params, feedback_rating, feedback_tags, feedback_details
+    )
+    SELECT
+      legacy_request_id, tenant_id, agent_id, user_id, agent_name, trace_id,
+      session_key, session_id, timestamp, duration_ms,
+      CASE WHEN outcome_rank = 1 THEN 'pending' ELSE ${normalizeAttemptStatusSql('status')} END,
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_message END,
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_http_status END,
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_code END,
+      ${autofixStatusFromAttempt('terminal')},
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_origin END,
+      CASE WHEN outcome_rank = 1 THEN NULL ELSE error_class END,
+      COALESCE(fallback_from_model, model), caller_attribution, request_headers,
+      request_params, feedback_rating, feedback_tags, feedback_details
+    FROM terminal
+    ON CONFLICT (id) DO UPDATE SET
+      timestamp = LEAST(requests.timestamp, EXCLUDED.timestamp),
+      status = CASE
+        WHEN requests.status IN ('ok', 'success') OR EXCLUDED.status IN ('ok', 'success')
+          THEN 'success'
+        WHEN EXCLUDED.status = 'pending' THEN requests.status
+        ELSE EXCLUDED.status
+      END,
+      autofix_status = COALESCE(EXCLUDED.autofix_status, requests.autofix_status),
+      error_message = CASE WHEN requests.status IN ('ok', 'success') OR EXCLUDED.status = 'pending'
+        THEN requests.error_message ELSE EXCLUDED.error_message END,
+      error_http_status = CASE WHEN requests.status IN ('ok', 'success') OR EXCLUDED.status = 'pending'
+        THEN requests.error_http_status ELSE EXCLUDED.error_http_status END,
+      error_code = CASE WHEN requests.status IN ('ok', 'success') OR EXCLUDED.status = 'pending'
+        THEN requests.error_code ELSE EXCLUDED.error_code END,
+      error_origin = CASE WHEN requests.status IN ('ok', 'success') OR EXCLUDED.status = 'pending'
+        THEN requests.error_origin ELSE EXCLUDED.error_origin END,
+      error_class = CASE WHEN requests.status IN ('ok', 'success') OR EXCLUDED.status = 'pending'
+        THEN requests.error_class ELSE EXCLUDED.error_class END
+    RETURNING (xmax = 0) AS inserted
+  )
+  SELECT count(*) FILTER (WHERE inserted)::int AS n FROM ins
+`;
+
+export const LINK_ATTEMPTS_SQL = `
+  WITH target_autofix_groups AS MATERIALIZED (
+    SELECT DISTINCT
+      COALESCE(tenant_id, '') AS tenant_key,
+      COALESCE(agent_id, '') AS agent_key,
+      autofix_group_id AS group_id
+    FROM "agent_messages"
+    WHERE "request_id" IS NULL AND id > $1 AND id <= $2
+      AND timestamp < $3
+      AND autofix_group_id IS NOT NULL
+      AND autofix_role IS NULL
+  ), autofix_group_stats AS MATERIALIZED (
+    SELECT target.tenant_key,
+           target.agent_key,
+           target.group_id,
+           count(*)::int AS attempt_count,
+           count(*) FILTER (
+             WHERE other.status = 'auto_fixed' AND COALESCE(other.superseded, false)
+           )::int AS original_count
+    FROM target_autofix_groups target
+    JOIN "agent_messages" other
+      ON COALESCE(other.tenant_id, '') = target.tenant_key
+     AND COALESCE(other.agent_id, '') = target.agent_key
+     AND other.autofix_group_id = target.group_id
+    GROUP BY target.tenant_key, target.agent_key, target.group_id
+  ), batch AS (
+    SELECT pa.id,
+           ${LEGACY_REQUEST_ID} AS legacy_request_id,
+           CASE
+             WHEN pa.autofix_group_id IS NOT NULL THEN CASE
+               WHEN pa.autofix_role = 'original' THEN 1
+               WHEN pa.autofix_role = 'retry' THEN 2
+               WHEN stats.attempt_count = 2 AND stats.original_count = 1 THEN CASE
+                 WHEN pa.status = 'auto_fixed' AND COALESCE(pa.superseded, false) THEN 1
+                 ELSE 2
+               END
+               ELSE NULL
+             END
+             WHEN pa.trace_id IS NULL THEN 1
+             ELSE NULL
+           END AS attempt_number
+    FROM "agent_messages" pa
+    LEFT JOIN autofix_group_stats stats
+      ON stats.tenant_key = COALESCE(pa.tenant_id, '')
+     AND stats.agent_key = COALESCE(pa.agent_id, '')
+     AND stats.group_id = pa.autofix_group_id
+    WHERE pa."request_id" IS NULL AND pa.id > $1 AND pa.id <= $2
+      AND pa.timestamp < $3
+  ), updated AS (
+    UPDATE "agent_messages" pa
+    SET "request_id" = batch.legacy_request_id,
+        "attempt_number" = batch.attempt_number
+    FROM batch
+    WHERE pa.id = batch.id AND pa."request_id" IS NULL
+    RETURNING 1
+  )
+  SELECT count(*)::int AS n FROM updated
+`;
+
+// A legacy request can span UUID-ordered windows. Recompute each affected
+// parent from every attempt linked so far, so the final outcome never depends
+// on which window happened to contain the success or terminal failure.
+export const REFRESH_ATTEMPT_REQUESTS_SQL = `
+  WITH affected AS (
+    SELECT DISTINCT request_id
+    FROM "agent_messages"
+    WHERE id > $1 AND id <= $2 AND timestamp < $3 AND request_id IS NOT NULL
+      AND (
+        request_id LIKE 'legacy-autofix-%'
+        OR request_id LIKE 'legacy-trace-%'
+        OR request_id = id
+      )
+  ), totals AS (
+    SELECT pa.request_id,
+           min(pa.timestamp) AS started_at,
+           sum(pa.duration_ms)::int AS duration_ms
+    FROM "agent_messages" pa
+    JOIN affected a ON a.request_id = pa.request_id
+    GROUP BY pa.request_id
+  ), terminal AS (
+    SELECT DISTINCT ON (pa.request_id) pa.*
+    FROM "agent_messages" pa
+    JOIN affected a ON a.request_id = pa.request_id
+    ORDER BY pa.request_id,
+      pa.attempt_number DESC NULLS LAST,
+      CASE
+        WHEN pa.status IN ('ok', 'success') THEN 3
+        WHEN NOT COALESCE(pa.superseded, false)
+          AND pa.status NOT IN ('fallback_error', 'auto_fixed') THEN 2
+        ELSE 1
+      END DESC,
+      pa.timestamp DESC,
+      pa.id DESC
+  ), autofix AS (
+    SELECT pa.request_id, ${autofixStatusFromAttempts('pa')} AS autofix_status
+    FROM "agent_messages" pa
+    JOIN affected a ON a.request_id = pa.request_id
+    GROUP BY pa.request_id
+  )
+  UPDATE "requests" r
+  SET timestamp = totals.started_at,
+      duration_ms = totals.duration_ms,
+      status = ${normalizeAttemptStatusSql('terminal.status')},
+      autofix_status = autofix.autofix_status,
+      error_message = terminal.error_message,
+      error_http_status = terminal.error_http_status,
+      error_code = terminal.error_code,
+      error_origin = terminal.error_origin,
+      error_class = terminal.error_class
+  FROM totals
+  JOIN terminal ON terminal.request_id = totals.request_id
+  JOIN autofix ON autofix.request_id = totals.request_id
+  WHERE r.id = totals.request_id
+`;
+
+export const FINALIZE_PENDING_REQUESTS_SQL = `
+  WITH pending AS (
+    SELECT r.id
+    FROM "requests" r
+    WHERE r.status = 'pending'
+      AND (
+        r.id LIKE 'legacy-autofix-%'
+        OR r.id LIKE 'legacy-trace-%'
+        OR EXISTS (
+          SELECT 1 FROM "agent_messages" pa
+          WHERE pa.request_id = r.id AND pa.id = r.id
+        )
+      )
+  ), last_attempt AS (
+    SELECT DISTINCT ON (pa.request_id) pa.*
+    FROM "agent_messages" pa
+    JOIN pending p ON p.id = pa.request_id
+    ORDER BY pa.request_id, pa.attempt_number DESC NULLS LAST, pa.timestamp DESC, pa.id DESC
+  )
+  UPDATE "requests" r
+  SET status = COALESCE(${normalizeAttemptStatusSql('last_attempt.status')}, 'failed'),
+      error_message = last_attempt.error_message,
+      error_http_status = last_attempt.error_http_status,
+      error_code = last_attempt.error_code,
+      error_origin = last_attempt.error_origin,
+      error_class = last_attempt.error_class
+  FROM last_attempt
+  WHERE r.id = last_attempt.request_id
+`;
+
+export class TypeOrmRequestBackfillGateway implements RequestBackfillGateway {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async analyze(): Promise<void> {
+    await this.dataSource.query('ANALYZE "agent_messages"');
+  }
+
+  async nextWindowEnd(afterId: string, batchSize: number, before: string): Promise<string | null> {
+    const rows = (await this.dataSource.query(REQUEST_BACKFILL_WINDOW_END_SQL, [
+      afterId,
+      batchSize,
+      before,
+    ])) as { end_id: string | null }[];
+    return rows[0]?.end_id ?? null;
+  }
+
+  async backfillFallbackGroups(
+    batchSize: number,
+    before: string,
+    timeouts: RequestBackfillTimeouts,
+    pause: () => Promise<void>,
+    reportProgress?: (message: string) => void,
+  ): Promise<{ requests: number; attempts: number }> {
+    const runner = this.dataSource.createQueryRunner();
+    await runner.connect();
+    let requests = 0;
+    let attempts = 0;
+    try {
+      await runner.query(`SET lock_timeout = '${timeouts.lockTimeoutMs}ms'`);
+      await runner.query(`SET statement_timeout = '${timeouts.statementTimeoutMs}ms'`);
+      // Parallel hashes were the source of the production /dev/shm failure.
+      // The staged tables trade a little elapsed time for bounded memory.
+      await runner.query(`SET max_parallel_workers_per_gather = 0`);
+      await runner.query(`SET max_parallel_maintenance_workers = 0`);
+      await runner.query(CREATE_LEGACY_FALLBACK_STAGING_SQL);
+      await runner.query(INSERT_LEGACY_FALLBACK_INDEXES_SQL, [before]);
+      await runner.query('ANALYZE "request_backfill_fallback_indexes"');
+
+      let afterId = '';
+      let primaryWindows = 0;
+      for (;;) {
+        const [{ end_id: endId = null } = { end_id: null }] = (await runner.query(
+          FALLBACK_PRIMARY_WINDOW_END_SQL,
+          [afterId, batchSize, before],
+        )) as { end_id: string | null }[];
+        if (endId === null) break;
+        await runner.query(INSERT_LEGACY_FALLBACK_PAIRS_SQL, [afterId, endId, before]);
+        afterId = endId;
+        primaryWindows += 1;
+        if (primaryWindows % 25 === 0) {
+          reportProgress?.(`scanned ${primaryWindows} fallback-primary window(s)`);
+        }
+        await pause();
+      }
+
+      const [{ max_seq: maxPairSeq = 0 } = { max_seq: 0 }] = (await runner.query(
+        `SELECT COALESCE(max(pair_seq), 0)::int AS max_seq
+         FROM "request_backfill_fallback_pairs"`,
+      )) as { max_seq: number }[];
+
+      reportProgress?.(`staged ${maxPairSeq} fallback candidate chain(s)`);
+
+      let memberWindows = 0;
+      for (let afterSeq = 0; afterSeq < maxPairSeq; afterSeq += batchSize) {
+        const params = [afterSeq, Math.min(afterSeq + batchSize, maxPairSeq)];
+        await runner.query(INSERT_LEGACY_FALLBACK_DIRECT_MEMBERS_SQL, params);
+        await runner.query(INSERT_LEGACY_FALLBACK_MEMBERS_SQL, params);
+        memberWindows += 1;
+        if (memberWindows % 25 === 0 || params[1] === maxPairSeq) {
+          reportProgress?.(
+            `staged members for ${params[1]}/${maxPairSeq} fallback candidate chain(s)`,
+          );
+        }
+        await pause();
+      }
+
+      // These operations touch session-local data only. Let them finish rather
+      // than restarting a large local index build because of the hot-table
+      // statement timeout used for every bounded source read.
+      await runner.query(`SET statement_timeout = '0'`);
+      await runner.query(INDEX_LEGACY_FALLBACK_PAIRS_SQL);
+      await runner.query(INDEX_LEGACY_FALLBACK_MEMBERS_SQL);
+      await runner.query(LEGACY_FALLBACK_STAGING_INDEX_SQL);
+      await runner.query(`SET statement_timeout = '${timeouts.statementTimeoutMs}ms'`);
+
+      let afterSeq = 0;
+      let linkBatchSize = batchSize;
+      let linkWindows = 0;
+      while (afterSeq < maxPairSeq) {
+        const endSeq = Math.min(afterSeq + linkBatchSize, maxPairSeq);
+        try {
+          const grouped = await this.inRunnerTransaction(runner, timeouts, async () => {
+            await runner.query(CREATE_LEGACY_FALLBACK_GROUPS_SQL, [afterSeq, endSeq]);
+            const [{ n: requestCount }] = (await runner.query(
+              INSERT_LEGACY_FALLBACK_REQUESTS_SQL,
+            )) as { n: number }[];
+            const [{ n: attemptCount }] = (await runner.query(
+              LINK_LEGACY_FALLBACK_ATTEMPTS_SQL,
+            )) as { n: number }[];
+            return { requests: requestCount, attempts: attemptCount };
+          });
+          requests += grouped.requests;
+          attempts += grouped.attempts;
+          afterSeq = endSeq;
+          linkWindows += 1;
+          if (linkWindows % 25 === 0 || afterSeq === maxPairSeq) {
+            reportProgress?.(
+              `linked ${afterSeq}/${maxPairSeq} fallback candidate chain(s) ` +
+                `into ${requests} request(s) and ${attempts} attempt(s)`,
+            );
+          }
+          await pause();
+        } catch (error) {
+          if (!canResizeStagedBatch(error) || linkBatchSize === 1) throw error;
+          const smallerBatchSize = Math.max(1, Math.floor(linkBatchSize / 2));
+          const reason = error instanceof Error ? error.message : String(error);
+          reportProgress?.(
+            `fallback batch after ${afterSeq} failed (${reason}); ` +
+              `reducing batch size from ${linkBatchSize} to ${smallerBatchSize}`,
+          );
+          linkBatchSize = smallerBatchSize;
+          await pause();
+        }
+      }
+      return { requests, attempts };
+    } finally {
+      await runner
+        .query(
+          `DROP TABLE IF EXISTS "request_backfill_fallback_groups",
+            "request_backfill_fallback_members", "request_backfill_fallback_pairs",
+            "request_backfill_fallback_indexes"`,
+        )
+        .catch(() => undefined);
+      await runner.query('RESET ALL').catch(() => undefined);
+      await runner.release();
+    }
+  }
+
+  async backfillWindow(
+    afterId: string,
+    endId: string,
+    before: string,
+    timeouts: RequestBackfillTimeouts,
+  ): Promise<{ requests: number; attempts: number; rejections: number }> {
+    return this.inTransaction(timeouts, async (runner) => {
+      const params = [afterId, endId, before];
+      const [{ n: requests }] = (await runner.query(INSERT_REJECTIONS_SQL, params)) as {
+        n: number;
+      }[];
+      const [{ n: rejections }] = (await runner.query(DELETE_REJECTIONS_SQL, params)) as {
+        n: number;
+      }[];
+      const [{ n: attemptRequests }] = (await runner.query(
+        INSERT_ATTEMPT_REQUESTS_SQL,
+        params,
+      )) as { n: number }[];
+      const [{ n: attempts }] = (await runner.query(LINK_ATTEMPTS_SQL, params)) as {
+        n: number;
+      }[];
+      await runner.query(REFRESH_ATTEMPT_REQUESTS_SQL, params);
+      return { requests: requests + attemptRequests, attempts, rejections };
+    });
+  }
+
+  async finalize(timeouts: RequestBackfillTimeouts): Promise<void> {
+    await this.inTransaction(timeouts, async (runner) => {
+      await runner.query(FINALIZE_PENDING_REQUESTS_SQL);
+      // Validation scans the table under SHARE UPDATE EXCLUSIVE: reads and
+      // writes continue, unlike adding a validated FK in the deploy migration.
+      await runner.query(`SET LOCAL statement_timeout = '0'`);
+      await runner.query(
+        'ALTER TABLE "agent_messages" VALIDATE CONSTRAINT "FK_agent_messages_request"',
+      );
+      await runner.query(
+        'ALTER TABLE "agent_messages" VALIDATE CONSTRAINT "CHK_agent_messages_attempt_number_positive"',
+      );
+    });
+  }
+
+  async finalizePending(timeouts: RequestBackfillTimeouts): Promise<void> {
+    await this.inTransaction(timeouts, async (runner) => {
+      await runner.query(FINALIZE_PENDING_REQUESTS_SQL);
+    });
+  }
+
+  private async inTransaction<T>(
+    timeouts: RequestBackfillTimeouts,
+    fn: (runner: QueryRunner) => Promise<T>,
+  ): Promise<T> {
+    const runner = this.dataSource.createQueryRunner();
+    await runner.connect();
+    await runner.startTransaction();
+    try {
+      await runner.query(`SET LOCAL lock_timeout = '${timeouts.lockTimeoutMs}ms'`);
+      await runner.query(`SET LOCAL statement_timeout = '${timeouts.statementTimeoutMs}ms'`);
+      const result = await fn(runner);
+      await runner.commitTransaction();
+      return result;
+    } catch (error) {
+      await runner.rollbackTransaction();
+      throw error;
+    } finally {
+      await runner.release();
+    }
+  }
+
+  private async inRunnerTransaction<T>(
+    runner: QueryRunner,
+    timeouts: RequestBackfillTimeouts,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    await runner.startTransaction();
+    try {
+      await runner.query(`SET LOCAL lock_timeout = '${timeouts.lockTimeoutMs}ms'`);
+      await runner.query(`SET LOCAL statement_timeout = '${timeouts.statementTimeoutMs}ms'`);
+      const result = await fn();
+      await runner.commitTransaction();
+      return result;
+    } catch (error) {
+      await runner.rollbackTransaction();
+      throw error;
+    }
+  }
+}

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.ts
@@ -386,7 +386,8 @@ export const LINK_LEGACY_FALLBACK_ATTEMPTS_SQL = `
 `;
 
 // These rows predate the explicit request table but never represented a
-// provider call. Copy them to requests and remove the pseudo-attempt.
+// provider call. Copy them to requests while the legacy dashboard still reads
+// agent_messages; #2485 can remove the preserved row after switching readers.
 export const INSERT_REJECTIONS_SQL = `
   WITH batch AS (
     SELECT * FROM "agent_messages"
@@ -413,16 +414,19 @@ export const INSERT_REJECTIONS_SQL = `
   SELECT count(*)::int AS n FROM ins
 `;
 
-export const DELETE_REJECTIONS_SQL = `
-  WITH deleted AS (
-    DELETE FROM "agent_messages"
+// Mark the preserved legacy row as staged so subsequent tail sweeps skip it.
+// attempt_number remains NULL because no provider call occurred.
+export const MARK_REJECTIONS_SQL = `
+  WITH marked AS (
+    UPDATE "agent_messages"
+    SET "request_id" = id
     WHERE "request_id" IS NULL AND id > $1 AND id <= $2
       AND timestamp < $3
       AND status NOT IN ('ok', 'success')
       AND error_origin IN (${REQUEST_LEVEL_ORIGINS})
     RETURNING 1
   )
-  SELECT count(*)::int AS n FROM deleted
+  SELECT count(*)::int AS n FROM marked
 `;
 
 const LEGACY_REQUEST_ID = `CASE
@@ -788,7 +792,7 @@ export class TypeOrmRequestBackfillGateway implements RequestBackfillGateway {
       const [{ n: requests }] = (await runner.query(INSERT_REJECTIONS_SQL, params)) as {
         n: number;
       }[];
-      const [{ n: rejections }] = (await runner.query(DELETE_REJECTIONS_SQL, params)) as {
+      const [{ n: rejections }] = (await runner.query(MARK_REJECTIONS_SQL, params)) as {
         n: number;
       }[];
       const [{ n: attemptRequests }] = (await runner.query(

--- a/packages/backend/src/database/backfills/backfill-requests.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.spec.ts
@@ -267,7 +267,9 @@ describe('runRequestBackfill', () => {
 
   it.each([
     ['batchSize', 0],
+    ['batchSize', 1.5],
     ['batchSize', Number.NaN],
+    ['batchSize', Number.MAX_SAFE_INTEGER + 1],
     ['throttleMs', -1],
     ['maxRetries', -1],
     ['retryBackoffMs', Number.POSITIVE_INFINITY],

--- a/packages/backend/src/database/backfills/backfill-requests.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.spec.ts
@@ -1,0 +1,336 @@
+import {
+  runRequestBackfill,
+  type RequestBackfillGateway,
+  type RequestBackfillTimeouts,
+} from './backfill-requests';
+import { FINALIZE_PENDING_REQUESTS_SQL } from './backfill-requests.gateway';
+
+describe('runRequestBackfill', () => {
+  it('walks bounded windows, throttles, and finalizes only after all rows link', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 1, attempts: 2 }),
+      nextWindowEnd: jest
+        .fn()
+        .mockResolvedValueOnce('b')
+        .mockResolvedValueOnce('d')
+        .mockResolvedValueOnce(null),
+      backfillWindow: jest
+        .fn()
+        .mockResolvedValueOnce({ requests: 2, attempts: 2, rejections: 0 })
+        .mockResolvedValueOnce({ requests: 1, attempts: 1, rejections: 1 }),
+      finalizePending: jest.fn().mockResolvedValue(undefined),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runRequestBackfill(gateway, { batchSize: 2, throttleMs: 5, sleep }),
+    ).resolves.toEqual({ windows: 2, requests: 4, attempts: 5, rejections: 1 });
+
+    expect(gateway.backfillFallbackGroups).toHaveBeenCalledWith(
+      2,
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+      expect.any(Function),
+    );
+    expect(gateway.nextWindowEnd).toHaveBeenNthCalledWith(1, '', 2, expect.any(String));
+    expect(gateway.nextWindowEnd).toHaveBeenNthCalledWith(2, 'b', 2, expect.any(String));
+    expect(gateway.backfillWindow).toHaveBeenNthCalledWith(
+      1,
+      '',
+      'b',
+      expect.any(String),
+      expect.any(Object),
+    );
+    expect(gateway.backfillWindow).toHaveBeenNthCalledWith(
+      2,
+      'b',
+      'd',
+      expect.any(String),
+      expect.any(Object),
+    );
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(gateway.finalize).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a timeout without advancing the cursor', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
+      nextWindowEnd: jest.fn().mockResolvedValueOnce('b').mockResolvedValueOnce(null),
+      backfillWindow: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('canceling statement due to statement timeout'))
+        .mockResolvedValueOnce({ requests: 1, attempts: 1, rejections: 0 }),
+      finalizePending: jest.fn().mockResolvedValue(undefined),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+
+    const result = await runRequestBackfill(gateway, {
+      throttleMs: 0,
+      retryBackoffMs: 10,
+      sleep,
+    });
+
+    expect(result.windows).toBe(1);
+    expect(gateway.backfillWindow).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(10);
+  });
+
+  it('uses defaults when options are omitted', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
+      nextWindowEnd: jest.fn().mockResolvedValue(null),
+      backfillWindow: jest.fn(),
+      finalizePending: jest.fn().mockResolvedValue(undefined),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(runRequestBackfill(gateway)).resolves.toEqual({
+      windows: 0,
+      requests: 0,
+      attempts: 0,
+      rejections: 0,
+    });
+  });
+
+  it('finalizes pending outcomes in tail mode without validating the foreign key', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
+      nextWindowEnd: jest.fn().mockResolvedValue(null),
+      backfillWindow: jest.fn(),
+      finalizePending: jest.fn().mockResolvedValue(undefined),
+      finalize: jest.fn(),
+    };
+
+    await runRequestBackfill(gateway, {
+      analyze: false,
+      finalize: false,
+      finalizePending: true,
+    });
+
+    expect(gateway.finalizePending).toHaveBeenCalledTimes(1);
+    expect(gateway.finalize).not.toHaveBeenCalled();
+  });
+
+  it('reports periodic progress and retries finalization', async () => {
+    const windowEnds = Array.from({ length: 25 }, (_, index) => `id-${index + 1}`);
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
+      nextWindowEnd: jest
+        .fn()
+        .mockImplementationOnce(async () => windowEnds[0])
+        .mockImplementation(async (_afterId: string) => {
+          const call = (gateway.nextWindowEnd as jest.Mock).mock.calls.length;
+          return windowEnds[call - 1] ?? null;
+        }),
+      backfillWindow: jest
+        .fn()
+        .mockRejectedValueOnce('deadlock detected')
+        .mockResolvedValue({ requests: 1, attempts: 1, rejections: 0 }),
+      finalizePending: jest.fn().mockResolvedValue(undefined),
+      finalize: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('lock timeout'))
+        .mockResolvedValueOnce(undefined),
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const logger = { log: jest.fn() };
+
+    const result = await runRequestBackfill(gateway, {
+      throttleMs: 0,
+      retryBackoffMs: 2,
+      sleep,
+      logger,
+    });
+
+    expect(result.windows).toBe(25);
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('25 window(s)'));
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('finalization failed'));
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('done'));
+    expect(sleep).toHaveBeenCalledWith(2);
+  });
+
+  it('uses the real throttle timer when no sleep override is provided', async () => {
+    jest.useFakeTimers();
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
+      nextWindowEnd: jest.fn().mockResolvedValueOnce('b').mockResolvedValueOnce(null),
+      backfillWindow: jest.fn().mockResolvedValue({ requests: 1, attempts: 1, rejections: 0 }),
+      finalizePending: jest.fn().mockResolvedValue(undefined),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const resultPromise = runRequestBackfill(gateway, { throttleMs: 1 });
+    await jest.runAllTimersAsync();
+
+    await expect(resultPromise).resolves.toEqual(
+      expect.objectContaining({ windows: 1, attempts: 1 }),
+    );
+    jest.useRealTimers();
+  });
+
+  it('uses the configured throttle while staging legacy fallback groups', async () => {
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn(
+        async (
+          _batchSize: number,
+          _before: string,
+          _timeouts: RequestBackfillTimeouts,
+          pause: () => Promise<void>,
+        ) => {
+          await pause();
+          return { requests: 0, attempts: 0 };
+        },
+      ),
+      nextWindowEnd: jest.fn().mockResolvedValue(null),
+      backfillWindow: jest.fn(),
+      finalizePending: jest.fn().mockResolvedValue(undefined),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await runRequestBackfill(gateway, { throttleMs: 5, sleep });
+
+    expect(sleep).toHaveBeenCalledWith(5);
+  });
+
+  it('does not retry a non-retryable failure', async () => {
+    const failure = new Error('invalid input');
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
+      nextWindowEnd: jest.fn().mockResolvedValue('b'),
+      backfillWindow: jest.fn().mockRejectedValue(failure),
+      finalizePending: jest.fn(),
+      finalize: jest.fn(),
+    };
+
+    await expect(runRequestBackfill(gateway, { throttleMs: 0 })).rejects.toBe(failure);
+  });
+
+  it('retries a string finalization error', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
+      nextWindowEnd: jest.fn().mockResolvedValue(null),
+      backfillWindow: jest.fn(),
+      finalizePending: jest.fn().mockResolvedValue(undefined),
+      finalize: jest
+        .fn()
+        .mockRejectedValueOnce('deadlock detected')
+        .mockResolvedValueOnce(undefined),
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+
+    await expect(runRequestBackfill(gateway, { retryBackoffMs: 1, sleep })).resolves.toEqual({
+      windows: 0,
+      requests: 0,
+      attempts: 0,
+      rejections: 0,
+    });
+    expect(gateway.finalize).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a non-retryable finalization error', async () => {
+    const failure = new Error('invalid final state');
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
+      nextWindowEnd: jest.fn().mockResolvedValue(null),
+      backfillWindow: jest.fn(),
+      finalizePending: jest.fn(),
+      finalize: jest.fn().mockRejectedValue(failure),
+    };
+
+    await expect(runRequestBackfill(gateway)).rejects.toBe(failure);
+  });
+
+  it('retries legacy fallback regrouping before scanning generic windows', async () => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn().mockResolvedValue(undefined),
+      backfillFallbackGroups: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('deadlock detected'))
+        .mockResolvedValueOnce({ requests: 1, attempts: 3 }),
+      nextWindowEnd: jest.fn().mockResolvedValue(null),
+      backfillWindow: jest.fn(),
+      finalizePending: jest.fn().mockResolvedValue(undefined),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+
+    await expect(runRequestBackfill(gateway, { retryBackoffMs: 2, sleep })).resolves.toEqual({
+      windows: 0,
+      requests: 1,
+      attempts: 3,
+      rejections: 0,
+    });
+    expect(sleep).toHaveBeenCalledWith(2);
+    expect(gateway.nextWindowEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['batchSize', 0],
+    ['batchSize', Number.NaN],
+    ['throttleMs', -1],
+    ['maxRetries', -1],
+    ['retryBackoffMs', Number.POSITIVE_INFINITY],
+    ['lockTimeoutMs', 0],
+    ['statementTimeoutMs', -1],
+  ] as const)('rejects invalid %s before touching the gateway', async (name, value) => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn(),
+      backfillFallbackGroups: jest.fn(),
+      nextWindowEnd: jest.fn(),
+      backfillWindow: jest.fn(),
+      finalizePending: jest.fn(),
+      finalize: jest.fn(),
+    };
+
+    await expect(runRequestBackfill(gateway, { [name]: value })).rejects.toThrow(name);
+    expect(gateway.analyze).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['before', 'not-a-date', undefined, 'before'],
+    ['fallbackBefore', '2026-01-01T00:00:00.000Z', 'not-a-date', 'fallbackBefore'],
+    [
+      'fallbackBefore ordering',
+      '2026-01-02T00:00:00.000Z',
+      '2026-01-01T00:00:00.000Z',
+      'must not precede',
+    ],
+  ])('rejects invalid %s dates', async (_name, before, fallbackBefore, message) => {
+    const gateway: RequestBackfillGateway = {
+      analyze: jest.fn(),
+      backfillFallbackGroups: jest.fn(),
+      nextWindowEnd: jest.fn(),
+      backfillWindow: jest.fn(),
+      finalizePending: jest.fn(),
+      finalize: jest.fn(),
+    };
+
+    await expect(runRequestBackfill(gateway, { before, fallbackBefore })).rejects.toThrow(message);
+    expect(gateway.analyze).not.toHaveBeenCalled();
+  });
+});
+
+describe('request backfill finalization', () => {
+  it('only finalizes backfill-created pending parents', () => {
+    expect(FINALIZE_PENDING_REQUESTS_SQL).toContain("r.id LIKE 'legacy-autofix-%'");
+    expect(FINALIZE_PENDING_REQUESTS_SQL).toContain("r.id LIKE 'legacy-trace-%'");
+    expect(FINALIZE_PENDING_REQUESTS_SQL).toContain('pa.id = r.id');
+    expect(FINALIZE_PENDING_REQUESTS_SQL).not.toContain(
+      `SELECT id FROM "requests" WHERE status = 'pending'`,
+    );
+  });
+});

--- a/packages/backend/src/database/backfills/backfill-requests.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.spec.ts
@@ -19,7 +19,6 @@ describe('runRequestBackfill', () => {
         .fn()
         .mockResolvedValueOnce({ requests: 2, attempts: 2, rejections: 0 })
         .mockResolvedValueOnce({ requests: 1, attempts: 1, rejections: 1 }),
-      finalizePending: jest.fn().mockResolvedValue(undefined),
       finalize: jest.fn().mockResolvedValue(undefined),
     };
     const sleep = jest.fn().mockResolvedValue(undefined);
@@ -64,7 +63,6 @@ describe('runRequestBackfill', () => {
         .fn()
         .mockRejectedValueOnce(new Error('canceling statement due to statement timeout'))
         .mockResolvedValueOnce({ requests: 1, attempts: 1, rejections: 0 }),
-      finalizePending: jest.fn().mockResolvedValue(undefined),
       finalize: jest.fn().mockResolvedValue(undefined),
     };
     const sleep = jest.fn().mockResolvedValue(undefined);
@@ -86,7 +84,6 @@ describe('runRequestBackfill', () => {
       backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
       nextWindowEnd: jest.fn().mockResolvedValue(null),
       backfillWindow: jest.fn(),
-      finalizePending: jest.fn().mockResolvedValue(undefined),
       finalize: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -98,24 +95,21 @@ describe('runRequestBackfill', () => {
     });
   });
 
-  it('finalizes pending outcomes in tail mode without validating the foreign key', async () => {
+  it('finalizes pending outcomes in tail mode', async () => {
     const gateway: RequestBackfillGateway = {
       analyze: jest.fn().mockResolvedValue(undefined),
       backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
       nextWindowEnd: jest.fn().mockResolvedValue(null),
       backfillWindow: jest.fn(),
-      finalizePending: jest.fn().mockResolvedValue(undefined),
       finalize: jest.fn(),
     };
 
     await runRequestBackfill(gateway, {
       analyze: false,
-      finalize: false,
-      finalizePending: true,
+      finalize: true,
     });
 
-    expect(gateway.finalizePending).toHaveBeenCalledTimes(1);
-    expect(gateway.finalize).not.toHaveBeenCalled();
+    expect(gateway.finalize).toHaveBeenCalledTimes(1);
   });
 
   it('reports periodic progress and retries finalization', async () => {
@@ -134,7 +128,6 @@ describe('runRequestBackfill', () => {
         .fn()
         .mockRejectedValueOnce('deadlock detected')
         .mockResolvedValue({ requests: 1, attempts: 1, rejections: 0 }),
-      finalizePending: jest.fn().mockResolvedValue(undefined),
       finalize: jest
         .fn()
         .mockRejectedValueOnce(new Error('lock timeout'))
@@ -164,7 +157,6 @@ describe('runRequestBackfill', () => {
       backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
       nextWindowEnd: jest.fn().mockResolvedValueOnce('b').mockResolvedValueOnce(null),
       backfillWindow: jest.fn().mockResolvedValue({ requests: 1, attempts: 1, rejections: 0 }),
-      finalizePending: jest.fn().mockResolvedValue(undefined),
       finalize: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -194,7 +186,6 @@ describe('runRequestBackfill', () => {
       ),
       nextWindowEnd: jest.fn().mockResolvedValue(null),
       backfillWindow: jest.fn(),
-      finalizePending: jest.fn().mockResolvedValue(undefined),
       finalize: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -210,7 +201,6 @@ describe('runRequestBackfill', () => {
       backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
       nextWindowEnd: jest.fn().mockResolvedValue('b'),
       backfillWindow: jest.fn().mockRejectedValue(failure),
-      finalizePending: jest.fn(),
       finalize: jest.fn(),
     };
 
@@ -223,7 +213,6 @@ describe('runRequestBackfill', () => {
       backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
       nextWindowEnd: jest.fn().mockResolvedValue(null),
       backfillWindow: jest.fn(),
-      finalizePending: jest.fn().mockResolvedValue(undefined),
       finalize: jest
         .fn()
         .mockRejectedValueOnce('deadlock detected')
@@ -247,7 +236,6 @@ describe('runRequestBackfill', () => {
       backfillFallbackGroups: jest.fn().mockResolvedValue({ requests: 0, attempts: 0 }),
       nextWindowEnd: jest.fn().mockResolvedValue(null),
       backfillWindow: jest.fn(),
-      finalizePending: jest.fn(),
       finalize: jest.fn().mockRejectedValue(failure),
     };
 
@@ -263,7 +251,6 @@ describe('runRequestBackfill', () => {
         .mockResolvedValueOnce({ requests: 1, attempts: 3 }),
       nextWindowEnd: jest.fn().mockResolvedValue(null),
       backfillWindow: jest.fn(),
-      finalizePending: jest.fn().mockResolvedValue(undefined),
       finalize: jest.fn().mockResolvedValue(undefined),
     };
     const sleep = jest.fn().mockResolvedValue(undefined);
@@ -292,7 +279,6 @@ describe('runRequestBackfill', () => {
       backfillFallbackGroups: jest.fn(),
       nextWindowEnd: jest.fn(),
       backfillWindow: jest.fn(),
-      finalizePending: jest.fn(),
       finalize: jest.fn(),
     };
 
@@ -315,7 +301,6 @@ describe('runRequestBackfill', () => {
       backfillFallbackGroups: jest.fn(),
       nextWindowEnd: jest.fn(),
       backfillWindow: jest.fn(),
-      finalizePending: jest.fn(),
       finalize: jest.fn(),
     };
 

--- a/packages/backend/src/database/backfills/backfill-requests.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.ts
@@ -54,6 +54,12 @@ function assertPositiveFinite(name: string, value: number): void {
   }
 }
 
+function assertPositiveSafeInteger(name: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`request backfill ${name} must be a positive safe integer`);
+  }
+}
+
 function assertNonNegativeFinite(name: string, value: number): void {
   if (!Number.isFinite(value) || value < 0) {
     throw new Error(`request backfill ${name} must be a non-negative finite number`);
@@ -88,7 +94,7 @@ export async function runRequestBackfill(
     statementTimeoutMs: options.statementTimeoutMs ?? DEFAULT_BACKFILL_OPTIONS.statementTimeoutMs,
   };
 
-  assertPositiveFinite('batchSize', batchSize);
+  assertPositiveSafeInteger('batchSize', batchSize);
   assertNonNegativeFinite('throttleMs', throttleMs);
   assertNonNegativeFinite('maxRetries', maxRetries);
   assertNonNegativeFinite('retryBackoffMs', retryBackoffMs);

--- a/packages/backend/src/database/backfills/backfill-requests.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.ts
@@ -1,0 +1,205 @@
+import { DEFAULT_BACKFILL_OPTIONS, isRetryableBackfillError } from './backfill-message-providers';
+
+export interface RequestBackfillTimeouts {
+  lockTimeoutMs: number;
+  statementTimeoutMs: number;
+}
+
+export interface RequestBackfillGateway {
+  analyze(): Promise<void>;
+  backfillFallbackGroups(
+    batchSize: number,
+    before: string,
+    timeouts: RequestBackfillTimeouts,
+    pause: () => Promise<void>,
+    reportProgress?: (message: string) => void,
+  ): Promise<{ requests: number; attempts: number }>;
+  nextWindowEnd(afterId: string, batchSize: number, before: string): Promise<string | null>;
+  backfillWindow(
+    afterId: string,
+    endId: string,
+    before: string,
+    timeouts: RequestBackfillTimeouts,
+  ): Promise<{ requests: number; attempts: number; rejections: number }>;
+  finalizePending(timeouts: RequestBackfillTimeouts): Promise<void>;
+  finalize(timeouts: RequestBackfillTimeouts): Promise<void>;
+}
+
+export interface RequestBackfillOptions {
+  batchSize?: number;
+  throttleMs?: number;
+  lockTimeoutMs?: number;
+  statementTimeoutMs?: number;
+  maxRetries?: number;
+  retryBackoffMs?: number;
+  /** Fallback rows may match sooner than generic rows, leaving a safety gap for late terminals. */
+  fallbackBefore?: string;
+  /** Only generic attempts older than this boundary are linked. */
+  before?: string;
+  analyze?: boolean;
+  /** Finalize legacy pending outcomes without validating the foreign key. */
+  finalizePending?: boolean;
+  finalize?: boolean;
+  logger?: { log: (message: string) => void };
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface RequestBackfillResult {
+  windows: number;
+  requests: number;
+  attempts: number;
+  rejections: number;
+}
+
+function assertPositiveFinite(name: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`request backfill ${name} must be a positive finite number`);
+  }
+}
+
+function assertNonNegativeFinite(name: string, value: number): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`request backfill ${name} must be a non-negative finite number`);
+  }
+}
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Regroup history after startup in short, retryable keyset windows. This is
+ * deliberately not a TypeORM migration: deploy readiness must not wait for a
+ * scan and rewrite of the hot agent_messages table.
+ */
+export async function runRequestBackfill(
+  gateway: RequestBackfillGateway,
+  options: RequestBackfillOptions = {},
+): Promise<RequestBackfillResult> {
+  const batchSize = options.batchSize ?? DEFAULT_BACKFILL_OPTIONS.batchSize;
+  const throttleMs = options.throttleMs ?? DEFAULT_BACKFILL_OPTIONS.throttleMs;
+  const maxRetries = options.maxRetries ?? DEFAULT_BACKFILL_OPTIONS.maxRetries;
+  const retryBackoffMs = options.retryBackoffMs ?? DEFAULT_BACKFILL_OPTIONS.retryBackoffMs;
+  const sleep = options.sleep ?? realSleep;
+  const before = options.before ?? '9999-12-31 23:59:59';
+  const fallbackBefore = options.fallbackBefore ?? before;
+  const log = (message: string): void => options.logger?.log(message);
+  const pause = (): Promise<void> => (throttleMs > 0 ? sleep(throttleMs) : Promise.resolve());
+  const timeouts: RequestBackfillTimeouts = {
+    lockTimeoutMs: options.lockTimeoutMs ?? DEFAULT_BACKFILL_OPTIONS.lockTimeoutMs,
+    statementTimeoutMs: options.statementTimeoutMs ?? DEFAULT_BACKFILL_OPTIONS.statementTimeoutMs,
+  };
+
+  assertPositiveFinite('batchSize', batchSize);
+  assertNonNegativeFinite('throttleMs', throttleMs);
+  assertNonNegativeFinite('maxRetries', maxRetries);
+  assertNonNegativeFinite('retryBackoffMs', retryBackoffMs);
+  assertPositiveFinite('lockTimeoutMs', timeouts.lockTimeoutMs);
+  assertPositiveFinite('statementTimeoutMs', timeouts.statementTimeoutMs);
+  const beforeTime = Date.parse(before);
+  const fallbackBeforeTime = Date.parse(fallbackBefore);
+  if (Number.isNaN(beforeTime)) throw new Error('request backfill before must be valid');
+  if (Number.isNaN(fallbackBeforeTime)) {
+    throw new Error('request backfill fallbackBefore must be valid');
+  }
+  if (fallbackBeforeTime < beforeTime) {
+    throw new Error('request backfill fallbackBefore must not precede before');
+  }
+
+  if (options.analyze !== false) await gateway.analyze();
+
+  let afterId = '';
+  const result: RequestBackfillResult = {
+    windows: 0,
+    requests: 0,
+    attempts: 0,
+    rejections: 0,
+  };
+
+  let fallbackAttempt = 0;
+  for (;;) {
+    try {
+      log('request backfill: reconstructing legacy fallback chains');
+      const grouped = await gateway.backfillFallbackGroups(
+        batchSize,
+        fallbackBefore,
+        timeouts,
+        pause,
+        (message) => log(`request backfill: ${message}`),
+      );
+      result.requests += grouped.requests;
+      result.attempts += grouped.attempts;
+      if (grouped.attempts > 0) {
+        log(
+          `request backfill: reconstructed ${grouped.requests} legacy fallback request(s) from ${grouped.attempts} attempt(s)`,
+        );
+      }
+      break;
+    } catch (error) {
+      fallbackAttempt += 1;
+      if (fallbackAttempt > maxRetries || !isRetryableBackfillError(error)) throw error;
+      const reason = error instanceof Error ? error.message : String(error);
+      log(
+        `request backfill: fallback regrouping failed (attempt ${fallbackAttempt}/${maxRetries}: ${reason}); retrying`,
+      );
+      await sleep(retryBackoffMs * fallbackAttempt);
+    }
+  }
+
+  for (;;) {
+    const endId = await gateway.nextWindowEnd(afterId, batchSize, before);
+    if (endId === null) break;
+
+    let attempt = 0;
+    for (;;) {
+      try {
+        const window = await gateway.backfillWindow(afterId, endId, before, timeouts);
+        result.requests += window.requests;
+        result.attempts += window.attempts;
+        result.rejections += window.rejections;
+        break;
+      } catch (error) {
+        attempt += 1;
+        if (attempt > maxRetries || !isRetryableBackfillError(error)) throw error;
+        const reason = error instanceof Error ? error.message : String(error);
+        log(
+          `request backfill: window after "${afterId}" failed (attempt ${attempt}/${maxRetries}: ${reason}); retrying`,
+        );
+        await sleep(retryBackoffMs * attempt);
+      }
+    }
+
+    result.windows += 1;
+    afterId = endId;
+    if (result.windows % 25 === 0) {
+      log(
+        `request backfill: ${result.windows} window(s), ${result.attempts} attempt(s), ${result.rejections} zero-attempt rejection(s)`,
+      );
+    }
+    if (throttleMs > 0) await sleep(throttleMs);
+  }
+
+  if (options.finalize !== false || options.finalizePending === true) {
+    let finalizeAttempt = 0;
+    for (;;) {
+      try {
+        if (options.finalize !== false) await gateway.finalize(timeouts);
+        else await gateway.finalizePending(timeouts);
+        break;
+      } catch (error) {
+        finalizeAttempt += 1;
+        if (finalizeAttempt > maxRetries || !isRetryableBackfillError(error)) throw error;
+        const reason = error instanceof Error ? error.message : String(error);
+        log(
+          `request backfill: finalization failed (attempt ${finalizeAttempt}/${maxRetries}: ${reason}); retrying`,
+        );
+        await sleep(retryBackoffMs * finalizeAttempt);
+      }
+    }
+  }
+  log(
+    `request backfill: done — ${result.attempts} attempt(s) and ${result.rejections} rejection(s) across ${result.windows} window(s)`,
+  );
+  return result;
+}

--- a/packages/backend/src/database/backfills/backfill-requests.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.ts
@@ -21,7 +21,6 @@ export interface RequestBackfillGateway {
     before: string,
     timeouts: RequestBackfillTimeouts,
   ): Promise<{ requests: number; attempts: number; rejections: number }>;
-  finalizePending(timeouts: RequestBackfillTimeouts): Promise<void>;
   finalize(timeouts: RequestBackfillTimeouts): Promise<void>;
 }
 
@@ -37,8 +36,6 @@ export interface RequestBackfillOptions {
   /** Only generic attempts older than this boundary are linked. */
   before?: string;
   analyze?: boolean;
-  /** Finalize legacy pending outcomes without validating the foreign key. */
-  finalizePending?: boolean;
   finalize?: boolean;
   logger?: { log: (message: string) => void };
   sleep?: (ms: number) => Promise<void>;
@@ -180,12 +177,11 @@ export async function runRequestBackfill(
     if (throttleMs > 0) await sleep(throttleMs);
   }
 
-  if (options.finalize !== false || options.finalizePending === true) {
+  if (options.finalize !== false) {
     let finalizeAttempt = 0;
     for (;;) {
       try {
-        if (options.finalize !== false) await gateway.finalize(timeouts);
-        else await gateway.finalizePending(timeouts);
+        await gateway.finalize(timeouts);
         break;
       } catch (error) {
         finalizeAttempt += 1;

--- a/packages/backend/src/database/backfills/backfill.module.ts
+++ b/packages/backend/src/database/backfills/backfill.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { BackfillState } from '../../entities/backfill-state.entity';
 import { MessageProviderBackfillBootService } from './message-provider-backfill.boot.service';
+import { RequestBackfillBootService } from './request-backfill.boot.service';
 
 /**
  * Wires the post-deploy backfill boot task. The DataSource is provided globally
@@ -10,6 +11,6 @@ import { MessageProviderBackfillBootService } from './message-provider-backfill.
  */
 @Module({
   imports: [TypeOrmModule.forFeature([BackfillState])],
-  providers: [MessageProviderBackfillBootService],
+  providers: [MessageProviderBackfillBootService, RequestBackfillBootService],
 })
 export class BackfillModule {}

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
@@ -67,6 +67,39 @@ describe('MessageProviderBackfillBootService', () => {
 
       expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('post-deploy backfill failed'));
     });
+
+    it('waits and retries after advisory-lock contention', async () => {
+      jest.useFakeTimers();
+      process.env['NODE_ENV'] = 'production';
+      const state = makeState(false);
+      state.countBy.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+      const lock = makeLock(false);
+      const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+      new MessageProviderBackfillBootService(ds, state.repo).onApplicationBootstrap();
+      await jest.advanceTimersByTimeAsync(30_000);
+
+      expect(state.countBy).toHaveBeenCalledTimes(2);
+      expect(lock.release).toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+
+    it('keeps retrying until the competing backfill completes', async () => {
+      jest.useFakeTimers();
+      process.env['NODE_ENV'] = 'production';
+      const state = makeState(false);
+      const lock = makeLock(false);
+      const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+      new MessageProviderBackfillBootService(ds, state.repo).onApplicationBootstrap();
+      await jest.advanceTimersByTimeAsync(30_000 * 12);
+
+      expect(state.countBy.mock.calls.length).toBeGreaterThan(10);
+      expect(errSpy).not.toHaveBeenCalled();
+      state.countBy.mockResolvedValue(1);
+      await jest.advanceTimersByTimeAsync(30_000);
+      jest.useRealTimers();
+    });
   });
 
   describe('runOnce', () => {
@@ -74,7 +107,9 @@ describe('MessageProviderBackfillBootService', () => {
       const state = makeState(true);
       const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
       const runner = jest.fn();
-      await new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner);
+      await expect(
+        new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner),
+      ).resolves.toBe(true);
       expect(ds.createQueryRunner).not.toHaveBeenCalled();
       expect(runner).not.toHaveBeenCalled();
     });
@@ -83,7 +118,9 @@ describe('MessageProviderBackfillBootService', () => {
       const lock = makeLock(false);
       const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
       const runner = jest.fn();
-      await new MessageProviderBackfillBootService(ds, makeState(false).repo).runOnce(runner);
+      await expect(
+        new MessageProviderBackfillBootService(ds, makeState(false).repo).runOnce(runner),
+      ).resolves.toBe(false);
       expect(lock.query).toHaveBeenCalledWith(TRYLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
       expect(runner).not.toHaveBeenCalled();
       expect(lock.query).not.toHaveBeenCalledWith(UNLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
@@ -96,7 +133,9 @@ describe('MessageProviderBackfillBootService', () => {
       const state = makeState(false);
       const runner = jest.fn(async () => ({ windows: 3, stamped: 42 }));
 
-      await new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner);
+      await expect(
+        new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner),
+      ).resolves.toBe(true);
 
       expect(runner).toHaveBeenCalledWith(
         ds,
@@ -115,7 +154,9 @@ describe('MessageProviderBackfillBootService', () => {
       state.countBy.mockResolvedValueOnce(0).mockResolvedValueOnce(1); // free, then taken
       const runner = jest.fn();
 
-      await new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner);
+      await expect(
+        new MessageProviderBackfillBootService(ds, state.repo).runOnce(runner),
+      ).resolves.toBe(true);
 
       expect(runner).not.toHaveBeenCalled();
       expect(lock.query).toHaveBeenCalledWith(UNLOCK, [MESSAGE_PROVIDER_BACKFILL_LOCK_KEY]);
@@ -152,7 +193,7 @@ describe('MessageProviderBackfillBootService', () => {
 
       await expect(
         new MessageProviderBackfillBootService(ds, makeState(false).repo).runOnce(runner),
-      ).resolves.toBeUndefined();
+      ).resolves.toBe(true);
       expect(lock.release).toHaveBeenCalled();
     });
 

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.spec.ts
@@ -37,8 +37,10 @@ describe('MessageProviderBackfillBootService', () => {
   let logSpy: jest.SpyInstance;
   let errSpy: jest.SpyInstance;
   const originalEnv = process.env['NODE_ENV'];
+  const originalMode = process.env['MANIFEST_MODE'];
 
   beforeEach(() => {
+    process.env['MANIFEST_MODE'] = 'selfhosted';
     logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
     errSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
   });
@@ -46,6 +48,8 @@ describe('MessageProviderBackfillBootService', () => {
     logSpy.mockRestore();
     errSpy.mockRestore();
     process.env['NODE_ENV'] = originalEnv;
+    if (originalMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = originalMode;
   });
 
   describe('onApplicationBootstrap', () => {
@@ -53,6 +57,16 @@ describe('MessageProviderBackfillBootService', () => {
       process.env['NODE_ENV'] = 'test';
       const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
       new MessageProviderBackfillBootService(ds, makeState(false).repo).onApplicationBootstrap();
+      expect(ds.createQueryRunner).not.toHaveBeenCalled();
+    });
+
+    it('leaves Cloud coordination to the direct request-backfill connection', () => {
+      process.env['NODE_ENV'] = 'production';
+      process.env['MANIFEST_MODE'] = 'cloud';
+      const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
+
+      new MessageProviderBackfillBootService(ds, makeState(false).repo).onApplicationBootstrap();
+
       expect(ds.createQueryRunner).not.toHaveBeenCalled();
     });
 

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
@@ -12,8 +12,15 @@ import { TypeOrmBackfillGateway } from './backfill-message-providers.gateway';
 
 /** Marker name in `backfill_state`; presence == this backfill has finished. */
 export const MESSAGE_PROVIDER_BACKFILL_NAME = 'agent_message_provider_attribution';
-/** Stable advisory-lock key so only one app instance runs the backfill at once. */
+/** Shared lock key so only one post-deploy backfill runs at once. */
 export const MESSAGE_PROVIDER_BACKFILL_LOCK_KEY = 1792000000;
+const LOCK_RETRY_MS = 30_000;
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    if (typeof timer === 'object' && 'unref' in timer) timer.unref();
+  });
 
 export type BackfillRunner = (
   dataSource: DataSource,
@@ -53,17 +60,23 @@ export class MessageProviderBackfillBootService implements OnApplicationBootstra
     if (process.env['NODE_ENV'] !== 'production') {
       return;
     }
-    void this.runOnce().catch((error) => {
+    void this.runUntilComplete().catch((error) => {
       this.logger.error(
         `post-deploy backfill failed: ${error instanceof Error ? error.message : String(error)}`,
       );
     });
   }
 
+  private async runUntilComplete(): Promise<void> {
+    while (!(await this.runOnce())) {
+      await wait(LOCK_RETRY_MS);
+    }
+  }
+
   /** `runner` is injectable for tests; production uses the real backfill. */
-  async runOnce(runner: BackfillRunner = defaultRunner): Promise<void> {
+  async runOnce(runner: BackfillRunner = defaultRunner): Promise<boolean> {
     if (await this.isCompleted()) {
-      return;
+      return true;
     }
     const lock = this.dataSource.createQueryRunner();
     await lock.connect();
@@ -74,13 +87,13 @@ export class MessageProviderBackfillBootService implements OnApplicationBootstra
       ])) as { locked: boolean }[];
       acquired = rows[0]?.locked === true;
       if (!acquired) {
-        this.logger.log('another instance is running the backfill; skipping');
-        return;
+        this.logger.log('another backfill is running; retrying provider attribution later');
+        return false;
       }
       // Re-check under the lock: a peer may have finished between the first
       // check and acquiring the lock.
       if (await this.isCompleted()) {
-        return;
+        return true;
       }
       this.logger.log('running post-deploy agent-message attribution backfill…');
       const result = await runner(this.dataSource, { logger: this.logger });
@@ -88,6 +101,7 @@ export class MessageProviderBackfillBootService implements OnApplicationBootstra
       this.logger.log(
         `post-deploy backfill complete: stamped ${result.stamped} message(s) across ${result.windows} window(s)`,
       );
+      return true;
     } finally {
       if (acquired) {
         await lock

--- a/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/message-provider-backfill.boot.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 
+import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import { BackfillState } from '../../entities/backfill-state.entity';
 import {
   BackfillOptions,
@@ -34,7 +35,8 @@ const defaultRunner: BackfillRunner = (dataSource, options) =>
  * Runs the post-deploy agent-message attribution backfill automatically, once,
  * after the app is up — so operators never have to invoke the CLI by hand.
  *
- * - Production only (like telemetry); dev/test never auto-run it.
+ * - Self-hosted production only; Cloud coordinates it over the direct backfill
+ *   connection before starting the request-history backfill.
  * - Fire-and-forget from onApplicationBootstrap: never blocks readiness/health
  *   and never crashes boot.
  * - Single-runner across replicas via a Postgres advisory lock.
@@ -57,7 +59,7 @@ export class MessageProviderBackfillBootService implements OnApplicationBootstra
 
   onApplicationBootstrap(): void {
     // Only on real deploys, and never await — boot must not wait on the backfill.
-    if (process.env['NODE_ENV'] !== 'production') {
+    if (process.env['NODE_ENV'] !== 'production' || !isSelfHosted()) {
       return;
     }
     void this.runUntilComplete().catch((error) => {
@@ -67,7 +69,7 @@ export class MessageProviderBackfillBootService implements OnApplicationBootstra
     });
   }
 
-  private async runUntilComplete(): Promise<void> {
+  async runUntilComplete(): Promise<void> {
     while (!(await this.runOnce())) {
       await wait(LOCK_RETRY_MS);
     }

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
@@ -1,0 +1,637 @@
+import { Logger } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { BackfillState } from '../../entities/backfill-state.entity';
+import * as requestBackfillDataSource from './request-backfill.datasource';
+import {
+  REQUEST_BACKFILL_LOCK_KEY,
+  REQUEST_BACKFILL_LOCK_RETRY_MS,
+  REQUEST_BACKFILL_NAME,
+  REQUEST_BACKFILL_TAIL_INTERVAL_MS,
+  RequestBackfillBootService,
+} from './request-backfill.boot.service';
+
+function makeLock(locked: boolean) {
+  return {
+    connect: jest.fn(async () => undefined),
+    release: jest.fn(async () => undefined),
+    query: jest.fn(async (sql: string) =>
+      sql.includes('pg_try_advisory_lock') ? [{ locked }] : undefined,
+    ),
+  };
+}
+
+function makeState(completed: boolean) {
+  const execute = jest.fn(async () => undefined);
+  const orIgnore = jest.fn(() => ({ execute }));
+  const values = jest.fn(() => ({ orIgnore }));
+  const into = jest.fn(() => ({ values }));
+  const insert = jest.fn(() => ({ into }));
+  const createQueryBuilder = jest.fn(() => ({ insert }));
+  const countBy = jest.fn(async () => (completed ? 1 : 0));
+  const repo = { countBy, createQueryBuilder } as unknown as Repository<BackfillState>;
+  return { repo, countBy, values, execute };
+}
+
+describe('RequestBackfillBootService', () => {
+  const originalEnv = process.env['NODE_ENV'];
+  const originalMode = process.env['MANIFEST_MODE'];
+  const originalBackfillUrl = process.env['BACKFILL_DATABASE_URL'];
+  const originalMigrationUrl = process.env['MIGRATION_DATABASE_URL'];
+  const originalUnpooledUrl = process.env['DATABASE_UNPOOLED_URL'];
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.env['NODE_ENV'] = originalEnv;
+    if (originalMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = originalMode;
+    if (originalBackfillUrl === undefined) delete process.env['BACKFILL_DATABASE_URL'];
+    else process.env['BACKFILL_DATABASE_URL'] = originalBackfillUrl;
+    if (originalMigrationUrl === undefined) delete process.env['MIGRATION_DATABASE_URL'];
+    else process.env['MIGRATION_DATABASE_URL'] = originalMigrationUrl;
+    if (originalUnpooledUrl === undefined) delete process.env['DATABASE_UNPOOLED_URL'];
+    else process.env['DATABASE_UNPOOLED_URL'] = originalUnpooledUrl;
+    jest.restoreAllMocks();
+  });
+
+  it('does nothing outside production', () => {
+    process.env['NODE_ENV'] = 'test';
+    const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
+    new RequestBackfillBootService(ds, makeState(false).repo).onApplicationBootstrap();
+    expect(ds.createQueryRunner).not.toHaveBeenCalled();
+  });
+
+  it('uses a separate direct DataSource in cloud production', async () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['MANIFEST_MODE'] = 'cloud';
+    process.env['MIGRATION_DATABASE_URL'] = 'postgres://direct/cloud';
+    const appDataSource = { createQueryRunner: jest.fn() } as unknown as DataSource;
+    const directState = makeState(true);
+    const directDataSource = {
+      initialize: jest.fn(async () => undefined),
+      destroy: jest.fn(async () => undefined),
+      isInitialized: true,
+      getRepository: jest.fn(() => directState.repo),
+      query: jest.fn(async () => [{ present: false }]),
+      createQueryRunner: jest.fn(),
+    } as unknown as DataSource;
+    const factory = jest
+      .spyOn(requestBackfillDataSource, 'createRequestBackfillDataSource')
+      .mockReturnValue(directDataSource);
+    const service = new RequestBackfillBootService(appDataSource, makeState(false).repo);
+
+    service.onApplicationBootstrap();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(factory).toHaveBeenCalledWith(process.env);
+    expect(directDataSource.initialize).toHaveBeenCalled();
+    expect(directDataSource.getRepository).toHaveBeenCalledWith(BackfillState);
+    expect(appDataSource.createQueryRunner).not.toHaveBeenCalled();
+    await service.onApplicationShutdown();
+    expect(directDataSource.destroy).toHaveBeenCalled();
+  });
+
+  it('closes a Cloud direct pool that finishes connecting during shutdown', async () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['MANIFEST_MODE'] = 'cloud';
+    process.env['MIGRATION_DATABASE_URL'] = 'postgres://direct/cloud';
+    let finishInitialize!: () => void;
+    const directDataSource = {
+      initialize: jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishInitialize = resolve;
+          }),
+      ),
+      destroy: jest.fn(async () => undefined),
+      isInitialized: true,
+      getRepository: jest.fn(),
+    } as unknown as DataSource;
+    jest
+      .spyOn(requestBackfillDataSource, 'createRequestBackfillDataSource')
+      .mockReturnValue(directDataSource);
+    const service = new RequestBackfillBootService(
+      { createQueryRunner: jest.fn() } as unknown as DataSource,
+      makeState(false).repo,
+    );
+
+    service.onApplicationBootstrap();
+    await Promise.resolve();
+    await service.onApplicationShutdown();
+    finishInitialize();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(directDataSource.destroy).toHaveBeenCalledTimes(1);
+    expect(directDataSource.getRepository).not.toHaveBeenCalled();
+  });
+
+  it('does not leave a Cloud tail sweep running when shutdown races with startup', async () => {
+    jest.useFakeTimers();
+    process.env['NODE_ENV'] = 'production';
+    process.env['MANIFEST_MODE'] = 'cloud';
+    process.env['MIGRATION_DATABASE_URL'] = 'postgres://direct/cloud';
+    let finishCompatibilityCheck!: () => void;
+    const directState = makeState(true);
+    const directDataSource = {
+      initialize: jest.fn(async () => undefined),
+      destroy: jest.fn(async () => undefined),
+      isInitialized: true,
+      getRepository: jest.fn(() => directState.repo),
+      query: jest.fn(
+        () =>
+          new Promise<Array<{ present: boolean }>>((resolve) => {
+            finishCompatibilityCheck = () => resolve([{ present: true }]);
+          }),
+      ),
+    } as unknown as DataSource;
+    jest
+      .spyOn(requestBackfillDataSource, 'createRequestBackfillDataSource')
+      .mockReturnValue(directDataSource);
+    const service = new RequestBackfillBootService(
+      { createQueryRunner: jest.fn() } as unknown as DataSource,
+      makeState(false).repo,
+    );
+
+    try {
+      service.onApplicationBootstrap();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(directDataSource.query).toHaveBeenCalled();
+
+      await service.onApplicationShutdown();
+      finishCompatibilityCheck();
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(jest.getTimerCount()).toBe(0);
+      expect(directDataSource.destroy).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('retries a self-hosted startup failure without requiring a restart or direct URL', async () => {
+    jest.useFakeTimers();
+    process.env['NODE_ENV'] = 'production';
+    process.env['MANIFEST_MODE'] = 'selfhosted';
+    delete process.env['BACKFILL_DATABASE_URL'];
+    delete process.env['MIGRATION_DATABASE_URL'];
+    delete process.env['DATABASE_UNPOOLED_URL'];
+    const state = makeState(false);
+    state.countBy.mockRejectedValueOnce(new Error('db down')).mockResolvedValue(1);
+    const ds = {
+      query: jest.fn(async () => [{ present: false }]),
+      createQueryRunner: jest.fn(),
+    } as unknown as DataSource;
+    const factory = jest.spyOn(requestBackfillDataSource, 'createRequestBackfillDataSource');
+    const service = new RequestBackfillBootService(ds, state.repo);
+
+    try {
+      service.onApplicationBootstrap();
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('post-deploy request backfill failed: db down; retrying in 30s'),
+      );
+      await jest.advanceTimersByTimeAsync(REQUEST_BACKFILL_LOCK_RETRY_MS);
+
+      expect(state.countBy).toHaveBeenCalledTimes(2);
+      expect(factory).not.toHaveBeenCalled();
+      await service.onApplicationShutdown();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('stops retrying a self-hosted failure during shutdown', async () => {
+    jest.useFakeTimers();
+    process.env['NODE_ENV'] = 'production';
+    process.env['MANIFEST_MODE'] = 'selfhosted';
+    const state = makeState(false);
+    state.countBy.mockRejectedValue(new Error('db down'));
+    const service = new RequestBackfillBootService(
+      { createQueryRunner: jest.fn() } as unknown as DataSource,
+      state.repo,
+    );
+
+    try {
+      service.onApplicationBootstrap();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(state.countBy).toHaveBeenCalledTimes(1);
+
+      await service.onApplicationShutdown();
+      await jest.advanceTimersByTimeAsync(REQUEST_BACKFILL_LOCK_RETRY_MS);
+
+      expect(state.countBy).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('recreates the Cloud direct pool after a transient coordinator failure', async () => {
+    jest.useFakeTimers();
+    process.env['NODE_ENV'] = 'production';
+    process.env['MANIFEST_MODE'] = 'cloud';
+    process.env['MIGRATION_DATABASE_URL'] = 'postgres://direct/cloud';
+    const failedState = makeState(false);
+    failedState.countBy.mockRejectedValue(new Error('connection reset'));
+    const completedState = makeState(true);
+    const firstDirect = {
+      initialize: jest.fn(async () => undefined),
+      destroy: jest.fn(async () => undefined),
+      isInitialized: true,
+      getRepository: jest.fn(() => failedState.repo),
+    } as unknown as DataSource;
+    const secondDirect = {
+      initialize: jest.fn(async () => undefined),
+      destroy: jest.fn(async () => undefined),
+      isInitialized: true,
+      getRepository: jest.fn(() => completedState.repo),
+      query: jest.fn(async () => [{ present: false }]),
+    } as unknown as DataSource;
+    const factory = jest
+      .spyOn(requestBackfillDataSource, 'createRequestBackfillDataSource')
+      .mockReturnValueOnce(firstDirect)
+      .mockReturnValueOnce(secondDirect);
+    const service = new RequestBackfillBootService(
+      { createQueryRunner: jest.fn() } as unknown as DataSource,
+      makeState(false).repo,
+    );
+
+    try {
+      service.onApplicationBootstrap();
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(firstDirect.destroy).toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('connection reset; retrying in 30s'),
+      );
+
+      await jest.advanceTimersByTimeAsync(REQUEST_BACKFILL_LOCK_RETRY_MS);
+
+      expect(factory).toHaveBeenCalledTimes(2);
+      expect(secondDirect.initialize).toHaveBeenCalled();
+      expect(completedState.countBy).toHaveBeenCalled();
+      await service.onApplicationShutdown();
+      expect(secondDirect.destroy).toHaveBeenCalled();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('waits and retries when the shared lock is initially busy', async () => {
+    jest.useFakeTimers();
+    const state = makeState(false);
+    state.countBy.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+    const lock = makeLock(false);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+    try {
+      const result = new RequestBackfillBootService(ds, state.repo).runUntilComplete();
+      await jest.advanceTimersByTimeAsync(30_000);
+      await result;
+
+      expect(state.countBy).toHaveBeenCalledTimes(2);
+      expect(lock.release).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps retrying until the competing backfill completes', async () => {
+    jest.useFakeTimers();
+    const state = makeState(false);
+    const lock = makeLock(false);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+    try {
+      const result = new RequestBackfillBootService(ds, state.repo).runUntilComplete();
+      await jest.advanceTimersByTimeAsync(30_000 * 12);
+
+      expect(state.countBy.mock.calls.length).toBeGreaterThan(10);
+      expect(errorSpy).not.toHaveBeenCalled();
+      state.countBy.mockResolvedValue(1);
+      await jest.advanceTimersByTimeAsync(30_000);
+      await result;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('returns true without taking a lock when already complete', async () => {
+    const ds = { createQueryRunner: jest.fn() } as unknown as DataSource;
+    const runner = jest.fn();
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(true).repo).runOnce(runner),
+    ).resolves.toBe(true);
+    expect(ds.createQueryRunner).not.toHaveBeenCalled();
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('returns false and releases its connection when the shared lock is busy', async () => {
+    const lock = makeLock(false);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+    const runner = jest.fn();
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(false).repo).runOnce(runner),
+    ).resolves.toBe(false);
+    expect(lock.query).toHaveBeenCalledWith('SELECT pg_try_advisory_lock($1) AS locked', [
+      REQUEST_BACKFILL_LOCK_KEY,
+    ]);
+    expect(runner).not.toHaveBeenCalled();
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('passes its logger, marks completion, and releases the shared lock', async () => {
+    const lock = makeLock(true);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+    const state = makeState(false);
+    const runner = jest.fn(async () => ({ windows: 2, requests: 2, attempts: 3, rejections: 1 }));
+
+    await expect(new RequestBackfillBootService(ds, state.repo).runOnce(runner)).resolves.toBe(
+      true,
+    );
+    expect(runner).toHaveBeenCalledWith(
+      ds,
+      expect.objectContaining({ log: expect.any(Function) }),
+      expect.objectContaining({
+        analyze: true,
+        finalize: true,
+        before: expect.any(String),
+        fallbackBefore: expect.any(String),
+      }),
+    );
+    expect(state.values).toHaveBeenCalledWith({ name: REQUEST_BACKFILL_NAME });
+    expect(state.execute).toHaveBeenCalled();
+    expect(lock.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1)', [
+      REQUEST_BACKFILL_LOCK_KEY,
+    ]);
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('re-checks completion after acquiring the lock', async () => {
+    const lock = makeLock(true);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+    const state = makeState(false);
+    state.countBy.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+    const runner = jest.fn();
+
+    await expect(new RequestBackfillBootService(ds, state.repo).runOnce(runner)).resolves.toBe(
+      true,
+    );
+    expect(runner).not.toHaveBeenCalled();
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('unlocks and releases when the runner fails', async () => {
+    const lock = makeLock(true);
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+    const runner = jest.fn(async () => {
+      throw new Error('boom');
+    });
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(false).repo).runOnce(runner),
+    ).rejects.toThrow('boom');
+    expect(lock.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1)', [
+      REQUEST_BACKFILL_LOCK_KEY,
+    ]);
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('swallows unlock failures and still releases', async () => {
+    const lock = makeLock(true);
+    lock.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) return [{ locked: true }];
+      throw new Error('unlock failed');
+    });
+    const ds = { createQueryRunner: jest.fn(() => lock) } as unknown as DataSource;
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(false).repo).runOnce(
+        jest.fn().mockResolvedValue({ windows: 0, requests: 0, attempts: 0, rejections: 0 }),
+      ),
+    ).resolves.toBe(true);
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('uses the production backfill runner by default', async () => {
+    const lock = makeLock(true);
+    const transaction = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockImplementation(async (sql: string) => {
+        if (sql.includes('FALLBACK_PRIMARY_WINDOW_END_SQL')) return [{ end_id: null }];
+        if (sql.includes("status = 'fallback_error'") && sql.includes('max(id)')) {
+          return [{ end_id: null }];
+        }
+        if (sql.includes('max(pair_seq)')) return [{ max_seq: 0 }];
+        if (sql.includes('INSERT INTO "requests"')) return [{ n: 0 }];
+        if (sql.includes('UPDATE "agent_messages"')) return [{ n: 0 }];
+        return undefined;
+      }),
+    };
+    const ds = {
+      createQueryRunner: jest.fn().mockReturnValueOnce(lock).mockReturnValue(transaction),
+      query: jest
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([{ end_id: null }]),
+    } as unknown as DataSource;
+    const state = makeState(false);
+
+    await expect(new RequestBackfillBootService(ds, state.repo).runOnce()).resolves.toBe(true);
+    expect(state.execute).toHaveBeenCalled();
+  });
+
+  it('skips a tail sweep when no grace-aged writes are waiting', async () => {
+    const ds = {
+      query: jest.fn().mockResolvedValue([{ pending: false }]),
+      createQueryRunner: jest.fn(),
+    } as unknown as DataSource;
+    const runner = jest.fn();
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(true).repo).runTailOnce(runner),
+    ).resolves.toBe(true);
+    expect(ds.createQueryRunner).not.toHaveBeenCalled();
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('reports whether any attempts remain unlinked', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ pending: true }])
+      .mockResolvedValueOnce([{ pending: false }]);
+    const ds = { query } as unknown as DataSource;
+    const service = new RequestBackfillBootService(ds, makeState(true).repo);
+
+    await expect(service.hasUnlinkedAttempts()).resolves.toBe(true);
+    await expect(service.hasUnlinkedAttempts()).resolves.toBe(false);
+  });
+
+  it('tail-sweeps old-replica writes without re-analyzing or re-finalizing', async () => {
+    const lock = makeLock(true);
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ pending: true }])
+      .mockResolvedValueOnce([{ pending: true }]);
+    const ds = {
+      query,
+      createQueryRunner: jest.fn(() => lock),
+    } as unknown as DataSource;
+    const runner = jest.fn(
+      async (
+        _dataSource: DataSource,
+        _logger: Pick<Logger, 'log'>,
+        _options: {
+          analyze?: boolean;
+          finalizePending?: boolean;
+          finalize?: boolean;
+          before?: string;
+          fallbackBefore?: string;
+        },
+      ) => ({
+        windows: 1,
+        requests: 1,
+        attempts: 2,
+        rejections: 0,
+      }),
+    );
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(true).repo).runTailOnce(runner),
+    ).resolves.toBe(true);
+
+    const options = runner.mock.calls[0]![2];
+    expect(options).toEqual(
+      expect.objectContaining({
+        analyze: false,
+        finalizePending: true,
+        finalize: false,
+        before: expect.any(String),
+        fallbackBefore: expect.any(String),
+      }),
+    );
+    expect(Date.parse(options.fallbackBefore!)).toBeGreaterThan(Date.parse(options.before!));
+    expect(query).toHaveBeenNthCalledWith(1, expect.any(String), [options.fallbackBefore]);
+    expect(query).toHaveBeenNthCalledWith(2, expect.any(String), [options.fallbackBefore]);
+    expect(lock.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1)', [
+      REQUEST_BACKFILL_LOCK_KEY,
+    ]);
+  });
+
+  it('uses the default tail runner only after eligible attempts are found', async () => {
+    const ds = {
+      query: jest.fn().mockResolvedValue([{ pending: false }]),
+      createQueryRunner: jest.fn(),
+    } as unknown as DataSource;
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(true).repo).runTailOnce(),
+    ).resolves.toBe(true);
+    expect(ds.createQueryRunner).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the tail sweep cannot acquire the shared lock', async () => {
+    const lock = makeLock(false);
+    const ds = {
+      query: jest.fn().mockResolvedValue([{ pending: true }]),
+      createQueryRunner: jest.fn(() => lock),
+    } as unknown as DataSource;
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(true).repo).runTailOnce(jest.fn()),
+    ).resolves.toBe(false);
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('rechecks tail eligibility after acquiring the lock', async () => {
+    const lock = makeLock(true);
+    const ds = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([{ pending: true }])
+        .mockResolvedValueOnce([{ pending: false }]),
+      createQueryRunner: jest.fn(() => lock),
+    } as unknown as DataSource;
+    const runner = jest.fn();
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(true).repo).runTailOnce(runner),
+    ).resolves.toBe(true);
+    expect(runner).not.toHaveBeenCalled();
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('swallows tail unlock failures and still releases', async () => {
+    const lock = makeLock(true);
+    lock.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) return [{ locked: true }];
+      throw new Error('unlock failed');
+    });
+    const ds = {
+      query: jest.fn().mockResolvedValue([{ pending: true }]),
+      createQueryRunner: jest.fn(() => lock),
+    } as unknown as DataSource;
+
+    await expect(
+      new RequestBackfillBootService(ds, makeState(true).repo).runTailOnce(
+        jest.fn().mockResolvedValue({ windows: 0, requests: 0, attempts: 0, rejections: 0 }),
+      ),
+    ).resolves.toBe(true);
+    expect(lock.release).toHaveBeenCalled();
+  });
+
+  it('starts, reports, and stops the delta tail timer while agent_messages exists', async () => {
+    jest.useFakeTimers();
+    process.env['NODE_ENV'] = 'production';
+    process.env['MANIFEST_MODE'] = 'selfhosted';
+    const ds = {
+      query: jest.fn().mockResolvedValue([{ present: true }]),
+      createQueryRunner: jest.fn(),
+    } as unknown as DataSource;
+    const service = new RequestBackfillBootService(ds, makeState(true).repo);
+    const tail = jest.spyOn(service, 'runTailOnce').mockRejectedValue(new Error('tail failed'));
+
+    service.onApplicationBootstrap();
+    await jest.advanceTimersByTimeAsync(0);
+    await jest.advanceTimersByTimeAsync(REQUEST_BACKFILL_TAIL_INTERVAL_MS);
+
+    expect(tail).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('request backfill tail sweep failed'),
+    );
+    service.onApplicationShutdown();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('does not schedule tail sweeps when the attempt table is absent', async () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['MANIFEST_MODE'] = 'selfhosted';
+    const ds = {
+      query: jest.fn().mockResolvedValue([{ present: false }]),
+      createQueryRunner: jest.fn(),
+    } as unknown as DataSource;
+    const service = new RequestBackfillBootService(ds, makeState(true).repo);
+    const tail = jest.spyOn(service, 'runTailOnce');
+
+    service.onApplicationBootstrap();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(ds.query).toHaveBeenCalledTimes(1);
+    expect(tail).not.toHaveBeenCalled();
+    service.onApplicationShutdown();
+  });
+});

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { BackfillState } from '../../entities/backfill-state.entity';
 import * as requestBackfillDataSource from './request-backfill.datasource';
+import { MessageProviderBackfillBootService } from './message-provider-backfill.boot.service';
 import {
   REQUEST_BACKFILL_LOCK_KEY,
   REQUEST_BACKFILL_LOCK_RETRY_MS,
@@ -81,6 +82,9 @@ describe('RequestBackfillBootService', () => {
     const factory = jest
       .spyOn(requestBackfillDataSource, 'createRequestBackfillDataSource')
       .mockReturnValue(directDataSource);
+    const providerBackfill = jest
+      .spyOn(MessageProviderBackfillBootService.prototype, 'runUntilComplete')
+      .mockResolvedValue(undefined);
     const service = new RequestBackfillBootService(appDataSource, makeState(false).repo);
 
     service.onApplicationBootstrap();
@@ -89,6 +93,7 @@ describe('RequestBackfillBootService', () => {
     expect(factory).toHaveBeenCalledWith(process.env);
     expect(directDataSource.initialize).toHaveBeenCalled();
     expect(directDataSource.getRepository).toHaveBeenCalledWith(BackfillState);
+    expect(providerBackfill).toHaveBeenCalledTimes(1);
     expect(appDataSource.createQueryRunner).not.toHaveBeenCalled();
     await service.onApplicationShutdown();
     expect(directDataSource.destroy).toHaveBeenCalled();
@@ -293,7 +298,7 @@ describe('RequestBackfillBootService', () => {
 
     try {
       const result = new RequestBackfillBootService(ds, state.repo).runUntilComplete();
-      await jest.advanceTimersByTimeAsync(30_000);
+      await jest.advanceTimersByTimeAsync(REQUEST_BACKFILL_LOCK_RETRY_MS);
       await result;
 
       expect(state.countBy).toHaveBeenCalledTimes(2);
@@ -311,12 +316,12 @@ describe('RequestBackfillBootService', () => {
 
     try {
       const result = new RequestBackfillBootService(ds, state.repo).runUntilComplete();
-      await jest.advanceTimersByTimeAsync(30_000 * 12);
+      await jest.advanceTimersByTimeAsync(REQUEST_BACKFILL_LOCK_RETRY_MS * 12);
 
       expect(state.countBy.mock.calls.length).toBeGreaterThan(10);
       expect(errorSpy).not.toHaveBeenCalled();
       state.countBy.mockResolvedValue(1);
-      await jest.advanceTimersByTimeAsync(30_000);
+      await jest.advanceTimersByTimeAsync(REQUEST_BACKFILL_LOCK_RETRY_MS);
       await result;
     } finally {
       jest.useRealTimers();
@@ -610,7 +615,7 @@ describe('RequestBackfillBootService', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('request backfill tail sweep failed'),
     );
-    service.onApplicationShutdown();
+    await service.onApplicationShutdown();
     jest.clearAllTimers();
     jest.useRealTimers();
   });
@@ -630,6 +635,6 @@ describe('RequestBackfillBootService', () => {
 
     expect(ds.query).toHaveBeenCalledTimes(1);
     expect(tail).not.toHaveBeenCalled();
-    service.onApplicationShutdown();
+    await service.onApplicationShutdown();
   });
 });

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
@@ -480,7 +480,7 @@ describe('RequestBackfillBootService', () => {
     await expect(service.hasUnlinkedAttempts()).resolves.toBe(false);
   });
 
-  it('tail-sweeps old-replica writes without re-analyzing or re-finalizing', async () => {
+  it('tail-sweeps old-replica writes without re-analyzing', async () => {
     const lock = makeLock(true);
     const query = jest
       .fn()
@@ -496,7 +496,6 @@ describe('RequestBackfillBootService', () => {
         _logger: Pick<Logger, 'log'>,
         _options: {
           analyze?: boolean;
-          finalizePending?: boolean;
           finalize?: boolean;
           before?: string;
           fallbackBefore?: string;
@@ -517,8 +516,7 @@ describe('RequestBackfillBootService', () => {
     expect(options).toEqual(
       expect.objectContaining({
         analyze: false,
-        finalizePending: true,
-        finalize: false,
+        finalize: true,
         before: expect.any(String),
         fallbackBefore: expect.any(String),
       }),

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.ts
@@ -1,0 +1,282 @@
+import { Injectable, Logger, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { toLocalSqlTimestamp } from '../../common/utils/postgres-sql';
+import { isSelfHosted } from '../../common/utils/detect-self-hosted';
+import { BackfillState } from '../../entities/backfill-state.entity';
+import {
+  runRequestBackfill,
+  type RequestBackfillOptions,
+  type RequestBackfillResult,
+} from './backfill-requests';
+import { TypeOrmRequestBackfillGateway } from './backfill-requests.gateway';
+import { MESSAGE_PROVIDER_BACKFILL_LOCK_KEY } from './message-provider-backfill.boot.service';
+import { createRequestBackfillDataSource } from './request-backfill.datasource';
+
+/** Initial historical pass marker; legacy-writer delta is tracked by unlinked rows. */
+export const REQUEST_BACKFILL_NAME = 'requests_agent_messages_v1';
+// Both post-deploy jobs update agent_messages. Sharing the lock guarantees
+// that Cloud never runs their batches concurrently; a contending job releases
+// its connection and retries until both completion markers exist.
+export const REQUEST_BACKFILL_LOCK_KEY = MESSAGE_PROVIDER_BACKFILL_LOCK_KEY;
+
+type RequestBackfillRunner = (
+  dataSource: DataSource,
+  logger: Pick<Logger, 'log'>,
+  options: Pick<
+    RequestBackfillOptions,
+    'analyze' | 'before' | 'fallbackBefore' | 'finalizePending' | 'finalize'
+  >,
+) => Promise<RequestBackfillResult>;
+
+const defaultRunner: RequestBackfillRunner = (dataSource, logger, options) =>
+  runRequestBackfill(new TypeOrmRequestBackfillGateway(dataSource), { logger, ...options });
+
+export const REQUEST_BACKFILL_LOCK_RETRY_MS = 30_000;
+export const REQUEST_BACKFILL_TAIL_INTERVAL_MS = 60_000;
+export const REQUEST_BACKFILL_FALLBACK_GRACE_MS = 5 * 60_000;
+export const REQUEST_BACKFILL_GENERIC_GRACE_MS = 10 * 60_000;
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    if (typeof timer === 'object' && 'unref' in timer) timer.unref();
+  });
+
+/**
+ * Runs historical regrouping without blocking application readiness. Self-hosted
+ * reuses its DATABASE_URL-backed app connection. Cloud opens a separate direct
+ * connection so session locks and temporary tables never cross PgBouncer.
+ */
+@Injectable()
+export class RequestBackfillBootService implements OnApplicationBootstrap, OnApplicationShutdown {
+  private readonly logger = new Logger(RequestBackfillBootService.name);
+  private tailTimer: ReturnType<typeof setInterval> | undefined;
+  private stopping = false;
+  private managedCoordinator: RequestBackfillBootService | undefined;
+  private ownedDataSource: DataSource | undefined;
+
+  constructor(
+    private readonly dataSource: DataSource,
+    @InjectRepository(BackfillState)
+    private readonly stateRepo: Repository<BackfillState>,
+  ) {}
+
+  onApplicationBootstrap(): void {
+    if (process.env['NODE_ENV'] !== 'production') return;
+    this.stopping = false;
+    void this.runManagedBackfill();
+  }
+
+  async onApplicationShutdown(): Promise<void> {
+    this.stopping = true;
+    if (this.tailTimer) clearInterval(this.tailTimer);
+    if (this.managedCoordinator && this.managedCoordinator !== this) {
+      this.managedCoordinator.stopTailSweep();
+    }
+    const ownedDataSource = this.ownedDataSource;
+    this.ownedDataSource = undefined;
+    if (ownedDataSource?.isInitialized) await ownedDataSource.destroy();
+  }
+
+  /**
+   * Self-hosted reuses its DATABASE_URL-backed application DataSource. Cloud
+   * creates a separate direct pool so advisory locks and temporary staging
+   * tables never cross transaction-mode PgBouncer.
+   */
+  private async runManagedBackfill(): Promise<void> {
+    while (!this.stopping) {
+      try {
+        const coordinator = isSelfHosted() ? this : await this.createCloudCoordinator();
+        if (!coordinator || this.stopping) return;
+        this.managedCoordinator = coordinator;
+        await coordinator.runUntilComplete();
+        if (this.stopping) return;
+        await coordinator.startTailSweep();
+        if (this.stopping) coordinator.stopTailSweep();
+        return;
+      } catch (error) {
+        await this.releaseCloudCoordinator();
+        if (this.stopping) return;
+        this.logger.error(
+          `post-deploy request backfill failed: ${error instanceof Error ? error.message : String(error)}; retrying in ${REQUEST_BACKFILL_LOCK_RETRY_MS / 1000}s`,
+        );
+        await wait(REQUEST_BACKFILL_LOCK_RETRY_MS);
+      }
+    }
+  }
+
+  private async createCloudCoordinator(): Promise<RequestBackfillBootService | null> {
+    const dataSource = createRequestBackfillDataSource(process.env);
+    await dataSource.initialize();
+    if (this.stopping) {
+      await dataSource.destroy();
+      return null;
+    }
+    this.ownedDataSource = dataSource;
+    return new RequestBackfillBootService(dataSource, dataSource.getRepository(BackfillState));
+  }
+
+  private async releaseCloudCoordinator(): Promise<void> {
+    if (this.managedCoordinator && this.managedCoordinator !== this) {
+      this.managedCoordinator.stopTailSweep();
+    }
+    this.managedCoordinator = undefined;
+    const dataSource = this.ownedDataSource;
+    this.ownedDataSource = undefined;
+    if (dataSource?.isInitialized) await dataSource.destroy().catch(() => undefined);
+  }
+
+  private stopTailSweep(): void {
+    if (this.tailTimer) clearInterval(this.tailTimer);
+    this.tailTimer = undefined;
+  }
+
+  async runUntilComplete(): Promise<void> {
+    while (!(await this.runOnce())) {
+      await wait(REQUEST_BACKFILL_LOCK_RETRY_MS);
+    }
+  }
+
+  async runOnce(runner: RequestBackfillRunner = defaultRunner): Promise<boolean> {
+    if (await this.isCompleted()) return true;
+    const lock = this.dataSource.createQueryRunner();
+    await lock.connect();
+    let acquired = false;
+    try {
+      const rows = (await lock.query('SELECT pg_try_advisory_lock($1) AS locked', [
+        REQUEST_BACKFILL_LOCK_KEY,
+      ])) as { locked: boolean }[];
+      acquired = rows[0]?.locked === true;
+      if (!acquired) {
+        this.logger.log('another backfill is running; retrying request backfill later');
+        return false;
+      }
+      if (await this.isCompleted()) return true;
+      this.logger.log('running post-deploy request/provider-attempt backfill…');
+      const result = await runner(this.dataSource, this.logger, this.runOptions(true));
+      await this.stateRepo
+        .createQueryBuilder()
+        .insert()
+        .into(BackfillState)
+        .values({ name: REQUEST_BACKFILL_NAME })
+        .orIgnore()
+        .execute();
+      this.logger.log(
+        `request backfill complete: ${result.attempts} attempt(s), ${result.rejections} rejection(s), ${result.windows} window(s)`,
+      );
+      return true;
+    } finally {
+      if (acquired) {
+        await lock
+          .query('SELECT pg_advisory_unlock($1)', [REQUEST_BACKFILL_LOCK_KEY])
+          .catch(() => undefined);
+      }
+      await lock.release();
+    }
+  }
+
+  /**
+   * Old replicas write their unchanged column set without request_id.
+   * Revisit those rows after a grace period, using a larger delay for generic
+   * linking so a fallback terminal always gets another reconstruction pass.
+   */
+  async runTailOnce(runner: RequestBackfillRunner = defaultRunner): Promise<boolean> {
+    const options = this.runOptions(false);
+    if (!(await this.hasEligibleAttempts(options.fallbackBefore!))) return true;
+
+    const lock = this.dataSource.createQueryRunner();
+    await lock.connect();
+    let acquired = false;
+    try {
+      const rows = (await lock.query('SELECT pg_try_advisory_lock($1) AS locked', [
+        REQUEST_BACKFILL_LOCK_KEY,
+      ])) as { locked: boolean }[];
+      acquired = rows[0]?.locked === true;
+      if (!acquired) return false;
+      if (!(await this.hasEligibleAttempts(options.fallbackBefore!))) return true;
+
+      const result = await runner(this.dataSource, this.logger, options);
+      this.logger.log(
+        `request backfill tail sweep: ${result.attempts} attempt(s), ${result.rejections} rejection(s), ${result.windows} window(s)`,
+      );
+      return true;
+    } finally {
+      if (acquired) {
+        await lock
+          .query('SELECT pg_advisory_unlock($1)', [REQUEST_BACKFILL_LOCK_KEY])
+          .catch(() => undefined);
+      }
+      await lock.release();
+    }
+  }
+
+  async hasUnlinkedAttempts(): Promise<boolean> {
+    const rows = (await this.dataSource.query(
+      `SELECT EXISTS (
+         SELECT 1 FROM "agent_messages"
+         WHERE "request_id" IS NULL
+         LIMIT 1
+       ) AS pending`,
+    )) as { pending: boolean }[];
+    return rows[0]?.pending === true;
+  }
+
+  private async startTailSweep(): Promise<void> {
+    if (!(await this.hasAttemptTable())) return;
+    this.tailTimer = setInterval(() => {
+      void this.runTailOnce().catch((error) => {
+        this.logger.error(
+          `request backfill tail sweep failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    }, REQUEST_BACKFILL_TAIL_INTERVAL_MS);
+    if (typeof this.tailTimer === 'object' && 'unref' in this.tailTimer) this.tailTimer.unref();
+  }
+
+  private runOptions(
+    initial: boolean,
+  ): Pick<
+    RequestBackfillOptions,
+    'analyze' | 'before' | 'fallbackBefore' | 'finalizePending' | 'finalize'
+  > {
+    const now = Date.now();
+    return {
+      analyze: initial,
+      finalizePending: !initial,
+      finalize: initial,
+      fallbackBefore: toLocalSqlTimestamp(new Date(now - REQUEST_BACKFILL_FALLBACK_GRACE_MS)),
+      before: toLocalSqlTimestamp(new Date(now - REQUEST_BACKFILL_GENERIC_GRACE_MS)),
+    };
+  }
+
+  private async hasEligibleAttempts(before: string): Promise<boolean> {
+    const rows = (await this.dataSource.query(
+      `SELECT EXISTS (
+         SELECT 1 FROM "agent_messages"
+         WHERE "request_id" IS NULL AND timestamp < $1
+         LIMIT 1
+       ) AS pending`,
+      [before],
+    )) as { pending: boolean }[];
+    return rows[0]?.pending === true;
+  }
+
+  private async hasAttemptTable(): Promise<boolean> {
+    const rows = (await this.dataSource.query(
+      `SELECT EXISTS (
+         SELECT 1
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relname = 'agent_messages'
+           AND c.relkind IN ('r', 'p')
+       ) AS present`,
+    )) as { present: boolean }[];
+    return rows[0]?.present === true;
+  }
+
+  private async isCompleted(): Promise<boolean> {
+    return (await this.stateRepo.countBy({ name: REQUEST_BACKFILL_NAME })) > 0;
+  }
+}

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.ts
@@ -10,7 +10,10 @@ import {
   type RequestBackfillResult,
 } from './backfill-requests';
 import { TypeOrmRequestBackfillGateway } from './backfill-requests.gateway';
-import { MESSAGE_PROVIDER_BACKFILL_LOCK_KEY } from './message-provider-backfill.boot.service';
+import {
+  MESSAGE_PROVIDER_BACKFILL_LOCK_KEY,
+  MessageProviderBackfillBootService,
+} from './message-provider-backfill.boot.service';
 import { createRequestBackfillDataSource } from './request-backfill.datasource';
 
 /** Initial historical pass marker; legacy-writer delta is tracked by unlinked rows. */
@@ -111,7 +114,11 @@ export class RequestBackfillBootService implements OnApplicationBootstrap, OnApp
       return null;
     }
     this.ownedDataSource = dataSource;
-    return new RequestBackfillBootService(dataSource, dataSource.getRepository(BackfillState));
+    const stateRepo = dataSource.getRepository(BackfillState);
+    // The older provider-attribution task uses the same direct connection in
+    // Cloud. Its session advisory lock must never cross transaction PgBouncer.
+    await new MessageProviderBackfillBootService(dataSource, stateRepo).runUntilComplete();
+    return new RequestBackfillBootService(dataSource, stateRepo);
   }
 
   private async releaseCloudCoordinator(): Promise<void> {

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.ts
@@ -23,10 +23,7 @@ export const REQUEST_BACKFILL_LOCK_KEY = MESSAGE_PROVIDER_BACKFILL_LOCK_KEY;
 type RequestBackfillRunner = (
   dataSource: DataSource,
   logger: Pick<Logger, 'log'>,
-  options: Pick<
-    RequestBackfillOptions,
-    'analyze' | 'before' | 'fallbackBefore' | 'finalizePending' | 'finalize'
-  >,
+  options: Pick<RequestBackfillOptions, 'analyze' | 'before' | 'fallbackBefore' | 'finalize'>,
 ) => Promise<RequestBackfillResult>;
 
 const defaultRunner: RequestBackfillRunner = (dataSource, logger, options) =>
@@ -236,15 +233,11 @@ export class RequestBackfillBootService implements OnApplicationBootstrap, OnApp
 
   private runOptions(
     initial: boolean,
-  ): Pick<
-    RequestBackfillOptions,
-    'analyze' | 'before' | 'fallbackBefore' | 'finalizePending' | 'finalize'
-  > {
+  ): Pick<RequestBackfillOptions, 'analyze' | 'before' | 'fallbackBefore' | 'finalize'> {
     const now = Date.now();
     return {
       analyze: initial,
-      finalizePending: !initial,
-      finalize: initial,
+      finalize: true,
       fallbackBefore: toLocalSqlTimestamp(new Date(now - REQUEST_BACKFILL_FALLBACK_GRACE_MS)),
       before: toLocalSqlTimestamp(new Date(now - REQUEST_BACKFILL_GENERIC_GRACE_MS)),
     };

--- a/packages/backend/src/database/backfills/request-backfill.cli.spec.ts
+++ b/packages/backend/src/database/backfills/request-backfill.cli.spec.ts
@@ -41,7 +41,7 @@ describe('resolveRequestBackfillDatabaseUrl', () => {
       }),
     ).toThrow('A direct PostgreSQL URL is required');
     expect(() => resolveRequestBackfillDatabaseUrl({})).toThrow(
-      'A direct PostgreSQL URL is required',
+      'set MIGRATION_DATABASE_URL, DATABASE_UNPOOLED_URL, or BACKFILL_DATABASE_URL',
     );
   });
 });

--- a/packages/backend/src/database/backfills/request-backfill.cli.spec.ts
+++ b/packages/backend/src/database/backfills/request-backfill.cli.spec.ts
@@ -1,0 +1,179 @@
+import { DataSource } from 'typeorm';
+
+import {
+  createRequestBackfillDataSource,
+  main,
+  resolveRequestBackfillDatabaseUrl,
+} from './request-backfill.cli';
+import {
+  REQUEST_BACKFILL_GENERIC_GRACE_MS,
+  REQUEST_BACKFILL_LOCK_RETRY_MS,
+} from './request-backfill.boot.service';
+
+describe('resolveRequestBackfillDatabaseUrl', () => {
+  it('prefers explicit direct connection variables', () => {
+    expect(
+      resolveRequestBackfillDatabaseUrl({
+        BACKFILL_DATABASE_URL: 'postgres://backfill/db',
+        MIGRATION_DATABASE_URL: 'postgres://migration/db',
+        DATABASE_UNPOOLED_URL: 'postgres://unpooled/db',
+      }),
+    ).toBe('postgres://migration/db');
+    expect(
+      resolveRequestBackfillDatabaseUrl({
+        MIGRATION_DATABASE_URL: '  ',
+        DATABASE_UNPOOLED_URL: 'postgres://unpooled/db',
+        BACKFILL_DATABASE_URL: 'postgres://backfill/db',
+      }),
+    ).toBe('postgres://unpooled/db');
+    expect(
+      resolveRequestBackfillDatabaseUrl({
+        DATABASE_UNPOOLED_URL: '',
+        BACKFILL_DATABASE_URL: 'postgres://backfill/db',
+      }),
+    ).toBe('postgres://backfill/db');
+  });
+
+  it('refuses the pooled application URL regardless of NODE_ENV', () => {
+    expect(() =>
+      resolveRequestBackfillDatabaseUrl({
+        DATABASE_URL: 'postgres://pgbouncer/db',
+      }),
+    ).toThrow('A direct PostgreSQL URL is required');
+    expect(() => resolveRequestBackfillDatabaseUrl({})).toThrow(
+      'A direct PostgreSQL URL is required',
+    );
+  });
+});
+
+describe('createRequestBackfillDataSource', () => {
+  it('uses a two-connection direct pool', () => {
+    const dataSource = createRequestBackfillDataSource({
+      BACKFILL_DATABASE_URL: 'postgres://backfill/db',
+    });
+    expect(dataSource.options).toEqual(
+      expect.objectContaining({
+        url: 'postgres://backfill/db',
+        extra: { max: 2 },
+      }),
+    );
+  });
+});
+
+describe('main', () => {
+  function fakeDataSource(): DataSource & {
+    initialize: jest.Mock;
+    destroy: jest.Mock;
+    getRepository: jest.Mock;
+    query: jest.Mock;
+  } {
+    return {
+      initialize: jest.fn(async () => undefined),
+      destroy: jest.fn(async () => undefined),
+      getRepository: jest.fn(() => ({ countBy: jest.fn(async () => 1) })),
+      query: jest.fn(async () => [{ pending: false }]),
+      createQueryRunner: jest.fn(),
+    } as unknown as DataSource & {
+      initialize: jest.Mock;
+      destroy: jest.Mock;
+      getRepository: jest.Mock;
+      query: jest.Mock;
+    };
+  }
+
+  it('runs the initial pass, waits through grace, retries the lock, and catches up', async () => {
+    const dataSource = fakeDataSource();
+    const coordinator = {
+      runUntilComplete: jest.fn(async () => undefined),
+      runTailOnce: jest.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true),
+      hasUnlinkedAttempts: jest.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false),
+    };
+    const sleep = jest.fn(async () => undefined);
+    const logger = { log: jest.fn(), error: jest.fn() };
+
+    await main({
+      env: {},
+      logger,
+      dataSource,
+      coordinator,
+      sleep,
+    });
+
+    expect(coordinator.runUntilComplete).toHaveBeenCalled();
+    expect(coordinator.hasUnlinkedAttempts).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, REQUEST_BACKFILL_GENERIC_GRACE_MS);
+    expect(sleep).toHaveBeenNthCalledWith(2, REQUEST_BACKFILL_LOCK_RETRY_MS);
+    expect(coordinator.runTailOnce).toHaveBeenCalledTimes(2);
+    expect(logger.log).toHaveBeenLastCalledWith(
+      'request/provider-attempt backfill and catch-up complete',
+    );
+    expect(dataSource.destroy).toHaveBeenCalled();
+  });
+
+  it('can stop after the historical pass while live writes continue', async () => {
+    const dataSource = fakeDataSource();
+    const coordinator = {
+      runUntilComplete: jest.fn(async () => undefined),
+      runTailOnce: jest.fn(),
+      hasUnlinkedAttempts: jest.fn(),
+    };
+    const logger = { log: jest.fn(), error: jest.fn() };
+
+    await main({ dataSource, coordinator, logger, initialOnly: true });
+
+    expect(coordinator.runUntilComplete).toHaveBeenCalledTimes(1);
+    expect(coordinator.hasUnlinkedAttempts).not.toHaveBeenCalled();
+    expect(coordinator.runTailOnce).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenLastCalledWith(
+      'request/provider-attempt historical backfill complete; live-write delta deferred',
+    );
+    expect(dataSource.destroy).toHaveBeenCalled();
+  });
+
+  it('uses the real coordinator and exits when nothing remains unlinked', async () => {
+    const dataSource = fakeDataSource();
+    const sleep = jest.fn(async () => undefined);
+    await main({ dataSource, sleep, logger: { log: jest.fn(), error: jest.fn() } });
+
+    expect(dataSource.getRepository).toHaveBeenCalled();
+    expect(dataSource.query).toHaveBeenCalled();
+    expect(sleep).not.toHaveBeenCalled();
+    expect(dataSource.destroy).toHaveBeenCalled();
+  });
+
+  it('destroys the data source when the worker fails', async () => {
+    const dataSource = fakeDataSource();
+    const failure = new Error('backfill failed');
+    const coordinator = {
+      runUntilComplete: jest.fn(async () => {
+        throw failure;
+      }),
+      runTailOnce: jest.fn(),
+      hasUnlinkedAttempts: jest.fn(),
+    };
+
+    await expect(main({ dataSource, coordinator })).rejects.toBe(failure);
+    expect(dataSource.destroy).toHaveBeenCalled();
+  });
+
+  it('uses a real timer when no sleep dependency is supplied', async () => {
+    jest.useFakeTimers();
+    const dataSource = fakeDataSource();
+    const coordinator = {
+      runUntilComplete: jest.fn(async () => undefined),
+      runTailOnce: jest.fn(async () => true),
+      hasUnlinkedAttempts: jest.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false),
+    };
+    try {
+      const result = main({
+        dataSource,
+        coordinator,
+        logger: { log: jest.fn(), error: jest.fn() },
+      });
+      await jest.advanceTimersByTimeAsync(REQUEST_BACKFILL_GENERIC_GRACE_MS);
+      await result;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/packages/backend/src/database/backfills/request-backfill.cli.ts
+++ b/packages/backend/src/database/backfills/request-backfill.cli.ts
@@ -1,0 +1,79 @@
+import 'dotenv/config';
+import { DataSource } from 'typeorm';
+
+import { BackfillState } from '../../entities/backfill-state.entity';
+import {
+  createRequestBackfillDataSource,
+  resolveRequestBackfillDatabaseUrl,
+} from './request-backfill.datasource';
+import {
+  REQUEST_BACKFILL_GENERIC_GRACE_MS,
+  REQUEST_BACKFILL_LOCK_RETRY_MS,
+  RequestBackfillBootService,
+} from './request-backfill.boot.service';
+
+export { createRequestBackfillDataSource, resolveRequestBackfillDatabaseUrl };
+
+interface BackfillCoordinator {
+  runUntilComplete(): Promise<void>;
+  runTailOnce(): Promise<boolean>;
+  hasUnlinkedAttempts(): Promise<boolean>;
+}
+
+export interface MainDeps {
+  env?: NodeJS.ProcessEnv;
+  logger?: { log: (message: string) => void; error: (message: unknown) => void };
+  dataSource?: DataSource;
+  coordinator?: BackfillCoordinator;
+  sleep?: (ms: number) => Promise<void>;
+  initialOnly?: boolean;
+}
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/** Run after the new Railway deployment is healthy and the old replica drained. */
+export async function main(deps: MainDeps = {}): Promise<void> {
+  const env = deps.env ?? process.env;
+  const logger = deps.logger ?? console;
+  const sleep = deps.sleep ?? realSleep;
+  const dataSource = deps.dataSource ?? createRequestBackfillDataSource(env);
+
+  await dataSource.initialize();
+  try {
+    const coordinator =
+      deps.coordinator ??
+      new RequestBackfillBootService(dataSource, dataSource.getRepository(BackfillState));
+    await coordinator.runUntilComplete();
+    if (deps.initialOnly === true) {
+      logger.log(
+        'request/provider-attempt historical backfill complete; live-write delta deferred',
+      );
+      return;
+    }
+
+    // Old replicas can write their unchanged columns during the rolling
+    // handover. If any unlinked rows remain after the historical pass, give them a
+    // full generic grace window, then perform one explicit catch-up.
+    while (await coordinator.hasUnlinkedAttempts()) {
+      logger.log(`waiting ${REQUEST_BACKFILL_GENERIC_GRACE_MS / 1000}s for legacy writes to age`);
+      await sleep(REQUEST_BACKFILL_GENERIC_GRACE_MS);
+      while (!(await coordinator.runTailOnce())) {
+        await sleep(REQUEST_BACKFILL_LOCK_RETRY_MS);
+      }
+    }
+    logger.log('request/provider-attempt backfill and catch-up complete');
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+/* istanbul ignore next -- thin process entrypoint, exercised by the Railway worker */
+if (require.main === module) {
+  main({ initialOnly: process.argv.slice(2).includes('--initial-only') }).catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/backend/src/database/backfills/request-backfill.datasource.ts
+++ b/packages/backend/src/database/backfills/request-backfill.datasource.ts
@@ -1,0 +1,32 @@
+import { DataSource } from 'typeorm';
+
+import { BackfillState } from '../../entities/backfill-state.entity';
+
+/**
+ * Resolve the direct connection used by Cloud migration/backfill workers.
+ * Self-hosted boot never calls this helper; it reuses the application's
+ * DATABASE_URL-backed DataSource instead. The standalone worker always fails
+ * closed: NODE_ENV is not a reliable signal that DATABASE_URL bypasses a
+ * transaction-mode pooler.
+ */
+export function resolveRequestBackfillDatabaseUrl(env: NodeJS.ProcessEnv): string {
+  const directUrl =
+    env['MIGRATION_DATABASE_URL']?.trim() ||
+    env['DATABASE_UNPOOLED_URL']?.trim() ||
+    env['BACKFILL_DATABASE_URL']?.trim();
+  if (directUrl) return directUrl;
+
+  throw new Error(
+    'A direct PostgreSQL URL is required; set BACKFILL_DATABASE_URL, MIGRATION_DATABASE_URL, or DATABASE_UNPOOLED_URL',
+  );
+}
+
+/** Two direct connections: one holds the advisory lock, one runs backfill SQL. */
+export function createRequestBackfillDataSource(env: NodeJS.ProcessEnv): DataSource {
+  return new DataSource({
+    type: 'postgres',
+    url: resolveRequestBackfillDatabaseUrl(env),
+    entities: [BackfillState],
+    extra: { max: 2 },
+  });
+}

--- a/packages/backend/src/database/backfills/request-backfill.datasource.ts
+++ b/packages/backend/src/database/backfills/request-backfill.datasource.ts
@@ -17,7 +17,7 @@ export function resolveRequestBackfillDatabaseUrl(env: NodeJS.ProcessEnv): strin
   if (directUrl) return directUrl;
 
   throw new Error(
-    'A direct PostgreSQL URL is required; set BACKFILL_DATABASE_URL, MIGRATION_DATABASE_URL, or DATABASE_UNPOOLED_URL',
+    'A direct PostgreSQL URL is required; set MIGRATION_DATABASE_URL, DATABASE_UNPOOLED_URL, or BACKFILL_DATABASE_URL',
   );
 }
 

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -145,6 +145,8 @@ import { AddAutofixMessageFields1799000100000 } from './migrations/1799000100000
 import { AddAutofixPhoenixIds1799000200000 } from './migrations/1799000200000-AddAutofixPhoenixIds';
 import { MakeAutofixEnabledNullable1799000300000 } from './migrations/1799000300000-MakeAutofixEnabledNullable';
 import { AddAutofixAccessGrant1799000400000 } from './migrations/1799000400000-AddAutofixAccessGrant';
+import { AddRequestsAndProviderAttempts1801000000000 } from './migrations/1801000000000-AddRequestsAndProviderAttempts';
+import { AddProviderAttemptOrdering1801100000000 } from './migrations/1801100000000-AddProviderAttemptOrdering';
 
 export const entities = [
   AgentMessage,
@@ -292,4 +294,6 @@ export const migrations = [
   ReclassifyPlanRequestLimitMessages1800100000000,
   AddMessageErrorCode1800200000000,
   DropUnusedAgentMessageIndexes1800300000000,
+  AddRequestsAndProviderAttempts1801000000000,
+  AddProviderAttemptOrdering1801100000000,
 ];

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
@@ -45,6 +45,7 @@ describe('AddRequestsAndProviderAttempts1801000000000', () => {
       '"IDX_agent_messages_request_id" ON "agent_messages" ("request_id", "id")',
     );
     expect(sql).toContain('"IDX_agent_messages_unlinked_fallback"');
+    expect(sql).toContain(`"IDX_requests_pending" ON "requests" ("id") WHERE "status" = 'pending'`);
     expect(sql).not.toMatch(/INSERT\s+INTO\s+"requests"/i);
     expect(sql).not.toMatch(/UPDATE\s+"agent_messages"/i);
   });

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
@@ -21,6 +21,7 @@ describe('AddRequestsAndProviderAttempts1801000000000', () => {
     const sql = queries.join('\n');
     expect(migration.transaction).toBe(false);
     expect(queries[0]).toContain("SET lock_timeout = '5s'");
+    expect(queries.at(-1)).toContain('RESET lock_timeout');
     expect(sql).toContain('CREATE TABLE IF NOT EXISTS "requests"');
     expect(sql).toContain('"autofix_status" varchar');
     expect(sql).toContain('CONSTRAINT "CHK_requests_autofix_status"');
@@ -38,6 +39,7 @@ describe('AddRequestsAndProviderAttempts1801000000000', () => {
     expect(sql).not.toMatch(/RENAME\s+COLUMN/i);
     expect(sql).toContain('ADD COLUMN IF NOT EXISTS "request_id"');
     expect(sql).toContain('NOT VALID');
+    expect(sql).toContain("conrelid = 'agent_messages'::regclass");
     expect(sql).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
     expect(sql).toContain(
       '"IDX_agent_messages_request_id" ON "agent_messages" ("request_id", "id")',
@@ -118,6 +120,71 @@ describe('AddRequestsAndProviderAttempts1801000000000', () => {
         sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_unlinked_fallback"'),
       ),
     ).toBe(true);
+  });
+
+  it('rebuilds a fallback index missing its covering columns or predicate', async () => {
+    (runner as { query: jest.Mock }).query.mockImplementation((sql: string) => {
+      queries.push(sql);
+      if (sql.includes("c.relname = 'IDX_agent_messages_request_id'")) {
+        return Promise.resolve([{ valid: true, definition: '(request_id, id)' }]);
+      }
+      if (sql.includes("c.relname = 'IDX_agent_messages_unlinked_fallback'")) {
+        return Promise.resolve([
+          {
+            valid: true,
+            definition: '(fallback_from_model, "timestamp", tenant_id, agent_id)',
+          },
+        ]);
+      }
+      return Promise.resolve();
+    });
+
+    await migration.up(runner);
+
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_unlinked_fallback"'),
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps a valid fallback index with the expected covering predicate', async () => {
+    (runner as { query: jest.Mock }).query.mockImplementation((sql: string) => {
+      queries.push(sql);
+      if (sql.includes("c.relname = 'IDX_agent_messages_request_id'")) {
+        return Promise.resolve([{ valid: true, definition: '(request_id, id)' }]);
+      }
+      if (sql.includes("c.relname = 'IDX_agent_messages_unlinked_fallback'")) {
+        return Promise.resolve([
+          {
+            valid: true,
+            definition:
+              '(fallback_from_model, "timestamp", tenant_id, agent_id) INCLUDE (fallback_index, status, superseded) WHERE ((request_id IS NULL) AND (fallback_from_model IS NOT NULL))',
+          },
+        ]);
+      }
+      return Promise.resolve();
+    });
+
+    await migration.up(runner);
+
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_unlinked_fallback"'),
+      ),
+    ).toBe(false);
+  });
+
+  it('resets the lock timeout when the migration fails', async () => {
+    const failure = new Error('lock timeout');
+    (runner as { query: jest.Mock }).query.mockImplementation((sql: string) => {
+      queries.push(sql);
+      if (sql.includes('CREATE TABLE')) return Promise.reject(failure);
+      return Promise.resolve();
+    });
+
+    await expect(migration.up(runner)).rejects.toBe(failure);
+    expect(queries.at(-1)).toContain('RESET lock_timeout');
   });
 
   it('rolls back only the additive request schema', async () => {

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.spec.ts
@@ -1,0 +1,132 @@
+import { AddRequestsAndProviderAttempts1801000000000 } from './1801000000000-AddRequestsAndProviderAttempts';
+
+describe('AddRequestsAndProviderAttempts1801000000000', () => {
+  const migration = new AddRequestsAndProviderAttempts1801000000000();
+  let queries: string[];
+  const runner = {
+    query: jest.fn().mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve();
+    }),
+  } as never;
+
+  beforeEach(() => {
+    queries = [];
+    jest.clearAllMocks();
+  });
+
+  it('keeps historical data work out of the deploy migration', async () => {
+    await migration.up(runner);
+
+    const sql = queries.join('\n');
+    expect(migration.transaction).toBe(false);
+    expect(queries[0]).toContain("SET lock_timeout = '5s'");
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "requests"');
+    expect(sql).toContain('"autofix_status" varchar');
+    expect(sql).toContain('CONSTRAINT "CHK_requests_autofix_status"');
+    for (const status of [
+      'no_patch',
+      'resolving',
+      'retry_succeeded',
+      'retry_failed',
+      'service_error',
+    ]) {
+      expect(sql).toContain(`'${status}'`);
+    }
+    expect(sql).not.toMatch(/ALTER TABLE\s+"agent_messages"\s+RENAME/i);
+    expect(sql).not.toMatch(/CREATE\s+VIEW/i);
+    expect(sql).not.toMatch(/RENAME\s+COLUMN/i);
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "request_id"');
+    expect(sql).toContain('NOT VALID');
+    expect(sql).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
+    expect(sql).toContain(
+      '"IDX_agent_messages_request_id" ON "agent_messages" ("request_id", "id")',
+    );
+    expect(sql).toContain('"IDX_agent_messages_unlinked_fallback"');
+    expect(sql).not.toMatch(/INSERT\s+INTO\s+"requests"/i);
+    expect(sql).not.toMatch(/UPDATE\s+"agent_messages"/i);
+  });
+
+  it('is restart-safe after a partially completed non-transactional run', async () => {
+    await migration.up(runner);
+    const sql = queries.join('\n');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "request_id"');
+    expect(sql).toContain('IF NOT EXISTS (');
+    expect(sql).toContain('IF NOT EXISTS "IDX_agent_messages_request_id"');
+  });
+
+  it('keeps agent_messages as the physical relation for rolling-deploy compatibility', async () => {
+    await migration.up(runner);
+
+    const sql = queries.join('\n');
+    expect(sql).toContain('ALTER TABLE "agent_messages" ADD COLUMN IF NOT EXISTS "request_id"');
+    expect(sql).not.toContain('DROP TABLE "agent_messages"');
+    expect(sql).not.toContain('DROP VIEW "agent_messages"');
+    expect(sql).not.toContain('RENAME TO');
+  });
+
+  it('preserves every legacy column name', async () => {
+    await migration.up(runner);
+
+    const sql = queries.join('\n');
+    expect(sql).not.toContain('autofix_phoenix');
+    expect(sql).not.toContain('autofix_decision');
+  });
+
+  it('drops an invalid concurrent index before rebuilding it', async () => {
+    (runner as { query: jest.Mock }).query.mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve(sql.includes('i.indisvalid') ? [{ valid: false }] : undefined);
+    });
+
+    await migration.up(runner);
+
+    const drop = queries.findIndex((sql) => sql.includes('DROP INDEX CONCURRENTLY'));
+    const create = queries.findIndex((sql) => sql.includes('CREATE INDEX CONCURRENTLY'));
+    expect(drop).toBeGreaterThan(-1);
+    expect(create).toBeGreaterThan(drop);
+  });
+
+  it('checks index validity on agent_messages rather than by global name alone', async () => {
+    await migration.up(runner);
+
+    const validityQuery = queries.find((sql) => sql.includes('i.indisvalid'));
+    expect(validityQuery).toContain("i.indrelid = 'agent_messages'::regclass");
+  });
+
+  it('rebuilds a valid fallback index whose key order cannot support the bounded lookup', async () => {
+    (runner as { query: jest.Mock }).query.mockImplementation((sql: string) => {
+      queries.push(sql);
+      if (sql.includes("c.relname = 'IDX_agent_messages_request_id'")) {
+        return Promise.resolve([{ valid: true, definition: '(request_id, id)' }]);
+      }
+      if (sql.includes("c.relname = 'IDX_agent_messages_unlinked_fallback'")) {
+        return Promise.resolve([
+          {
+            valid: true,
+            definition: '(tenant_id, agent_id, fallback_from_model, "timestamp")',
+          },
+        ]);
+      }
+      return Promise.resolve();
+    });
+
+    await migration.up(runner);
+
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_unlinked_fallback"'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rolls back only the additive request schema', async () => {
+    await migration.down(runner);
+
+    const sql = queries.join('\n');
+    expect(sql).toContain('DROP COLUMN IF EXISTS "request_id"');
+    expect(sql).toContain('DROP TABLE IF EXISTS "requests"');
+    expect(sql).not.toContain('DROP VIEW');
+    expect(sql).not.toContain('RENAME');
+  });
+});

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
@@ -1,0 +1,146 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Introduces the request/attempt boundary without rewriting historical data in
+ * the deploy path. History is linked later by the resumable boot backfill.
+ *
+ * This migration runs outside a transaction because the request_id index is
+ * built CONCURRENTLY. Every statement is restart-safe so a process failure
+ * between statements can be retried.
+ */
+export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInterface {
+  name = 'AddRequestsAndProviderAttempts1801000000000';
+  transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Fail the deploy attempt instead of queueing an ACCESS EXCLUSIVE schema
+    // change behind a long Cloud query and then blocking newer traffic.
+    await queryRunner.query(`SET lock_timeout = '5s'`);
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "requests" (
+        "id" varchar NOT NULL,
+        "tenant_id" varchar,
+        "agent_id" varchar,
+        "user_id" varchar,
+        "agent_name" varchar,
+        "trace_id" varchar,
+        "session_key" varchar,
+        "session_id" varchar,
+        "timestamp" timestamp NOT NULL,
+        "duration_ms" integer,
+        "status" varchar NOT NULL,
+        "autofix_status" varchar,
+        "error_message" varchar,
+        "error_http_status" integer,
+        "error_code" varchar(8),
+        "error_origin" varchar,
+        "error_class" varchar,
+        "requested_model" varchar,
+        "caller_attribution" text,
+        "request_headers" text,
+        "request_params" jsonb,
+        "feedback_rating" varchar,
+        "feedback_tags" varchar,
+        "feedback_details" text,
+        CONSTRAINT "CHK_requests_autofix_status" CHECK (
+          "autofix_status" IN (
+            'no_patch', 'resolving', 'retry_succeeded', 'retry_failed', 'service_error'
+          )
+        ),
+        CONSTRAINT "PK_requests" PRIMARY KEY ("id")
+      )
+    `);
+
+    // Keep agent_messages as the physical table. The new columns are nullable,
+    // so replicas from the previous release can continue inserting and updating
+    // their unchanged column set while Railway rolls the new release out.
+    await queryRunner.query(
+      `ALTER TABLE "agent_messages" ADD COLUMN IF NOT EXISTS "request_id" varchar`,
+    );
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_agent_messages_request'
+        ) THEN
+          ALTER TABLE "agent_messages"
+            ADD CONSTRAINT "FK_agent_messages_request"
+            FOREIGN KEY ("request_id") REFERENCES "requests"("id")
+            ON DELETE CASCADE NOT VALID;
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_agent_timestamp" ON "requests" ("tenant_id", "agent_id", "timestamp")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_timestamp" ON "requests" ("tenant_id", "timestamp")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_trace" ON "requests" ("tenant_id", "trace_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_status_timestamp" ON "requests" ("tenant_id", "status", "timestamp")`,
+    );
+    const requestIndex = (await queryRunner.query(`
+      SELECT i.indisvalid AS valid,
+             pg_get_indexdef(i.indexrelid) AS definition
+      FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = 'IDX_agent_messages_request_id'
+        AND i.indrelid = 'agent_messages'::regclass
+    `)) as Array<{ valid: boolean; definition: string }>;
+    // PostgreSQL leaves an invalid shell behind when CREATE INDEX
+    // CONCURRENTLY is interrupted. IF NOT EXISTS would treat that shell as a
+    // usable index, so remove it before retrying the build.
+    const expectedRequestIndex = '(request_id, id)';
+    if (
+      requestIndex?.[0] &&
+      (!requestIndex[0].valid || !requestIndex[0].definition.includes(expectedRequestIndex))
+    ) {
+      await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_request_id"`);
+    }
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_request_id" ON "agent_messages" ("request_id", "id")`,
+    );
+
+    // Temporary migration support: exact fallback reconstruction repeatedly
+    // probes legacy fallback rows by their original model and encoded time.
+    // The partial index empties as the backfill links rows, and new request-aware
+    // writes never enter it. A later cleanup migration can remove the empty shell.
+    const fallbackIndex = (await queryRunner.query(`
+      SELECT i.indisvalid AS valid,
+             pg_get_indexdef(i.indexrelid) AS definition
+      FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = 'IDX_agent_messages_unlinked_fallback'
+        AND i.indrelid = 'agent_messages'::regclass
+    `)) as Array<{ valid: boolean; definition: string }>;
+    const expectedFallbackIndex = '(fallback_from_model, "timestamp", tenant_id, agent_id)';
+    if (
+      fallbackIndex?.[0] &&
+      (!fallbackIndex[0].valid || !fallbackIndex[0].definition.includes(expectedFallbackIndex))
+    ) {
+      await queryRunner.query(
+        `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_unlinked_fallback"`,
+      );
+    }
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_unlinked_fallback" ON "agent_messages" ("fallback_from_model", "timestamp", "tenant_id", "agent_id") INCLUDE ("fallback_index", "status", "superseded") WHERE "request_id" IS NULL AND "fallback_from_model" IS NOT NULL`,
+    );
+    await queryRunner.query(`RESET lock_timeout`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_unlinked_fallback"`,
+    );
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_request_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "agent_messages" DROP CONSTRAINT IF EXISTS "FK_agent_messages_request"`,
+    );
+    await queryRunner.query(`ALTER TABLE "agent_messages" DROP COLUMN IF EXISTS "request_id"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "requests"`);
+  }
+}

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
@@ -93,6 +93,11 @@ export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInt
     await queryRunner.query(
       `CREATE INDEX IF NOT EXISTS "IDX_requests_tenant_status_timestamp" ON "requests" ("tenant_id", "status", "timestamp")`,
     );
+    // Tail sweeps finalize only legacy parents still marked pending. This index
+    // is created while requests is empty, then stays small as parents settle.
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_requests_pending" ON "requests" ("id") WHERE "status" = 'pending'`,
+    );
     const requestIndex = (await queryRunner.query(`
       SELECT i.indisvalid AS valid,
              pg_get_indexdef(i.indexrelid) AS definition

--- a/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
+++ b/packages/backend/src/database/migrations/1801000000000-AddRequestsAndProviderAttempts.ts
@@ -16,6 +16,14 @@ export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInt
     // Fail the deploy attempt instead of queueing an ACCESS EXCLUSIVE schema
     // change behind a long Cloud query and then blocking newer traffic.
     await queryRunner.query(`SET lock_timeout = '5s'`);
+    try {
+      await this.addRequestSchema(queryRunner);
+    } finally {
+      await queryRunner.query(`RESET lock_timeout`);
+    }
+  }
+
+  private async addRequestSchema(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       CREATE TABLE IF NOT EXISTS "requests" (
         "id" varchar NOT NULL,
@@ -61,7 +69,9 @@ export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInt
       DO $$
       BEGIN
         IF NOT EXISTS (
-          SELECT 1 FROM pg_constraint WHERE conname = 'FK_agent_messages_request'
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'FK_agent_messages_request'
+            AND conrelid = 'agent_messages'::regclass
         ) THEN
           ALTER TABLE "agent_messages"
             ADD CONSTRAINT "FK_agent_messages_request"
@@ -117,10 +127,16 @@ export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInt
       WHERE c.relname = 'IDX_agent_messages_unlinked_fallback'
         AND i.indrelid = 'agent_messages'::regclass
     `)) as Array<{ valid: boolean; definition: string }>;
-    const expectedFallbackIndex = '(fallback_from_model, "timestamp", tenant_id, agent_id)';
+    const expectedFallbackIndexParts = [
+      '(fallback_from_model, "timestamp", tenant_id, agent_id)',
+      'INCLUDE (fallback_index, status, superseded)',
+      'request_id IS NULL',
+      'fallback_from_model IS NOT NULL',
+    ];
     if (
       fallbackIndex?.[0] &&
-      (!fallbackIndex[0].valid || !fallbackIndex[0].definition.includes(expectedFallbackIndex))
+      (!fallbackIndex[0].valid ||
+        expectedFallbackIndexParts.some((part) => !fallbackIndex[0].definition.includes(part)))
     ) {
       await queryRunner.query(
         `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_unlinked_fallback"`,
@@ -129,7 +145,6 @@ export class AddRequestsAndProviderAttempts1801000000000 implements MigrationInt
     await queryRunner.query(
       `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_unlinked_fallback" ON "agent_messages" ("fallback_from_model", "timestamp", "tenant_id", "agent_id") INCLUDE ("fallback_index", "status", "superseded") WHERE "request_id" IS NULL AND "fallback_from_model" IS NOT NULL`,
     );
-    await queryRunner.query(`RESET lock_timeout`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/backend/src/database/migrations/1801100000000-AddProviderAttemptOrdering.spec.ts
+++ b/packages/backend/src/database/migrations/1801100000000-AddProviderAttemptOrdering.spec.ts
@@ -1,0 +1,23 @@
+import { AddProviderAttemptOrdering1801100000000 } from './1801100000000-AddProviderAttemptOrdering';
+
+describe('AddProviderAttemptOrdering1801100000000', () => {
+  it('adds restart-safe ordering constraints without rewriting existing rows', async () => {
+    const statements: string[] = [];
+    const queryRunner = {
+      query: jest.fn(async (sql: string) => {
+        statements.push(sql);
+        if (sql.includes('pg_get_indexdef')) return [];
+        return undefined;
+      }),
+    };
+
+    await new AddProviderAttemptOrdering1801100000000().up(queryRunner as never);
+
+    const sql = statements.join('\n');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "attempt_number" integer');
+    expect(sql).toContain('CHECK ("attempt_number" IS NULL OR "attempt_number" > 0) NOT VALID');
+    expect(sql).toContain('CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS');
+    expect(sql).toContain('("request_id", "attempt_number")');
+    expect(sql).not.toMatch(/UPDATE\s+"agent_messages"/i);
+  });
+});

--- a/packages/backend/src/database/migrations/1801100000000-AddProviderAttemptOrdering.spec.ts
+++ b/packages/backend/src/database/migrations/1801100000000-AddProviderAttemptOrdering.spec.ts
@@ -11,13 +11,35 @@ describe('AddProviderAttemptOrdering1801100000000', () => {
       }),
     };
 
-    await new AddProviderAttemptOrdering1801100000000().up(queryRunner as never);
+    const migration = new AddProviderAttemptOrdering1801100000000();
+    await migration.up(queryRunner as never);
 
     const sql = statements.join('\n');
+    expect(migration.transaction).toBe(false);
+    expect(statements[0]).toContain("SET lock_timeout = '5s'");
+    expect(statements.at(-1)).toContain('RESET lock_timeout');
     expect(sql).toContain('ADD COLUMN IF NOT EXISTS "attempt_number" integer');
     expect(sql).toContain('CHECK ("attempt_number" IS NULL OR "attempt_number" > 0) NOT VALID');
     expect(sql).toContain('CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS');
     expect(sql).toContain('("request_id", "attempt_number")');
+    expect(sql).toContain('WHERE "request_id" IS NOT NULL AND "attempt_number" IS NOT NULL');
     expect(sql).not.toMatch(/UPDATE\s+"agent_messages"/i);
+  });
+
+  it('resets the lock timeout when the migration fails', async () => {
+    const statements: string[] = [];
+    const failure = new Error('lock timeout');
+    const queryRunner = {
+      query: jest.fn(async (sql: string) => {
+        statements.push(sql);
+        if (sql.includes('ADD COLUMN')) throw failure;
+        return undefined;
+      }),
+    };
+
+    await expect(
+      new AddProviderAttemptOrdering1801100000000().up(queryRunner as never),
+    ).rejects.toBe(failure);
+    expect(statements.at(-1)).toContain('RESET lock_timeout');
   });
 });

--- a/packages/backend/src/database/migrations/1801100000000-AddProviderAttemptOrdering.ts
+++ b/packages/backend/src/database/migrations/1801100000000-AddProviderAttemptOrdering.ts
@@ -11,6 +11,14 @@ export class AddProviderAttemptOrdering1801100000000 implements MigrationInterfa
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`SET lock_timeout = '5s'`);
+    try {
+      await this.addAttemptOrdering(queryRunner);
+    } finally {
+      await queryRunner.query(`RESET lock_timeout`);
+    }
+  }
+
+  private async addAttemptOrdering(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE "agent_messages" ADD COLUMN IF NOT EXISTS "attempt_number" integer`,
     );
@@ -49,7 +57,6 @@ export class AddProviderAttemptOrdering1801100000000 implements MigrationInterfa
       ON "agent_messages" ("request_id", "attempt_number")
       WHERE "request_id" IS NOT NULL AND "attempt_number" IS NOT NULL
     `);
-    await queryRunner.query(`RESET lock_timeout`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/backend/src/database/migrations/1801100000000-AddProviderAttemptOrdering.ts
+++ b/packages/backend/src/database/migrations/1801100000000-AddProviderAttemptOrdering.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds explicit provider-call order without rewriting the historical hot table.
+ * Live writers populate the column immediately; the request backfill assigns it
+ * only where the legacy chain has an unambiguous order.
+ */
+export class AddProviderAttemptOrdering1801100000000 implements MigrationInterface {
+  name = 'AddProviderAttemptOrdering1801100000000';
+  transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET lock_timeout = '5s'`);
+    await queryRunner.query(
+      `ALTER TABLE "agent_messages" ADD COLUMN IF NOT EXISTS "attempt_number" integer`,
+    );
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'CHK_agent_messages_attempt_number_positive'
+            AND conrelid = 'agent_messages'::regclass
+        ) THEN
+          ALTER TABLE "agent_messages"
+            ADD CONSTRAINT "CHK_agent_messages_attempt_number_positive"
+            CHECK ("attempt_number" IS NULL OR "attempt_number" > 0) NOT VALID;
+        END IF;
+      END $$
+    `);
+
+    const indexes = (await queryRunner.query(`
+      SELECT i.indisvalid AS valid,
+             pg_get_indexdef(i.indexrelid) AS definition
+      FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = 'UQ_agent_messages_request_attempt_number'
+        AND i.indrelid = 'agent_messages'::regclass
+    `)) as Array<{ valid: boolean; definition: string }>;
+    const expected = '(request_id, attempt_number)';
+    if (indexes[0] && (!indexes[0].valid || !indexes[0].definition.includes(expected))) {
+      await queryRunner.query(
+        `DROP INDEX CONCURRENTLY IF EXISTS "UQ_agent_messages_request_attempt_number"`,
+      );
+    }
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+        "UQ_agent_messages_request_attempt_number"
+      ON "agent_messages" ("request_id", "attempt_number")
+      WHERE "request_id" IS NOT NULL AND "attempt_number" IS NOT NULL
+    `);
+    await queryRunner.query(`RESET lock_timeout`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "UQ_agent_messages_request_attempt_number"`,
+    );
+    await queryRunner.query(`
+      ALTER TABLE "agent_messages"
+      DROP CONSTRAINT IF EXISTS "CHK_agent_messages_attempt_number_positive"
+    `);
+    await queryRunner.query(`ALTER TABLE "agent_messages" DROP COLUMN IF EXISTS "attempt_number"`);
+  }
+}

--- a/packages/backend/test/request-backfill-fallbacks.e2e-spec.ts
+++ b/packages/backend/test/request-backfill-fallbacks.e2e-spec.ts
@@ -1,0 +1,629 @@
+import { DataSource } from 'typeorm';
+import { runRequestBackfill } from '../src/database/backfills/backfill-requests';
+import { TypeOrmRequestBackfillGateway } from '../src/database/backfills/backfill-requests.gateway';
+import { AddRequestsAndProviderAttempts1801000000000 } from '../src/database/migrations/1801000000000-AddRequestsAndProviderAttempts';
+import { AddProviderAttemptOrdering1801100000000 } from '../src/database/migrations/1801100000000-AddProviderAttemptOrdering';
+
+interface LegacyAttempt {
+  id: string;
+  timestamp: string;
+  status: string;
+  model: string;
+  fallbackFrom?: string;
+  fallbackIndex?: number;
+  superseded?: boolean;
+  autofixGroup?: string;
+  autofixApplied?: boolean;
+  autofixRole?: string;
+  autofixDecision?: object;
+  errorOrigin?: string;
+  requestParams?: object;
+  traceId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+}
+
+describe('request backfill legacy fallback reconstruction (e2e)', () => {
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'postgres',
+      url:
+        process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/mydatabase',
+    });
+    await dataSource.initialize();
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) await dataSource.destroy();
+  });
+
+  beforeEach(async () => {
+    await dataSource.query('DROP SCHEMA public CASCADE');
+    await dataSource.query('CREATE SCHEMA public');
+    await dataSource.query(`
+      CREATE TABLE agent_messages (
+        id varchar PRIMARY KEY,
+        tenant_id varchar,
+        agent_id varchar,
+        user_id varchar,
+        agent_name varchar,
+        trace_id varchar,
+        session_key varchar,
+        session_id varchar,
+        timestamp timestamp NOT NULL,
+        duration_ms integer,
+        status varchar NOT NULL,
+        error_message varchar,
+        error_http_status integer,
+        error_code varchar(8),
+        error_origin varchar,
+        error_class varchar,
+        model varchar,
+        caller_attribution text,
+        request_headers text,
+        request_params jsonb,
+        feedback_rating varchar,
+        feedback_tags varchar,
+        feedback_details text,
+        autofix_group_id varchar,
+        autofix_applied boolean DEFAULT false,
+        autofix_role varchar,
+        autofix_phoenix jsonb,
+        superseded boolean DEFAULT false,
+        fallback_from_model varchar,
+        fallback_index integer
+      )
+    `);
+    const runner = dataSource.createQueryRunner();
+    try {
+      await new AddRequestsAndProviderAttempts1801000000000().up(runner);
+      await new AddProviderAttemptOrdering1801100000000().up(runner);
+    } finally {
+      await runner.release();
+    }
+  });
+
+  async function insertAttempt(attempt: LegacyAttempt): Promise<void> {
+    await dataSource.query(
+      `INSERT INTO agent_messages (
+        id, tenant_id, agent_id, agent_name, timestamp, duration_ms, status,
+        model, fallback_from_model, fallback_index, superseded,
+        autofix_group_id, autofix_applied, autofix_role, autofix_phoenix,
+        error_origin, caller_attribution, request_headers,
+        request_params, trace_id, session_key, session_id
+      ) VALUES (
+        $1, 'tenant-1', 'agent-1', 'Agent', $2, 100, $3, $4, $5, $6, $7,
+        $8, $9, $10, $11, $12, '{"agent":"openai-sdk"}',
+        '{"content-type":"application/json"}', $13, $14, $15, $16
+      )`,
+      [
+        attempt.id,
+        attempt.timestamp,
+        attempt.status,
+        attempt.model,
+        attempt.fallbackFrom ?? null,
+        attempt.fallbackIndex ?? null,
+        attempt.superseded ?? false,
+        attempt.autofixGroup ?? null,
+        attempt.autofixApplied ?? false,
+        attempt.autofixRole ?? null,
+        attempt.autofixDecision ?? null,
+        attempt.errorOrigin ?? null,
+        attempt.requestParams ?? { model: 'openai/gpt-4o' },
+        attempt.traceId ?? null,
+        attempt.sessionKey ?? null,
+        attempt.sessionId ?? null,
+      ],
+    );
+  }
+
+  async function backfill(
+    options: {
+      batchSize?: number;
+      before?: string;
+      fallbackBefore?: string;
+      finalize?: boolean;
+      finalizePending?: boolean;
+    } = {},
+  ): Promise<void> {
+    await runRequestBackfill(new TypeOrmRequestBackfillGateway(dataSource), {
+      batchSize: options.batchSize ?? 2,
+      throttleMs: 0,
+      before: options.before,
+      fallbackBefore: options.fallbackBefore,
+      finalize: options.finalize,
+      finalizePending: options.finalizePending,
+    });
+  }
+
+  it('groups a recovered fallback chain without traceparent', async () => {
+    await insertAttempt({
+      id: 'recovered-primary',
+      timestamp: '2026-01-01 00:00:00.000',
+      status: 'fallback_error',
+      model: 'openai/gpt-4o',
+      superseded: true,
+      errorOrigin: 'provider',
+    });
+    await insertAttempt({
+      id: 'recovered-fallback-0',
+      timestamp: '2026-01-01 00:00:00.200',
+      status: 'fallback_error',
+      model: 'anthropic/claude-sonnet',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 0,
+      superseded: true,
+      errorOrigin: 'provider',
+    });
+    await insertAttempt({
+      id: 'recovered-fallback-1',
+      timestamp: '2026-01-01 00:00:00.100',
+      status: 'fallback_error',
+      model: 'google/gemini-flash',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 1,
+      superseded: true,
+      errorOrigin: 'provider',
+    });
+    await insertAttempt({
+      id: 'recovered-terminal',
+      timestamp: '2026-01-01 00:00:00.300',
+      status: 'ok',
+      model: 'google/gemini-pro',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 2,
+    });
+
+    await backfill({ batchSize: 1 });
+
+    const [request] = await dataSource.query(
+      `SELECT status, requested_model, duration_ms FROM requests`,
+    );
+    const [{ parents, attempts }] = await dataSource.query(
+      `SELECT count(DISTINCT request_id)::int parents, count(*)::int attempts
+       FROM agent_messages`,
+    );
+    expect({ ...request, parents, attempts }).toEqual({
+      status: 'success',
+      requested_model: 'openai/gpt-4o',
+      duration_ms: 400,
+      parents: 1,
+      attempts: 4,
+    });
+  });
+
+  it('groups an exhausted fallback chain around its legacy primary anchor', async () => {
+    await insertAttempt({
+      id: 'exhausted-fallback-0',
+      timestamp: '2026-01-01 00:01:00.200',
+      status: 'fallback_error',
+      model: 'anthropic/claude-sonnet',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 0,
+      superseded: true,
+      errorOrigin: 'provider',
+    });
+    await insertAttempt({
+      id: 'exhausted-terminal',
+      timestamp: '2026-01-01 00:01:00.100',
+      status: 'error',
+      model: 'google/gemini-pro',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 1,
+      errorOrigin: 'provider',
+    });
+    await insertAttempt({
+      id: 'exhausted-primary',
+      timestamp: '2026-01-01 00:01:00.300',
+      status: 'fallback_error',
+      model: 'openai/gpt-4o',
+      superseded: true,
+      errorOrigin: 'provider',
+    });
+
+    await backfill();
+
+    const [request] = await dataSource.query(`SELECT status, requested_model FROM requests`);
+    const [{ parents }] = await dataSource.query(
+      `SELECT count(DISTINCT request_id)::int parents FROM agent_messages`,
+    );
+    expect({ ...request, parents }).toEqual({
+      status: 'failed',
+      requested_model: 'openai/gpt-4o',
+      parents: 1,
+    });
+  });
+
+  it('leaves ambiguous fallback signatures as separate synthetic requests', async () => {
+    for (const id of ['ambiguous-primary-a', 'ambiguous-primary-b']) {
+      await insertAttempt({
+        id,
+        timestamp: '2026-01-01 00:02:00.000',
+        status: 'fallback_error',
+        model: 'openai/gpt-4o',
+        superseded: true,
+        errorOrigin: 'provider',
+      });
+    }
+    await insertAttempt({
+      id: 'ambiguous-terminal',
+      timestamp: '2026-01-01 00:02:00.100',
+      status: 'ok',
+      model: 'anthropic/claude-sonnet',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 0,
+    });
+
+    await backfill();
+
+    const [{ requests, parents }] = await dataSource.query(
+      `SELECT (SELECT count(*)::int FROM requests) requests,
+              (SELECT count(DISTINCT request_id)::int FROM agent_messages) parents`,
+    );
+    expect({ requests, parents }).toEqual({ requests: 3, parents: 3 });
+  });
+
+  it('does not reconstruct a fallback chain across trace or session identity', async () => {
+    await insertAttempt({
+      id: 'identity-primary',
+      timestamp: '2026-01-01 00:02:30.000',
+      status: 'fallback_error',
+      model: 'openai/gpt-4o',
+      superseded: true,
+      errorOrigin: 'provider',
+      traceId: 'trace-a',
+      sessionKey: 'session-key-a',
+      sessionId: 'session-a',
+    });
+    await insertAttempt({
+      id: 'identity-terminal',
+      timestamp: '2026-01-01 00:02:30.100',
+      status: 'ok',
+      model: 'anthropic/claude-sonnet',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 0,
+      traceId: 'trace-b',
+      sessionKey: 'session-key-b',
+      sessionId: 'session-b',
+    });
+
+    await backfill();
+
+    const [{ requests, parents, fallbackRequests }] = await dataSource.query(
+      `SELECT (SELECT count(*)::int FROM requests) requests,
+              (SELECT count(DISTINCT request_id)::int FROM agent_messages) parents,
+              (SELECT count(*)::int FROM requests
+               WHERE id LIKE 'legacy-fallback-%') AS "fallbackRequests"`,
+    );
+    expect({ requests, parents, fallbackRequests }).toEqual({
+      requests: 2,
+      parents: 2,
+      fallbackRequests: 0,
+    });
+  });
+
+  it('does not attach a fallback member from another trace or session', async () => {
+    const identity = {
+      traceId: 'trace-a',
+      sessionKey: 'session-key-a',
+      sessionId: 'session-a',
+    };
+    await insertAttempt({
+      id: 'member-primary',
+      timestamp: '2026-01-01 00:02:40.000',
+      status: 'fallback_error',
+      model: 'openai/gpt-4o',
+      superseded: true,
+      errorOrigin: 'provider',
+      ...identity,
+    });
+    await insertAttempt({
+      id: 'foreign-member',
+      timestamp: '2026-01-01 00:02:40.200',
+      status: 'fallback_error',
+      model: 'anthropic/claude-sonnet',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 0,
+      superseded: true,
+      errorOrigin: 'provider',
+      traceId: 'trace-b',
+      sessionKey: 'session-key-b',
+      sessionId: 'session-b',
+    });
+    await insertAttempt({
+      id: 'member-terminal',
+      timestamp: '2026-01-01 00:02:40.300',
+      status: 'ok',
+      model: 'google/gemini-pro',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 2,
+      ...identity,
+    });
+
+    await backfill();
+
+    const rows = (await dataSource.query(
+      `SELECT r.id, count(pa.id)::int AS attempts
+       FROM requests r
+       JOIN agent_messages pa ON pa.request_id = r.id
+       GROUP BY r.id
+       ORDER BY attempts DESC`,
+    )) as { id: string; attempts: number }[];
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ id: expect.stringMatching(/^legacy-fallback-/), attempts: 2 });
+    expect(rows[1]).toEqual({ id: expect.not.stringMatching(/^legacy-fallback-/), attempts: 1 });
+  });
+
+  it('rejects member ambiguity that spans separate source batches', async () => {
+    await insertAttempt({
+      id: 'cross-batch-primary-a',
+      timestamp: '2026-01-01 00:04:00.000',
+      status: 'fallback_error',
+      model: 'openai/gpt-4o',
+      superseded: true,
+      errorOrigin: 'provider',
+    });
+    await insertAttempt({
+      id: 'cross-batch-primary-b',
+      timestamp: '2026-01-01 00:04:00.100',
+      status: 'fallback_error',
+      model: 'openai/gpt-4o',
+      superseded: true,
+      errorOrigin: 'provider',
+    });
+    await insertAttempt({
+      id: 'cross-batch-shared-member',
+      timestamp: '2026-01-01 00:04:00.200',
+      status: 'fallback_error',
+      model: 'anthropic/claude-sonnet',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 0,
+      superseded: true,
+      errorOrigin: 'provider',
+    });
+    await insertAttempt({
+      id: 'cross-batch-terminal-a',
+      timestamp: '2026-01-01 00:04:00.300',
+      status: 'ok',
+      model: 'google/gemini-pro',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 2,
+    });
+    await insertAttempt({
+      id: 'cross-batch-terminal-b',
+      timestamp: '2026-01-01 00:04:00.300',
+      status: 'ok',
+      model: 'mistral/large',
+      fallbackFrom: 'openai/gpt-4o',
+      fallbackIndex: 1,
+    });
+
+    await backfill({ batchSize: 1 });
+
+    const [{ requests, parents }] = await dataSource.query(
+      `SELECT (SELECT count(*)::int FROM requests) requests,
+              (SELECT count(DISTINCT request_id)::int FROM agent_messages) parents`,
+    );
+    expect({ requests, parents }).toEqual({ requests: 5, parents: 5 });
+  });
+
+  it('waits for a late old-replica terminal before linking its primary', async () => {
+    await dataSource.query(`
+      INSERT INTO agent_messages (
+        id, tenant_id, agent_id, agent_name, timestamp, duration_ms, status,
+        model, superseded, error_origin, caller_attribution, request_headers, request_params
+      ) VALUES (
+        'late-primary', 'tenant-1', 'agent-1', 'Agent',
+        '2026-01-01 00:05:00.000', 100, 'fallback_error', 'openai/gpt-4o', true,
+        'provider', '{"agent":"openai-sdk"}', '{"content-type":"application/json"}',
+        '{"model":"openai/gpt-4o"}'::jsonb
+      )
+    `);
+    await dataSource.query(`
+      INSERT INTO agent_messages (
+        id, tenant_id, agent_id, agent_name, timestamp, duration_ms, status,
+        model, fallback_from_model, fallback_index, superseded,
+        caller_attribution, request_headers, request_params
+      ) VALUES (
+        'late-terminal', 'tenant-1', 'agent-1', 'Agent',
+        '2026-01-01 00:05:00.100', 100, 'ok', 'anthropic/claude-sonnet',
+        'openai/gpt-4o', 0, false, '{"agent":"openai-sdk"}',
+        '{"content-type":"application/json"}', '{"model":"openai/gpt-4o"}'::jsonb
+      )
+    `);
+
+    await backfill({
+      batchSize: 1,
+      fallbackBefore: '2026-01-01 00:05:00.050',
+      before: '2025-12-31 23:55:00.000',
+    });
+    const [{ unlinkedAfterFirstSweep }] = await dataSource.query(
+      `SELECT count(*)::int AS "unlinkedAfterFirstSweep"
+       FROM agent_messages WHERE request_id IS NULL`,
+    );
+    expect(unlinkedAfterFirstSweep).toBe(2);
+
+    await backfill({
+      batchSize: 1,
+      fallbackBefore: '2026-01-01 00:06:00.000',
+      before: '2026-01-01 00:05:30.000',
+    });
+    const [{ requests, parents, unlinked }] = await dataSource.query(
+      `SELECT (SELECT count(*)::int FROM requests) requests,
+              (SELECT count(DISTINCT request_id)::int FROM agent_messages) parents,
+              (SELECT count(*)::int FROM agent_messages WHERE request_id IS NULL) unlinked`,
+    );
+    expect({ requests, parents, unlinked }).toEqual({ requests: 1, parents: 1, unlinked: 0 });
+  });
+
+  it('keeps the legacy table and column shape writable after the additive migrations', async () => {
+    const [relation] = await dataSource.query(`
+      SELECT c.relkind,
+             to_regclass('public.provider_attempts')::text AS renamed_relation
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relname = 'agent_messages'
+    `);
+    expect(relation).toEqual({ relkind: 'r', renamed_relation: null });
+
+    await dataSource.query(`
+      INSERT INTO agent_messages (
+        id, tenant_id, agent_id, agent_name, timestamp, status, model, autofix_phoenix
+      ) VALUES (
+        'old-replica', 'tenant-1', 'agent-1', 'Agent',
+        '2026-01-01 00:05:00.000', 'error', 'openai/gpt-4o',
+        '{"status":"no_patch","issueId":"issue-1"}'::jsonb
+      )
+    `);
+    await dataSource.query(`
+      UPDATE agent_messages
+      SET status = 'ok', autofix_phoenix = '{"status":"no_patch","issueId":"issue-2"}'::jsonb
+      WHERE id = 'old-replica'
+    `);
+
+    const [attempt] = await dataSource.query(
+      `SELECT status, autofix_phoenix, request_id, attempt_number
+       FROM agent_messages WHERE id = 'old-replica'`,
+    );
+    expect(attempt).toEqual({
+      status: 'ok',
+      autofix_phoenix: { status: 'no_patch', issueId: 'issue-2' },
+      request_id: null,
+      attempt_number: null,
+    });
+  });
+
+  it('finalizes an incomplete fallback chain during a tail sweep', async () => {
+    await insertAttempt({
+      id: 'incomplete-primary',
+      timestamp: '2026-01-01 00:06:00.000',
+      status: 'fallback_error',
+      model: 'openai/gpt-4o',
+      superseded: true,
+      errorOrigin: 'provider',
+    });
+
+    await backfill({
+      before: '2026-01-01 00:07:00.000',
+      fallbackBefore: '2026-01-01 00:07:00.000',
+      finalize: false,
+      finalizePending: true,
+    });
+
+    const [request] = await dataSource.query(`SELECT status FROM requests`);
+    expect(request).toEqual({ status: 'failed' });
+  });
+
+  it('preserves ordinary and Auto-fix grouping behavior', async () => {
+    await insertAttempt({
+      id: 'plain',
+      timestamp: '2026-01-01 00:03:00.000',
+      status: 'ok',
+      model: 'openai/gpt-4o',
+    });
+    await insertAttempt({
+      id: 'autofix-original',
+      timestamp: '2026-01-01 00:03:01.000',
+      status: 'auto_fixed',
+      model: 'openai/gpt-4o',
+      superseded: true,
+      autofixGroup: 'heal-1',
+      errorOrigin: 'provider',
+    });
+    await insertAttempt({
+      id: 'autofix-retry',
+      timestamp: '2026-01-01 00:03:01.100',
+      status: 'ok',
+      model: 'openai/gpt-4o',
+      autofixGroup: 'heal-1',
+    });
+
+    await backfill();
+
+    const [{ requests, parents, ordered }] = await dataSource.query(
+      `SELECT (SELECT count(*)::int FROM requests) requests,
+              (SELECT count(DISTINCT request_id)::int FROM agent_messages) parents,
+              (SELECT array_agg(attempt_number ORDER BY attempt_number)
+               FROM agent_messages
+               WHERE autofix_group_id = 'heal-1') ordered`,
+    );
+    expect({ requests, parents, ordered }).toEqual({
+      requests: 2,
+      parents: 2,
+      ordered: [1, 2],
+    });
+  });
+
+  it('backfills each recorded Auto-fix outcome onto its request', async () => {
+    const base = {
+      timestamp: '2026-01-01 00:03:00.000',
+      status: 'error',
+      model: 'openai/gpt-4o',
+      errorOrigin: 'provider',
+      autofixApplied: true,
+    };
+    await insertAttempt({
+      ...base,
+      id: 'no-patch',
+      autofixDecision: { status: 'no_patch', issueId: 'issue-no-patch' },
+    });
+    await insertAttempt({
+      ...base,
+      id: 'resolving',
+      autofixDecision: { status: 'resolving', issueId: 'issue-resolving' },
+    });
+    await insertAttempt({ ...base, id: 'service-error' });
+    await insertAttempt({
+      ...base,
+      id: 'legacy-no-patch',
+      autofixDecision: { issueId: 'legacy-issue' },
+    });
+    await insertAttempt({
+      ...base,
+      id: 'retry-success-original',
+      status: 'auto_fixed',
+      superseded: true,
+      autofixGroup: 'success-group',
+      autofixRole: 'original',
+      autofixDecision: { status: 'patched', healAttemptId: 'heal-success' },
+    });
+    await insertAttempt({
+      ...base,
+      id: 'retry-success',
+      timestamp: '2026-01-01 00:03:00.100',
+      status: 'ok',
+      autofixGroup: 'success-group',
+      autofixRole: 'retry',
+    });
+    await insertAttempt({
+      ...base,
+      id: 'retry-failed',
+      autofixGroup: 'failed-group',
+      autofixRole: 'retry',
+      autofixDecision: { status: 'patched', healAttemptId: 'heal-failed' },
+    });
+
+    await backfill({ batchSize: 1 });
+
+    const rows = await dataSource.query(`
+      SELECT pa.id, r.autofix_status
+      FROM agent_messages pa
+      JOIN requests r ON r.id = pa.request_id
+      WHERE pa.id IN (
+        'no-patch', 'resolving', 'service-error', 'legacy-no-patch',
+        'retry-success', 'retry-failed'
+      )
+      ORDER BY pa.id
+    `);
+    expect(rows).toEqual([
+      { id: 'legacy-no-patch', autofix_status: 'no_patch' },
+      { id: 'no-patch', autofix_status: 'no_patch' },
+      { id: 'resolving', autofix_status: 'resolving' },
+      { id: 'retry-failed', autofix_status: 'retry_failed' },
+      { id: 'retry-success', autofix_status: 'retry_succeeded' },
+      { id: 'service-error', autofix_status: 'service_error' },
+    ]);
+  });
+});

--- a/packages/backend/test/request-backfill-fallbacks.e2e-spec.ts
+++ b/packages/backend/test/request-backfill-fallbacks.e2e-spec.ts
@@ -125,7 +125,6 @@ describe('request backfill legacy fallback reconstruction (e2e)', () => {
       before?: string;
       fallbackBefore?: string;
       finalize?: boolean;
-      finalizePending?: boolean;
     } = {},
   ): Promise<void> {
     await runRequestBackfill(new TypeOrmRequestBackfillGateway(dataSource), {
@@ -134,7 +133,6 @@ describe('request backfill legacy fallback reconstruction (e2e)', () => {
       before: options.before,
       fallbackBefore: options.fallbackBefore,
       finalize: options.finalize,
-      finalizePending: options.finalizePending,
     });
   }
 
@@ -508,8 +506,7 @@ describe('request backfill legacy fallback reconstruction (e2e)', () => {
     await backfill({
       before: '2026-01-01 00:07:00.000',
       fallbackBefore: '2026-01-01 00:07:00.000',
-      finalize: false,
-      finalizePending: true,
+      finalize: true,
     });
 
     const [request] = await dataSource.query(`SELECT status FROM requests`);

--- a/packages/backend/test/request-backfill-fallbacks.e2e-spec.ts
+++ b/packages/backend/test/request-backfill-fallbacks.e2e-spec.ts
@@ -136,6 +136,46 @@ describe('request backfill legacy fallback reconstruction (e2e)', () => {
     });
   }
 
+  it('stages Manifest rejections without deleting their legacy rows', async () => {
+    const expected = [
+      { id: 'manifest-config', error_code: 'M100', error_origin: 'config' },
+      { id: 'manifest-internal', error_code: 'M500', error_origin: 'internal' },
+      { id: 'manifest-policy', error_code: 'M201', error_origin: 'policy' },
+      { id: 'manifest-request', error_code: 'M300', error_origin: 'request' },
+    ];
+    await dataSource.query(`
+      INSERT INTO agent_messages (
+        id, tenant_id, agent_id, agent_name, timestamp, duration_ms, status,
+        error_code, error_origin, error_class, model
+      ) VALUES
+        ('manifest-config', 'tenant-1', 'agent-1', 'Agent',
+         '2026-01-01 00:00:00.000', 0, 'error', 'M100', 'config', 'no_provider_key', 'auto'),
+        ('manifest-policy', 'tenant-1', 'agent-1', 'Agent',
+         '2026-01-01 00:00:01.000', 0, 'rate_limited', 'M201', 'policy', 'rate_limit', 'auto'),
+        ('manifest-request', 'tenant-1', 'agent-1', 'Agent',
+         '2026-01-01 00:00:02.000', 0, 'error', 'M300', 'request', 'invalid_request', 'auto'),
+        ('manifest-internal', 'tenant-1', 'agent-1', 'Agent',
+         '2026-01-01 00:00:03.000', 0, 'error', 'M500', 'internal', 'internal_error', 'auto')
+    `);
+
+    await backfill({ batchSize: 1 });
+    const legacyRows = await dataSource.query(`
+      SELECT id, request_id, attempt_number, error_code, error_origin
+      FROM agent_messages
+      ORDER BY id
+    `);
+    const requestRows = await dataSource.query(`
+      SELECT id, status, error_code, error_origin
+      FROM requests
+      ORDER BY id
+    `);
+
+    expect(legacyRows).toEqual(
+      expected.map((row) => ({ ...row, request_id: row.id, attempt_number: null })),
+    );
+    expect(requestRows).toEqual(expected.map((row) => ({ ...row, status: 'failed' })));
+  });
+
   it('groups a recovered fallback chain without traceparent', async () => {
     await insertAttempt({
       id: 'recovered-primary',

--- a/railway.toml
+++ b/railway.toml
@@ -8,6 +8,10 @@ startCommand = "npm start"
 # so replicas never migrate concurrently on boot. migrate.js also holds an advisory
 # lock, so overlapping deployments serialize instead of deadlocking on agent_messages.
 preDeployCommand = "npm run migration:run:prod --workspace=packages/backend"
+# Request history is regrouped after readiness by a non-blocking worker. Cloud
+# uses the direct MIGRATION_DATABASE_URL, while self-hosted deployments reuse
+# their ordinary DATABASE_URL. The current application keeps writing
+# agent_messages throughout the backfill.
 healthcheckPath = "/api/v1/health"
 healthcheckTimeout = 300
 # Zero-downtime rolling deploys. The new deployment runs alongside the old one


### PR DESCRIPTION
### ✨ What changed
- Add request schema while retaining the physical `agent_messages` table.
- Backfill request history without deleting legacy rows.
- Sweep new legacy writes and serialize backfills across replicas.

### 💭 Why
Rewriting more than 7 million messages during #2485 deployment is too expensive. Preparing history separately keeps that deployment bounded.

### 👤 For users
No visible UI change in this release.

### 🔧 For operators
Deploy this PR before #2485, then wait for the backfill to drain.
Cloud uses the existing direct migration URL. Self-hosted installs need no new variable.
No manual backfill command is required.
Constraint validation is deferred to avoid a full-table deployment scan.

### 📝 Notes
Precedes #2485. Legacy rows remain until its request-backed reader is live.