### PR TITLE
fix(proxy): unwrap cline-pass { data, success } envelope on non-streaming chat completions

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -1729,6 +1729,58 @@ describe('proxy-response-handler', () => {
       expect(res.json).toHaveBeenCalledWith(body);
     });
 
+    it('should unwrap cline-pass { data, success } envelope', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const inner = {
+        id: 'chatcmpl-cp-1',
+        object: 'chat.completion',
+        model: 'qwen3.7-plus',
+        choices: [
+          { index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 1 },
+      };
+      const wrapped = { data: inner, success: true };
+      const forward = mockForward(wrapped);
+      const meta = makeMeta();
+
+      const usage = await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+      );
+
+      expect(usage).toEqual({
+        prompt_tokens: 10,
+        completion_tokens: 1,
+        cache_read_tokens: undefined,
+        cache_creation_tokens: undefined,
+      });
+      expect(res.json).toHaveBeenCalledWith(inner);
+    });
+
+    it('should not unwrap standard OpenAI responses that happen to have a data field', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const body = {
+        id: 'chatcmpl-123',
+        data: [{ foo: 'bar' }],
+        choices: [
+          { index: 0, message: { role: 'assistant', content: 'hello' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta();
+
+      await handleNonStreamResponse(res as any, forward as any, meta, {}, client as any);
+
+      expect(res.json).toHaveBeenCalledWith(body);
+    });
+
     it('should extract cached prompt tokens from prompt_tokens_details', async () => {
       const { res } = mockResponse();
       const client = mockProviderClient();

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -730,6 +730,12 @@ export async function handleNonStreamResponse(
     responseBody = providerClient.collectChatGptSseResponse(sseText, meta.model);
   } else {
     responseBody = await forward.response.json();
+    // cline-pass wraps non-streaming chat completions in a { data, success }
+    // envelope. Unwrap so downstream code and clients see a standard OpenAI shape.
+    const r = responseBody as Record<string, unknown> | undefined;
+    if (r && typeof r === 'object' && 'data' in r && !('choices' in r)) {
+      responseBody = (r as { data: unknown; success?: boolean }).data;
+    }
     if (supportsReasoningContent(meta.provider, meta.model)) {
       cacheReasoningContent(responseBody, reasoningCache, sessionKey);
     }


### PR DESCRIPTION
## Summary

The **cline-pass** upstream provider (`api.cline.bot`) wraps non-streaming chat completion responses in a non-standard envelope:

```json
{
  "data": { "choices": [...], "model": "...", "usage": {...} },
  "success": true
}
```

Standard OpenAI clients expect the body at the top level, so the Python SDK (and any other strict client) crashes with `TypeError` when trying to access `response.choices`. Streaming responses are unaffected since cline-pass uses standard SSE.

## Change

In `handleNonStreamResponse`, after parsing the provider JSON, check generically: if the parsed body is an object that contains a `data` key but no `choices` key at the top level, unwrap to `body.data`. This is safe because all standard OpenAI-compatible responses carry `choices` at the top level.

This mirrors the existing unwrapping patterns for CodeAssist (`unwrapCodeAssistResponse`) and Google responses, but is applied in the generic `else` branch that catches `format: 'openai'` providers that happen to wrap their responses.

## Test plan

- `packages/backend` jest: `npx jest proxy-response-handler --no-coverage`
  - New test: `should unwrap cline-pass { data, success } envelope`
  - New test: `should not unwrap standard OpenAI responses that happen to have a data field`
  - Result: 97 passed, 0 failed

- `proxy.controller.spec.ts`: 102 passed, 0 failed

- Prettier and lint passed via pre-commit hook.

## Risks

- The check is conservative (`choices` not at top level + `data` present), so standard OpenAI, OpenRouter, Anthropic, Google, and Codex responses are never touched.
- If any other `format: 'openai'` provider in the future also wraps responses this way, they will be unwrapped automatically without a code change.

## Related

- PR #2412 — added cline-pass as a subscription provider (the envelope was not handled at that time).
- PR #2527 — open PR for dynamic cline-pass model discovery (orthogonal).
