### PR TITLE
feat(proxy): expose model capabilities from /v1/models on request

### DIFF
--- a/.changeset/model-capabilities-projection.md
+++ b/.changeset/model-capabilities-projection.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Expose structured model capability metadata (input/output modalities, endpoint features, supported endpoints) from `GET /v1/models?capabilities=true`, keeping the default response unchanged. Curated modality facts now identify `gpt-5.3-codex-spark` as text-only input.

--- a/.changeset/model-capabilities-projection.md
+++ b/.changeset/model-capabilities-projection.md
@@ -2,4 +2,4 @@
 'manifest': minor
 ---
 
-Expose structured model capability metadata (input/output modalities, endpoint features, supported endpoints) from `GET /v1/models?capabilities=true`, keeping the default response unchanged. Curated modality facts now identify `gpt-5.3-codex-spark` as text-only input.
+Expose structured model capability metadata (input/output modalities, endpoint features, supported endpoints) from `GET /v1/models?capabilities=true`, keeping the default response unchanged, resolved through the same pipeline as the routing model picker. Curated modality facts identify `gpt-5.3-codex-spark` as text-only input and mainline ChatGPT subscription models as image-capable in both the API and the picker.

--- a/packages/backend/src/model-discovery/known-model-modalities.spec.ts
+++ b/packages/backend/src/model-discovery/known-model-modalities.spec.ts
@@ -1,0 +1,15 @@
+import { lookupKnownModalities } from './known-model-modalities';
+
+describe('lookupKnownModalities', () => {
+  it('identifies gpt-5.3-codex-spark as text-only, case-insensitively', () => {
+    expect(lookupKnownModalities('OpenAI', 'GPT-5.3-Codex-Spark')).toEqual({
+      input: ['text'],
+      output: ['text'],
+    });
+  });
+
+  it('returns undefined for models without a curated entry', () => {
+    expect(lookupKnownModalities('openai', 'gpt-5.4')).toBeUndefined();
+    expect(lookupKnownModalities('anthropic', 'gpt-5.3-codex-spark')).toBeUndefined();
+  });
+});

--- a/packages/backend/src/model-discovery/known-model-modalities.spec.ts
+++ b/packages/backend/src/model-discovery/known-model-modalities.spec.ts
@@ -5,6 +5,7 @@ describe('lookupKnownModalities', () => {
     expect(lookupKnownModalities('OpenAI', 'GPT-5.3-Codex-Spark')).toEqual({
       input: ['text'],
       output: ['text'],
+      capabilities: ['text', 'tools', 'stream'],
     });
   });
 
@@ -20,6 +21,7 @@ describe('lookupKnownModalities', () => {
       expect(lookupKnownModalities('openai', modelId)).toEqual({
         input: ['text', 'image'],
         output: ['text'],
+        capabilities: ['text', 'image', 'tools', 'stream'],
       });
     }
   });

--- a/packages/backend/src/model-discovery/known-model-modalities.spec.ts
+++ b/packages/backend/src/model-discovery/known-model-modalities.spec.ts
@@ -8,8 +8,24 @@ describe('lookupKnownModalities', () => {
     });
   });
 
+  it('identifies mainline ChatGPT subscription models as accepting image input', () => {
+    for (const modelId of [
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+    ]) {
+      expect(lookupKnownModalities('openai', modelId)).toEqual({
+        input: ['text', 'image'],
+        output: ['text'],
+      });
+    }
+  });
+
   it('returns undefined for models without a curated entry', () => {
-    expect(lookupKnownModalities('openai', 'gpt-5.4')).toBeUndefined();
+    expect(lookupKnownModalities('openai', 'unlisted-model')).toBeUndefined();
     expect(lookupKnownModalities('anthropic', 'gpt-5.3-codex-spark')).toBeUndefined();
   });
 });

--- a/packages/backend/src/model-discovery/known-model-modalities.ts
+++ b/packages/backend/src/model-discovery/known-model-modalities.ts
@@ -1,0 +1,29 @@
+import type { ModelModality } from 'manifest-shared';
+
+/**
+ * Hand-curated modality facts for models where both the provider's own
+ * metadata and models.dev are silent.
+ *
+ * **Priority:** entries here only fill gaps — modalities already discovered
+ * from the provider or models.dev win. Keep this list minimal: add an entry
+ * only when the modality support was confirmed against the provider's actual
+ * behavior and no upstream catalog carries it.
+ */
+interface KnownModalities {
+  input: readonly ModelModality[];
+  output: readonly ModelModality[];
+}
+
+/** Keyed by `<provider-id>/<model-id>`, lowercase. */
+const KNOWN_MODEL_MODALITIES: Readonly<Record<string, KnownModalities>> = {
+  // ChatGPT subscription (Codex models API) publishes no modality metadata
+  // and models.dev has no entry; the model rejects image input (#2537).
+  'openai/gpt-5.3-codex-spark': { input: ['text'], output: ['text'] },
+};
+
+export function lookupKnownModalities(
+  providerId: string,
+  modelId: string,
+): KnownModalities | undefined {
+  return KNOWN_MODEL_MODALITIES[`${providerId.toLowerCase()}/${modelId.toLowerCase()}`];
+}

--- a/packages/backend/src/model-discovery/known-model-modalities.ts
+++ b/packages/backend/src/model-discovery/known-model-modalities.ts
@@ -14,11 +14,22 @@ interface KnownModalities {
   output: readonly ModelModality[];
 }
 
+const TEXT_IMAGE_IN: KnownModalities = { input: ['text', 'image'], output: ['text'] };
+const TEXT_ONLY: KnownModalities = { input: ['text'], output: ['text'] };
+
 /** Keyed by `<provider-id>/<model-id>`, lowercase. */
 const KNOWN_MODEL_MODALITIES: Readonly<Record<string, KnownModalities>> = {
-  // ChatGPT subscription (Codex models API) publishes no modality metadata
-  // and models.dev has no entry; the model rejects image input (#2537).
-  'openai/gpt-5.3-codex-spark': { input: ['text'], output: ['text'] },
+  // ChatGPT subscription (Codex models API) publishes no modality metadata,
+  // and models.dev lags behind new launches. These facts bootstrap the
+  // subscription catalog until an upstream source carries them (#2537).
+  'openai/gpt-5.6-sol': TEXT_IMAGE_IN,
+  'openai/gpt-5.6-terra': TEXT_IMAGE_IN,
+  'openai/gpt-5.6-luna': TEXT_IMAGE_IN,
+  'openai/gpt-5.5': TEXT_IMAGE_IN,
+  'openai/gpt-5.4': TEXT_IMAGE_IN,
+  'openai/gpt-5.4-mini': TEXT_IMAGE_IN,
+  // Rejects image input (#2537).
+  'openai/gpt-5.3-codex-spark': TEXT_ONLY,
 };
 
 export function lookupKnownModalities(

--- a/packages/backend/src/model-discovery/known-model-modalities.ts
+++ b/packages/backend/src/model-discovery/known-model-modalities.ts
@@ -1,40 +1,50 @@
-import type { ModelModality } from 'manifest-shared';
+import type { ModelCapability, ModelModality } from 'manifest-shared';
 
 /**
- * Hand-curated modality facts for models where both the provider's own
+ * Hand-curated capability facts for models where both the provider's own
  * metadata and models.dev are silent.
  *
- * **Priority:** entries here only fill gaps — modalities already discovered
- * from the provider or models.dev win. Keep this list minimal: add an entry
- * only when the modality support was confirmed against the provider's actual
- * behavior and no upstream catalog carries it.
+ * **Authority:** modalities already discovered from the provider or models.dev
+ * win. Capability lists are positive assertions, so they merge; an upstream
+ * omission means unknown, never unsupported. Keep this list minimal: add an
+ * entry only when support was confirmed against the provider's actual behavior
+ * and no upstream catalog carries it.
  */
-interface KnownModalities {
+interface KnownCapabilities {
   input: readonly ModelModality[];
   output: readonly ModelModality[];
+  capabilities: readonly ModelCapability[];
 }
 
-const TEXT_IMAGE_IN: KnownModalities = { input: ['text', 'image'], output: ['text'] };
-const TEXT_ONLY: KnownModalities = { input: ['text'], output: ['text'] };
+const TEXT_IMAGE_TOOLS: KnownCapabilities = {
+  input: ['text', 'image'],
+  output: ['text'],
+  capabilities: ['text', 'image', 'tools', 'stream'],
+};
+const TEXT_TOOLS: KnownCapabilities = {
+  input: ['text'],
+  output: ['text'],
+  capabilities: ['text', 'tools', 'stream'],
+};
 
 /** Keyed by `<provider-id>/<model-id>`, lowercase. */
-const KNOWN_MODEL_MODALITIES: Readonly<Record<string, KnownModalities>> = {
+const KNOWN_MODEL_MODALITIES: Readonly<Record<string, KnownCapabilities>> = {
   // ChatGPT subscription (Codex models API) publishes no modality metadata,
   // and models.dev lags behind new launches. These facts bootstrap the
   // subscription catalog until an upstream source carries them (#2537).
-  'openai/gpt-5.6-sol': TEXT_IMAGE_IN,
-  'openai/gpt-5.6-terra': TEXT_IMAGE_IN,
-  'openai/gpt-5.6-luna': TEXT_IMAGE_IN,
-  'openai/gpt-5.5': TEXT_IMAGE_IN,
-  'openai/gpt-5.4': TEXT_IMAGE_IN,
-  'openai/gpt-5.4-mini': TEXT_IMAGE_IN,
+  'openai/gpt-5.6-sol': TEXT_IMAGE_TOOLS,
+  'openai/gpt-5.6-terra': TEXT_IMAGE_TOOLS,
+  'openai/gpt-5.6-luna': TEXT_IMAGE_TOOLS,
+  'openai/gpt-5.5': TEXT_IMAGE_TOOLS,
+  'openai/gpt-5.4': TEXT_IMAGE_TOOLS,
+  'openai/gpt-5.4-mini': TEXT_IMAGE_TOOLS,
   // Rejects image input (#2537).
-  'openai/gpt-5.3-codex-spark': TEXT_ONLY,
+  'openai/gpt-5.3-codex-spark': TEXT_TOOLS,
 };
 
 export function lookupKnownModalities(
   providerId: string,
   modelId: string,
-): KnownModalities | undefined {
+): KnownCapabilities | undefined {
   return KNOWN_MODEL_MODALITIES[`${providerId.toLowerCase()}/${modelId.toLowerCase()}`];
 }

--- a/packages/backend/src/model-discovery/model-capabilities.spec.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.spec.ts
@@ -109,6 +109,33 @@ describe('resolveModelCapabilityMetadata', () => {
     expect(resolved.outputModalities).toEqual(['text']);
   });
 
+  it('falls back to curated known modalities when discovery and models.dev are silent', async () => {
+    const resolved = await resolveModelCapabilityMetadata(
+      makeModel({ id: 'gpt-5.4-mini', provider: 'openai', authType: 'subscription' }),
+      paramSpecs,
+      modelsDevSync,
+    );
+
+    expect(resolved.inputModalities).toEqual(['text', 'image']);
+    expect(resolved.outputModalities).toEqual(['text']);
+  });
+
+  it('prefers discovered modalities over the curated known list', async () => {
+    const resolved = await resolveModelCapabilityMetadata(
+      makeModel({
+        id: 'gpt-5.4-mini',
+        provider: 'openai',
+        inputModalities: ['text'],
+        outputModalities: ['text'],
+      }),
+      paramSpecs,
+      modelsDevSync,
+    );
+
+    expect(resolved.inputModalities).toEqual(['text']);
+    expect(resolved.outputModalities).toEqual(['text']);
+  });
+
   it('looks up metadata under the underlying provider for vendor-prefixed ids', async () => {
     await resolveModelCapabilityMetadata(
       makeModel({ id: 'anthropic.claude-sonnet-5-v1:0', provider: 'bedrock' }),

--- a/packages/backend/src/model-discovery/model-capabilities.spec.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.spec.ts
@@ -1,4 +1,37 @@
-import { inputModalitiesFromCapabilities } from './model-capabilities';
+import {
+  inputModalitiesFromCapabilities,
+  resolveModelCapabilityMetadata,
+} from './model-capabilities';
+import type { DiscoveredModel } from './model-fetcher';
+import type { ModelsDevModelEntry } from '../database/models-dev-sync.service';
+
+function makeModel(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
+  return {
+    id: 'gpt-4o',
+    displayName: 'GPT-4o',
+    provider: 'openai',
+    contextWindow: 128000,
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 3,
+    ...overrides,
+  };
+}
+
+function makeModelsDevEntry(overrides: Partial<ModelsDevModelEntry> = {}): ModelsDevModelEntry {
+  return {
+    id: 'gpt-4o',
+    name: 'GPT-4o',
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    capabilities: ['text', 'image'],
+    inputModalities: ['text', 'image'],
+    outputModalities: ['text'],
+    ...overrides,
+  };
+}
 
 describe('inputModalitiesFromCapabilities', () => {
   it('keeps text first and appends each novel capability once', () => {
@@ -15,5 +48,74 @@ describe('inputModalitiesFromCapabilities', () => {
 
   it('defaults to text-only for nullish capabilities', () => {
     expect(inputModalitiesFromCapabilities(null)).toEqual(['text']);
+  });
+});
+
+describe('resolveModelCapabilityMetadata', () => {
+  const paramSpecs = { getCapabilities: jest.fn() };
+  const modelsDevSync = { lookupModel: jest.fn() };
+
+  beforeEach(() => {
+    paramSpecs.getCapabilities.mockReset().mockResolvedValue(null);
+    modelsDevSync.lookupModel.mockReset().mockReturnValue(null);
+  });
+
+  it('merges discovery, models.dev, param-spec, and streaming-heuristic capabilities', async () => {
+    paramSpecs.getCapabilities.mockResolvedValue(['tools']);
+    modelsDevSync.lookupModel.mockReturnValue(makeModelsDevEntry());
+
+    const resolved = await resolveModelCapabilityMetadata(
+      makeModel({ capabilities: ['audio'], authType: 'subscription' }),
+      paramSpecs,
+      modelsDevSync,
+    );
+
+    expect(paramSpecs.getCapabilities).toHaveBeenCalledWith('openai', 'subscription', 'gpt-4o');
+    expect(resolved.capabilities).toEqual(['audio', 'text', 'image', 'tools', 'stream']);
+    expect(resolved.inputModalities).toEqual(['text', 'image']);
+    expect(resolved.outputModalities).toEqual(['text']);
+    expect(resolved.modelsDevEntry).not.toBeNull();
+  });
+
+  it('leaves everything undefined when no source knows the model', async () => {
+    const resolved = await resolveModelCapabilityMetadata(
+      makeModel({ id: 'mystery', provider: 'kiro' }),
+      paramSpecs,
+      modelsDevSync,
+    );
+
+    expect(paramSpecs.getCapabilities).toHaveBeenCalledWith('kiro', 'api_key', 'mystery');
+    expect(resolved).toEqual({
+      capabilities: undefined,
+      inputModalities: undefined,
+      outputModalities: undefined,
+      modelsDevEntry: null,
+    });
+  });
+
+  it('keeps discovery-time modalities when models.dev has no entry', async () => {
+    const resolved = await resolveModelCapabilityMetadata(
+      makeModel({
+        id: 'mystery',
+        provider: 'kiro',
+        inputModalities: ['text'],
+        outputModalities: ['text'],
+      }),
+      paramSpecs,
+      modelsDevSync,
+    );
+
+    expect(resolved.inputModalities).toEqual(['text']);
+    expect(resolved.outputModalities).toEqual(['text']);
+  });
+
+  it('looks up metadata under the underlying provider for vendor-prefixed ids', async () => {
+    await resolveModelCapabilityMetadata(
+      makeModel({ id: 'anthropic.claude-sonnet-5-v1:0', provider: 'bedrock' }),
+      paramSpecs,
+      modelsDevSync,
+    );
+
+    expect(modelsDevSync.lookupModel).toHaveBeenCalledWith('anthropic', 'claude-sonnet-5-v1:0');
   });
 });

--- a/packages/backend/src/model-discovery/model-capabilities.spec.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.spec.ts
@@ -109,7 +109,7 @@ describe('resolveModelCapabilityMetadata', () => {
     expect(resolved.outputModalities).toEqual(['text']);
   });
 
-  it('falls back to curated known modalities when discovery and models.dev are silent', async () => {
+  it('falls back to curated known capability facts when discovery and models.dev are silent', async () => {
     const resolved = await resolveModelCapabilityMetadata(
       makeModel({ id: 'gpt-5.4-mini', provider: 'openai', authType: 'subscription' }),
       paramSpecs,
@@ -118,6 +118,7 @@ describe('resolveModelCapabilityMetadata', () => {
 
     expect(resolved.inputModalities).toEqual(['text', 'image']);
     expect(resolved.outputModalities).toEqual(['text']);
+    expect(resolved.capabilities).toEqual(['stream', 'text', 'image', 'tools']);
   });
 
   it('prefers discovered modalities over the curated known list', async () => {

--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -142,6 +142,7 @@ export async function resolveModelCapabilityMetadata(
       modelsDevEntry?.capabilities,
       specCapabilities,
       modelSupportsStreaming(metadataProvider, metadata.model) ? ['stream'] : undefined,
+      known?.capabilities,
     ),
     inputModalities: modelsDevEntry?.inputModalities ?? model.inputModalities ?? known?.input,
     outputModalities: modelsDevEntry?.outputModalities ?? model.outputModalities ?? known?.output,

--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -3,6 +3,7 @@ import { resolveProviderMetadataIdentity } from 'manifest-shared';
 import type { AuthType, ModelCapability, ModelModality } from 'manifest-shared';
 import type { DiscoveredModel } from './model-fetcher';
 import type { ModelsDevModelEntry } from '../database/models-dev-sync.service';
+import { lookupKnownModalities } from './known-model-modalities';
 
 type RawModalities = { input?: string[]; output?: string[] } | undefined;
 
@@ -132,6 +133,9 @@ export async function resolveModelCapabilityMetadata(
   const metadata = resolveProviderMetadataIdentity(model.provider, model.id);
   const metadataProvider = metadata.provider ?? model.provider;
   const modelsDevEntry = modelsDevSync.lookupModel(metadataProvider, metadata.model);
+  // Curated facts are the last resort, and applying them here (not only at
+  // discovery time) means stale cached_models still resolve correctly.
+  const known = lookupKnownModalities(metadataProvider, metadata.model);
   return {
     capabilities: mergeModelCapabilities(
       model.capabilities,
@@ -139,8 +143,8 @@ export async function resolveModelCapabilityMetadata(
       specCapabilities,
       modelSupportsStreaming(metadataProvider, metadata.model) ? ['stream'] : undefined,
     ),
-    inputModalities: modelsDevEntry?.inputModalities ?? model.inputModalities,
-    outputModalities: modelsDevEntry?.outputModalities ?? model.outputModalities,
+    inputModalities: modelsDevEntry?.inputModalities ?? model.inputModalities ?? known?.input,
+    outputModalities: modelsDevEntry?.outputModalities ?? model.outputModalities ?? known?.output,
     modelsDevEntry,
   };
 }

--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -1,5 +1,8 @@
 import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
-import type { ModelCapability, ModelModality } from 'manifest-shared';
+import { resolveProviderMetadataIdentity } from 'manifest-shared';
+import type { AuthType, ModelCapability, ModelModality } from 'manifest-shared';
+import type { DiscoveredModel } from './model-fetcher';
+import type { ModelsDevModelEntry } from '../database/models-dev-sync.service';
 
 type RawModalities = { input?: string[]; output?: string[] } | undefined;
 
@@ -90,6 +93,56 @@ export function capabilitiesFromModelsDev(
   if (toolCall === true) add('tools');
   if (modelSupportsStreaming(providerId, modelId)) add('stream');
   return out;
+}
+
+export interface ResolvedCapabilityMetadata {
+  capabilities?: readonly ModelCapability[];
+  inputModalities?: readonly ModelModality[];
+  outputModalities?: readonly ModelModality[];
+  modelsDevEntry: ModelsDevModelEntry | null;
+}
+
+/**
+ * Resolve a discovered model's capability metadata the way the dashboard's
+ * model picker does: merge discovery-time capabilities with the curated
+ * param-spec catalog, a live models.dev lookup, and the streaming heuristic.
+ * Shared by the routing `available-models` endpoint and the
+ * `/v1/models?capabilities=true` proxy projection so both surfaces report the
+ * same facts. Fields stay undefined when no source knows them — callers, not
+ * this resolver, decide whether to default unknowns for display.
+ */
+export async function resolveModelCapabilityMetadata(
+  model: DiscoveredModel,
+  paramSpecs: {
+    getCapabilities(
+      providerId: string | undefined,
+      authType: AuthType | undefined,
+      model: string | undefined,
+    ): Promise<readonly ModelCapability[] | null>;
+  },
+  modelsDevSync: { lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null },
+): Promise<ResolvedCapabilityMetadata> {
+  const specCapabilities = await paramSpecs.getCapabilities(
+    model.provider,
+    model.authType ?? 'api_key',
+    model.id,
+  );
+  // Some routable ids proxy another provider's model namespace (gateway ids,
+  // Bedrock vendor-prefixed ids). Resolve that provenance for metadata only.
+  const metadata = resolveProviderMetadataIdentity(model.provider, model.id);
+  const metadataProvider = metadata.provider ?? model.provider;
+  const modelsDevEntry = modelsDevSync.lookupModel(metadataProvider, metadata.model);
+  return {
+    capabilities: mergeModelCapabilities(
+      model.capabilities,
+      modelsDevEntry?.capabilities,
+      specCapabilities,
+      modelSupportsStreaming(metadataProvider, metadata.model) ? ['stream'] : undefined,
+    ),
+    inputModalities: modelsDevEntry?.inputModalities ?? model.inputModalities,
+    outputModalities: modelsDevEntry?.outputModalities ?? model.outputModalities,
+    modelsDevEntry,
+  };
 }
 
 export function modelSupportsStreaming(providerId: string, modelId: string): boolean {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -200,7 +200,7 @@ describe('ModelDiscoveryService', () => {
       expect(fetcher.fetch).toHaveBeenCalledWith('kiro', 'kiro-access', 'subscription', undefined);
     });
 
-    it('should fill modality gaps from the curated known-modalities list', async () => {
+    it('should fill capability gaps from the curated known-modalities list', async () => {
       fetcher.fetch.mockResolvedValue([
         makeModel({ id: 'gpt-5.3-codex-spark', inputPricePerToken: 0, outputPricePerToken: 0 }),
       ]);
@@ -209,6 +209,7 @@ describe('ModelDiscoveryService', () => {
 
       expect(result[0].inputModalities).toEqual(['text']);
       expect(result[0].outputModalities).toEqual(['text']);
+      expect(result[0].capabilities).toEqual(['text', 'tools', 'stream']);
     });
 
     it('should keep discovered modalities over the curated known-modalities list', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -200,6 +200,34 @@ describe('ModelDiscoveryService', () => {
       expect(fetcher.fetch).toHaveBeenCalledWith('kiro', 'kiro-access', 'subscription', undefined);
     });
 
+    it('should fill modality gaps from the curated known-modalities list', async () => {
+      fetcher.fetch.mockResolvedValue([
+        makeModel({ id: 'gpt-5.3-codex-spark', inputPricePerToken: 0, outputPricePerToken: 0 }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputModalities).toEqual(['text']);
+      expect(result[0].outputModalities).toEqual(['text']);
+    });
+
+    it('should keep discovered modalities over the curated known-modalities list', async () => {
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'gpt-5.3-codex-spark',
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          inputModalities: ['text', 'image'],
+          outputModalities: ['text', 'image'],
+        }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputModalities).toEqual(['text', 'image']);
+      expect(result[0].outputModalities).toEqual(['text', 'image']);
+    });
+
     it('should enrich models with openRouter pricing when available', async () => {
       mockPricingSync.lookupPricing.mockImplementation((key: string) => {
         if (key === 'openai/gpt-4') {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -209,7 +209,7 @@ describe('ModelDiscoveryService', () => {
 
       expect(result[0].inputModalities).toEqual(['text']);
       expect(result[0].outputModalities).toEqual(['text']);
-      expect(result[0].capabilities).toEqual(['text', 'tools', 'stream']);
+      expect(result[0].capabilities).toEqual(expect.arrayContaining(['text', 'tools', 'stream']));
     });
 
     it('should keep discovered modalities over the curated known-modalities list', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -585,6 +585,7 @@ export class ModelDiscoveryService {
         ...model,
         inputModalities: model.inputModalities ?? knownModalities.input,
         outputModalities: model.outputModalities ?? knownModalities.output,
+        capabilities: mergeModelCapabilities(model.capabilities, knownModalities.capabilities),
       };
     }
 

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -41,6 +41,7 @@ import {
   supplementWithKnownModels,
 } from './model-fallback';
 import { lookupKnownPrice } from './known-model-prices';
+import { lookupKnownModalities } from './known-model-modalities';
 import { mergeModelCapabilities, modelSupportsStreaming } from './model-capabilities';
 // Import static helpers directly to avoid circular dependency with RoutingModule
 const customProviderKey = (id: string) => `custom:${id}`;
@@ -576,6 +577,17 @@ export class ModelDiscoveryService {
   }
 
   private enrichModel(model: DiscoveredModel, providerId: string): DiscoveredModel {
+    // Fill modality gaps from the curated list before enrichment, so
+    // provider-native and models.dev modalities (applied below) still win.
+    const knownModalities = lookupKnownModalities(providerId, model.id);
+    if (knownModalities) {
+      model = {
+        ...model,
+        inputModalities: model.inputModalities ?? knownModalities.input,
+        outputModalities: model.outputModalities ?? knownModalities.output,
+      };
+    }
+
     // Skip pricing enrichment when both prices are already set (price=0 for free/subscription)
     // but still apply capability flags from models.dev for better scoring
     if (

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -286,6 +286,16 @@ describe('ModelController', () => {
       });
     });
 
+    it('surfaces curated known modalities in the picker payload when discovery has none', async () => {
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([
+        makeDiscovered({ id: 'gpt-5.4-mini', provider: 'openai', authType: 'subscription' }),
+      ]);
+
+      const result = await controller.getAvailableModels(mockCtx, mockAgentName);
+
+      expect(result[0].input_modalities).toEqual(['text', 'image']);
+    });
+
     it('includes the per-request cost for OpenCode Go subscription models', async () => {
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([
         makeDiscovered({

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -11,8 +11,7 @@ import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { resolveProviderMetadataIdentity } from 'manifest-shared';
 import {
   inputModalitiesFromCapabilities,
-  mergeModelCapabilities,
-  modelSupportsStreaming,
+  resolveModelCapabilityMetadata,
 } from '../model-discovery/model-capabilities';
 import {
   AgentNameParamDto,
@@ -127,28 +126,13 @@ export class ModelController {
       models.map(async (m) => {
         const isCustom = CustomProviderService.isCustom(m.provider);
         const authType = m.authType ?? 'api_key';
-        const capabilities = await this.providerParamSpecs.getCapabilities(
-          m.provider,
-          authType,
-          m.id,
-        );
-        // Some routable ids proxy another provider's model namespace (gateway
-        // ids, Bedrock vendor-prefixed ids). Resolve that provenance for
-        // metadata only; the routable provider/model below stay unchanged.
-        const capId = resolveProviderMetadataIdentity(m.provider, m.id);
-        const capProvider = capId.provider ?? m.provider;
-        const modelsDevEntry = this.modelsDevSync.lookupModel(capProvider, capId.model);
-        const modelsDevCapabilities = modelsDevEntry?.capabilities;
-        const modelCapabilities = mergeModelCapabilities(
-          m.capabilities,
-          modelsDevCapabilities,
-          capabilities,
-          modelSupportsStreaming(capProvider, capId.model) ? ['stream'] : undefined,
-        );
+        const {
+          capabilities: modelCapabilities,
+          inputModalities: knownInputModalities,
+          modelsDevEntry,
+        } = await resolveModelCapabilityMetadata(m, this.providerParamSpecs, this.modelsDevSync);
         const inputModalities =
-          modelsDevEntry?.inputModalities ??
-          m.inputModalities ??
-          inputModalitiesFromCapabilities(modelCapabilities);
+          knownInputModalities ?? inputModalitiesFromCapabilities(modelCapabilities);
         // OpenCode Go bills a per-request slice of its dollar quota rather than
         // per token, so surface that cost; other subscriptions stay flat-fee.
         const costPerRequest =

--- a/packages/backend/src/routing/proxy/__tests__/openai-model-capabilities.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/openai-model-capabilities.spec.ts
@@ -1,0 +1,56 @@
+import { openAiModelCapabilities } from '../openai-model-capabilities';
+import type { DiscoveredModel } from '../../../model-discovery/model-fetcher';
+
+function makeModel(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
+  return {
+    id: 'gpt-4o',
+    displayName: 'GPT-4o',
+    provider: 'openai',
+    contextWindow: 128000,
+    inputPricePerToken: 0.0000025,
+    outputPricePerToken: 0.00001,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 4,
+    authType: 'api_key',
+    ...overrides,
+  };
+}
+
+describe('openAiModelCapabilities', () => {
+  it('returns undefined when nothing is known — unknown is not reported as unsupported', () => {
+    expect(openAiModelCapabilities(makeModel())).toBeUndefined();
+    expect(
+      openAiModelCapabilities(
+        makeModel({ inputModalities: [], outputModalities: [], supportedEndpoints: [] }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it('projects input and output modalities as separate fields', () => {
+    expect(
+      openAiModelCapabilities(
+        makeModel({ inputModalities: ['text', 'image'], outputModalities: ['text'] }),
+      ),
+    ).toEqual({
+      input_modalities: ['text', 'image'],
+      output_modalities: ['text'],
+    });
+  });
+
+  it('keeps only endpoint features from the merged capability list', () => {
+    expect(
+      openAiModelCapabilities(makeModel({ capabilities: ['text', 'image', 'stream', 'tools'] })),
+    ).toEqual({ features: ['stream', 'tools'] });
+  });
+
+  it('omits features when the capability list carries no endpoint features', () => {
+    expect(openAiModelCapabilities(makeModel({ capabilities: ['text'] }))).toBeUndefined();
+  });
+
+  it('passes supported endpoints through verbatim', () => {
+    expect(openAiModelCapabilities(makeModel({ supportedEndpoints: ['/responses'] }))).toEqual({
+      supported_endpoints: ['/responses'],
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -325,12 +325,12 @@ describe('ProxyController', () => {
   it('should omit the capabilities field for models with unknown metadata and for auto', async () => {
     modelDiscovery.getModelsForAgent.mockResolvedValue([
       makeDiscoveredModel({ id: 'mystery-model', provider: 'kiro' }),
+      // No discovery-time modalities: the curated known-modalities fallback
+      // must supply them even when cached_models predate the curated list.
       makeDiscoveredModel({
         id: 'gpt-5.3-codex-spark',
         provider: 'openai',
         authType: 'subscription',
-        inputModalities: ['text'],
-        outputModalities: ['text'],
       }),
     ]);
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -123,6 +123,8 @@ describe('ProxyController', () => {
   };
   let mockPricingCache: { getByModel: jest.Mock };
   let modelDiscovery: { getModelsForAgent: jest.Mock };
+  let providerParamSpecs: { getCapabilities: jest.Mock };
+  let modelsDevSync: { lookupModel: jest.Mock };
   let recorder: ProxyMessageRecorder;
   let planService: { assertWithinRequestLimit: jest.Mock };
 
@@ -162,6 +164,8 @@ describe('ProxyController', () => {
     modelDiscovery = {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
     };
+    providerParamSpecs = { getCapabilities: jest.fn().mockResolvedValue(null) };
+    modelsDevSync = { lookupModel: jest.fn().mockReturnValue(null) };
     const mockCustomProviders = {
       canonicalizeAgentMessageKeys: jest
         .fn()
@@ -194,6 +198,8 @@ describe('ProxyController', () => {
       modelDiscovery as never,
       planService as never,
       { report: jest.fn() } as never,
+      providerParamSpecs as never,
+      modelsDevSync as never,
     );
   });
 
@@ -318,7 +324,7 @@ describe('ProxyController', () => {
 
   it('should omit the capabilities field for models with unknown metadata and for auto', async () => {
     modelDiscovery.getModelsForAgent.mockResolvedValue([
-      makeDiscoveredModel({ id: 'mystery-model', provider: 'openai' }),
+      makeDiscoveredModel({ id: 'mystery-model', provider: 'kiro' }),
       makeDiscoveredModel({
         id: 'gpt-5.3-codex-spark',
         provider: 'openai',
@@ -332,16 +338,58 @@ describe('ProxyController', () => {
       object: 'list',
       data: [
         { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
-        { id: 'openai/mystery-model', object: 'model', created: 0, owned_by: 'openai' },
+        { id: 'kiro/mystery-model', object: 'model', created: 0, owned_by: 'kiro' },
         {
           id: 'openai/gpt-5.3-codex-spark-subscription',
           object: 'model',
           created: 0,
           owned_by: 'openai',
-          capabilities: { input_modalities: ['text'], output_modalities: ['text'] },
+          capabilities: {
+            input_modalities: ['text'],
+            output_modalities: ['text'],
+            // OpenAI is a streaming-endpoint provider, so the same heuristic
+            // the routing model picker uses asserts stream support here.
+            features: ['stream'],
+          },
         },
       ],
     });
+  });
+
+  it('should resolve capabilities from the same sources as the routing model picker', async () => {
+    modelDiscovery.getModelsForAgent.mockResolvedValue([
+      makeDiscoveredModel({ id: 'gpt-4o', provider: 'openai' }),
+    ]);
+    providerParamSpecs.getCapabilities.mockResolvedValue(['tools']);
+    modelsDevSync.lookupModel.mockReturnValue({
+      id: 'gpt-4o',
+      name: 'GPT-4o',
+      inputPricePerToken: null,
+      outputPricePerToken: null,
+      capabilities: ['text', 'image'],
+      inputModalities: ['text', 'image'],
+      outputModalities: ['text'],
+    });
+
+    await expect(controller.models(mockRequest({}) as never, 'true')).resolves.toEqual({
+      object: 'list',
+      data: [
+        { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
+        {
+          id: 'openai/gpt-4o',
+          object: 'model',
+          created: 0,
+          owned_by: 'openai',
+          capabilities: {
+            input_modalities: ['text', 'image'],
+            output_modalities: ['text'],
+            features: ['tools', 'stream'],
+          },
+        },
+      ],
+    });
+    expect(providerParamSpecs.getCapabilities).toHaveBeenCalledWith('openai', 'api_key', 'gpt-4o');
+    expect(modelsDevSync.lookupModel).toHaveBeenCalledWith('openai', 'gpt-4o');
   });
 
   it('should return JSON response for non-streaming OpenAI provider', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -262,6 +262,88 @@ describe('ProxyController', () => {
     });
   });
 
+  it('should keep the default /v1/models shape unchanged even when capability metadata exists', async () => {
+    modelDiscovery.getModelsForAgent.mockResolvedValue([
+      makeDiscoveredModel({
+        id: 'gpt-4o',
+        provider: 'openai',
+        inputModalities: ['text', 'image'],
+        outputModalities: ['text'],
+        capabilities: ['text', 'image', 'stream', 'tools'],
+        supportedEndpoints: ['/responses'],
+      }),
+    ]);
+
+    await expect(controller.models(mockRequest({}) as never)).resolves.toEqual({
+      object: 'list',
+      data: [
+        { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
+        { id: 'openai/gpt-4o', object: 'model', created: 0, owned_by: 'openai' },
+      ],
+    });
+  });
+
+  it('should expose capability metadata when ?capabilities=true, preserving subscription ids', async () => {
+    modelDiscovery.getModelsForAgent.mockResolvedValue([
+      makeDiscoveredModel({
+        id: 'gpt-5.4-mini',
+        provider: 'openai',
+        authType: 'subscription',
+        inputModalities: ['text', 'image'],
+        outputModalities: ['text'],
+        capabilities: ['text', 'image', 'stream', 'tools'],
+        supportedEndpoints: ['/responses'],
+      }),
+    ]);
+
+    await expect(controller.models(mockRequest({}) as never, 'true')).resolves.toEqual({
+      object: 'list',
+      data: [
+        { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
+        {
+          id: 'openai/gpt-5.4-mini-subscription',
+          object: 'model',
+          created: 0,
+          owned_by: 'openai',
+          capabilities: {
+            input_modalities: ['text', 'image'],
+            output_modalities: ['text'],
+            features: ['stream', 'tools'],
+            supported_endpoints: ['/responses'],
+          },
+        },
+      ],
+    });
+  });
+
+  it('should omit the capabilities field for models with unknown metadata and for auto', async () => {
+    modelDiscovery.getModelsForAgent.mockResolvedValue([
+      makeDiscoveredModel({ id: 'mystery-model', provider: 'openai' }),
+      makeDiscoveredModel({
+        id: 'gpt-5.3-codex-spark',
+        provider: 'openai',
+        authType: 'subscription',
+        inputModalities: ['text'],
+        outputModalities: ['text'],
+      }),
+    ]);
+
+    await expect(controller.models(mockRequest({}) as never, 'true')).resolves.toEqual({
+      object: 'list',
+      data: [
+        { id: 'auto', object: 'model', created: 0, owned_by: 'manifest' },
+        { id: 'openai/mystery-model', object: 'model', created: 0, owned_by: 'openai' },
+        {
+          id: 'openai/gpt-5.3-codex-spark-subscription',
+          object: 'model',
+          created: 0,
+          owned_by: 'openai',
+          capabilities: { input_modalities: ['text'], output_modalities: ['text'] },
+        },
+      ],
+    });
+  });
+
   it('should return JSON response for non-streaming OpenAI provider', async () => {
     const responseBody = { choices: [{ message: { content: 'hello' } }] };
     const mockProviderResp = new Response(JSON.stringify(responseBody), {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -348,8 +348,9 @@ describe('ProxyController', () => {
             input_modalities: ['text'],
             output_modalities: ['text'],
             // OpenAI is a streaming-endpoint provider, so the same heuristic
-            // the routing model picker uses asserts stream support here.
-            features: ['stream'],
+            // the routing model picker uses asserts stream support here. The
+            // curated fallback additionally confirms tools support.
+            features: ['stream', 'tools'],
           },
         },
       ],

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
@@ -133,6 +133,8 @@ describe('ProxyController streaming abort', () => {
       modelDiscovery as never,
       { assertWithinRequestLimit: jest.fn().mockResolvedValue(undefined) } as never,
       { report: jest.fn() } as never,
+      { getCapabilities: jest.fn().mockResolvedValue(null) } as never,
+      { lookupModel: jest.fn().mockReturnValue(null) } as never,
     );
   });
 

--- a/packages/backend/src/routing/proxy/openai-model-capabilities.ts
+++ b/packages/backend/src/routing/proxy/openai-model-capabilities.ts
@@ -1,0 +1,35 @@
+import type { ModelModality } from 'manifest-shared';
+import type { DiscoveredModel } from '../../model-discovery/model-fetcher';
+
+const FEATURE_CAPABILITIES = ['stream', 'tools'] as const;
+
+type FeatureCapability = (typeof FEATURE_CAPABILITIES)[number];
+
+/**
+ * Opt-in capability extension for `/v1/models` entries
+ * (`GET /v1/models?capabilities=true`).
+ *
+ * Every field is optional: a missing field means "unknown", never
+ * "unsupported". Discovery metadata is positive-assertion only, so the
+ * projection must not coerce absent data into `false` or `["text"]`.
+ */
+export interface OpenAiModelCapabilities {
+  input_modalities?: readonly ModelModality[];
+  output_modalities?: readonly ModelModality[];
+  features?: readonly FeatureCapability[];
+  supported_endpoints?: readonly string[];
+}
+
+export function openAiModelCapabilities(
+  model: DiscoveredModel,
+): OpenAiModelCapabilities | undefined {
+  const out: OpenAiModelCapabilities = {};
+  if (model.inputModalities?.length) out.input_modalities = model.inputModalities;
+  if (model.outputModalities?.length) out.output_modalities = model.outputModalities;
+  const features = model.capabilities?.filter((capability): capability is FeatureCapability =>
+    (FEATURE_CAPABILITIES as readonly string[]).includes(capability),
+  );
+  if (features?.length) out.features = features;
+  if (model.supportedEndpoints?.length) out.supported_endpoints = model.supportedEndpoints;
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -25,6 +25,9 @@ import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { ReasoningContentCache } from './reasoning-content-cache';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
+import { ProviderParamSpecService } from '../routing-core/provider-param-spec.service';
+import { resolveModelCapabilityMetadata } from '../../model-discovery/model-capabilities';
 import { classifyCaller } from './caller-classifier';
 import { ObservationReporter } from '../autofix/observation-reporter';
 import { sanitizeRequestHeaders } from './request-headers';
@@ -89,6 +92,8 @@ export class ProxyController {
     private readonly modelDiscovery: ModelDiscoveryService,
     private readonly planService: PlanService,
     private readonly observationReporter: ObservationReporter,
+    private readonly providerParamSpecs: ProviderParamSpecService,
+    private readonly modelsDevSync: ModelsDevSyncService,
   ) {}
 
   @Get('models')
@@ -124,7 +129,14 @@ export class ProxyController {
         owned_by: model.provider,
       };
       if (includeCapabilities) {
-        const modelCapabilities = openAiModelCapabilities(model);
+        // Same resolution as the dashboard's model picker, so agents and the
+        // routing UI report identical capability facts.
+        const resolved = await resolveModelCapabilityMetadata(
+          model,
+          this.providerParamSpecs,
+          this.modelsDevSync,
+        );
+        const modelCapabilities = openAiModelCapabilities({ ...model, ...resolved });
         if (modelCapabilities) entry.capabilities = modelCapabilities;
       }
       data.push(entry);

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Query,
   Req,
   Res,
   UseGuards,
@@ -48,6 +49,7 @@ import type { ProxyApiMode } from './proxy-types';
 import { ResponsesSseError } from './chatgpt-adapter';
 import { redactInlineImageDataUrls } from './inline-image-redaction';
 import { openAiModelId } from './openai-model-id';
+import { openAiModelCapabilities, type OpenAiModelCapabilities } from './openai-model-capabilities';
 import { PlanService } from '../../billing/plan.service';
 
 const MAX_SEEN_TENANTS = 10_000;
@@ -59,6 +61,7 @@ interface OpenAiModelObject {
   object: 'model';
   created: number;
   owned_by: string;
+  capabilities?: OpenAiModelCapabilities;
 }
 
 interface OpenAiModelList {
@@ -91,11 +94,15 @@ export class ProxyController {
   @Get('models')
   async models(
     @Req() req: Request & { ingestionContext: IngestionContext },
+    @Query('capabilities') capabilities?: string,
   ): Promise<OpenAiModelList> {
+    const includeCapabilities = capabilities === 'true';
     const models = await this.modelDiscovery.getModelsForAgent(
       req.ingestionContext.tenantId,
       req.ingestionContext.agentId,
     );
+    // The synthetic `auto` route never carries capabilities — it resolves to a
+    // different concrete model per request, so any claim would be wrong.
     const data: OpenAiModelObject[] = [
       {
         id: 'auto',
@@ -110,12 +117,17 @@ export class ProxyController {
       const id = openAiModelId(model);
       if (seen.has(id)) continue;
       seen.add(id);
-      data.push({
+      const entry: OpenAiModelObject = {
         id,
         object: 'model',
         created: MODEL_CREATED_UNKNOWN,
         owned_by: model.provider,
-      });
+      };
+      if (includeCapabilities) {
+        const modelCapabilities = openAiModelCapabilities(model);
+        if (modelCapabilities) entry.capabilities = modelCapabilities;
+      }
+      data.push(entry);
     }
 
     return {


### PR DESCRIPTION
Closes #2537.

`GET /v1/models?capabilities=true` now adds a `capabilities` object (separate `input_modalities` / `output_modalities`, endpoint `features`, `supported_endpoints`) to concrete model entries, while the default response stays byte-for-byte unchanged. Capability facts are resolved through the same pipeline as the dashboard's routing model picker — discovery metadata merged with the provider-param-spec catalog, a live models.dev lookup, and the streaming heuristic, extracted into a shared `resolveModelCapabilityMetadata()` used by both surfaces. Unknown metadata is omitted rather than coerced to unsupported, routable ids keep their `-subscription` suffix, and the synthetic `auto` route never claims capabilities. A curated `known-model-modalities` list (mirroring `known-model-prices.ts`) fills discovery gaps where every source is silent, identifying `gpt-5.3-codex-spark` as text-only input across all discovery paths. Includes controller tests for the default, opt-in, unknown-metadata, `auto`, subscription-id, and picker-parity cases, unit tests for the new modules and resolver, and a minor changeset.