### PR TITLE
feat(providers): add Eden AI (EU, OpenAI-compatible gateway)

### DIFF
--- a/.changeset/add-edenai-provider.md
+++ b/.changeset/add-edenai-provider.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add Eden AI as a provider — an EU-based, GDPR-compliant OpenAI-compatible gateway that exposes 700+ models from many vendors behind a single key. Registered in the shared provider registry, the model fetcher (`GET /v3/models`), and the proxy endpoint (`/v3/chat/completions`).

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -623,6 +623,11 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     buildHeaders: bearerHeaders,
     parse: parseOpenAI,
   },
+  edenai: {
+    endpoint: 'https://api.edenai.run/v3/models',
+    buildHeaders: bearerHeaders,
+    parse: parseOpenAI,
+  },
   byteplus: {
     endpoint: BYTEPLUS_CODING_MODELS_URL,
     buildHeaders: bearerHeaders,

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -169,6 +169,15 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     format: 'openai',
     ...openaiStreamUsage,
   },
+  // Eden AI — EU-based, OpenAI-compatible gateway. Chat completions live at
+  // /v3/chat/completions (not /v1); models use `provider/model` ids.
+  edenai: {
+    baseUrl: 'https://api.edenai.run',
+    buildHeaders: openaiHeaders,
+    buildPath: () => '/v3/chat/completions',
+    format: 'openai',
+    ...openaiStreamUsage,
+  },
   byteplus: {
     baseUrl: BYTEPLUS_CODING_BASE,
     buildHeaders: openaiHeaders,

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -453,6 +453,11 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
     ],
     models: [],
   },
+  edenai: {
+    initial: 'EA',
+    subtitle: 'One key, 700+ models (EU)',
+    models: [],
+  },
 };
 
 /** @internal Exported for testing only */
@@ -507,6 +512,7 @@ const PROVIDER_ORDER = [
   'xai',
   'xiaomi',
   'zai',
+  'edenai',
 ];
 
 export const PROVIDERS: ProviderDef[] = PROVIDER_ORDER.map((id) => {

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -425,6 +425,18 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     minKeyLength: 30,
     keyPlaceholder: 'API key',
   },
+  {
+    id: 'edenai',
+    displayName: 'Eden AI',
+    aliases: ['eden-ai', 'eden ai'],
+    openRouterPrefixes: [],
+    requiresApiKey: true,
+    localOnly: false,
+    color: '#5646ff',
+    keyPrefix: '',
+    minKeyLength: 40,
+    keyPlaceholder: 'Eden AI API key',
+  },
 ] as const;
 
 /**


### PR DESCRIPTION
## What

Adds **Eden AI** as a provider. [Eden AI](https://www.edenai.co) is a French, EU-based, GDPR-compliant gateway that exposes 700+ models from many vendors (OpenAI, Anthropic, Mistral, Google, …) behind a **single OpenAI-compatible key**, with unified billing. It fits Manifest's OpenAI-compatible path exactly like OpenRouter does.

Follows the documented *"To add a new provider"* procedure in `common/constants/providers.ts`:

- `packages/shared/src/providers.ts` — `SHARED_PROVIDERS` entry (`edenai`)
- `packages/backend/src/routing/proxy/provider-endpoints.ts` — proxy endpoint (`https://api.edenai.run` + `/v3/chat/completions`, OpenAI format)
- `packages/backend/src/model-discovery/provider-model-fetcher.service.ts` — catalog fetcher (`GET /v3/models`, OpenAI parser)
- `packages/frontend/src/services/providers.ts` — UI overlay + `PROVIDER_ORDER` (appended last, so positional UI tests don't shift)
- changeset (`minor`)

## Verification

Verified live against the Eden AI API:

- `POST https://api.edenai.run/v3/chat/completions` → HTTP 200 (`openai/gpt-4o-mini` and `mistral/mistral-large-latest`)
- `GET https://api.edenai.run/v3/models` → HTTP 200, 779 models, OpenAI `{ data: [{ id }] }` shape

`packages/shared/src/providers.ts` type-checks clean. Note: I couldn't run the full monorepo build locally (my env is on Node 18; Manifest targets Node 24), so I'm relying on CI for the full build — happy to iterate on anything it flags.

## Notes

- Brand color is set to `#5646ff` as a placeholder — glad to swap it for the exact Eden AI brand hex.
- Model IDs use Eden AI's `provider/model` scheme (e.g. `openai/gpt-4o-mini`).
- I help maintain integrations at Eden AI and am happy to keep this provider current. See the [Eden AI docs](https://www.edenai.co/docs).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `edenai` as an EU, OpenAI-compatible provider. Lets users access 700+ models with a single Eden AI key through our existing OpenAI path.

- **New Features**
  - Registered `edenai` in `packages/shared` (`SHARED_PROVIDERS`) with key settings.
  - Added proxy routing in `packages/backend` to `https://api.edenai.run/v3/chat/completions` (OpenAI format; streams; model IDs like `provider/model`).
  - Enabled model discovery via `https://api.edenai.run/v3/models` using the OpenAI parser.
  - Added UI overlay and appended `edenai` to `PROVIDER_ORDER` in `packages/frontend`; included a minor changeset.

<sup>Written for commit 2bfe10159815f41b337a20eefaeb9814f5c1596c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

