### PR TITLE
fix: stop request tail sweeps

### DIFF
--- a/.changeset/stop-request-tail-sweep.md
+++ b/.changeset/stop-request-tail-sweep.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop request-history tail sweeps after the initial backfill.

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.spec.ts
@@ -7,7 +7,6 @@ import {
   REQUEST_BACKFILL_LOCK_KEY,
   REQUEST_BACKFILL_LOCK_RETRY_MS,
   REQUEST_BACKFILL_NAME,
-  REQUEST_BACKFILL_TAIL_INTERVAL_MS,
   RequestBackfillBootService,
 } from './request-backfill.boot.service';
 
@@ -95,8 +94,10 @@ describe('RequestBackfillBootService', () => {
     expect(directDataSource.getRepository).toHaveBeenCalledWith(BackfillState);
     expect(providerBackfill).toHaveBeenCalledTimes(1);
     expect(appDataSource.createQueryRunner).not.toHaveBeenCalled();
+    expect(directDataSource.query).not.toHaveBeenCalled();
+    expect(directDataSource.destroy).toHaveBeenCalledTimes(1);
     await service.onApplicationShutdown();
-    expect(directDataSource.destroy).toHaveBeenCalled();
+    expect(directDataSource.destroy).toHaveBeenCalledTimes(1);
   });
 
   it('closes a Cloud direct pool that finishes connecting during shutdown', async () => {
@@ -131,50 +132,6 @@ describe('RequestBackfillBootService', () => {
 
     expect(directDataSource.destroy).toHaveBeenCalledTimes(1);
     expect(directDataSource.getRepository).not.toHaveBeenCalled();
-  });
-
-  it('does not leave a Cloud tail sweep running when shutdown races with startup', async () => {
-    jest.useFakeTimers();
-    process.env['NODE_ENV'] = 'production';
-    process.env['MANIFEST_MODE'] = 'cloud';
-    process.env['MIGRATION_DATABASE_URL'] = 'postgres://direct/cloud';
-    let finishCompatibilityCheck!: () => void;
-    const directState = makeState(true);
-    const directDataSource = {
-      initialize: jest.fn(async () => undefined),
-      destroy: jest.fn(async () => undefined),
-      isInitialized: true,
-      getRepository: jest.fn(() => directState.repo),
-      query: jest.fn(
-        () =>
-          new Promise<Array<{ present: boolean }>>((resolve) => {
-            finishCompatibilityCheck = () => resolve([{ present: true }]);
-          }),
-      ),
-    } as unknown as DataSource;
-    jest
-      .spyOn(requestBackfillDataSource, 'createRequestBackfillDataSource')
-      .mockReturnValue(directDataSource);
-    const service = new RequestBackfillBootService(
-      { createQueryRunner: jest.fn() } as unknown as DataSource,
-      makeState(false).repo,
-    );
-
-    try {
-      service.onApplicationBootstrap();
-      await jest.advanceTimersByTimeAsync(0);
-      expect(directDataSource.query).toHaveBeenCalled();
-
-      await service.onApplicationShutdown();
-      finishCompatibilityCheck();
-      await jest.advanceTimersByTimeAsync(0);
-
-      expect(jest.getTimerCount()).toBe(0);
-      expect(directDataSource.destroy).toHaveBeenCalledTimes(1);
-    } finally {
-      jest.clearAllTimers();
-      jest.useRealTimers();
-    }
   });
 
   it('retries a self-hosted startup failure without requiring a restart or direct URL', async () => {
@@ -596,7 +553,7 @@ describe('RequestBackfillBootService', () => {
     expect(lock.release).toHaveBeenCalled();
   });
 
-  it('starts, reports, and stops the delta tail timer while agent_messages exists', async () => {
+  it('does not schedule delta tail sweeps after the historical pass', async () => {
     jest.useFakeTimers();
     process.env['NODE_ENV'] = 'production';
     process.env['MANIFEST_MODE'] = 'selfhosted';
@@ -605,36 +562,17 @@ describe('RequestBackfillBootService', () => {
       createQueryRunner: jest.fn(),
     } as unknown as DataSource;
     const service = new RequestBackfillBootService(ds, makeState(true).repo);
-    const tail = jest.spyOn(service, 'runTailOnce').mockRejectedValue(new Error('tail failed'));
-
-    service.onApplicationBootstrap();
-    await jest.advanceTimersByTimeAsync(0);
-    await jest.advanceTimersByTimeAsync(REQUEST_BACKFILL_TAIL_INTERVAL_MS);
-
-    expect(tail).toHaveBeenCalledTimes(1);
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('request backfill tail sweep failed'),
-    );
-    await service.onApplicationShutdown();
-    jest.clearAllTimers();
-    jest.useRealTimers();
-  });
-
-  it('does not schedule tail sweeps when the attempt table is absent', async () => {
-    process.env['NODE_ENV'] = 'production';
-    process.env['MANIFEST_MODE'] = 'selfhosted';
-    const ds = {
-      query: jest.fn().mockResolvedValue([{ present: false }]),
-      createQueryRunner: jest.fn(),
-    } as unknown as DataSource;
-    const service = new RequestBackfillBootService(ds, makeState(true).repo);
     const tail = jest.spyOn(service, 'runTailOnce');
 
     service.onApplicationBootstrap();
-    await new Promise((resolve) => setImmediate(resolve));
+    await jest.advanceTimersByTimeAsync(0);
+    await jest.advanceTimersByTimeAsync(5 * 60_000);
 
-    expect(ds.query).toHaveBeenCalledTimes(1);
+    expect(ds.query).not.toHaveBeenCalled();
     expect(tail).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
     await service.onApplicationShutdown();
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 });

--- a/packages/backend/src/database/backfills/request-backfill.boot.service.ts
+++ b/packages/backend/src/database/backfills/request-backfill.boot.service.ts
@@ -33,7 +33,6 @@ const defaultRunner: RequestBackfillRunner = (dataSource, logger, options) =>
   runRequestBackfill(new TypeOrmRequestBackfillGateway(dataSource), { logger, ...options });
 
 export const REQUEST_BACKFILL_LOCK_RETRY_MS = 30_000;
-export const REQUEST_BACKFILL_TAIL_INTERVAL_MS = 60_000;
 export const REQUEST_BACKFILL_FALLBACK_GRACE_MS = 5 * 60_000;
 export const REQUEST_BACKFILL_GENERIC_GRACE_MS = 10 * 60_000;
 
@@ -51,9 +50,7 @@ const wait = (ms: number): Promise<void> =>
 @Injectable()
 export class RequestBackfillBootService implements OnApplicationBootstrap, OnApplicationShutdown {
   private readonly logger = new Logger(RequestBackfillBootService.name);
-  private tailTimer: ReturnType<typeof setInterval> | undefined;
   private stopping = false;
-  private managedCoordinator: RequestBackfillBootService | undefined;
   private ownedDataSource: DataSource | undefined;
 
   constructor(
@@ -70,10 +67,6 @@ export class RequestBackfillBootService implements OnApplicationBootstrap, OnApp
 
   async onApplicationShutdown(): Promise<void> {
     this.stopping = true;
-    if (this.tailTimer) clearInterval(this.tailTimer);
-    if (this.managedCoordinator && this.managedCoordinator !== this) {
-      this.managedCoordinator.stopTailSweep();
-    }
     const ownedDataSource = this.ownedDataSource;
     this.ownedDataSource = undefined;
     if (ownedDataSource?.isInitialized) await ownedDataSource.destroy();
@@ -89,11 +82,11 @@ export class RequestBackfillBootService implements OnApplicationBootstrap, OnApp
       try {
         const coordinator = isSelfHosted() ? this : await this.createCloudCoordinator();
         if (!coordinator || this.stopping) return;
-        this.managedCoordinator = coordinator;
         await coordinator.runUntilComplete();
         if (this.stopping) return;
-        await coordinator.startTailSweep();
-        if (this.stopping) coordinator.stopTailSweep();
+        // This release only stages historical rows. The requests-backed
+        // rollout owns the final catch-up of legacy writes.
+        await this.releaseCloudCoordinator();
         return;
       } catch (error) {
         await this.releaseCloudCoordinator();
@@ -122,18 +115,9 @@ export class RequestBackfillBootService implements OnApplicationBootstrap, OnApp
   }
 
   private async releaseCloudCoordinator(): Promise<void> {
-    if (this.managedCoordinator && this.managedCoordinator !== this) {
-      this.managedCoordinator.stopTailSweep();
-    }
-    this.managedCoordinator = undefined;
     const dataSource = this.ownedDataSource;
     this.ownedDataSource = undefined;
     if (dataSource?.isInitialized) await dataSource.destroy().catch(() => undefined);
-  }
-
-  private stopTailSweep(): void {
-    if (this.tailTimer) clearInterval(this.tailTimer);
-    this.tailTimer = undefined;
   }
 
   async runUntilComplete(): Promise<void> {
@@ -226,18 +210,6 @@ export class RequestBackfillBootService implements OnApplicationBootstrap, OnApp
     return rows[0]?.pending === true;
   }
 
-  private async startTailSweep(): Promise<void> {
-    if (!(await this.hasAttemptTable())) return;
-    this.tailTimer = setInterval(() => {
-      void this.runTailOnce().catch((error) => {
-        this.logger.error(
-          `request backfill tail sweep failed: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      });
-    }, REQUEST_BACKFILL_TAIL_INTERVAL_MS);
-    if (typeof this.tailTimer === 'object' && 'unref' in this.tailTimer) this.tailTimer.unref();
-  }
-
   private runOptions(
     initial: boolean,
   ): Pick<RequestBackfillOptions, 'analyze' | 'before' | 'fallbackBefore' | 'finalize'> {
@@ -260,20 +232,6 @@ export class RequestBackfillBootService implements OnApplicationBootstrap, OnApp
       [before],
     )) as { pending: boolean }[];
     return rows[0]?.pending === true;
-  }
-
-  private async hasAttemptTable(): Promise<boolean> {
-    const rows = (await this.dataSource.query(
-      `SELECT EXISTS (
-         SELECT 1
-         FROM pg_class c
-         JOIN pg_namespace n ON n.oid = c.relnamespace
-         WHERE n.nspname = 'public'
-           AND c.relname = 'agent_messages'
-           AND c.relkind IN ('r', 'p')
-       ) AS present`,
-    )) as { present: boolean }[];
-    return rows[0]?.present === true;
   }
 
   private async isCompleted(): Promise<boolean> {


### PR DESCRIPTION
### ✨ What changed
- Stop periodic request-history sweeps after the initial backfill.
- Close the direct Cloud pool when the historical pass is complete.

### 💭 Why
The historical backlog is staged. New legacy rows stay in `agent_messages`, and #2485 owns the final catch-up when its requests-backed reader deploys.

### ✅ Validation
- 7,723 backend tests
- Backend and shared builds
- Lint, format, and changeset checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop running request-history tail sweeps after the initial backfill and close the Cloud direct pool once the historical pass completes. This removes unnecessary timers and cleans up connections.

- **Bug Fixes**
  - Removed the tail sweep scheduler and related checks; no delta sweeps after the historical pass.
  - Released the Cloud coordinator and destroyed the owned `DataSource` after completion.
  - Simplified shutdown by removing timer/coordinator management.

<sup>Written for commit ff6402b9d236c269d34ae186beb01072ae763d9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

