### PR TITLE
fix: refresh all connected provider keys

### DIFF
--- a/.changeset/refresh-openai-api-models.md
+++ b/.changeset/refresh-openai-api-models.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Refresh every matching provider connection so models returned by an API key are cached for each connected key.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -589,11 +589,10 @@ describe('ModelDiscoveryService', () => {
         last_fetched_at: null,
         error: expect.stringContaining('only available in self-hosted Manifest'),
       });
-      expect(providerRepo.findOne).not.toHaveBeenCalled();
+      expect(providerRepo.find).not.toHaveBeenCalled();
     });
 
     it('returns Provider not found when no row matches', async () => {
-      providerRepo.findOne.mockResolvedValue(null);
       const result = await service.refreshProvider('agent-1', 'openai');
       expect(result).toEqual({
         ok: false,
@@ -604,13 +603,13 @@ describe('ModelDiscoveryService', () => {
     });
 
     it('refuses custom providers and reports the cached count', async () => {
-      providerRepo.findOne.mockResolvedValue(
+      providerRepo.find.mockResolvedValue([
         makeProvider({
           provider: 'custom:cp-1',
           cached_models: [makeModel({ id: 'foo' }), makeModel({ id: 'bar' })],
           models_fetched_at: '2026-04-12T08:00:00.000Z',
         }),
-      );
+      ]);
       const result = await service.refreshProvider('agent-1', 'custom:cp-1');
       expect(result.ok).toBe(false);
       expect(result.model_count).toBe(2);
@@ -620,14 +619,14 @@ describe('ModelDiscoveryService', () => {
 
     it('returns ok with the discovered count on success', async () => {
       const provider = makeProvider({ provider: 'openai' });
-      providerRepo.findOne.mockResolvedValue(provider);
+      providerRepo.find.mockResolvedValue([provider]);
       fetcher.fetch.mockResolvedValue([
         makeModel({ id: 'gpt-4o' }),
         makeModel({ id: 'gpt-4o-mini' }),
       ]);
 
       const result = await service.refreshProvider('tenant-1', 'openai', 'api_key');
-      expect(providerRepo.findOne).toHaveBeenCalledWith({
+      expect(providerRepo.find).toHaveBeenCalledWith({
         where: { tenant_id: 'tenant-1', provider: 'openai', is_active: true, auth_type: 'api_key' },
       });
       expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'decrypted-key', 'api_key', undefined, {
@@ -639,9 +638,48 @@ describe('ModelDiscoveryService', () => {
       expect(result.last_fetched_at).toBeDefined();
     });
 
+    it('refreshes every matching API-key connection', async () => {
+      const first = makeProvider({
+        id: 'openai-key-1',
+        api_key_encrypted: 'encrypted-key-1',
+      });
+      const second = makeProvider({
+        id: 'openai-key-2',
+        api_key_encrypted: 'encrypted-key-2',
+      });
+      providerRepo.find.mockResolvedValue([first, second]);
+      mockDecrypt.mockImplementation((encrypted) => encrypted.replace('encrypted-', ''));
+      fetcher.fetch.mockImplementation(async (_provider, apiKey) =>
+        apiKey === 'key-1'
+          ? [makeModel({ id: 'gpt-4o' })]
+          : [
+              makeModel({ id: 'gpt-5.6-sol' }),
+              makeModel({ id: 'gpt-5.6-terra' }),
+              makeModel({ id: 'gpt-5.6-luna' }),
+            ],
+      );
+
+      const result = await service.refreshProvider('tenant-1', 'openai', 'api_key');
+
+      expect(fetcher.fetch).toHaveBeenCalledTimes(2);
+      expect(first.cached_models?.map((model) => model.id)).toEqual(['gpt-4o']);
+      expect(second.cached_models?.map((model) => model.id)).toEqual([
+        'gpt-5.6-sol',
+        'gpt-5.6-terra',
+        'gpt-5.6-luna',
+      ]);
+      expect(mockModelsDevSync.refreshCache).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        ok: true,
+        model_count: 3,
+        last_fetched_at: expect.any(String),
+        error: null,
+      });
+    });
+
     it('returns ok=false with hint when provider returns no models', async () => {
       const provider = makeProvider({ provider: 'openai', cached_models: null });
-      providerRepo.findOne.mockResolvedValue(provider);
+      providerRepo.find.mockResolvedValue([provider]);
       fetcher.fetch.mockResolvedValue([]);
 
       const result = await service.refreshProvider('agent-1', 'openai');
@@ -652,13 +690,13 @@ describe('ModelDiscoveryService', () => {
 
     it('preserves cached models and reports prior count when discovery throws', async () => {
       const cachedModels = [makeModel({ id: 'gpt-4o' }), makeModel({ id: 'gpt-4o-mini' })];
-      providerRepo.findOne.mockResolvedValue(
+      providerRepo.find.mockResolvedValue([
         makeProvider({
           provider: 'openai',
           cached_models: cachedModels,
           models_fetched_at: '2026-04-01T08:00:00.000Z',
         }),
-      );
+      ]);
       // discoverModels itself swallows fetcher errors, so to land in the
       // refreshProvider catch we make the cache-write throw instead.
       fetcher.fetch.mockResolvedValue([makeModel({ id: 'gpt-4o' })]);
@@ -672,7 +710,7 @@ describe('ModelDiscoveryService', () => {
     });
 
     it('reports a non-Error thrown value via String() in the error field', async () => {
-      providerRepo.findOne.mockResolvedValue(makeProvider({ provider: 'openai' }));
+      providerRepo.find.mockResolvedValue([makeProvider({ provider: 'openai' })]);
       fetcher.fetch.mockResolvedValue([makeModel({ id: 'gpt-4o' })]);
       providerRepo.save.mockRejectedValueOnce('plain-string-failure');
 

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -402,45 +402,78 @@ export class ModelDiscoveryService {
       is_active: true,
     };
     if (authType) where.auth_type = authType;
-    const provider = await this.providerRepo.findOne({ where });
-    if (!provider) {
+    // A tenant can connect multiple keys for the same provider/auth type. The
+    // picker reads whichever rows are enabled for the agent, so refresh all of
+    // them instead of leaving an arbitrary `findOne` row's siblings stale.
+    const providers = await this.providerRepo.find({ where });
+    if (providers.length === 0) {
       return { ok: false, model_count: 0, last_fetched_at: null, error: 'Provider not found' };
     }
-    // Snapshot the pre-refresh state so error/skip paths can report the count
-    // and timestamp the user already had on disk, even after `discoverModels`
-    // mutates the entity in-memory.
-    const previousCount = Array.isArray(provider.cached_models) ? provider.cached_models.length : 0;
-    const previousFetchedAt = provider.models_fetched_at;
 
-    if (provider.provider.startsWith('custom:')) {
+    if (providers[0].provider.startsWith('custom:')) {
+      const previousCount = Math.max(
+        ...providers.map((provider) =>
+          Array.isArray(provider.cached_models) ? provider.cached_models.length : 0,
+        ),
+      );
+      const previousFetchedAt = providers
+        .map((provider) => provider.models_fetched_at)
+        .filter((value): value is string => value !== null)
+        .sort()
+        .pop();
       return {
         ok: false,
         model_count: previousCount,
-        last_fetched_at: previousFetchedAt,
+        last_fetched_at: previousFetchedAt ?? null,
         error: 'Custom providers are managed manually — edit the provider to update its model list',
       };
     }
 
-    try {
-      const models = await this.discoverModels(provider, { forceRefresh: true });
-      return {
-        ok: models.length > 0,
-        model_count: models.length,
-        last_fetched_at: provider.models_fetched_at,
-        error: models.length === 0 ? 'Provider returned no models' : null,
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.warn(
-        `Per-provider refresh failed for ${provider.provider} (tenant ${tenantId}): ${message}`,
-      );
-      return {
-        ok: false,
-        model_count: previousCount,
-        last_fetched_at: previousFetchedAt,
-        error: message,
-      };
-    }
+    await this.refreshModelsDevCache();
+    const results = await Promise.all(
+      providers.map(async (provider) => {
+        const previousCount = Array.isArray(provider.cached_models)
+          ? provider.cached_models.length
+          : 0;
+        const previousFetchedAt = provider.models_fetched_at;
+        try {
+          const models = await this.discoverModels(provider, {
+            forceRefresh: true,
+            skipModelsDevRefresh: true,
+          });
+          return {
+            ok: models.length > 0,
+            modelCount: models.length,
+            lastFetchedAt: provider.models_fetched_at,
+            error: models.length === 0 ? 'Provider returned no models' : null,
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.logger.warn(
+            `Per-provider refresh failed for ${provider.provider} (tenant ${tenantId}): ${message}`,
+          );
+          return {
+            ok: false,
+            modelCount: previousCount,
+            lastFetchedAt: previousFetchedAt,
+            error: message,
+          };
+        }
+      }),
+    );
+
+    const failed = results.find((result) => !result.ok);
+    const lastFetchedAt = results
+      .map((result) => result.lastFetchedAt)
+      .filter((value): value is string => value !== null)
+      .sort()
+      .pop();
+    return {
+      ok: failed === undefined,
+      model_count: Math.max(...results.map((result) => result.modelCount)),
+      last_fetched_at: lastFetchedAt ?? null,
+      error: failed?.error ?? null,
+    };
   }
 
   /**

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -461,6 +461,27 @@ describe('ProviderModelFetcherService', () => {
       expect(result.map((m) => m.id)).toEqual(['gpt-4o', 'gpt-4.1']);
     });
 
+    it('should keep GPT-5.6 models returned by OpenAI', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-5.6-sol', object: 'model', created: 1782228018, owned_by: 'system' },
+            { id: 'gpt-5.6-terra', object: 'model', created: 1782228459, owned_by: 'system' },
+            { id: 'gpt-5.6-luna', object: 'model', created: 1782228658, owned_by: 'system' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+
+      expect(result.map((model) => model.id)).toEqual([
+        'gpt-5.6-sol',
+        'gpt-5.6-terra',
+        'gpt-5.6-luna',
+      ]);
+    });
+
     it('should keep Responses-only chat models (Codex/-pro/o1-pro/deep-research) so the proxy can route them to /v1/responses', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,


### PR DESCRIPTION
### ✨ What changed
- Refresh every matching key instead of one arbitrary connection.
- Cover GPT-5.6 IDs returned by OpenAI model discovery.

### 💭 Why
Multiple keys can share a provider and auth type. Refresh could update a different cache from the key enabled for the agent.

### 👤 For users
Refreshing OpenAI models now exposes newly returned models for every connected key.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes model lists for all matching provider connections so each connected key gets its own cache. Also accepts new OpenAI `gpt-5.6-*` model IDs.

- Bug Fixes
  - Refreshes every active connection for the given provider/auth type and aggregates the result; refreshes the models-dev cache once; custom providers remain manual with correct prior counts.
  - Keeps OpenAI `gpt-5.6-*` models in the fetcher; tests added.

<sup>Written for commit 29f94dc544f74deb17474e563a7fee2f015cd72d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

