### PR TITLE
fix: bound request tail refreshes

### DIFF
--- a/.changeset/fix-request-tail-refresh.md
+++ b/.changeset/fix-request-tail-refresh.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Limit request backfill refreshes to parents linked by the current batch.

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.spec.ts
@@ -63,6 +63,12 @@ describe('TypeOrmRequestBackfillGateway', () => {
     expect(LINK_ATTEMPTS_SQL).not.toMatch(/WHEN \(\s*SELECT count\(\*\)/);
   });
 
+  it('scopes request refreshes to parents linked by the current window', () => {
+    expect(LINK_ATTEMPTS_SQL).toContain('array_agg(DISTINCT request_id)');
+    expect(REFRESH_ATTEMPT_REQUESTS_SQL).toContain('unnest($1::text[])');
+    expect(REFRESH_ATTEMPT_REQUESTS_SQL).not.toContain('id > $1');
+  });
+
   it('analyzes attempts and finds keyset window ends', async () => {
     const query = jest
       .fn()
@@ -86,7 +92,7 @@ describe('TypeOrmRequestBackfillGateway', () => {
       .mockResolvedValueOnce([{ n: 2 }])
       .mockResolvedValueOnce([{ n: 1 }])
       .mockResolvedValueOnce([{ n: 3 }])
-      .mockResolvedValueOnce([{ n: 4 }])
+      .mockResolvedValueOnce([{ n: 4, request_ids: ['request-1', 'request-2'] }])
       .mockResolvedValueOnce(undefined);
     const gateway = new TypeOrmRequestBackfillGateway({
       createQueryRunner: jest.fn(() => runner),
@@ -101,6 +107,9 @@ describe('TypeOrmRequestBackfillGateway', () => {
     expect(runner.query).toHaveBeenNthCalledWith(2, "SET LOCAL statement_timeout = '60000ms'");
     expect(runner.query).toHaveBeenNthCalledWith(3, INSERT_REJECTIONS_SQL, ['a', 'b', before]);
     expect(runner.query).toHaveBeenNthCalledWith(4, MARK_REJECTIONS_SQL, ['a', 'b', before]);
+    expect(runner.query).toHaveBeenNthCalledWith(7, REFRESH_ATTEMPT_REQUESTS_SQL, [
+      ['request-1', 'request-2'],
+    ]);
     expect(runner.commitTransaction).toHaveBeenCalled();
     expect(runner.rollbackTransaction).not.toHaveBeenCalled();
     expect(runner.release).toHaveBeenCalled();

--- a/packages/backend/src/database/backfills/backfill-requests.gateway.ts
+++ b/packages/backend/src/database/backfills/backfill-requests.gateway.ts
@@ -552,24 +552,19 @@ export const LINK_ATTEMPTS_SQL = `
         "attempt_number" = batch.attempt_number
     FROM batch
     WHERE pa.id = batch.id AND pa."request_id" IS NULL
-    RETURNING 1
+    RETURNING pa."request_id"::text AS request_id
   )
-  SELECT count(*)::int AS n FROM updated
+  SELECT count(*)::int AS n,
+         COALESCE(array_agg(DISTINCT request_id), ARRAY[]::text[]) AS request_ids
+  FROM updated
 `;
 
 // A legacy request can span UUID-ordered windows. Recompute each affected
 // parent from every attempt linked so far, so the final outcome never depends
 // on which window happened to contain the success or terminal failure.
 export const REFRESH_ATTEMPT_REQUESTS_SQL = `
-  WITH affected AS (
-    SELECT DISTINCT request_id
-    FROM "agent_messages"
-    WHERE id > $1 AND id <= $2 AND timestamp < $3 AND request_id IS NOT NULL
-      AND (
-        request_id LIKE 'legacy-autofix-%'
-        OR request_id LIKE 'legacy-trace-%'
-        OR request_id = id
-      )
+  WITH affected AS MATERIALIZED (
+    SELECT unnest($1::text[]) AS request_id
   ), totals AS (
     SELECT pa.request_id,
            min(pa.timestamp) AS started_at,
@@ -799,10 +794,11 @@ export class TypeOrmRequestBackfillGateway implements RequestBackfillGateway {
         INSERT_ATTEMPT_REQUESTS_SQL,
         params,
       )) as { n: number }[];
-      const [{ n: attempts }] = (await runner.query(LINK_ATTEMPTS_SQL, params)) as {
-        n: number;
-      }[];
-      await runner.query(REFRESH_ATTEMPT_REQUESTS_SQL, params);
+      const [{ n: attempts, request_ids: requestIds }] = (await runner.query(
+        LINK_ATTEMPTS_SQL,
+        params,
+      )) as { n: number; request_ids: string[] }[];
+      await runner.query(REFRESH_ATTEMPT_REQUESTS_SQL, [requestIds]);
       return { requests: requests + attemptRequests, attempts, rejections };
     });
   }

--- a/packages/backend/test/request-backfill-fallbacks.e2e-spec.ts
+++ b/packages/backend/test/request-backfill-fallbacks.e2e-spec.ts
@@ -176,6 +176,31 @@ describe('request backfill legacy fallback reconstruction (e2e)', () => {
     expect(requestRows).toEqual(expected.map((row) => ({ ...row, status: 'failed' })));
   });
 
+  it('refreshes only requests linked by the current sparse window', async () => {
+    await insertAttempt({
+      id: 'a-linked',
+      timestamp: '2026-01-01 00:00:00.000',
+      status: 'ok',
+      model: 'openai/gpt-4o',
+    });
+    await backfill({ batchSize: 1 });
+    await dataSource.query(`UPDATE requests SET duration_ms = 999 WHERE id = 'a-linked'`);
+
+    await insertAttempt({
+      id: 'z-delta',
+      timestamp: '2026-01-01 00:00:01.000',
+      status: 'ok',
+      model: 'openai/gpt-4o',
+    });
+    await backfill({ batchSize: 1 });
+
+    const requests = await dataSource.query(`SELECT id, duration_ms FROM requests ORDER BY id`);
+    expect(requests).toEqual([
+      { id: 'a-linked', duration_ms: 999 },
+      { id: 'z-delta', duration_ms: 100 },
+    ]);
+  });
+
   it('groups a recovered fallback chain without traceparent', async () => {
     await insertAttempt({
       id: 'recovered-primary',


### PR DESCRIPTION
### ✨ What changed
- Refresh only Requests linked by the current backfill window.
- Add sparse-delta regression coverage.

### 💭 Why
UUID windows become sparse after the historical pass. Range-based refreshes then rescan millions of already-linked rows and exceed the statement timeout.

### 🔧 For operators
No migration or configuration change. The existing completion marker skips the historical pass; the next tail sweep drains the remaining delta.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope request backfill refreshes to only the requests linked in the current window to avoid wide rescans on sparse UUID tails and prevent statement timeouts.

- **Bug Fixes**
  - Refresh only the `request_ids` linked by the current batch; remove range-based refresh.
  - Aggregate distinct `request_ids` in link step and pass them to the refresh via `unnest($1::text[])`.
  - Add unit and e2e regression coverage for sparse windows.
  - No migration or config changes.

<sup>Written for commit a19b4aae92c23085b65da02e6db3f2ad700eb3ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

