### PR TITLE
fix: clarify offline tunnel errors

### DIFF
--- a/.changeset/clean-tunnel-errors.md
+++ b/.changeset/clean-tunnel-errors.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Clarify offline tunnel errors and keep HTML error pages out of message records.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -853,6 +853,20 @@ describe('ProxyMessageRecorder', () => {
       expect(insertMock.mock.calls[0][0].provider).toBeNull();
     });
 
+    it('does not persist an HTML error page when no HTTP status was captured', async () => {
+      await recorder.recordPrimaryFailure(
+        ctx,
+        'standard',
+        'gpt-4o',
+        '<html><body>Tunnel failed</body></html>',
+        '2025-01-01T00:00:00.000Z',
+      );
+
+      expect(insertMock.mock.calls[0][0].error_message).toBe(
+        'Upstream endpoint returned an HTML error page',
+      );
+    });
+
     it('persists routing_reason when passed via opts', async () => {
       await recorder.recordPrimaryFailure(
         ctx,

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -67,6 +67,20 @@ describe('sanitizeProviderError', () => {
     );
   });
 
+  it('detects HTML error pages prefixed by server comments', () => {
+    const body = '<!-- served by edge --><html><body>Not found</body></html>';
+    expect(sanitizeProviderError(404, body, 'production')).toBe(
+      'Upstream endpoint returned HTTP 404',
+    );
+  });
+
+  it('does not classify an HTML page as a model context error', () => {
+    const body = '<html><body>context_length_exceeded while rendering the error</body></html>';
+    expect(sanitizeProviderError(404, body, 'production')).toBe(
+      'Upstream endpoint returned HTTP 404',
+    );
+  });
+
   it('ignores empty string message in JSON', () => {
     const body = JSON.stringify({ error: { message: '' } });
     expect(sanitizeProviderError(500, body, 'development')).toBe(
@@ -148,6 +162,11 @@ describe('normalizeProviderErrorForStorage', () => {
     expect(normalizeProviderErrorForStorage(undefined, '<html><p>Tunnel failed</p></html>')).toBe(
       'Upstream endpoint returned an HTML error page',
     );
+  });
+
+  it('collapses comment-prefixed HTML error pages for storage', () => {
+    const body = '<!-- proxy --><!doctype html><p>Bad gateway</p>';
+    expect(normalizeProviderErrorForStorage(502, body)).toBe('Upstream endpoint returned HTTP 502');
   });
 
   it('preserves an offline ngrok diagnostic when no HTTP status was captured', () => {

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -68,9 +68,15 @@ describe('sanitizeProviderError', () => {
   });
 
   it('detects HTML error pages prefixed by server comments', () => {
-    const body = '<!-- served by edge --><html><body>Not found</body></html>';
+    const body = '\n\t<!-- served by edge --><html><body>Not found</body></html>';
     expect(sanitizeProviderError(404, body, 'production')).toBe(
       'Upstream endpoint returned HTTP 404',
+    );
+  });
+
+  it('does not treat an unterminated leading comment as HTML', () => {
+    expect(sanitizeProviderError(502, '<!-- edge failure', 'production')).toBe(
+      'Upstream provider returned bad gateway',
     );
   });
 

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -144,6 +144,20 @@ describe('normalizeProviderErrorForStorage', () => {
     );
   });
 
+  it('collapses HTML error pages even when no HTTP status was captured', () => {
+    expect(normalizeProviderErrorForStorage(undefined, '<html><p>Tunnel failed</p></html>')).toBe(
+      'Upstream endpoint returned an HTML error page',
+    );
+  });
+
+  it('preserves an offline ngrok diagnostic when no HTTP status was captured', () => {
+    const body =
+      '<!DOCTYPE html><html><noscript>The endpoint example.ngrok-free.dev is offline. (ERR_NGROK_3200)</noscript></html>';
+    expect(normalizeProviderErrorForStorage(null, body)).toBe(
+      'Tunnel endpoint is offline (ERR_NGROK_3200)',
+    );
+  });
+
   it('keeps structured and plain-text provider errors unchanged', () => {
     const json = '{"error":{"message":"bad model"}}';
     expect(normalizeProviderErrorForStorage(400, json)).toBe(json);

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -1,6 +1,7 @@
 import {
   classifyProviderError,
   openAiErrorTypeForStatus,
+  normalizeProviderErrorForStorage,
   sanitizeProviderError,
 } from './proxy-error-sanitizer';
 
@@ -36,7 +37,7 @@ describe('sanitizeProviderError', () => {
 
   it('returns generic message for unknown status with non-JSON body', () => {
     expect(sanitizeProviderError(418, '<html>Teapot</html>', 'development')).toBe(
-      'Upstream provider returned HTTP 418',
+      'Upstream endpoint returned HTTP 418',
     );
   });
 
@@ -50,6 +51,20 @@ describe('sanitizeProviderError', () => {
     expect(sanitizeProviderError(502, '')).toBe('Upstream provider returned bad gateway');
     expect(sanitizeProviderError(503, '')).toBe('Upstream provider temporarily unavailable');
     expect(sanitizeProviderError(504, '')).toBe('Upstream provider gateway timeout');
+  });
+
+  it('reports an offline ngrok endpoint instead of a missing model', () => {
+    const body =
+      '<!DOCTYPE html><html><noscript>The endpoint example.ngrok-free.dev is offline. (ERR_NGROK_3200)</noscript></html>';
+    expect(sanitizeProviderError(404, body, 'production')).toBe(
+      'Tunnel endpoint is offline (ERR_NGROK_3200)',
+    );
+  });
+
+  it('describes generic HTML failures as endpoint responses', () => {
+    expect(sanitizeProviderError(404, '<html><body>Not found</body></html>', 'production')).toBe(
+      'Upstream endpoint returned HTTP 404',
+    );
   });
 
   it('ignores empty string message in JSON', () => {
@@ -119,6 +134,20 @@ describe('sanitizeProviderError', () => {
       const result = sanitizeProviderError(401, body, 'production');
       expect(result).toBe('Authentication failed with upstream provider');
     });
+  });
+});
+
+describe('normalizeProviderErrorForStorage', () => {
+  it('collapses HTML error pages to a concise diagnostic', () => {
+    expect(normalizeProviderErrorForStorage(502, '<!doctype html><p>Bad gateway</p>')).toBe(
+      'Upstream endpoint returned HTTP 502',
+    );
+  });
+
+  it('keeps structured and plain-text provider errors unchanged', () => {
+    const json = '{"error":{"message":"bad model"}}';
+    expect(normalizeProviderErrorForStorage(400, json)).toBe(json);
+    expect(normalizeProviderErrorForStorage(500, 'socket closed')).toBe('socket closed');
   });
 });
 

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -74,6 +74,13 @@ describe('sanitizeProviderError', () => {
     );
   });
 
+  it('detects many leading HTML comments without backtracking', () => {
+    const body = `${'<!-- edge -->'.repeat(1_000)}<html><body>Not found</body></html>`;
+    expect(sanitizeProviderError(404, body, 'production')).toBe(
+      'Upstream endpoint returned HTTP 404',
+    );
+  });
+
   it('does not classify an HTML page as a model context error', () => {
     const body = '<html><body>context_length_exceeded while rendering the error</body></html>';
     expect(sanitizeProviderError(404, body, 'production')).toBe(

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -57,7 +57,17 @@ function extractProviderMessage(rawBody: string): string | null {
 }
 
 function isHtmlErrorBody(rawBody: string): boolean {
-  return /^\s*(?:<!--[\s\S]*?-->\s*)*(?:<!doctype\s+html|<html)\b/i.test(rawBody);
+  let offset = 0;
+  while (offset < rawBody.length) {
+    while (/\s/.test(rawBody[offset] ?? '')) offset += 1;
+    if (!rawBody.startsWith('<!--', offset)) break;
+
+    const commentEnd = rawBody.indexOf('-->', offset + 4);
+    if (commentEnd === -1) return false;
+    offset = commentEnd + 3;
+  }
+
+  return /^(?:<!doctype\s+html|<html)\b/i.test(rawBody.slice(offset));
 }
 
 function htmlEndpointError(status: number | null | undefined, rawBody: string): string | null {

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -57,7 +57,7 @@ function extractProviderMessage(rawBody: string): string | null {
 }
 
 function isHtmlErrorBody(rawBody: string): boolean {
-  return /^\s*(?:<!doctype\s+html|<html)\b/i.test(rawBody);
+  return /^\s*(?:<!--[\s\S]*?-->\s*)*(?:<!doctype\s+html|<html)\b/i.test(rawBody);
 }
 
 function htmlEndpointError(status: number | null | undefined, rawBody: string): string | null {
@@ -122,10 +122,10 @@ export function classifyProviderError(
 
 export function sanitizeProviderError(status: number, rawBody: string, nodeEnv?: string): string {
   const generic = KNOWN_ERROR_MESSAGES[status] ?? `Upstream provider returned HTTP ${status}`;
-  const classified = classifyProviderError(status, rawBody);
-  if (classified) return classified.message;
   const endpointError = htmlEndpointError(status, rawBody);
   if (endpointError) return endpointError;
+  const classified = classifyProviderError(status, rawBody);
+  if (classified) return classified.message;
 
   // In production, only return generic error messages to avoid leaking provider internals
   if ((nodeEnv ?? 'production') === 'production') return generic;

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -56,6 +56,19 @@ function extractProviderMessage(rawBody: string): string | null {
   }
 }
 
+function isHtmlErrorBody(rawBody: string): boolean {
+  return /^\s*(?:<!doctype\s+html|<html)\b/i.test(rawBody);
+}
+
+function htmlEndpointError(status: number, rawBody: string): string | null {
+  if (!isHtmlErrorBody(rawBody)) return null;
+  const ngrokCode = rawBody.match(/\bERR_NGROK_\d+\b/i)?.[0]?.toUpperCase();
+  if (ngrokCode && /\bendpoint\b[\s\S]{0,300}\bis offline\b/i.test(rawBody)) {
+    return `Tunnel endpoint is offline (${ngrokCode})`;
+  }
+  return `Upstream endpoint returned HTTP ${status}`;
+}
+
 function extractProviderErrorCode(rawBody: string): string | null {
   try {
     const parsed = JSON.parse(rawBody) as Record<string, unknown>;
@@ -109,6 +122,8 @@ export function sanitizeProviderError(status: number, rawBody: string, nodeEnv?:
   const generic = KNOWN_ERROR_MESSAGES[status] ?? `Upstream provider returned HTTP ${status}`;
   const classified = classifyProviderError(status, rawBody);
   if (classified) return classified.message;
+  const endpointError = htmlEndpointError(status, rawBody);
+  if (endpointError) return endpointError;
 
   // In production, only return generic error messages to avoid leaking provider internals
   if ((nodeEnv ?? 'production') === 'production') return generic;
@@ -119,4 +134,8 @@ export function sanitizeProviderError(status: number, rawBody: string, nodeEnv?:
   }
 
   return generic;
+}
+
+export function normalizeProviderErrorForStorage(status: number, rawBody: string): string {
+  return isHtmlErrorBody(rawBody) ? sanitizeProviderError(status, rawBody, 'production') : rawBody;
 }

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -59,7 +59,7 @@ function extractProviderMessage(rawBody: string): string | null {
 function isHtmlErrorBody(rawBody: string): boolean {
   let offset = 0;
   while (offset < rawBody.length) {
-    while (/\s/.test(rawBody[offset] ?? '')) offset += 1;
+    while (/\s/.test(rawBody.charAt(offset))) offset += 1;
     if (!rawBody.startsWith('<!--', offset)) break;
 
     const commentEnd = rawBody.indexOf('-->', offset + 4);

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -60,13 +60,15 @@ function isHtmlErrorBody(rawBody: string): boolean {
   return /^\s*(?:<!doctype\s+html|<html)\b/i.test(rawBody);
 }
 
-function htmlEndpointError(status: number, rawBody: string): string | null {
+function htmlEndpointError(status: number | null | undefined, rawBody: string): string | null {
   if (!isHtmlErrorBody(rawBody)) return null;
   const ngrokCode = rawBody.match(/\bERR_NGROK_\d+\b/i)?.[0]?.toUpperCase();
   if (ngrokCode && /\bendpoint\b[\s\S]{0,300}\bis offline\b/i.test(rawBody)) {
     return `Tunnel endpoint is offline (${ngrokCode})`;
   }
-  return `Upstream endpoint returned HTTP ${status}`;
+  return status == null
+    ? 'Upstream endpoint returned an HTML error page'
+    : `Upstream endpoint returned HTTP ${status}`;
 }
 
 function extractProviderErrorCode(rawBody: string): string | null {
@@ -136,6 +138,9 @@ export function sanitizeProviderError(status: number, rawBody: string, nodeEnv?:
   return generic;
 }
 
-export function normalizeProviderErrorForStorage(status: number, rawBody: string): string {
-  return isHtmlErrorBody(rawBody) ? sanitizeProviderError(status, rawBody, 'production') : rawBody;
+export function normalizeProviderErrorForStorage(
+  status: number | null | undefined,
+  rawBody: string,
+): string {
+  return htmlEndpointError(status, rawBody) ?? rawBody;
 }

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -564,9 +564,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         status: 'fallback_error',
         ...autofixColumns(opts?.autofix, terminalAutofixRole(opts?.autofix)),
         error_message: scrubSecrets(
-          opts?.httpStatus == null
-            ? errorBody
-            : normalizeProviderErrorForStorage(opts.httpStatus, errorBody),
+          normalizeProviderErrorForStorage(opts?.httpStatus, errorBody),
         ).slice(0, 2000),
         error_http_status: opts?.httpStatus ?? null,
         model: canonical.model,

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -24,6 +24,7 @@ import {
   type AutofixRecord,
 } from '../autofix/autofix.types';
 import { serializeProviderError } from '../autofix/provider-error-normalizer';
+import { normalizeProviderErrorForStorage } from './proxy-error-sanitizer';
 
 /**
  * Phoenix's decision metadata for a healed row: its issue/patch/heal-attempt ids
@@ -334,7 +335,9 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         trace_id: traceId ?? null,
         timestamp: new Date().toISOString(),
         status: messageStatus,
-        error_message: scrubSecrets(errorMessage).slice(0, 2000),
+        error_message: scrubSecrets(
+          normalizeProviderErrorForStorage(httpStatus, errorMessage),
+        ).slice(0, 2000),
         error_http_status: httpStatus,
         ...autofixColumns(autofix, terminalAutofixRole(autofix)),
         model: canonical.model,
@@ -497,7 +500,9 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
           trace_id: traceId ?? null,
           timestamp: ts,
           status,
-          error_message: scrubSecrets(f.errorBody).slice(0, 2000),
+          error_message: scrubSecrets(
+            normalizeProviderErrorForStorage(f.status, f.errorBody),
+          ).slice(0, 2000),
           error_http_status: f.status,
           model: canonical.model,
           provider: canonical.provider,
@@ -558,7 +563,11 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         timestamp,
         status: 'fallback_error',
         ...autofixColumns(opts?.autofix, terminalAutofixRole(opts?.autofix)),
-        error_message: scrubSecrets(errorBody).slice(0, 2000),
+        error_message: scrubSecrets(
+          opts?.httpStatus == null
+            ? errorBody
+            : normalizeProviderErrorForStorage(opts.httpStatus, errorBody),
+        ).slice(0, 2000),
         error_http_status: opts?.httpStatus ?? null,
         model: canonical.model,
         provider: canonical.provider,


### PR DESCRIPTION
### ✨ What changed
- Recognize HTML endpoint failures before generic provider status mapping.
- Report offline ngrok endpoints with their diagnostic code.
- Store concise endpoint errors instead of full HTML pages.

### 💭 Why
An offline tunnel returned HTTP 404 HTML, which looked like a missing model and polluted message records.

### 👤 For users
Offline tunnels now produce a clear endpoint error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies offline tunnel errors: HTML error pages are recognized as endpoint failures and stored as short messages. Works with statusless and comment‑prefixed HTML; preserves offline `ngrok` ERR codes.

- Bug Fixes
  - Collapse HTML error pages to endpoint messages, including when no HTTP status is captured and when HTML is prefixed by many server comments; scanner is linear and ignores unterminated comments.
  - Report offline `ngrok` tunnel endpoints with their ERR code, even without an HTTP status (e.g., ERR_NGROK_3200).
  - Normalize errors before storage via `normalizeProviderErrorForStorage` in `proxy-message-recorder` to keep HTML pages out of message records.

<sup>Written for commit e3421b997307f31116ed688d2fb297c81048ffd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

