### PR TITLE
docs: add Manifest upgrade section to Apple Containers tutorial

### DIFF
--- a/deploy/apple-containers/TUTORIAL.md
+++ b/deploy/apple-containers/TUTORIAL.md
@@ -132,6 +132,23 @@ The PostgreSQL named volume is retained, so a later `up` restores the same datab
 
 Running `up` repeatedly is safe. A running PostgreSQL container is reused, while Manifest is recreated to pick up the current PostgreSQL IP and configuration.
 
+## Upgrade Manifest
+
+The script always launches `manifestdotbuild/manifest:latest`, but `container run` uses the locally cached copy of that tag. To upgrade to a new release, pull the image explicitly and re-run `up`:
+
+```bash
+container image pull manifestdotbuild/manifest:latest
+./deploy/apple-containers/start.sh up
+```
+
+`up` recreates the Manifest container, so it starts from the freshly pulled image. Database migrations run automatically on boot — no manual steps. The PostgreSQL container and the `mnfst-postgres-data` named volume are not touched, so all data is preserved across upgrades.
+
+To back up the database before upgrading:
+
+```bash
+container exec mnfst-postgres pg_dump -U manifest manifest > manifest-backup-$(date +%F).sql
+```
+
 ## Local LLM Servers
 
 Apple Containers does not provide Docker's `host.docker.internal` hostname. By default, the script uses the container network gateway for Ollama:

--- a/deploy/apple-containers/TUTORIAL.md
+++ b/deploy/apple-containers/TUTORIAL.md
@@ -134,6 +134,12 @@ Running `up` repeatedly is safe. A running PostgreSQL container is reused, while
 
 ## Upgrade Manifest
 
+First, back up the database:
+
+```bash
+container exec mnfst-postgres pg_dump -U manifest manifest > manifest-backup-$(date +%F).sql
+```
+
 The script always launches `manifestdotbuild/manifest:latest`, but `container run` uses the locally cached copy of that tag. To upgrade to a new release, pull the image explicitly and re-run `up`:
 
 ```bash
@@ -142,12 +148,6 @@ container image pull manifestdotbuild/manifest:latest
 ```
 
 `up` recreates the Manifest container, so it starts from the freshly pulled image. Database migrations run automatically on boot — no manual steps. The PostgreSQL container and the `mnfst-postgres-data` named volume are not touched, so all data is preserved across upgrades.
-
-To back up the database before upgrading:
-
-```bash
-container exec mnfst-postgres pg_dump -U manifest manifest > manifest-backup-$(date +%F).sql
-```
 
 ## Local LLM Servers
 


### PR DESCRIPTION
## Summary

The Apple Containers tutorial covers upgrading Apple Containers itself (the `container system` restart dance) but not upgrading the **Manifest image** — there was no equivalent of the `docker compose pull && docker compose up -d` flow documented in `docker/DOCKER_README.md`.

This adds an **Upgrade Manifest** section after "Manage the Stack":

- `container image pull manifestdotbuild/manifest:latest` followed by `./deploy/apple-containers/start.sh up` — the explicit pull is required because `container run` reuses the locally cached `:latest` tag.
- Notes that `up` recreates the app container (picking up the new image), migrations run automatically on boot, and the `mnfst-postgres-data` volume is untouched so data survives.
- A pre-upgrade `pg_dump` backup command mirroring the one in the Docker README.

Verified the flow end-to-end on a live Apple Containers deployment: pulled a new image digest, re-ran `up`, confirmed `/api/v1/health` and that the existing database (all 31 tables) was preserved.

Docs-only change — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an “Upgrade Manifest” section to the Apple Containers tutorial that explains how to safely update the Manifest image by pulling the latest tag, recreating the app container, and doing a pre-upgrade database backup first.

- **Migration**
  - Backup first: `container exec mnfst-postgres pg_dump -U manifest manifest > manifest-backup-$(date +%F).sql`
  - Pull latest image: `container image pull manifestdotbuild/manifest:latest` (explicit pull needed because `container run` reuses cached `:latest`)
  - Recreate app: `./deploy/apple-containers/start.sh up` (migrations run on boot; `mnfst-postgres-data` is preserved)

<sup>Written for commit 847930bd4a440ebbd753992ad76e4ad58c47e1df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

