### PR TITLE
fix: normalize Anthropic adaptive thinking

### DIFF
--- a/.changeset/normalize-anthropic-thinking.md
+++ b/.changeset/normalize-anthropic-thinking.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Strip legacy `budget_tokens` from Anthropic adaptive thinking requests.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -168,6 +168,22 @@ describe('Anthropic Adapter', () => {
       });
     });
 
+    it('drops the manual budget when forwarding adaptive thinking', () => {
+      const thinking = { type: 'adaptive', budget_tokens: 8192, display: 'omitted' };
+
+      const result = toAnthropicRequest(
+        { messages: [{ role: 'user', content: 'Hi' }], thinking },
+        'claude-opus-4-8',
+      );
+
+      expect(result.thinking).toEqual({ type: 'adaptive', display: 'omitted' });
+      expect(thinking).toEqual({
+        type: 'adaptive',
+        budget_tokens: 8192,
+        display: 'omitted',
+      });
+    });
+
     it('wraps a bare string `stop` value into stop_sequences (chat_completions accepts both shapes)', () => {
       // Cubic flagged: if a chat_completions client sends `stop: "END"`,
       // the previous code dropped it because it only handled arrays.
@@ -2183,6 +2199,33 @@ describe('Anthropic Adapter', () => {
   });
 
   describe('applyAnthropicMessagesMutations', () => {
+    it('drops the manual budget from native adaptive thinking without mutating the body', () => {
+      const inbound = {
+        messages: [{ role: 'user', content: 'hi' }],
+        thinking: { type: 'adaptive', budget_tokens: 8192, display: 'omitted' },
+      };
+
+      const result = applyAnthropicMessagesMutations(inbound);
+
+      expect(result.thinking).toEqual({ type: 'adaptive', display: 'omitted' });
+      expect(inbound.thinking).toEqual({
+        type: 'adaptive',
+        budget_tokens: 8192,
+        display: 'omitted',
+      });
+    });
+
+    it('preserves the budget for native manual thinking', () => {
+      const thinking = { type: 'enabled', budget_tokens: 8192 };
+
+      const result = applyAnthropicMessagesMutations({
+        messages: [{ role: 'user', content: 'hi' }],
+        thinking,
+      });
+
+      expect(result.thinking).toBe(thinking);
+    });
+
     it('preserves Anthropic server tools with their type discriminator and skips input_schema (issue #1886)', () => {
       const inbound = {
         model: 'claude-sonnet-4-20250514',

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -59,6 +59,15 @@ function shouldForwardAnthropicThinking(thinking: unknown, model: string): boole
   return true;
 }
 
+function normalizeAnthropicThinking(thinking: unknown): unknown {
+  if (!isObjectRecord(thinking) || thinking.type !== 'adaptive' || !('budget_tokens' in thinking)) {
+    return thinking;
+  }
+  const normalized = { ...thinking };
+  delete normalized.budget_tokens;
+  return normalized;
+}
+
 /**
  * System prompt required by Anthropic's subscription OAuth API to unlock
  * sonnet/opus model families. Without it, subscription tokens can only
@@ -386,7 +395,7 @@ export function toAnthropicRequest(
   // Anthropic Messages (POST /v1/messages). Chat-completions clients won't
   // set these, so this is a no-op for the OpenAI-compat path.
   if (body.thinking !== undefined && shouldForwardAnthropicThinking(body.thinking, _model)) {
-    result.thinking = body.thinking;
+    result.thinking = normalizeAnthropicThinking(body.thinking);
   }
   // chat_completions `stop` accepts string OR string[]; Anthropic
   // `stop_sequences` is always an array. Wrap a bare string so a single
@@ -448,6 +457,9 @@ export function applyAnthropicMessagesMutations(
   options?: AnthropicRequestOptions,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = { ...body };
+  if (body.thinking !== undefined) {
+    result.thinking = normalizeAnthropicThinking(body.thinking);
+  }
   const cacheBudget = {
     remaining: Math.max(0, MAX_CACHE_CONTROL_BLOCKS - countCacheControlBlocks(body)),
   };


### PR DESCRIPTION
### ✨ What changed
- Strip `budget_tokens` from adaptive thinking at the Anthropic wire boundary.
- Cover native Messages and converted requests without mutating caller bodies.

### 💭 Why
Route parameters could switch thinking to `adaptive` while preserving the caller's manual budget, causing an Anthropic 400.

### 📝 Notes
Replaces #2545 with an adapter-local fix.
Part of #2543.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Anthropic adaptive thinking by dropping legacy `budget_tokens` before forwarding to prevent 400 errors when thinking switches to adaptive.

- **Bug Fixes**
  - Strip `budget_tokens` from `thinking: { type: 'adaptive' }` for native Messages and OpenAI-compat conversions.
  - Keep manual budgets for `enabled` thinking.
  - Avoid mutating caller bodies; added tests for both paths.

<sup>Written for commit c4c9cf77201c59f0cf961ea86ecbfba07002fede. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

