### PR TITLE
fix: block local providers on cloud

### DIFF
--- a/.changeset/quiet-local-runtimes.md
+++ b/.changeset/quiet-local-runtimes.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Block built-in local providers on Manifest Cloud.

--- a/packages/backend/src/analytics/controllers/provider-usage.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/provider-usage.controller.spec.ts
@@ -3,6 +3,17 @@ import type { TenantContext } from '../../common/decorators/tenant-context.decor
 import type { ProviderUsageSummary } from '../services/provider-usage.service';
 
 describe('ProviderUsageController', () => {
+  const previousMode = process.env['MANIFEST_MODE'];
+
+  beforeEach(() => {
+    process.env['MANIFEST_MODE'] = 'cloud';
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
+  });
+
   it('delegates to ProviderUsageService and wraps the result in { providers }', async () => {
     const summaries: ProviderUsageSummary[] = [
       {
@@ -33,5 +44,27 @@ describe('ProviderUsageController', () => {
 
     expect(service.getUsage).toHaveBeenCalledWith(null);
     expect(result).toEqual({ providers: [] });
+  });
+
+  it('hides built-in local usage in cloud without hiding custom tunnel usage', async () => {
+    const base = {
+      auth_type: 'local',
+      consumption_tokens: 10,
+      consumption_messages: 1,
+      consumption_cost: 0,
+      last_used_at: null,
+      sparkline_7d: [0, 0, 0, 0, 0, 0, 10],
+    };
+    const service = {
+      getUsage: jest.fn().mockResolvedValue([
+        { ...base, provider: 'ollama' },
+        { ...base, provider: 'custom:runtime-id' },
+      ]),
+    };
+    const controller = new ProviderUsageController(service as never);
+
+    const result = await controller.getUsage({ tenantId: 'tenant-1', userId: 'user-1' });
+
+    expect(result.providers.map((provider) => provider.provider)).toEqual(['custom:runtime-id']);
   });
 });

--- a/packages/backend/src/analytics/controllers/provider-usage.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-usage.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
 import { ProviderUsageService, ProviderUsageSummary } from '../services/provider-usage.service';
+import { filterProvidersForDeployment } from '../../common/utils/provider-availability';
 
 /**
  * Usage half of the provider dashboard split. Config (cheap, from
@@ -19,6 +20,6 @@ export class ProviderUsageController {
   @Get()
   async getUsage(@TenantCtx() ctx: TenantContext): Promise<{ providers: ProviderUsageSummary[] }> {
     const providers = await this.providerUsage.getUsage(ctx.tenantId);
-    return { providers };
+    return { providers: filterProvidersForDeployment(providers) };
   }
 }

--- a/packages/backend/src/common/errors/__tests__/manifest-error.spec.ts
+++ b/packages/backend/src/common/errors/__tests__/manifest-error.spec.ts
@@ -92,6 +92,16 @@ describe('every documented error code is accounted for', () => {
     expect(error_class).toBe('not_found');
   });
 
+  it('puts a cloud-inaccessible local provider on the config origin', () => {
+    const { error_origin, error_class } = classifyMessageError({
+      status: 'error',
+      routingReason: MANIFEST_CODE_TO_REASON.M303,
+    });
+
+    expect(error_origin).toBe('config');
+    expect(error_class).toBe('local_provider_unavailable');
+  });
+
   it('keeps a Manifest internal error off the provider reliability signal', () => {
     const { error_origin } = classifyMessageError({
       status: 'error',

--- a/packages/backend/src/common/errors/error-codes.ts
+++ b/packages/backend/src/common/errors/error-codes.ts
@@ -67,6 +67,11 @@ export const MANIFEST_ERRORS = {
     template:
       'Model "{model}" is not available for this agent. Use GET /v1/models to list available model IDs, or make the provider available for this agent here: {dashboardUrl}',
   },
+  M303: {
+    title: 'Local provider unavailable on Manifest Cloud',
+    template:
+      'Built-in local providers are only available in self-hosted Manifest. On Manifest Cloud, expose the runtime through a public URL or tunnel and connect it as a custom provider.',
+  },
   M500: {
     title: 'Internal server error',
     template: 'Something broke on our end. Try again in a moment.',

--- a/packages/backend/src/common/errors/manifest-error.ts
+++ b/packages/backend/src/common/errors/manifest-error.ts
@@ -17,6 +17,7 @@ export const MANIFEST_BLOCKED_REQUEST_REASONS = [
   'manifest_ip_rate_limited',
   'manifest_concurrency_limited',
   'manifest_invalid_request',
+  'local_provider_unavailable',
   'model_not_available',
   'manifest_internal_error',
 ] as const;
@@ -54,7 +55,7 @@ export const MANIFEST_CODE_TO_REASON: Record<RecordableManifestCode, ManifestBlo
     M204: 'plan_request_limit_exceeded',
     M300: 'manifest_invalid_request',
     M302: 'model_not_available',
-    M303: 'manifest_invalid_request',
+    M303: 'local_provider_unavailable',
     M500: 'manifest_internal_error',
   };
 

--- a/packages/backend/src/common/errors/manifest-error.ts
+++ b/packages/backend/src/common/errors/manifest-error.ts
@@ -54,6 +54,7 @@ export const MANIFEST_CODE_TO_REASON: Record<RecordableManifestCode, ManifestBlo
     M204: 'plan_request_limit_exceeded',
     M300: 'manifest_invalid_request',
     M302: 'model_not_available',
+    M303: 'manifest_invalid_request',
     M500: 'manifest_internal_error',
   };
 

--- a/packages/backend/src/common/utils/provider-availability.spec.ts
+++ b/packages/backend/src/common/utils/provider-availability.spec.ts
@@ -1,0 +1,48 @@
+import {
+  filterProvidersForDeployment,
+  isLocalOnlyProvider,
+  isProviderAvailableForDeployment,
+} from './provider-availability';
+
+describe('provider availability', () => {
+  const previousMode = process.env['MANIFEST_MODE'];
+
+  afterEach(() => {
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
+  });
+
+  it('recognizes canonical local providers and their aliases', () => {
+    expect(isLocalOnlyProvider('ollama')).toBe(true);
+    expect(isLocalOnlyProvider(' LM Studio ')).toBe(true);
+    expect(isLocalOnlyProvider('lm.studio')).toBe(true);
+    expect(isLocalOnlyProvider('llama.cpp')).toBe(true);
+    expect(isLocalOnlyProvider('llama_cpp')).toBe(true);
+    expect(isLocalOnlyProvider('openai')).toBe(false);
+    expect(isLocalOnlyProvider('custom:runtime-id')).toBe(false);
+  });
+
+  it('allows built-in local providers only in self-hosted mode', () => {
+    process.env['MANIFEST_MODE'] = 'cloud';
+    expect(isProviderAvailableForDeployment('ollama')).toBe(false);
+    expect(isProviderAvailableForDeployment('custom:runtime-id')).toBe(true);
+
+    process.env['MANIFEST_MODE'] = 'selfhosted';
+    expect(isProviderAvailableForDeployment('ollama')).toBe(true);
+  });
+
+  it('filters local provider rows in cloud without cloning unchanged arrays', () => {
+    process.env['MANIFEST_MODE'] = 'cloud';
+    const providers = [{ provider: 'openai' }, { provider: 'ollama' }];
+    expect(filterProvidersForDeployment(providers)).toEqual([{ provider: 'openai' }]);
+
+    const unchanged = [{ provider: 'custom:runtime-id' }];
+    expect(filterProvidersForDeployment(unchanged)).toBe(unchanged);
+  });
+
+  it('keeps all provider rows in self-hosted mode', () => {
+    process.env['MANIFEST_MODE'] = 'selfhosted';
+    const providers = [{ provider: 'openai' }, { provider: 'ollama' }];
+    expect(filterProvidersForDeployment(providers)).toBe(providers);
+  });
+});

--- a/packages/backend/src/common/utils/provider-availability.ts
+++ b/packages/backend/src/common/utils/provider-availability.ts
@@ -1,0 +1,24 @@
+import { normalizeProviderName, SHARED_PROVIDER_BY_ID_OR_ALIAS } from 'manifest-shared';
+import { isSelfHosted } from './detect-self-hosted';
+
+export const CLOUD_LOCAL_PROVIDER_MESSAGE =
+  'Built-in local providers are only available in self-hosted Manifest. On Manifest Cloud, expose the runtime through a public URL or tunnel and connect it as a custom provider.';
+
+export function isLocalOnlyProvider(provider: string): boolean {
+  const lower = provider.trim().toLowerCase();
+  const entry =
+    SHARED_PROVIDER_BY_ID_OR_ALIAS.get(lower) ??
+    SHARED_PROVIDER_BY_ID_OR_ALIAS.get(normalizeProviderName(lower));
+  return entry?.localOnly === true;
+}
+
+export function isProviderAvailableForDeployment(provider: string): boolean {
+  return isSelfHosted() || !isLocalOnlyProvider(provider);
+}
+
+export function filterProvidersForDeployment<T extends { provider: string }>(providers: T[]): T[] {
+  if (isSelfHosted() || !providers.some((provider) => isLocalOnlyProvider(provider.provider))) {
+    return providers;
+  }
+  return providers.filter((provider) => !isLocalOnlyProvider(provider.provider));
+}

--- a/packages/backend/src/entities/agent-message.entity.ts
+++ b/packages/backend/src/entities/agent-message.entity.ts
@@ -95,8 +95,9 @@ export class AgentMessage {
   /**
    * WHAT kind of failure it was (normalized): 'rate_limit' | 'auth' |
    * 'invalid_request' | 'billing' | 'server_error' | 'timeout' | 'network' |
-   * 'no_provider' | 'no_provider_key' | 'limit_exceeded' |
-   * 'plan_request_limit_exceeded' | 'internal' | … A rate limit is a *class*
+   * 'no_provider' | 'no_provider_key' | 'local_provider_unavailable' |
+   * 'limit_exceeded' | 'plan_request_limit_exceeded' | 'internal' | … A rate
+   * limit is a *class*
    * of error here, not a top-level status. NULL on success.
    */
   @Column('varchar', { nullable: true })

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -86,6 +86,7 @@ function makeMockRepo() {
 }
 
 describe('ModelDiscoveryService', () => {
+  const previousMode = process.env['MANIFEST_MODE'];
   let service: ModelDiscoveryService;
   let providerRepo: ReturnType<typeof makeMockRepo>;
   let customProviderRepo: ReturnType<typeof makeMockRepo>;
@@ -103,6 +104,7 @@ describe('ModelDiscoveryService', () => {
   let mockCopilotTokenService: { getCopilotToken: jest.Mock };
 
   beforeEach(() => {
+    process.env['MANIFEST_MODE'] = 'selfhosted';
     providerRepo = makeMockRepo();
     customProviderRepo = makeMockRepo();
     fetcher = { fetch: jest.fn().mockResolvedValue([]) };
@@ -138,6 +140,11 @@ describe('ModelDiscoveryService', () => {
     );
   });
 
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -145,6 +152,18 @@ describe('ModelDiscoveryService', () => {
   /* ── discoverModels ── */
 
   describe('discoverModels', () => {
+    it('does not contact a built-in local runtime from cloud', async () => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+
+      const result = await service.discoverModels(
+        makeProvider({ provider: 'ollama', auth_type: 'local', api_key_encrypted: null }),
+      );
+
+      expect(result).toEqual([]);
+      expect(fetcher.fetch).not.toHaveBeenCalled();
+      expect(providerRepo.save).not.toHaveBeenCalled();
+    });
+
     it('should decrypt key, fetch, enrich, and cache models', async () => {
       const models = [makeModel({ id: 'gpt-4' })];
       fetcher.fetch.mockResolvedValue(models);
@@ -530,6 +549,20 @@ describe('ModelDiscoveryService', () => {
   /* ── refreshProvider ── */
 
   describe('refreshProvider', () => {
+    it('rejects built-in local refreshes in cloud before reading the provider row', async () => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+
+      const result = await service.refreshProvider('tenant-1', 'ollama', 'local');
+
+      expect(result).toEqual({
+        ok: false,
+        model_count: 0,
+        last_fetched_at: null,
+        error: expect.stringContaining('only available in self-hosted Manifest'),
+      });
+      expect(providerRepo.findOne).not.toHaveBeenCalled();
+    });
+
     it('returns Provider not found when no row matches', async () => {
       providerRepo.findOne.mockResolvedValue(null);
       const result = await service.refreshProvider('agent-1', 'openai');
@@ -647,6 +680,30 @@ describe('ModelDiscoveryService', () => {
   /* ── getModelsForAgent ── */
 
   describe('getModelsForAgent', () => {
+    it('hides built-in local models in cloud but keeps tunneled custom models', async () => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+      providerRepo.find.mockResolvedValue([
+        makeProvider({
+          id: 'ollama-row',
+          provider: 'ollama',
+          auth_type: 'local',
+          cached_models: [makeModel({ id: 'qwen2.5:0.5b', provider: 'ollama' })],
+        }),
+        makeProvider({
+          id: 'custom-row',
+          provider: 'custom:cp-1',
+          auth_type: 'local',
+          cached_models: null,
+        }),
+      ]);
+      customProviderRepo.find.mockResolvedValue([makeCustomProvider()]);
+
+      const result = await service.getModelsForAgent('tenant-1');
+
+      expect(result.map((model) => model.id)).toEqual(['custom:cp-1/custom-llm']);
+      expect(result[0].authType).toBe('local');
+    });
+
     it('should merge cached models from providers and custom providers', async () => {
       const cachedModels = [makeModel({ id: 'gpt-4', provider: 'openai' })];
       const providers = [makeProvider({ cached_models: cachedModels })];

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -42,6 +42,11 @@ import {
 } from './model-fallback';
 import { lookupKnownPrice } from './known-model-prices';
 import { mergeModelCapabilities, modelSupportsStreaming } from './model-capabilities';
+import {
+  CLOUD_LOCAL_PROVIDER_MESSAGE,
+  filterProvidersForDeployment,
+  isProviderAvailableForDeployment,
+} from '../common/utils/provider-availability';
 // Import static helpers directly to avoid circular dependency with RoutingModule
 const customProviderKey = (id: string) => `custom:${id}`;
 const customModelKey = (id: string, modelName: string) => `custom:${id}/${modelName}`;
@@ -126,6 +131,7 @@ export class ModelDiscoveryService {
     provider: TenantProvider,
     options: DiscoverModelsOptions = {},
   ): Promise<DiscoveredModel[]> {
+    if (!isProviderAvailableForDeployment(provider.provider)) return [];
     let apiKey = '';
     let endpointOverride: string | undefined;
     const lowerProvider = provider.provider.toLowerCase();
@@ -345,9 +351,11 @@ export class ModelDiscoveryService {
     const discoveryOptions = options.forceRefresh
       ? { ...options, skipModelsDevRefresh: true }
       : options;
-    const providers = await this.providerRepo.find({
-      where: { tenant_id: tenantId, is_active: true },
-    });
+    const providers = filterProvidersForDeployment(
+      await this.providerRepo.find({
+        where: { tenant_id: tenantId, is_active: true },
+      }),
+    );
     await Promise.all(
       providers
         .filter((p) => !p.provider.startsWith('custom:'))
@@ -379,6 +387,14 @@ export class ModelDiscoveryService {
     last_fetched_at: string | null;
     error: string | null;
   }> {
+    if (!isProviderAvailableForDeployment(providerId)) {
+      return {
+        ok: false,
+        model_count: 0,
+        last_fetched_at: null,
+        error: CLOUD_LOCAL_PROVIDER_MESSAGE,
+      };
+    }
     const where: { tenant_id: string; provider: string; is_active: true; auth_type?: AuthType } = {
       tenant_id: tenantId,
       provider: providerId,
@@ -475,9 +491,11 @@ export class ModelDiscoveryService {
     tenantId: string,
     agentId?: string,
   ): Promise<DiscoveredModel[]> {
-    const allProviders = await this.providerRepo.find({
-      where: { tenant_id: tenantId, is_active: true },
-    });
+    const allProviders = filterProvidersForDeployment(
+      await this.providerRepo.find({
+        where: { tenant_id: tenantId, is_active: true },
+      }),
+    );
     const providers = await this.filterProvidersForAgent(allProviders, agentId);
 
     const models: DiscoveredModel[] = [];

--- a/packages/backend/src/routing/dto/routing.dto.ts
+++ b/packages/backend/src/routing/dto/routing.dto.ts
@@ -1,3 +1,4 @@
+import type { AuthType } from 'manifest-shared';
 import {
   IsString,
   IsIn,
@@ -73,7 +74,7 @@ export class ConnectProviderDto {
 
   @IsOptional()
   @IsIn(AUTH_TYPES)
-  authType?: 'api_key' | 'subscription';
+  authType?: AuthType;
 
   @IsOptional()
   @IsString()

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -31,6 +31,7 @@ function makeDiscovered(overrides: Partial<DiscoveredModel> = {}): DiscoveredMod
 }
 
 describe('ModelController', () => {
+  const previousMode = process.env['MANIFEST_MODE'];
   let controller: ModelController;
   let mockDiscoveryService: Record<string, jest.Mock>;
   let mockOllamaSync: Record<string, jest.Mock>;
@@ -43,6 +44,7 @@ describe('ModelController', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env['MANIFEST_MODE'] = 'selfhosted';
     mockDiscoveryService = {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
       discoverAllForAgent: jest.fn().mockResolvedValue(undefined),
@@ -91,6 +93,11 @@ describe('ModelController', () => {
       mockModelsDevSync as unknown as ModelsDevSyncService,
       mockOpencodeGoCatalog as unknown as OpencodeGoCatalogService,
     );
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
   });
 
   /* ── pricingHealth ── */
@@ -157,6 +164,15 @@ describe('ModelController', () => {
       const result = await controller.syncOllama();
       expect(mockOllamaSync.sync).toHaveBeenCalled();
       expect(result).toEqual({ count: 0 });
+    });
+
+    it('rejects Ollama sync in cloud without dialing localhost', async () => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+
+      await expect(controller.syncOllama()).rejects.toThrow(
+        'Built-in local providers are only available in self-hosted Manifest',
+      );
+      expect(mockOllamaSync.sync).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { BadRequestException, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { TenantCtx, TenantContext } from '../common/decorators/tenant-context.decorator';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
 import { CustomProviderService } from './custom-provider/custom-provider.service';
@@ -19,6 +19,10 @@ import {
   AgentProviderParamDto,
   RemoveProviderQueryDto,
 } from './dto/routing.dto';
+import {
+  CLOUD_LOCAL_PROVIDER_MESSAGE,
+  isProviderAvailableForDeployment,
+} from '../common/utils/provider-availability';
 
 function formatModelSlug(slug: string): string {
   return slug.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
@@ -104,6 +108,9 @@ export class ModelController {
 
   @Post('ollama/sync')
   async syncOllama() {
+    if (!isProviderAvailableForDeployment('ollama')) {
+      throw new BadRequestException(CLOUD_LOCAL_PROVIDER_MESSAGE);
+    }
     return this.ollamaSync.sync();
   }
 

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -14,6 +14,7 @@ const TEST_AGENT_ID = 'agent-001';
 const TEST_TENANT_ID = 'tenant-1';
 
 describe('ProviderController', () => {
+  const previousMode = process.env['MANIFEST_MODE'];
   let controller: ProviderController;
   let mockProviderService: Record<string, jest.Mock>;
   let mockDiscoveryService: Record<string, jest.Mock>;
@@ -25,6 +26,7 @@ describe('ProviderController', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env['MANIFEST_MODE'] = 'selfhosted';
     mockProviderService = {
       getProviders: jest.fn().mockResolvedValue([]),
       upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: false }),
@@ -67,6 +69,11 @@ describe('ProviderController', () => {
       mockPricingSync as unknown as PricingSyncService,
       mockCacheManager as never,
     );
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
   });
 
   describe('upsertProvider region validation', () => {
@@ -505,10 +512,38 @@ describe('ProviderController', () => {
         isNew: true,
       });
 
-      await controller.upsertProvider(mockCtx, mockAgentName, { provider: 'ollama' });
+      await controller.upsertProvider(mockCtx, mockAgentName, {
+        provider: 'ollama',
+        authType: 'local',
+      });
 
       expect(mockOllamaSync.sync).toHaveBeenCalled();
       expect(mockProviderService.upsertProvider).toHaveBeenCalled();
+    });
+
+    it('rejects built-in local providers in cloud before contacting localhost', async () => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+
+      await expect(
+        controller.upsertProvider(mockCtx, mockAgentName, {
+          provider: 'ollama',
+          authType: 'local',
+        }),
+      ).rejects.toThrow('Built-in local providers are only available in self-hosted Manifest');
+
+      expect(mockOllamaSync.sync).not.toHaveBeenCalled();
+      expect(mockProviderService.upsertProvider).not.toHaveBeenCalled();
+    });
+
+    it('rejects local auth on a non-local built-in provider in cloud', async () => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+
+      await expect(
+        controller.upsertProvider(mockCtx, mockAgentName, {
+          provider: 'openai',
+          authType: 'local',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
     });
 
     it('should accept region=cn for MiniMax subscription', async () => {

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -32,6 +32,10 @@ import {
 import { QWEN_REGION_VALIDATION_MESSAGE, isQwenRegion } from './qwen-region';
 import { getSubscriptionEndpointRegionConfig } from './subscription-region';
 import { isBedrockProvider, isBedrockRegion } from './bedrock-region';
+import {
+  CLOUD_LOCAL_PROVIDER_MESSAGE,
+  isProviderAvailableForDeployment,
+} from '../common/utils/provider-availability';
 
 @Controller('api/v1/routing')
 export class ProviderController {
@@ -108,6 +112,12 @@ export class ProviderController {
       allowPlayground: true,
     });
     const lowerProvider = body.provider.toLowerCase();
+    if (
+      !isProviderAvailableForDeployment(lowerProvider) ||
+      (body.authType === 'local' && !isProviderAvailableForDeployment('ollama'))
+    ) {
+      throw new BadRequestException(CLOUD_LOCAL_PROVIDER_MESSAGE);
+    }
     const isQwenProvider = lowerProvider === 'qwen' || lowerProvider === 'alibaba';
     const qwenBaseUrl = body.baseUrl ?? body.base_url;
     const qwenRegion = qwenBaseUrl ?? body.region;

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1,4 +1,5 @@
 import { ProviderClient } from '../provider-client';
+import { ManifestError } from '../../../common/errors/manifest-error';
 import { buildCustomEndpoint } from '../provider-endpoints';
 import { ThinkingBlockCache, type ThinkingBlockRouteContext } from '../thinking-block-cache';
 import type { ProviderModelRegistryService } from '../../../model-discovery/provider-model-registry.service';
@@ -7,11 +8,18 @@ const mockFetch = jest.fn();
 (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
 
 describe('ProviderClient', () => {
+  const previousMode = process.env['MANIFEST_MODE'];
   let client: ProviderClient;
 
   beforeEach(() => {
+    process.env['MANIFEST_MODE'] = 'selfhosted';
     client = new ProviderClient();
     mockFetch.mockReset();
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
   });
 
   const body = {
@@ -20,6 +28,25 @@ describe('ProviderClient', () => {
   };
 
   describe('OpenAI-compatible providers', () => {
+    it('refuses to dial a built-in local provider from cloud', async () => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+
+      const request = client.forward({
+        provider: 'ollama',
+        apiKey: '',
+        model: 'qwen2.5:0.5b',
+        body,
+        stream: false,
+      });
+
+      await expect(request).rejects.toMatchObject({ code: 'M303' });
+      await expect(request).rejects.toBeInstanceOf(ManifestError);
+      await expect(request).rejects.toThrow(
+        'Built-in local providers are only available in self-hosted Manifest',
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it('builds correct URL and headers for openai', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { HttpStatus, Injectable, Logger, Optional } from '@nestjs/common';
 import { OPENAI_RESPONSES_ONLY_RE, stripVendorPrefix } from '../../common/constants/openai-models';
 import { XAI_RESPONSES_ONLY_RE } from '../../common/constants/xai-models';
 import { PROVIDER_ENDPOINTS, ProviderEndpoint, resolveEndpointKey } from './provider-endpoints';
@@ -30,6 +30,8 @@ import { toNativeResponsesRequest } from './responses-adapter';
 import { forwardKiroChat } from './kiro-adapter';
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
 import { ProviderModelRegistryService } from '../../model-discovery/provider-model-registry.service';
+import { isProviderAvailableForDeployment } from '../../common/utils/provider-availability';
+import { ManifestError } from '../../common/errors/manifest-error';
 
 export interface ForwardResult {
   response: Response;
@@ -209,6 +211,10 @@ export class ProviderClient {
       customEndpoint,
       authType,
     } = opts;
+
+    if (!customEndpoint && !isProviderAvailableForDeployment(provider)) {
+      throw new ManifestError('M303', HttpStatus.BAD_REQUEST);
+    }
 
     const { endpoint, endpointKey } = await this.resolveEndpoint(
       customEndpoint,

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -56,6 +56,7 @@ const makeRepo = (agents: AgentRow[] = ['agent-1']) => ({
 });
 
 describe('ProviderService — route-only cleanup paths', () => {
+  const previousMode = process.env['MANIFEST_MODE'];
   let providerRepo: ReturnType<typeof makeRepo>;
   let tierRepo: ReturnType<typeof makeRepo>;
   let specRepo: ReturnType<typeof makeRepo>;
@@ -70,6 +71,7 @@ describe('ProviderService — route-only cleanup paths', () => {
   let svc: ProviderService;
 
   beforeEach(() => {
+    process.env['MANIFEST_MODE'] = 'selfhosted';
     providerRepo = makeRepo();
     tierRepo = makeRepo();
     specRepo = makeRepo();
@@ -91,6 +93,11 @@ describe('ProviderService — route-only cleanup paths', () => {
       pricingCache as unknown as ModelPricingCacheService,
       routingCache as unknown as RoutingCacheService,
     );
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
   });
 
   describe('removeProvider — route guards', () => {
@@ -1065,6 +1072,19 @@ describe('ProviderService — route-only cleanup paths', () => {
       const result = await svc.getProviders('tenant-1');
       expect(result).toBe(cached);
       expect(providerRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('filters legacy built-in local providers from cloud routing', async () => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+      providerRepo.find.mockResolvedValue([
+        { id: 'p1', provider: 'ollama', auth_type: 'local', is_active: true },
+        { id: 'p2', provider: 'custom:runtime-id', auth_type: 'local', is_active: true },
+      ]);
+
+      const result = await svc.getProviders('tenant-1');
+
+      expect(result.map((provider) => provider.provider)).toEqual(['custom:runtime-id']);
+      expect(routingCache.setProviders).toHaveBeenCalledWith('tenant-1', result);
     });
   });
 

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -40,6 +40,7 @@ import {
   getSubscriptionEndpointRegionConfig,
   SubscriptionEndpointRegionConfig,
 } from '../subscription-region';
+import { filterProvidersForDeployment } from '../../common/utils/provider-availability';
 
 const MAX_KEYS_PER_PROVIDER = 5;
 const MAX_LABEL_LENGTH = 50;
@@ -128,11 +129,13 @@ export class ProviderService {
 
   async getProviders(tenantId: string): Promise<TenantProvider[]> {
     const cached = this.routingCache.getProviders(tenantId);
-    if (cached) return cached;
+    if (cached) return filterProvidersForDeployment(cached);
 
     await this.cleanupUnsupportedSubscriptionProviders(tenantId);
-    const providers = (await this.providerRepo.find({ where: { tenant_id: tenantId } })).filter(
-      isManifestUsableProvider,
+    const providers = filterProvidersForDeployment(
+      (await this.providerRepo.find({ where: { tenant_id: tenantId } })).filter(
+        isManifestUsableProvider,
+      ),
     );
     this.routingCache.setProviders(tenantId, providers);
     return providers;

--- a/packages/backend/src/routing/tenant-providers.controller.spec.ts
+++ b/packages/backend/src/routing/tenant-providers.controller.spec.ts
@@ -3,7 +3,17 @@ import type { TenantContext } from '../common/decorators/tenant-context.decorato
 import type { TenantProvider } from '../entities/tenant-provider.entity';
 
 describe('TenantProvidersController', () => {
+  const previousMode = process.env['MANIFEST_MODE'];
   const ctx: TenantContext = { tenantId: 'tenant-1', userId: 'user-1' };
+
+  beforeEach(() => {
+    process.env['MANIFEST_MODE'] = 'cloud';
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
+  });
 
   const makeProvider = (id: string, label: string): TenantProvider =>
     ({
@@ -95,6 +105,28 @@ describe('TenantProvidersController', () => {
 
     expect(result.providers).toEqual([]);
     expect(result.model_counts).toEqual({});
+  });
+
+  it('hides legacy built-in local rows in cloud but keeps tunneled custom providers', async () => {
+    const providerRepo = {
+      find: jest.fn().mockResolvedValue([
+        { ...makeProvider('ollama-row', 'Default'), provider: 'ollama', auth_type: 'local' },
+        {
+          ...makeProvider('tunnel-row', 'Default'),
+          provider: 'custom:runtime-id',
+          auth_type: 'local',
+        },
+      ]),
+    };
+    const controller = new TenantProvidersController(
+      providerRepo as never,
+      { getAll: jest.fn().mockReturnValue([]) } as never,
+      { list: jest.fn().mockResolvedValue([{ id: 'runtime-id', name: 'LM Studio' }]) } as never,
+    );
+
+    const result = await controller.listProviders(ctx);
+
+    expect(result.providers.map((provider) => provider.provider)).toEqual(['custom:runtime-id']);
   });
 
   it('returns empty providers when ctx has no tenant (fresh account)', async () => {

--- a/packages/backend/src/routing/tenant-providers.controller.ts
+++ b/packages/backend/src/routing/tenant-providers.controller.ts
@@ -5,6 +5,7 @@ import { TenantCtx, TenantContext } from '../common/decorators/tenant-context.de
 import { TenantProvider } from '../entities/tenant-provider.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { CustomProviderService } from './custom-provider/custom-provider.service';
+import { filterProvidersForDeployment } from '../common/utils/provider-availability';
 
 /**
  * Tenant-level provider management endpoints.
@@ -35,9 +36,9 @@ export class TenantProvidersController {
   @Get()
   async listProviders(@TenantCtx() ctx: TenantContext) {
     const tenantId = ctx.tenantId;
-    const providers = tenantId
-      ? await this.providerRepo.find({ where: { tenant_id: tenantId } })
-      : [];
+    const providers = filterProvidersForDeployment(
+      tenantId ? await this.providerRepo.find({ where: { tenant_id: tenantId } }) : [],
+    );
 
     // Group providers and build response
     const grouped = new Map<

--- a/packages/shared/__tests__/error-taxonomy.spec.ts
+++ b/packages/shared/__tests__/error-taxonomy.spec.ts
@@ -68,6 +68,7 @@ describe('classifyMessageError', () => {
   it.each([
     ['no_provider', 'config', 'no_provider'],
     ['no_provider_key', 'config', 'no_provider_key'],
+    ['local_provider_unavailable', 'config', 'local_provider_unavailable'],
     ['key_expired', 'config', 'auth'],
     ['limit_exceeded', 'policy', 'limit_exceeded'],
     ['plan_request_limit_exceeded', 'policy', 'plan_request_limit_exceeded'],

--- a/packages/shared/src/error-taxonomy.ts
+++ b/packages/shared/src/error-taxonomy.ts
@@ -79,6 +79,7 @@ export const ERROR_CLASSES = [
   // manifest (config / policy / internal / request)
   'no_provider',
   'no_provider_key',
+  'local_provider_unavailable',
   'limit_exceeded',
   'plan_request_limit_exceeded',
   'internal',
@@ -101,6 +102,10 @@ const MANIFEST_REASON_TO_CLASSIFICATION: Record<
 > = {
   no_provider: { origin: 'config', errorClass: 'no_provider' },
   no_provider_key: { origin: 'config', errorClass: 'no_provider_key' },
+  local_provider_unavailable: {
+    origin: 'config',
+    errorClass: 'local_provider_unavailable',
+  },
   key_expired: { origin: 'config', errorClass: 'auth' },
   limit_exceeded: { origin: 'policy', errorClass: 'limit_exceeded' },
   plan_request_limit_exceeded: {


### PR DESCRIPTION
### ✨ What changed
- Reject built-in local providers and normalized aliases on Manifest Cloud.
- Hide legacy local rows from routing, discovery, and usage APIs.
- Return an M303 setup error before any localhost request.

### 💭 Why
Manifest Cloud cannot reach a user's localhost. The API still accepted those connections even though the UI hid them.

### 👤 For users
Cloud users get public URL or tunnel guidance. Self-hosted local runtimes are unchanged.