### PR TITLE
fix(routing): scrub stale catalog params stranded by the model-param merge (#2543)

### DIFF
--- a/.changeset/stale-thinking-budget-scrub.md
+++ b/.changeset/stale-thinking-budget-scrub.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix Anthropic 400 "thinking.adaptive.budget_tokens: Extra inputs are not permitted": when configured model params rewrite a nested request root (e.g. flip `thinking.type` to `adaptive`), caller-sent siblings that the MPS catalog knows but the resolved model's spec no longer defines (like a legacy `thinking.budget_tokens`) are now scrubbed from the outbound body instead of riding into a wire shape the provider rejects.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -34,6 +34,60 @@ const specCatalog: ProviderParamSpecCatalog = [
       },
     ],
   },
+  // Older Anthropic generation: knows both `enabled` and `thinking.budget_tokens`.
+  {
+    provider: 'anthropic',
+    authType: 'subscription',
+    model: 'claude-opus-4',
+    params: [
+      {
+        path: 'thinking.type',
+        type: 'enum',
+        label: 'Thinking mode',
+        description: 'Controls Anthropic thinking mode.',
+        default: 'disabled',
+        values: ['disabled', 'adaptive', 'enabled'],
+        group: 'reasoning',
+      },
+      {
+        path: 'thinking.budget_tokens',
+        type: 'integer',
+        label: 'Budget tokens',
+        description: 'Extended thinking token budget.',
+        default: 4096,
+        range: { min: 1024 },
+        group: 'reasoning',
+        applicability: { only: { 'thinking.type': 'enabled' } },
+      },
+    ],
+  },
+  // Current generation: adaptive-only, no budget param at all.
+  {
+    provider: 'anthropic',
+    authType: 'subscription',
+    model: 'claude-opus-4-8',
+    params: [
+      {
+        path: 'thinking.type',
+        type: 'enum',
+        label: 'Thinking mode',
+        description: 'Controls Anthropic thinking mode.',
+        default: 'disabled',
+        values: ['disabled', 'adaptive'],
+        group: 'reasoning',
+      },
+      {
+        path: 'thinking.display',
+        type: 'enum',
+        label: 'Thinking display',
+        description: 'Controls how thinking is surfaced.',
+        default: 'omitted',
+        values: ['summarized', 'omitted'],
+        group: 'reasoning',
+        applicability: { only: { 'thinking.type': ['adaptive'] } },
+      },
+    ],
+  },
 ];
 
 describe('ProxyFallbackService', () => {
@@ -158,6 +212,9 @@ describe('ProxyFallbackService', () => {
         getProviderParamSpecs(specCatalog, provider, authType as 'api_key' | 'subscription', model),
       ),
       list: jest.fn().mockResolvedValue(specCatalog),
+      knownParamPaths: jest.fn(
+        () => new Set(specCatalog.flatMap((entry) => entry.params.map((param) => param.path))),
+      ),
     } as unknown as jest.Mocked<ProviderParamSpecService>;
 
     reasoningCache = {
@@ -548,6 +605,40 @@ describe('ProxyFallbackService', () => {
 
       const forwarded = providerClient.forward.mock.calls[0][0];
       expect(forwarded.body.thinking).toEqual({ type: 'disabled' });
+    });
+
+    it('drops a caller thinking.budget_tokens stranded by a merged adaptive thinking type (#2543)', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+      // The route's saved knobs: adaptive thinking (claude-opus-4-8 has no
+      // budget param). The caller (e.g. Claude Code on /v1/messages) sends the
+      // legacy enabled+budget shape; without the scrub the merge flips `type`
+      // to adaptive and leaves budget_tokens behind → Anthropic 400
+      // "thinking.adaptive.budget_tokens: Extra inputs are not permitted".
+      modelParamsService.get.mockResolvedValueOnce({
+        thinking: { type: 'adaptive', display: 'omitted' },
+      });
+
+      await service.tryForwardToProvider({
+        provider: 'anthropic',
+        apiKey: 'sk-ant',
+        model: 'claude-opus-4-8',
+        body: {
+          messages: [{ role: 'user', content: 'hi' }],
+          thinking: { type: 'enabled', budget_tokens: 8192 },
+        },
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'subscription',
+        paramMergeContext: { agentId: 'agent-1', scopeKey: 'tier:default' },
+      });
+
+      const forwarded = providerClient.forward.mock.calls[0][0];
+      expect(forwarded.body.thinking).toEqual({ type: 'adaptive', display: 'omitted' });
     });
 
     it('skips the lookup when paramMergeContext is omitted (e.g. legacy callers)', async () => {

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -153,7 +153,12 @@ export class ProxyFallbackService {
       model,
     );
     const specs = await this.providerParamSpecs.getSpecs(provider, authType as AuthType, model);
-    return applyRequestParamDefaults(body, modelParams, specs);
+    return applyRequestParamDefaults(
+      body,
+      modelParams,
+      specs,
+      this.providerParamSpecs.knownParamPaths(),
+    );
   }
 
   async tryFallbacks(

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -29,6 +29,18 @@ describe('ProviderParamSpecService', () => {
     expect(localSpecs.map((spec) => spec.path)).toEqual([]);
   });
 
+  it('exposes the catalog-wide param path set once, including paths absent from newer specs', () => {
+    const service = new ProviderParamSpecService();
+
+    const paths = service.knownParamPaths();
+    // `thinking.budget_tokens` only exists on older Anthropic specs — the
+    // catalog-wide set is what lets the merge scrub it off routes whose
+    // current spec no longer defines it (#2543).
+    expect(paths.has('thinking.budget_tokens')).toBe(true);
+    expect(paths.has('temperature')).toBe(true);
+    expect(service.knownParamPaths()).toBe(paths);
+  });
+
   it('lists model identities without param details and canonicalizes provider aliases', async () => {
     const service = new ProviderParamSpecService();
 

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -64,9 +64,24 @@ const requireFromThisModule = createRequire(__filename);
 @Injectable()
 export class ProviderParamSpecService {
   private readonly specs: ProviderParamSpecCatalog = loadModelparamsCatalog();
+  private knownPaths?: ReadonlySet<string>;
 
   async list(): Promise<ProviderParamSpecCatalog> {
     return this.specs;
+  }
+
+  /**
+   * Every param path defined anywhere in the catalog, across all providers
+   * and models. Fuel for the merge's stale-sibling scrub: a body param under
+   * a merge-rewritten root is dropped when the catalog knows the path but the
+   * resolved model's spec doesn't (see #2543 — a caller `thinking.budget_tokens`
+   * next to a merged `thinking.type: "adaptive"` is an Anthropic 400).
+   * Catalog-wide on purpose, so routes whose provider id doesn't match a
+   * catalog entry (custom providers proxying claude models) are covered too.
+   */
+  knownParamPaths(): ReadonlySet<string> {
+    this.knownPaths ??= new Set(this.specs.flatMap((entry) => entry.params.map((p) => p.path)));
+    return this.knownPaths;
   }
 
   /**

--- a/packages/shared/__tests__/request-params.spec.ts
+++ b/packages/shared/__tests__/request-params.spec.ts
@@ -139,4 +139,198 @@ describe('applyRequestParamDefaults', () => {
     expect(defaults).toEqual({ thinking: { type: 'enabled' } });
     expect(merged).not.toBe(body);
   });
+
+  describe('stale catalog siblings (#2543)', () => {
+    // claude-opus-4-8-shaped spec: `adaptive`-only thinking, NO budget_tokens
+    // param at all — so the applicability scrub has nothing to judge a caller
+    // `thinking.budget_tokens` against.
+    const adaptiveOnlySpecs: readonly ProviderParamSpec[] = [
+      {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-opus-4-8',
+        path: 'thinking.type',
+        type: 'enum',
+        label: 'Thinking mode',
+        description: 'Controls Anthropic thinking mode.',
+        default: 'disabled',
+        values: ['disabled', 'adaptive'],
+        group: 'reasoning',
+      },
+      {
+        provider: 'anthropic',
+        authType: 'subscription',
+        model: 'claude-opus-4-8',
+        path: 'thinking.display',
+        type: 'enum',
+        label: 'Thinking display',
+        description: 'Controls how thinking is surfaced.',
+        default: 'omitted',
+        values: ['summarized', 'omitted'],
+        group: 'reasoning',
+        applicability: { only: { 'thinking.type': ['adaptive'] } },
+      },
+    ];
+    const knownParamPaths = new Set(['thinking.type', 'thinking.display', 'thinking.budget_tokens']);
+    // Claude Code /v1/messages body with extended thinking on.
+    const clientBody = () => ({
+      messages: [],
+      thinking: { type: 'enabled', budget_tokens: 8192 },
+    });
+
+    it('drops a caller param the catalog knows but the spec omits when the merge rewrites its root', () => {
+      const merged = applyRequestParamDefaults(
+        clientBody(),
+        { thinking: { type: 'adaptive', display: 'omitted' } },
+        adaptiveOnlySpecs,
+        knownParamPaths,
+      );
+      expect(merged.thinking).toEqual({ type: 'adaptive', display: 'omitted' });
+    });
+
+    it('keeps caller params when the merge does not change any value under the root', () => {
+      const body = { messages: [], thinking: { type: 'adaptive', budget_tokens: 8192 } };
+      const merged = applyRequestParamDefaults(
+        body,
+        { thinking: { type: 'adaptive' } },
+        adaptiveOnlySpecs,
+        knownParamPaths,
+      );
+      expect((merged.thinking as Record<string, unknown>).budget_tokens).toBe(8192);
+    });
+
+    it('keeps unknown vendor extensions even when the merge rewrites the root', () => {
+      const body = {
+        messages: [],
+        thinking: { type: 'enabled', budget_tokens: 8192, vendor_note: 'client-only' },
+      };
+      const merged = applyRequestParamDefaults(
+        body,
+        { thinking: { type: 'adaptive' } },
+        adaptiveOnlySpecs,
+        knownParamPaths,
+      );
+      expect(merged.thinking).toEqual({
+        type: 'adaptive',
+        display: 'omitted',
+        vendor_note: 'client-only',
+      });
+    });
+
+    it('keeps caller params at paths the current spec still defines', () => {
+      // `thinking.effort` is spec-defined (no default, so the merge never
+      // writes it): the applicability machinery owns spec'd paths, so the
+      // stale-sibling drop must leave it alone even under a rewritten root.
+      const specsWithEffort: readonly ProviderParamSpec[] = [
+        ...adaptiveOnlySpecs,
+        {
+          provider: 'anthropic',
+          authType: 'subscription',
+          model: 'claude-opus-4-8',
+          path: 'thinking.effort',
+          type: 'enum',
+          label: 'Thinking effort',
+          description: 'Controls thinking effort.',
+          values: ['low', 'high'],
+          group: 'reasoning',
+        },
+      ];
+      const body = {
+        messages: [],
+        thinking: { type: 'enabled', effort: 'high', budget_tokens: 8192 },
+      };
+      const merged = applyRequestParamDefaults(
+        body,
+        { thinking: { type: 'adaptive' } },
+        specsWithEffort,
+        new Set([...knownParamPaths, 'thinking.effort']),
+      );
+      expect(merged.thinking).toEqual({ type: 'adaptive', display: 'omitted', effort: 'high' });
+    });
+
+    it('ignores roots the body does not carry and non-record merged roots', () => {
+      const specsWithMaxTokens: readonly ProviderParamSpec[] = [
+        ...adaptiveOnlySpecs,
+        {
+          provider: 'anthropic',
+          authType: 'subscription',
+          model: 'claude-opus-4-8',
+          path: 'max_tokens',
+          type: 'integer',
+          label: 'Max tokens',
+          description: 'Maximum output tokens.',
+          default: 4096,
+          range: { min: 1 },
+          group: 'generation_length',
+        },
+      ];
+      const merged = applyRequestParamDefaults(
+        { messages: [], max_tokens: 2048 },
+        { max_tokens: 1024, thinking: { type: 'adaptive' } },
+        specsWithMaxTokens,
+        knownParamPaths,
+      );
+      expect(merged).toEqual({
+        messages: [],
+        max_tokens: 1024,
+        thinking: { type: 'adaptive', display: 'omitted' },
+      });
+    });
+
+    it('scrubs nothing without the catalog path set', () => {
+      const merged = applyRequestParamDefaults(
+        clientBody(),
+        { thinking: { type: 'adaptive', display: 'omitted' } },
+        adaptiveOnlySpecs,
+      );
+      expect((merged.thinking as Record<string, unknown>).budget_tokens).toBe(8192);
+    });
+
+    it('tolerates a stale path whose parent the merge replaced with a scalar', () => {
+      const specsWithScalarDeep: readonly ProviderParamSpec[] = [
+        ...adaptiveOnlySpecs,
+        {
+          provider: 'anthropic',
+          authType: 'subscription',
+          model: 'claude-opus-4-8',
+          path: 'thinking.deep',
+          type: 'string',
+          label: 'Deep mode',
+          description: 'Scalar param whose path shadows a caller record.',
+          group: 'reasoning',
+        },
+      ];
+      const body = {
+        messages: [],
+        thinking: { type: 'enabled', deep: { budget_tokens: 5 } },
+      };
+      const merged = applyRequestParamDefaults(
+        body,
+        { thinking: { type: 'adaptive', deep: 'off' } },
+        specsWithScalarDeep,
+        new Set([...knownParamPaths, 'thinking.deep.budget_tokens']),
+      );
+      expect(merged.thinking).toEqual({ type: 'adaptive', display: 'omitted', deep: 'off' });
+    });
+
+    it('survives a nested caller record replaced wholesale by the merge', () => {
+      const body = {
+        messages: [],
+        thinking: { type: 'enabled', budget_tokens: { nested: true } },
+      };
+      const merged = applyRequestParamDefaults(
+        body,
+        { thinking: { type: 'adaptive' } },
+        adaptiveOnlySpecs,
+        knownParamPaths,
+      );
+      // The record-valued budget_tokens yields leaf `thinking.budget_tokens.nested`,
+      // which the catalog does not know — preserved as an unknown extension.
+      expect(merged.thinking).toEqual({
+        type: 'adaptive',
+        display: 'omitted',
+        budget_tokens: { nested: true },
+      });
+    });
+  });
 });

--- a/packages/shared/src/request-params.ts
+++ b/packages/shared/src/request-params.ts
@@ -17,11 +17,16 @@ export type RequestParamDefaults = Record<string, JsonValue>;
  * Merge configured Manifest params into a request body using the route's
  * param specs. Storage stays as UI values. The provider wire shape is the
  * same path shape unless a future provider needs a dedicated transformer.
+ *
+ * `knownParamPaths` is the set of param paths defined anywhere in the MPS
+ * catalog. When provided, body params that are stale next to the merged
+ * values are dropped — see {@link dropStaleCatalogSiblings}.
  */
 export function applyRequestParamDefaults<T extends Record<string, unknown>>(
   body: T,
   defaults: RequestParamDefaults | null | undefined,
   specs: readonly ProviderParamSpec[],
+  knownParamPaths?: ReadonlySet<string>,
 ): T {
   const orderedSpecs = [...specs].sort(compareProviderParamSpecs);
   if (!defaults) return omitProviderInapplicableParams(body, orderedSpecs);
@@ -34,7 +39,65 @@ export function applyRequestParamDefaults<T extends Record<string, unknown>>(
     merged = setProviderParamValue(merged, spec.path, getPath(expanded, spec.path) as JsonValue);
   }
 
-  return omitProviderInapplicableParams(deepMerge(body, merged), orderedSpecs) as T;
+  const result = deepMerge(body, merged);
+  dropStaleCatalogSiblings(result, body, merged, orderedSpecs, knownParamPaths);
+  return omitProviderInapplicableParams(result, orderedSpecs) as T;
+}
+
+/**
+ * Drop body params stranded by the merge. When a configured value rewrites a
+ * body value under a nested root (e.g. the caller sent
+ * `thinking: {type: "enabled", budget_tokens: N}` and the route's params flip
+ * `type` to `adaptive`), caller-sent siblings under that root described the
+ * shape the caller chose, not the merged one. A sibling is dropped when the
+ * catalog knows its path as a provider param but the current model's spec
+ * does not carry it — `omitProviderInapplicableParams` can only judge paths
+ * the spec defines, so without this a stale `thinking.budget_tokens` rides
+ * alongside the merged `type: "adaptive"` into an Anthropic 400 (#2543).
+ * Unknown paths (vendor extensions) and untouched roots are preserved.
+ */
+function dropStaleCatalogSiblings(
+  result: Record<string, unknown>,
+  body: Record<string, unknown>,
+  merged: Record<string, unknown>,
+  specs: readonly ProviderParamSpec[],
+  knownParamPaths: ReadonlySet<string> | undefined,
+): void {
+  if (!knownParamPaths) return;
+  for (const root of Object.keys(merged)) {
+    const bodyRoot = body[root];
+    if (!isRecord(merged[root]) || !isRecord(bodyRoot)) continue;
+    const rootRewritten = specs.some(
+      (spec) =>
+        spec.path.startsWith(`${root}.`) &&
+        hasPath(body, spec.path) &&
+        hasPath(merged, spec.path) &&
+        JSON.stringify(getPath(body, spec.path)) !== JSON.stringify(getPath(merged, spec.path)),
+    );
+    if (!rootRewritten) continue;
+    for (const path of leafPaths(bodyRoot, root)) {
+      if (!knownParamPaths.has(path)) continue;
+      if (specs.some((spec) => spec.path === path)) continue;
+      deletePath(result, path);
+    }
+  }
+}
+
+function leafPaths(value: Record<string, unknown>, prefix: string): string[] {
+  return Object.entries(value).flatMap(([key, child]) =>
+    isRecord(child) ? leafPaths(child, `${prefix}.${key}`) : [`${prefix}.${key}`],
+  );
+}
+
+function deletePath(values: Record<string, unknown>, path: string): void {
+  const segments = path.split('.');
+  let current: Record<string, unknown> = values;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const next = current[segments[i]];
+    if (!isRecord(next)) return;
+    current = next;
+  }
+  delete current[segments[segments.length - 1]];
 }
 
 function deepMerge(


### PR DESCRIPTION
Part of #2543 — fixes **root cause 1** (the wire-shape defect). The autofix reporting gap (root cause 2) is left for a follow-up; see notes below.

## What production is actually doing

The failing requests are **Claude Code (`claude-cli`) speaking the Anthropic Messages dialect** (`/v1/messages`), not stored-knob-only traffic:

1. Claude Code sends the legacy extended-thinking shape: `thinking: {type: "enabled", budget_tokens: N}`.
2. The route's saved knobs for `anthropic/subscription/claude-opus-4-8` are `{thinking: {type: "adaptive", display: "omitted"}}`.
3. `applyRequestParamDefaults` deep-merges the knobs **over** the caller's `thinking` object — flipping `type` to `adaptive` while the caller's `budget_tokens` survives underneath.
4. `omitProviderInapplicableParams` cannot scrub it: `claude-opus-4-8`'s MPS spec has **no** `thinking.budget_tokens` path at all (only older specs like `claude-opus-4` carry it), and the scrubber only judges paths the resolved spec defines.
5. Wire: `{"type":"adaptive","budget_tokens":N,"display":"omitted"}` → Anthropic 400 `thinking.adaptive.budget_tokens: Extra inputs are not permitted`.

Confirmed against prod data: no `agent_model_params` row combines `adaptive` + `budget_tokens` (so the stored knobs are clean — the stale field rides in on the request), and the failing `agent_messages` rows interleave with successful ones on the same route depending on whether the caller had extended thinking on. Reproduced byte-for-byte with the real catalog.

## The fix

When the merge **rewrites** a value under a nested root (a body value at a spec path changed), caller-sent siblings under that root are dropped iff the **catalog-wide** param path set knows the path but the resolved model's spec does not. That is exactly the "param that belonged to the shape the caller chose, which no spec on this route can vouch for next to the merged values" case.

Deliberately narrow:
- **Unknown vendor extensions are preserved** (pins the existing `vendor_note` test).
- **Untouched roots are preserved** — if the merge doesn't change anything under `thinking`, the caller's body passes through as before (including a caller's own invalid combos: pass-through fidelity is not Manifest's to rewrite).
- **Spec-defined paths are untouched** — the existing applicability machinery (`only`/`except` + `omitProviderInapplicableParams`) keeps owning those.
- The known-path set is catalog-wide (not per-provider) so custom providers proxying Claude models — which have the same stored `enabled`+`budget` rows in prod — are covered too.

## Changes

- `packages/shared/src/request-params.ts` — `applyRequestParamDefaults` gains an optional `knownParamPaths` set + `dropStaleCatalogSiblings`.
- `packages/backend/src/routing/routing-core/provider-param-spec.service.ts` — `knownParamPaths()`: catalog-wide path set, computed once.
- `packages/backend/src/routing/proxy/proxy-fallback.service.ts` — the per-attempt merge passes the set.
- Tests: 8 new shared cases (incl. the exact production repro against an opus-4-8-shaped spec) + fallback-service regression test + service test.

Backend: 413 suites / 7,560 tests green. Shared: 360 tests green, 100% line coverage kept (branch coverage on `request-params.ts` improved 92.85% → 96.42%).

## Root cause 2 (not in this PR)

Autofix still reports the pre-translation inbound body to Phoenix. The clean fix is to attach the built wire body (`BuiltProviderRequest.requestBody`) to `ForwardResult`, report that, and resend a healed wire body verbatim (skipping re-merge/re-translation). It needs a contract decision first: Phoenix's `api` enum (`chat_completions|responses|messages`) can describe Anthropic/OpenAI-shaped wire bodies but has no member for Google-format upstreams. Happy to do that as a follow-up once the Phoenix side is settled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic 400s by scrubbing stale caller params (e.g. `thinking.budget_tokens`) when the model-param merge rewrites a nested root (e.g. flips `thinking.type` to `adaptive`) — addresses #2543 root cause 1. Uses a catalog-wide param path set to drop paths the catalog knows but the resolved model’s spec no longer defines, preventing failures on `claude-opus-4-8` while preserving vendor extensions and unchanged roots.

- **Bug Fixes**
  - Added `knownParamPaths()` and passed it to `applyRequestParamDefaults` to drop stale siblings under rewritten roots.
  - Keeps unknown vendor extensions and untouched roots; spec-defined paths remain governed by applicability; works for custom providers too.
  - Added tests reproducing the prod failure and regression coverage across routing and shared utilities.

<sup>Written for commit 27b142c1ce2b8e83667f95ae8f4c2b0bf7df6869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

