### PR TITLE
perf: extend dashboard covering index and add skills index

### DIFF
--- a/.changeset/extend-dashboard-covering-index.md
+++ b/.changeset/extend-dashboard-covering-index.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Extend the dashboard covering index with the columns the request-first dashboard reads (key label, status, request id) and add a partial index for the skills panel, restoring index-only scans on the Overview and Provider Usage endpoints for large installs

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -30,6 +30,7 @@ import { RenameWaitlistClaimsTable1800000000000 } from './migrations/18000000000
 import { ReclassifyPlanRequestLimitMessages1800100000000 } from './migrations/1800100000000-ReclassifyPlanRequestLimitMessages';
 import { AddMessageErrorCode1800200000000 } from './migrations/1800200000000-AddMessageErrorCode';
 import { DropUnusedAgentMessageIndexes1800300000000 } from './migrations/1800300000000-DropUnusedAgentMessageIndexes';
+import { ExtendDashboardCoveringIndex1801200000000 } from './migrations/1801200000000-ExtendDashboardCoveringIndex';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -298,4 +299,5 @@ export const migrations = [
   DropUnusedAgentMessageIndexes1800300000000,
   AddRequestsAndProviderAttempts1801000000000,
   AddProviderAttemptOrdering1801100000000,
+  ExtendDashboardCoveringIndex1801200000000,
 ];

--- a/packages/backend/src/database/migrations/1801200000000-ExtendDashboardCoveringIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1801200000000-ExtendDashboardCoveringIndex.spec.ts
@@ -1,0 +1,170 @@
+import { ExtendDashboardCoveringIndex1801200000000 } from './1801200000000-ExtendDashboardCoveringIndex';
+
+const CONVERGED_INDEXDEF =
+  'CREATE INDEX "IDX_agent_messages_provider_usage" ON public.agent_messages USING btree (tenant_id, "timestamp") INCLUDE (model, provider, auth_type, provider_key_label, input_tokens, output_tokens, cost_usd, status, request_id, id)';
+
+const LEGACY_1793_INDEXDEF =
+  'CREATE INDEX "IDX_agent_messages_provider_usage" ON public.agent_messages USING btree (tenant_id, "timestamp") INCLUDE (model, provider, auth_type, input_tokens, output_tokens, cost_usd)';
+
+describe('ExtendDashboardCoveringIndex1801200000000', () => {
+  const migration = new ExtendDashboardCoveringIndex1801200000000();
+  let queries: string[];
+  let usageIndexdef: string | null;
+  let invalidIndexes: Set<string>;
+
+  const mockQueryRunner = {
+    query: jest.fn().mockImplementation((sql: string, params?: string[]) => {
+      queries.push(sql);
+      if (sql.includes('pg_indexes')) {
+        return Promise.resolve(usageIndexdef === null ? [] : [{ indexdef: usageIndexdef }]);
+      }
+      if (sql.includes('pg_index ')) {
+        return Promise.resolve(invalidIndexes.has(params?.[0] ?? '') ? [{ '?column?': 1 }] : []);
+      }
+      return Promise.resolve([]);
+    }),
+  } as never;
+
+  beforeEach(() => {
+    queries = [];
+    usageIndexdef = null;
+    invalidIndexes = new Set();
+    jest.clearAllMocks();
+  });
+
+  it('exposes the expected migration name', () => {
+    expect(migration.name).toBe('ExtendDashboardCoveringIndex1801200000000');
+  });
+
+  it('runs outside a transaction so the builds can be CONCURRENT', () => {
+    expect(migration.transaction).toBe(false);
+  });
+
+  it('swaps in the extended covering index when the canonical one predates the new columns', async () => {
+    usageIndexdef = LEGACY_1793_INDEXDEF;
+
+    await migration.up(mockQueryRunner);
+
+    const swapCreate = queries.find((sql) =>
+      sql.startsWith(
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage_swap"',
+      ),
+    );
+    expect(swapCreate).toBeDefined();
+    expect(swapCreate).toContain('ON "agent_messages" ("tenant_id", "timestamp")');
+    expect(swapCreate).toContain(
+      'INCLUDE ("model", "provider", "auth_type", "provider_key_label", "input_tokens", "output_tokens", "cost_usd", "status", "request_id", "id")',
+    );
+
+    // Swap order: build new → drop old → rename new into place.
+    const buildAt = queries.indexOf(swapCreate as string);
+    const dropOldAt = queries.findIndex((sql) =>
+      sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage"'),
+    );
+    const renameAt = queries.findIndex((sql) =>
+      sql.includes('RENAME TO "IDX_agent_messages_provider_usage"'),
+    );
+    expect(buildAt).toBeLessThan(dropOldAt);
+    expect(dropOldAt).toBeLessThan(renameAt);
+  });
+
+  it('runs the swap on a fresh database with no canonical index yet', async () => {
+    usageIndexdef = null;
+
+    await migration.up(mockQueryRunner);
+
+    expect(
+      queries.some((sql) =>
+        sql.startsWith(
+          'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage_swap"',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('SKIPS the swap when the canonical index already carries every column', async () => {
+    usageIndexdef = CONVERGED_INDEXDEF;
+
+    await migration.up(mockQueryRunner);
+
+    expect(queries.some((sql) => sql.includes('_swap'))).toBe(false);
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage"'),
+      ),
+    ).toBe(false);
+  });
+
+  it('drops the legacy v2 interim index in both branches', async () => {
+    usageIndexdef = CONVERGED_INDEXDEF;
+    await migration.up(mockQueryRunner);
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage_v2"'),
+      ),
+    ).toBe(true);
+
+    queries = [];
+    usageIndexdef = LEGACY_1793_INDEXDEF;
+    await migration.up(mockQueryRunner);
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_provider_usage_v2"'),
+      ),
+    ).toBe(true);
+  });
+
+  it('creates the skills partial index with the exact production definition', async () => {
+    await migration.up(mockQueryRunner);
+
+    const skillsCreate = queries.find((sql) =>
+      sql.startsWith('CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_skill_runs"'),
+    );
+    expect(skillsCreate).toBeDefined();
+    expect(skillsCreate).toContain('ON "agent_messages" ("tenant_id", "timestamp")');
+    expect(skillsCreate).toContain('INCLUDE ("skill_name", "agent_name", "agent_id")');
+    expect(skillsCreate).toContain('WHERE "skill_name" IS NOT NULL');
+  });
+
+  it('keeps a valid pre-existing skills index but clears an INVALID leftover', async () => {
+    await migration.up(mockQueryRunner);
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_skill_runs"'),
+      ),
+    ).toBe(false);
+
+    queries = [];
+    invalidIndexes.add('IDX_agent_messages_skill_runs');
+    await migration.up(mockQueryRunner);
+    const dropAt = queries.findIndex((sql) =>
+      sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_skill_runs"'),
+    );
+    const createAt = queries.findIndex((sql) =>
+      sql.startsWith('CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_skill_runs"'),
+    );
+    expect(dropAt).toBeGreaterThan(-1);
+    expect(dropAt).toBeLessThan(createAt);
+  });
+
+  it('restores the 1793 definition on rollback and drops the skills index', async () => {
+    await migration.down(mockQueryRunner);
+
+    const restore = queries.find((sql) =>
+      sql.startsWith(
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage_swap"',
+      ),
+    );
+    expect(restore).toContain(
+      'INCLUDE ("model", "provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")',
+    );
+    expect(
+      queries.some((sql) => sql.includes('RENAME TO "IDX_agent_messages_provider_usage"')),
+    ).toBe(true);
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_skill_runs"'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/backend/src/database/migrations/1801200000000-ExtendDashboardCoveringIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1801200000000-ExtendDashboardCoveringIndex.spec.ts
@@ -95,6 +95,21 @@ describe('ExtendDashboardCoveringIndex1801200000000', () => {
     ).toBe(false);
   });
 
+  it('runs the swap when the canonical index has every column but is INVALID', async () => {
+    usageIndexdef = CONVERGED_INDEXDEF;
+    invalidIndexes.add('IDX_agent_messages_provider_usage');
+
+    await migration.up(mockQueryRunner);
+
+    expect(
+      queries.some((sql) =>
+        sql.startsWith(
+          'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_provider_usage_swap"',
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it('drops the legacy v2 interim index in both branches', async () => {
     usageIndexdef = CONVERGED_INDEXDEF;
     await migration.up(mockQueryRunner);

--- a/packages/backend/src/database/migrations/1801200000000-ExtendDashboardCoveringIndex.ts
+++ b/packages/backend/src/database/migrations/1801200000000-ExtendDashboardCoveringIndex.ts
@@ -1,0 +1,132 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Extends the canonical dashboard covering index (1793200000000) with the
+ * columns the request-first dashboard (#2485) reads, and adds a partial index
+ * for the new skills aggregation.
+ *
+ * The provider usage rollup now groups by `provider_key_label` and reads
+ * `status` / `request_id` / `id` for its message counts. None of those are in
+ * the 1793 INCLUDE list, so the query loses its index-only scan and degrades
+ * to a bitmap heap scan — measured on a 455k-row/30d tenant: 257k heap blocks
+ * (~2 GB) read per call, 2.1s. Under concurrent dashboard loads the planner's
+ * parallel workers then exhaust the host's dynamic shared memory ("could not
+ * resize shared memory segment ... No space left on device"), failing the
+ * request outright. The extended INCLUDE list is a superset of 1793's, so
+ * every aggregation that index served stays index-only too.
+ *
+ * `IDX_agent_messages_skill_runs` serves the skills aggregation
+ * (`timeseries-queries.service.ts`, `skill_name IS NOT NULL`), which
+ * otherwise pays the same full bitmap scan to return a handful of rows.
+ * Partial on `skill_name IS NOT NULL` (the overwhelming majority of rows are
+ * NULL), so it costs nothing on the hot ingest path. Same tenant: 892ms
+ * parallel scan → 0.06ms.
+ *
+ * Same build-new-then-swap as 1793 (build CONCURRENTLY under a temp name,
+ * drop the old copy, rename into place) so a usable covering index always
+ * exists and no ACCESS EXCLUSIVE lock is taken against live writes. Two
+ * additions to that pattern:
+ *
+ *  - The swap is SKIPPED when the canonical index already carries every
+ *    needed column (deployments that converged out-of-band, e.g. hosted).
+ *    Rebuilding a multi-GB index at boot just to end up with an identical
+ *    definition would stall the deploy for nothing.
+ *  - `IDX_agent_messages_provider_usage_v2` (1793's temp name, also used as
+ *    an interim hotfix name on hosted) is dropped either way so no stale
+ *    duplicate keeps amplifying writes.
+ *
+ * `npm run migration:revert` cannot run `down()` (TypeORM opens a transaction
+ * for reverts regardless of `transaction = false`; Postgres rejects
+ * CONCURRENTLY inside one) — run the `down()` statements directly against the
+ * database, then delete this migration's row from `migrations`. Same caveat
+ * as every CONCURRENTLY migration here.
+ */
+export class ExtendDashboardCoveringIndex1801200000000 implements MigrationInterface {
+  name = 'ExtendDashboardCoveringIndex1801200000000';
+  transaction = false;
+
+  private static readonly USAGE_INDEX = 'IDX_agent_messages_provider_usage';
+  private static readonly SWAP_INDEX = 'IDX_agent_messages_provider_usage_swap';
+  private static readonly LEGACY_V2_INDEX = 'IDX_agent_messages_provider_usage_v2';
+  private static readonly SKILLS_INDEX = 'IDX_agent_messages_skill_runs';
+
+  /** Every column the dashboard aggregations read — superset of 1793's list. */
+  private static readonly USAGE_INCLUDE = [
+    'model',
+    'provider',
+    'auth_type',
+    'provider_key_label',
+    'input_tokens',
+    'output_tokens',
+    'cost_usd',
+    'status',
+    'request_id',
+    'id',
+  ];
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const { USAGE_INDEX, SWAP_INDEX, LEGACY_V2_INDEX, SKILLS_INDEX, USAGE_INCLUDE } =
+      ExtendDashboardCoveringIndex1801200000000;
+
+    if (!(await this.usageIndexConverged(queryRunner))) {
+      // Build-new-then-swap: the old covering index stays usable until the
+      // extended one is ready. The pre-drop only clears an INVALID leftover
+      // from an interrupted CONCURRENTLY build (CREATE ... IF NOT EXISTS
+      // matches on name and would skip over it, wedging it forever).
+      await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${SWAP_INDEX}"`);
+      await queryRunner.query(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${SWAP_INDEX}" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE (${USAGE_INCLUDE.map((col) => `"${col}"`).join(', ')})`,
+      );
+      await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${USAGE_INDEX}"`);
+      await queryRunner.query(`ALTER INDEX IF EXISTS "${SWAP_INDEX}" RENAME TO "${USAGE_INDEX}"`);
+    }
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${LEGACY_V2_INDEX}"`);
+
+    // Skills partial index. Clear only an INVALID leftover — a valid
+    // pre-existing copy (applied out-of-band) is kept, not rebuilt.
+    if (await this.indexIsInvalid(queryRunner, SKILLS_INDEX)) {
+      await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${SKILLS_INDEX}"`);
+    }
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${SKILLS_INDEX}" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("skill_name", "agent_name", "agent_id") WHERE "skill_name" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const { USAGE_INDEX, SWAP_INDEX, SKILLS_INDEX } = ExtendDashboardCoveringIndex1801200000000;
+
+    // Restore 1793's definition with the same swap.
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${SWAP_INDEX}"`);
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${SWAP_INDEX}" ON "agent_messages" ("tenant_id", "timestamp") INCLUDE ("model", "provider", "auth_type", "input_tokens", "output_tokens", "cost_usd")`,
+    );
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${USAGE_INDEX}"`);
+    await queryRunner.query(`ALTER INDEX IF EXISTS "${SWAP_INDEX}" RENAME TO "${USAGE_INDEX}"`);
+
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${SKILLS_INDEX}"`);
+  }
+
+  /** True when the canonical index already INCLUDEs every column we need. */
+  private async usageIndexConverged(queryRunner: QueryRunner): Promise<boolean> {
+    const rows: Array<{ indexdef: string }> = await queryRunner.query(
+      `SELECT indexdef FROM pg_indexes WHERE indexname = $1`,
+      [ExtendDashboardCoveringIndex1801200000000.USAGE_INDEX],
+    );
+    if (rows.length === 0) return false;
+    const match = rows[0].indexdef.match(/INCLUDE \(([^)]*)\)/);
+    if (!match) return false;
+    const columns = match[1].split(',').map((col) => col.trim().replace(/"/g, ''));
+    return ExtendDashboardCoveringIndex1801200000000.USAGE_INCLUDE.every((col) =>
+      columns.includes(col),
+    );
+  }
+
+  /** True when an index of this name exists but is INVALID (interrupted build). */
+  private async indexIsInvalid(queryRunner: QueryRunner, indexName: string): Promise<boolean> {
+    const rows: unknown[] = await queryRunner.query(
+      `SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = $1 AND NOT i.indisvalid`,
+      [indexName],
+    );
+    return rows.length > 0;
+  }
+}

--- a/packages/backend/src/database/migrations/1801200000000-ExtendDashboardCoveringIndex.ts
+++ b/packages/backend/src/database/migrations/1801200000000-ExtendDashboardCoveringIndex.ts
@@ -116,9 +116,18 @@ export class ExtendDashboardCoveringIndex1801200000000 implements MigrationInter
     const match = rows[0].indexdef.match(/INCLUDE \(([^)]*)\)/);
     if (!match) return false;
     const columns = match[1].split(',').map((col) => col.trim().replace(/"/g, ''));
-    return ExtendDashboardCoveringIndex1801200000000.USAGE_INCLUDE.every((col) =>
-      columns.includes(col),
-    );
+    if (
+      !ExtendDashboardCoveringIndex1801200000000.USAGE_INCLUDE.every((col) => columns.includes(col))
+    ) {
+      return false;
+    }
+    // pg_indexes lists INVALID indexes too — an interrupted out-of-band build
+    // under the canonical name would otherwise pass as converged and leave the
+    // dashboard with no usable covering index.
+    return !(await this.indexIsInvalid(
+      queryRunner,
+      ExtendDashboardCoveringIndex1801200000000.USAGE_INDEX,
+    ));
   }
 
   /** True when an index of this name exists but is INVALID (interrupted build). */


### PR DESCRIPTION
### ✨ What changed
- Migration 1801200000000 swaps `IDX_agent_messages_provider_usage` for a superset INCLUDE list (adds `provider_key_label`, `status`, `request_id`, `id`).
- New partial index `IDX_agent_messages_skill_runs` for the skills panel aggregation.
- The swap is skipped when the index already carries every column, so converged installs boot as a no-op.
- Drops the interim `IDX_agent_messages_provider_usage_v2` hotfix index.

### 💭 Why
The request-first dashboard (#2485) reads columns the 1793200000000 index lacks, so Overview and Provider Usage fell back to bitmap heap scans: 257k heap blocks (~2 GB) and 2.1s per call on a 455k-row/30d tenant. Under concurrent loads the parallel workers exhausted dynamic shared memory in production ("could not resize shared memory segment: No space left on device", QueryFailedError in Sentry). With the indexes both queries are index-only again (skills panel: 892ms parallel scan to 0.06ms).

### 🔧 For operators
Runs at boot, CONCURRENTLY, no write lock. Large installs pay one background rebuild of the covering index (minutes on multi-GB tables); the old index stays usable until the new one is renamed into place. Hosted prod was converged out-of-band on 2026-07-21, so this deploys as a no-op there.

### 📝 Notes
- Verified on fresh Postgres 16: final indexdef, rerun no-op, and converged-skip (index OID unchanged after re-running the migration).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the dashboard covering index on `agent_messages` and adds a partial skills index to restore index-only scans and remove heavy bitmap heap scans on large tenants.

- **Migration**
  - Runs at boot and `CONCURRENTLY`; no write lock.
  - Builds a swap index, drops the old one, then renames; also drops `IDX_agent_messages_provider_usage_v2`.
  - Skips rebuild only if the canonical index includes all needed columns and is VALID; treats an INVALID canonical index as not converged and rebuilds.
  - Adds `IDX_agent_messages_skill_runs` as a partial index (`skill_name IS NOT NULL`); only rebuilds if an INVALID leftover exists.

- **Performance**
  - Overview and Provider Usage return to index-only scans by including `provider_key_label`, `status`, `request_id`, and `id`.
  - Skills panel uses the new partial index, cutting scans from hundreds of thousands of heap blocks to near-zero.
  - Prevents parallel worker shared-memory errors under load.

<sup>Written for commit 6d68b244c7ea52605a59185ccdc5087f23eaee96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

