### PR TITLE
fix: surface interrupted provider streams

### DIFF
--- a/.changeset/report-interrupted-streams.md
+++ b/.changeset/report-interrupted-streams.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Surface interrupted upstream streams as terminal SSE errors.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -1162,7 +1162,7 @@ describe('proxy-response-handler', () => {
         res,
         undefined,
         undefined,
-        undefined,
+        expect.any(Function),
       );
     });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -93,6 +93,25 @@ function makeDiscoveredModel(overrides: Partial<DiscoveredModel> = {}): Discover
   };
 }
 
+function makeInterruptedSseResponse(firstChunk: string): Response {
+  const encoder = new TextEncoder();
+  let sentFirstChunk = false;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (!sentFirstChunk) {
+        sentFirstChunk = true;
+        controller.enqueue(encoder.encode(firstChunk));
+        return;
+      }
+      controller.error(new Error('mid-stream failure'));
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
 describe('ProxyController', () => {
   let controller: ProxyController;
   let proxyService: { proxyRequest: jest.Mock };
@@ -2153,16 +2172,12 @@ describe('ProxyController', () => {
       expect(headers['X-Manifest-Provider']).toBe('OpenAI');
     });
 
-    it('should end stream without error JSON when headers already sent and error occurs', async () => {
-      const failingStream = new ReadableStream({
-        start(ctrl) {
-          ctrl.error(new Error('mid-stream failure'));
-        },
-      });
-
+    it('should emit a terminal SSE error when the upstream dies after the first chunk', async () => {
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
-          response: new Response(failingStream, { status: 200 }),
+          response: makeInterruptedSseResponse(
+            'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n',
+          ),
           isGoogle: false,
           isAnthropic: false,
           isChatGpt: false,
@@ -2174,29 +2189,105 @@ describe('ProxyController', () => {
         messages: [{ role: 'user', content: 'hi' }],
         stream: true,
       });
-      const { res } = mockResponse();
+      const { res, written } = mockResponse();
 
       await controller.chatCompletions(req as never, res as never);
+      await flushRecorderMicrotasks();
 
+      const payload = written.join('');
+      expect(payload).toContain('"content":"hello"');
+      expect(payload).toContain('Upstream provider stream was interrupted.');
+      expect(payload).toContain('"code":"stream_interrupted"');
+      expect(payload).toContain('data: [DONE]');
       expect(res.end).toHaveBeenCalled();
       expect(res.json).not.toHaveBeenCalled();
+      expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          error_http_status: 503,
+          error_origin: 'transport',
+          error_class: 'network',
+          provider: 'OpenAI',
+          model: 'gpt-4o',
+        }),
+      );
+    });
+
+    it('should emit a terminal Responses API error when its upstream stream dies', async () => {
+      proxyService.proxyRequest.mockResolvedValue({
+        forward: {
+          response: makeInterruptedSseResponse(
+            'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n',
+          ),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+          isResponses: false,
+        },
+        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8 },
+      });
+
+      const req = mockRequest({ input: 'hi', stream: true });
+      const { res, written } = mockResponse();
+
+      await controller.responses(req as never, res as never);
+
+      const payload = written.join('');
+      expect(payload).toContain('event: error');
+      expect(payload).toContain('"type":"error"');
+      expect(payload).toContain('"code":"stream_interrupted"');
+      expect(payload).toContain('Upstream provider stream was interrupted.');
+      expect(res.end).toHaveBeenCalled();
+    });
+
+    it('should emit a terminal Anthropic error when its upstream stream dies', async () => {
+      proxyService.proxyRequest.mockResolvedValue({
+        forward: {
+          response: makeInterruptedSseResponse(
+            'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n',
+          ),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        },
+        meta: {
+          tier: 'standard',
+          model: 'claude-sonnet-4',
+          provider: 'OpenAI',
+          confidence: 0.8,
+        },
+      });
+
+      const req = mockRequest({
+        model: 'claude-sonnet-4',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      });
+      const { res, written } = mockResponse();
+
+      await controller.messages(req as never, res as never);
+
+      const payload = written.join('');
+      expect(payload).toContain('event: error');
+      expect(payload).toContain('"type":"api_error"');
+      expect(payload).toContain('Upstream provider stream was interrupted.');
+      expect(payload).not.toContain('message_stop');
+      expect(res.end).toHaveBeenCalled();
     });
 
     it('should not call res.end when headers sent and writableEnded is true', async () => {
-      const failingStream = new ReadableStream({
-        start(ctrl) {
-          ctrl.error(new Error('mid-stream failure'));
-        },
-      });
-
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
-          response: new Response(failingStream, { status: 200 }),
-          isGoogle: false,
+          response: new Response('data: {"candidates":[]}\n\n', { status: 200 }),
+          isGoogle: true,
           isAnthropic: false,
           isChatGpt: false,
         },
         meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8 },
+      });
+      providerClient.convertGoogleStreamChunk.mockImplementation(() => {
+        throw new Error('stream transform failed');
       });
 
       const req = mockRequest({
@@ -2205,22 +2296,13 @@ describe('ProxyController', () => {
       });
       const { res } = mockResponse();
 
-      // Simulate writableEnded becoming true before end is called
       (res.end as jest.Mock).mockImplementation(() => {
-        // no-op, already ended
-      });
-      // pipeStream will call res.end in its finally block, but the
-      // controller's catch checks writableEnded. We set it true after
-      // pipeStream's finally runs.
-      let flushCalled = false;
-      (res.flushHeaders as jest.Mock).mockImplementation(() => {
-        flushCalled = true;
+        res.writableEnded = true;
       });
 
       await controller.chatCompletions(req as never, res as never);
 
-      // Just verify it doesn't throw and end is called at least once (by pipeStream)
-      expect(flushCalled).toBe(true);
+      expect(res.end).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -2668,17 +2750,10 @@ describe('ProxyController', () => {
     });
 
     it('should close stream on error after headers sent', async () => {
-      // Simulate error during streaming (proxyRequest succeeds but stream fails)
-      const failingStream = new ReadableStream({
-        start(ctrl) {
-          ctrl.error(new Error('stream broke'));
-        },
-      });
-
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
-          response: new Response(failingStream, { status: 200 }),
-          isGoogle: false,
+          response: new Response('data: {"candidates":[]}\n\n', { status: 200 }),
+          isGoogle: true,
           isAnthropic: false,
           isChatGpt: false,
         },
@@ -2690,6 +2765,9 @@ describe('ProxyController', () => {
           reason: 'scored',
         },
       });
+      providerClient.convertGoogleStreamChunk.mockImplementation(() => {
+        throw new Error('stream transform failed');
+      });
 
       const req = mockRequest({
         messages: [{ role: 'user', content: 'test' }],
@@ -2699,8 +2777,7 @@ describe('ProxyController', () => {
 
       await controller.chatCompletions(req as never, res as never);
 
-      // Since headers are sent during streaming, error should just end the stream
-      expect(res.end).toHaveBeenCalled();
+      expect(res.end).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -2213,7 +2213,7 @@ describe('ProxyController', () => {
       );
     });
 
-    it('should emit a terminal Responses API error when its upstream stream dies', async () => {
+    it('should emit a sequenced Responses error when a converted chat stream dies', async () => {
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
           response: makeInterruptedSseResponse(
@@ -2237,10 +2237,38 @@ describe('ProxyController', () => {
       expect(payload).toContain('"type":"error"');
       expect(payload).toContain('"code":"stream_interrupted"');
       expect(payload).toContain('Upstream provider stream was interrupted.');
+      expect(payload).toContain('"sequence_number":5');
       expect(res.end).toHaveBeenCalled();
     });
 
-    it('should emit a terminal Anthropic error when its upstream stream dies', async () => {
+    it('should continue the upstream sequence for a native Responses stream error', async () => {
+      proxyService.proxyRequest.mockResolvedValue({
+        forward: {
+          response: makeInterruptedSseResponse(
+            'event: response.output_text.delta\n' +
+              'data: {"type":"response.output_text.delta","sequence_number":41,"delta":"hello"}\n\n',
+          ),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+          isResponses: true,
+        },
+        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8 },
+      });
+
+      const req = mockRequest({ input: 'hi', stream: true });
+      const { res, written } = mockResponse();
+
+      await controller.responses(req as never, res as never);
+
+      const payload = written.join('');
+      expect(payload).toContain('"sequence_number":41');
+      expect(payload).toContain('event: error');
+      expect(payload).toContain('"sequence_number":42');
+      expect(res.end).toHaveBeenCalled();
+    });
+
+    it('should emit an Anthropic error when a converted chat stream dies', async () => {
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
           response: makeInterruptedSseResponse(

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -2,6 +2,7 @@ import {
   initSseHeaders,
   pipePassthrough,
   pipeStream,
+  UpstreamStreamError,
   extractUsageFromSse,
   parseUsageObject,
 } from '../stream-writer';
@@ -462,11 +463,10 @@ describe('pipeStream', () => {
       },
     });
 
-    await expect(pipeStream(stream, res as never)).rejects.toThrow('stream read error');
+    await expect(pipeStream(stream, res as never)).rejects.toBeInstanceOf(UpstreamStreamError);
 
-    // After error, the reader lock should be released (finally block runs).
-    // We verify by checking that end was called (finally block behavior).
-    expect(res.end).toHaveBeenCalled();
+    expect(stream.locked).toBe(false);
+    expect(res.end).not.toHaveBeenCalled();
   });
 
   it('should not write remaining whitespace-only buffer through transform', async () => {
@@ -980,6 +980,22 @@ describe('pipePassthrough', () => {
     await expect(pipePassthrough(stream, res as never, () => null)).rejects.toThrow(
       'SSE buffer overflow',
     );
+  });
+
+  it('leaves the destination open when the upstream reader fails', async () => {
+    const { res } = mockResponse();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error('upstream disconnected'));
+      },
+    });
+
+    await expect(pipePassthrough(stream, res as never, () => null)).rejects.toBeInstanceOf(
+      UpstreamStreamError,
+    );
+
+    expect(stream.locked).toBe(false);
+    expect(res.end).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -14,6 +14,7 @@ import {
   pipeStream,
   StreamUsage,
 } from './stream-writer';
+import { createSsePayloadParser } from './sse-parser';
 import {
   classifyProviderError,
   openAiErrorTypeForStatus,
@@ -49,6 +50,48 @@ import {
 } from '../oauth/gemini/codeassist-envelope';
 
 const logger = new Logger('ProxyResponseHandler');
+
+interface ResponsesSequenceTracker {
+  feed(chunk: string): void;
+  next(): number;
+}
+
+function createResponsesSequenceTracker(): ResponsesSequenceTracker {
+  const parser = createSsePayloadParser();
+  let nextSequenceNumber = 0;
+
+  const feed = (chunk: string): void => {
+    for (const event of parser.feed(chunk)) {
+      const payload = event
+        .split('\n')
+        .filter((line) => !line.startsWith('event:') && !line.startsWith('id:'))
+        .join('\n');
+      try {
+        const data = JSON.parse(payload) as { sequence_number?: unknown };
+        const sequenceNumber = data.sequence_number;
+        if (
+          typeof sequenceNumber === 'number' &&
+          Number.isInteger(sequenceNumber) &&
+          sequenceNumber >= 0
+        ) {
+          nextSequenceNumber = Math.max(nextSequenceNumber, sequenceNumber + 1);
+        } else {
+          nextSequenceNumber += 1;
+        }
+      } catch {
+        nextSequenceNumber += 1;
+      }
+    }
+  };
+
+  return { feed, next: () => nextSequenceNumber };
+}
+
+const responsesSequenceTrackers = new WeakMap<ExpressResponse, ResponsesSequenceTracker>();
+
+export function nextResponsesSequenceNumber(res: ExpressResponse): number {
+  return responsesSequenceTrackers.get(res)?.next() ?? 0;
+}
 
 function recordSafely(promise: Promise<unknown>, label: string): void {
   promise.catch((e) => logger.warn(`Failed to record ${label}: ${e}`));
@@ -421,7 +464,12 @@ export async function handleStreamResponse(
 ): Promise<StreamUsage | null> {
   initSseHeaders(res, metaHeaders, 200);
 
-  const onClient = undefined;
+  const responsesSequenceTracker =
+    apiMode === 'responses' ? createResponsesSequenceTracker() : null;
+  if (responsesSequenceTracker) responsesSequenceTrackers.set(res, responsesSequenceTracker);
+  const onClient = responsesSequenceTracker
+    ? (chunk: string) => responsesSequenceTracker.feed(chunk)
+    : undefined;
 
   const messagesTransformer =
     apiMode === 'messages' ? createMessagesStreamTransformer(meta.model) : null;

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -49,6 +49,7 @@ import { ResponsesSseError } from './chatgpt-adapter';
 import { redactInlineImageDataUrls } from './inline-image-redaction';
 import { openAiModelId } from './openai-model-id';
 import { PlanService } from '../../billing/plan.service';
+import { UpstreamStreamError } from './stream-writer';
 
 const MAX_SEEN_TENANTS = 10_000;
 const SEEN_TENANT_TTL_MS = 24 * 60 * 60 * 1000;
@@ -199,6 +200,7 @@ export class ProxyController {
         traceId,
         callerAttribution,
         requestHeaders,
+        apiMode,
       );
       return;
     }
@@ -358,6 +360,7 @@ export class ProxyController {
         traceId,
         callerAttribution,
         requestHeaders,
+        apiMode,
         currentMeta,
       );
     } finally {
@@ -404,6 +407,7 @@ export class ProxyController {
     traceId: string | undefined,
     callerAttribution: ReturnType<typeof classifyCaller>,
     requestHeaders: ReturnType<typeof sanitizeRequestHeaders>,
+    apiMode: ProxyApiMode,
     meta?: RoutingMeta,
   ): void {
     if (clientAbort.signal.aborted) {
@@ -413,18 +417,20 @@ export class ProxyController {
 
     const message = this.extractErrorMessage(err);
     const status =
-      err instanceof ResponsesSseError
+      err instanceof UpstreamStreamError
         ? err.status
-        : err instanceof HttpException
-          ? err.getStatus()
-          : 500;
+        : err instanceof ResponsesSseError
+          ? err.status
+          : err instanceof HttpException
+            ? err.getStatus()
+            : 500;
     const providerErrorBody = err instanceof ResponsesSseError ? err.body : message;
     this.logger.error(`Proxy error: ${message}`);
 
-    // Who failed? A ManifestError says so explicitly. Everything a provider can
-    // do reaches us as a response — even a dead socket or a timeout, which
-    // proxy-transport turns into a synthetic 503/504 Response handled inline —
-    // so the only *thrown* errors left are Manifest's own bugs (M500).
+    // Who failed? A ManifestError says so explicitly. Pre-response dead sockets
+    // and timeouts become synthetic 503/504 responses in proxy-transport. A
+    // socket that dies after streaming starts is thrown as UpstreamStreamError.
+    // Other non-HTTP throws are Manifest's own bugs (M500).
     //
     // An unrecordable ManifestError (M001–M003, M005) writes NOTHING: it has no
     // tenant to attribute, and falling through to recordProviderError would blame
@@ -442,7 +448,11 @@ export class ProxyController {
           err.code,
         );
       }
-    } else if (!(err instanceof ResponsesSseError) && !(err instanceof HttpException)) {
+    } else if (
+      !(err instanceof UpstreamStreamError) &&
+      !(err instanceof ResponsesSseError) &&
+      !(err instanceof HttpException)
+    ) {
       // A non-HTTP throw is Manifest's own bug, never a provider fault.
       this.recordManifestBlockedRequest(
         err,
@@ -483,7 +493,13 @@ export class ProxyController {
     }
 
     if (headersSent) {
-      if (!res.writableEnded) res.end();
+      if (!res.writableEnded) {
+        if (err instanceof UpstreamStreamError) {
+          this.writeStreamError(res, apiMode, status, providerErrorBody, meta);
+        } else {
+          res.end();
+        }
+      }
       return;
     }
 
@@ -529,6 +545,44 @@ export class ProxyController {
         type: status >= 500 ? 'server_error' : 'invalid_request_error',
       },
     });
+  }
+
+  private writeStreamError(
+    res: ExpressResponse,
+    apiMode: ProxyApiMode,
+    status: number,
+    errorBody: string,
+    meta: RoutingMeta | undefined,
+  ): void {
+    const error = buildOpenAiCompatibleError(status, errorBody, {
+      source: 'provider',
+      code: 'stream_interrupted',
+      provider: meta?.provider,
+      model: meta?.model,
+    });
+    error.message = 'Upstream provider stream was interrupted.';
+
+    if (apiMode === 'messages') {
+      res.write(
+        `event: error\ndata: ${JSON.stringify({
+          type: 'error',
+          error: { type: 'api_error', message: error.message },
+        })}\n\n`,
+      );
+    } else if (apiMode === 'responses') {
+      res.write(
+        `event: error\ndata: ${JSON.stringify({
+          type: 'error',
+          code: error.code ?? 'server_error',
+          message: error.message,
+          param: null,
+          sequence_number: 0,
+        })}\n\n`,
+      );
+    } else {
+      res.write(`data: ${JSON.stringify({ error })}\n\ndata: [DONE]\n\n`);
+    }
+    res.end();
   }
 
   private extractTraceId(req: Request): string | undefined {

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -495,7 +495,7 @@ export class ProxyController {
     if (headersSent) {
       if (!res.writableEnded) {
         if (err instanceof UpstreamStreamError) {
-          this.writeStreamError(res, apiMode, status, providerErrorBody, meta);
+          this.writeStreamError(res, apiMode, status, meta);
         } else {
           res.end();
         }
@@ -551,10 +551,9 @@ export class ProxyController {
     res: ExpressResponse,
     apiMode: ProxyApiMode,
     status: number,
-    errorBody: string,
     meta: RoutingMeta | undefined,
   ): void {
-    const error = buildOpenAiCompatibleError(status, errorBody, {
+    const error = buildOpenAiCompatibleError(status, 'Upstream provider stream was interrupted.', {
       source: 'provider',
       code: 'stream_interrupted',
       provider: meta?.provider,

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -34,6 +34,7 @@ import {
   recordFallbackFailures,
   handleStreamResponse,
   handleNonStreamResponse,
+  nextResponsesSequenceNumber,
   recordSuccess,
 } from './proxy-response-handler';
 import { ProxyExceptionFilter, isChatRenderingClient } from './proxy-exception.filter';
@@ -53,6 +54,7 @@ import { UpstreamStreamError } from './stream-writer';
 
 const MAX_SEEN_TENANTS = 10_000;
 const SEEN_TENANT_TTL_MS = 24 * 60 * 60 * 1000;
+const STREAM_INTERRUPTED_MESSAGE = 'Upstream provider stream was interrupted.';
 const MODEL_CREATED_UNKNOWN = 0;
 
 interface OpenAiModelObject {
@@ -495,7 +497,7 @@ export class ProxyController {
     if (headersSent) {
       if (!res.writableEnded) {
         if (err instanceof UpstreamStreamError) {
-          this.writeStreamError(res, apiMode, status, meta);
+          this.writeStreamError(res, apiMode, err, meta);
         } else {
           res.end();
         }
@@ -550,22 +552,22 @@ export class ProxyController {
   private writeStreamError(
     res: ExpressResponse,
     apiMode: ProxyApiMode,
-    status: number,
+    streamError: UpstreamStreamError,
     meta: RoutingMeta | undefined,
   ): void {
-    const error = buildOpenAiCompatibleError(status, 'Upstream provider stream was interrupted.', {
+    const error = buildOpenAiCompatibleError(streamError.status, STREAM_INTERRUPTED_MESSAGE, {
       source: 'provider',
       code: 'stream_interrupted',
       provider: meta?.provider,
       model: meta?.model,
     });
-    error.message = 'Upstream provider stream was interrupted.';
+    error.message = STREAM_INTERRUPTED_MESSAGE;
 
     if (apiMode === 'messages') {
       res.write(
         `event: error\ndata: ${JSON.stringify({
           type: 'error',
-          error: { type: 'api_error', message: error.message },
+          error: { type: 'api_error', message: STREAM_INTERRUPTED_MESSAGE },
         })}\n\n`,
       );
     } else if (apiMode === 'responses') {
@@ -573,9 +575,9 @@ export class ProxyController {
         `event: error\ndata: ${JSON.stringify({
           type: 'error',
           code: error.code ?? 'server_error',
-          message: error.message,
+          message: STREAM_INTERRUPTED_MESSAGE,
           param: null,
-          sequence_number: 0,
+          sequence_number: nextResponsesSequenceNumber(res),
         })}\n\n`,
       );
     } else {

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -1,4 +1,5 @@
 import { Response as ExpressResponse } from 'express';
+import { TRANSPORT_NETWORK_HTTP_STATUS } from 'manifest-shared';
 import {
   createSsePayloadParser,
   DEFAULT_MAX_SSE_BUFFER_SIZE,
@@ -11,6 +12,25 @@ export interface StreamUsage {
   cache_read_tokens?: number;
   cache_creation_tokens?: number;
   reported_cost_usd?: number;
+}
+
+export class UpstreamStreamError extends Error {
+  readonly status = TRANSPORT_NETWORK_HTTP_STATUS;
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : 'Upstream stream interrupted', { cause });
+    this.name = 'UpstreamStreamError';
+  }
+}
+
+async function readUpstreamChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  try {
+    return await reader.read();
+  } catch (cause) {
+    throw new UpstreamStreamError(cause);
+  }
 }
 
 /**
@@ -205,13 +225,14 @@ export async function pipePassthrough(
   const reader = source.getReader();
   const decoder = new TextDecoder();
   let capturedUsage: StreamUsage | null = null;
+  let upstreamStreamFailed = false;
   const parser = createSsePayloadParser({ maxBufferSize: MAX_SSE_BUFFER_SIZE });
 
   try {
     let done = false;
     while (!done) {
       if (dest.writableEnded) break;
-      const result = await reader.read();
+      const result = await readUpstreamChunk(reader);
       done = result.done;
       if (result.value) {
         // Write the upstream bytes through unchanged so the client sees
@@ -245,9 +266,12 @@ export async function pipePassthrough(
         if (usage) capturedUsage = usage;
       }
     }
+  } catch (error) {
+    upstreamStreamFailed = error instanceof UpstreamStreamError;
+    throw error;
   } finally {
-    if (!dest.writableEnded) dest.end();
     reader.releaseLock();
+    if (!upstreamStreamFailed && !dest.writableEnded) dest.end();
   }
 
   return capturedUsage;
@@ -263,6 +287,7 @@ export async function pipeStream(
   const reader = source.getReader();
   const decoder = new TextDecoder();
   let capturedUsage: StreamUsage | null = null;
+  let upstreamStreamFailed = false;
 
   const writeOut = (s: string): void => {
     dest.write(s);
@@ -314,7 +339,7 @@ export async function pipeStream(
     while (!done) {
       if (dest.writableEnded) break;
 
-      const result = await reader.read();
+      const result = await readUpstreamChunk(reader);
       done = result.done;
 
       if (result.value) {
@@ -342,9 +367,12 @@ export async function pipeStream(
         writeOut('data: [DONE]\n\n');
       }
     }
+  } catch (error) {
+    upstreamStreamFailed = error instanceof UpstreamStreamError;
+    throw error;
   } finally {
     reader.releaseLock();
-    if (!dest.writableEnded) dest.end();
+    if (!upstreamStreamFailed && !dest.writableEnded) dest.end();
   }
 
   return capturedUsage;


### PR DESCRIPTION
### ✨ What changed
- Return terminal SSE errors when an upstream stream disconnects.
- Record reader failures as provider transport errors.
- Cover Chat Completions, Responses, and Anthropic Messages streams.

### 💭 Why
Clients received a silently truncated HTTP 200 after the first bytes were sent. Fallback cannot restart a response once bytes are on the wire.

### 👤 For users
Streaming clients receive a `stream_interrupted` error instead of an apparently successful truncated response.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit terminal SSE errors when an upstream provider stream dies mid-response, with a sanitized message and clean close. Responses streams now send a correctly sequenced `stream_interrupted` error; Chat Completions and Anthropic Messages emit the appropriate SSE error.

- Bug Fixes
  - Introduced `UpstreamStreamError` for reader failures; release the reader and keep the destination open so the controller can write a terminal SSE error.
  - Controller emits sanitized errors per API mode: OpenAI-compat writes `data: {"error": ...}` and `[DONE]`; Responses sends `event: error` with code `stream_interrupted`, 503, and the next `sequence_number` (works for native Responses and converted chat streams); Anthropic sends `event: error` with `api_error`.
  - Track Responses sequence numbers by parsing upstream SSE payloads; include provider/model metadata in errors.
  - Record provider failures as transport/network errors and avoid double-ending when headers are sent; tests cover mid-stream disconnects, transform failures, and Responses sequencing.
  - Changeset: `manifest` patch to surface interrupted upstream streams as terminal SSE errors.

<sup>Written for commit 766614d962807a8c55cb68a673c40355234defce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

