### PR TITLE
fix: record spec-less caller-sent knobs in request-params snapshots

### DIFF
--- a/.changeset/snapshot-specless-knobs.md
+++ b/.changeset/snapshot-specless-knobs.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Request-params snapshots now record caller-sent scalar parameters the model catalog has no spec for, so failure evidence shows the exact knob a provider rejected instead of silently omitting it.

--- a/.changeset/snapshot-specless-knobs.md
+++ b/.changeset/snapshot-specless-knobs.md
@@ -2,4 +2,4 @@
 "manifest": patch
 ---
 
-Request-params snapshots now record caller-sent scalar parameters the model catalog has no spec for, so failure evidence shows the exact knob a provider rejected instead of silently omitting it.
+Request-params snapshots are now derived from the raw request body: caller-sent parameters the model catalog has no spec for (scalars and small structured knobs, content excluded) are recorded, so failure evidence shows the exact knob a provider rejected instead of silently omitting it.

--- a/packages/shared/__tests__/request-params-snapshot.spec.ts
+++ b/packages/shared/__tests__/request-params-snapshot.spec.ts
@@ -150,6 +150,7 @@ describe('snapshotRequestParams', () => {
           response_format: { type: 'json_object' },
           thinking: { type: 'enabled' },
           stop: ['\\n\\n'],
+          logit_bias: null,
         },
         modelParams: null,
         specs: [],
@@ -158,6 +159,8 @@ describe('snapshotRequestParams', () => {
       response_format: { type: 'json_object' },
       thinking: { type: 'enabled' },
       stop: ['\\n\\n'],
+      // An explicit null is part of the raw request and is kept as sent.
+      logit_bias: null,
     });
   });
 
@@ -170,6 +173,8 @@ describe('snapshotRequestParams', () => {
           user: 'user-123',
           seed_note: 'x'.repeat(65),
           smuggled: { nested: { prompt: 'y'.repeat(65) } },
+          functions: [{ name: 'f', parameters: { type: 'object' } }],
+          'dotted.key': true,
           oversized: { keys: Array.from({ length: 600 }, (_, i) => `key_${i}`) },
           not_json: { cb: () => 'x' },
           verbosity: 'high',

--- a/packages/shared/__tests__/request-params-snapshot.spec.ts
+++ b/packages/shared/__tests__/request-params-snapshot.spec.ts
@@ -142,15 +142,36 @@ describe('snapshotRequestParams', () => {
     ).toEqual({ temperature: 0.7, parallel_tool_calls: false, service_tier: 'flex' });
   });
 
-  it('never records content-bearing or non-scalar spec-less keys', () => {
+  it('records spec-less structured knobs from the raw body', () => {
+    expect(
+      snapshotRequestParams({
+        body: {
+          messages: [{ role: 'user', content: 'hi' }],
+          response_format: { type: 'json_object' },
+          thinking: { type: 'enabled' },
+          stop: ['\\n\\n'],
+        },
+        modelParams: null,
+        specs: [],
+      }),
+    ).toEqual({
+      response_format: { type: 'json_object' },
+      thinking: { type: 'enabled' },
+      stop: ['\\n\\n'],
+    });
+  });
+
+  it('never records content-bearing spec-less keys', () => {
     expect(
       snapshotRequestParams({
         body: {
           messages: [{ role: 'user', content: 'hi' }],
           system: 'you are a bot',
           user: 'user-123',
-          response_format: { type: 'json_object' },
           seed_note: 'x'.repeat(65),
+          smuggled: { nested: { prompt: 'y'.repeat(65) } },
+          oversized: { keys: Array.from({ length: 600 }, (_, i) => `key_${i}`) },
+          not_json: { cb: () => 'x' },
           verbosity: 'high',
         },
         modelParams: null,

--- a/packages/shared/__tests__/request-params-snapshot.spec.ts
+++ b/packages/shared/__tests__/request-params-snapshot.spec.ts
@@ -118,6 +118,47 @@ describe('snapshotRequestParams', () => {
     ).toEqual({ thinking: { type: 'adaptive' } });
   });
 
+  it('records a caller-sent knob the route has no spec for', () => {
+    // claude-opus-4-8-style case: the catalog (correctly) dropped temperature
+    // for the model, the caller sent it anyway, the provider rejected it — the
+    // snapshot must show the knob that was actually on the wire.
+    const speclessTemperature = specs.filter((s) => s.path.split('.')[0] !== 'temperature');
+    expect(
+      snapshotRequestParams({
+        body: { temperature: 0.2, messages: [] },
+        modelParams: { thinking: { type: 'enabled' } },
+        specs: speclessTemperature,
+      }),
+    ).toEqual({ temperature: 0.2, thinking: { type: 'enabled', budget_tokens: 4096 } });
+  });
+
+  it('records spec-less scalar knobs even when the route has no specs at all', () => {
+    expect(
+      snapshotRequestParams({
+        body: { temperature: 0.7, parallel_tool_calls: false, service_tier: 'flex', messages: [] },
+        modelParams: null,
+        specs: [],
+      }),
+    ).toEqual({ temperature: 0.7, parallel_tool_calls: false, service_tier: 'flex' });
+  });
+
+  it('never records content-bearing or non-scalar spec-less keys', () => {
+    expect(
+      snapshotRequestParams({
+        body: {
+          messages: [{ role: 'user', content: 'hi' }],
+          system: 'you are a bot',
+          user: 'user-123',
+          response_format: { type: 'json_object' },
+          seed_note: 'x'.repeat(65),
+          verbosity: 'high',
+        },
+        modelParams: null,
+        specs: [],
+      }),
+    ).toEqual({ verbosity: 'high' });
+  });
+
   it('omits conflicted defaults from the snapshot', () => {
     expect(
       snapshotRequestParams({

--- a/packages/shared/src/request-params-snapshot.ts
+++ b/packages/shared/src/request-params-snapshot.ts
@@ -51,8 +51,63 @@ export function snapshotRequestParams(
     }
   }
 
-  const effective = omitProviderInapplicableParams(out, orderedSpecs);
+  const effective = addSpeclessKnobs(
+    omitProviderInapplicableParams(out, orderedSpecs),
+    body,
+    orderedSpecs,
+  );
   return Object.keys(effective).length > 0 ? effective : null;
+}
+
+/**
+ * Top-level body keys that are never model knobs: routing identity, message
+ * content, tool definitions, and transport flags.
+ */
+const NON_KNOB_KEYS = new Set([
+  'model',
+  'messages',
+  'input',
+  'tools',
+  'system',
+  'instructions',
+  'prompt',
+  'metadata',
+  'user',
+  'stream',
+  'stream_options',
+]);
+
+/** Longest string still plausibly a knob value rather than prompt content. */
+const MAX_KNOB_STRING = 64;
+
+/**
+ * Keep spec-less scalar knobs the caller sent. The spec walk above only records
+ * params the MPS catalog knows for the resolved route, but a param without a
+ * spec still reaches the provider verbatim — and when the provider rejects it,
+ * a snapshot that silently omitted it hides the very knob that caused the
+ * failure (a caller-sent `temperature` on a model whose catalog entry dropped
+ * the knob left a snapshot showing only `thinking`/`max_tokens` while the wire
+ * error said temperature). Scalars only: an unknown object or long string may
+ * carry content, which the snapshot must never store.
+ */
+function addSpeclessKnobs(
+  effective: RequestParamDefaults,
+  body: Record<string, unknown>,
+  specs: readonly ProviderParamSpec[],
+): RequestParamDefaults {
+  const specRoots = new Set(specs.map((spec) => spec.path.split('.')[0]));
+  let out = effective;
+  for (const [key, value] of Object.entries(body)) {
+    if (specRoots.has(key) || NON_KNOB_KEYS.has(key)) continue;
+    if (!isKnobScalar(value)) continue;
+    out = setProviderParamValue(out, key, value as JsonValue);
+  }
+  return out;
+}
+
+function isKnobScalar(value: unknown): boolean {
+  if (typeof value === 'number' || typeof value === 'boolean') return true;
+  return typeof value === 'string' && value.length <= MAX_KNOB_STRING;
 }
 
 function getPath(values: Record<string, unknown>, path: string): unknown {

--- a/packages/shared/src/request-params-snapshot.ts
+++ b/packages/shared/src/request-params-snapshot.ts
@@ -80,15 +80,21 @@ const NON_KNOB_KEYS = new Set([
 /** Longest string still plausibly a knob value rather than prompt content. */
 const MAX_KNOB_STRING = 64;
 
+/** Largest serialized structured knob (a schema-sized object is content, not a knob). */
+const MAX_KNOB_JSON_CHARS = 2048;
+
 /**
- * Keep spec-less scalar knobs the caller sent. The spec walk above only records
+ * Keep the raw request's spec-less knobs. The spec walk above only records
  * params the MPS catalog knows for the resolved route, but a param without a
  * spec still reaches the provider verbatim — and when the provider rejects it,
  * a snapshot that silently omitted it hides the very knob that caused the
  * failure (a caller-sent `temperature` on a model whose catalog entry dropped
  * the knob left a snapshot showing only `thinking`/`max_tokens` while the wire
- * error said temperature). Scalars only: an unknown object or long string may
- * carry content, which the snapshot must never store.
+ * error said temperature). The snapshot is body-first: everything the caller
+ * sent is recorded except content (the key denylist) and anything content-sized
+ * ({@link knobValueFits}) — the catalog's role is confined to the params it
+ * knows (saved-param overrides, defaults, applicability), never to deciding
+ * whether a caller-sent knob existed.
  */
 function addSpeclessKnobs(
   effective: RequestParamDefaults,
@@ -99,15 +105,28 @@ function addSpeclessKnobs(
   let out = effective;
   for (const [key, value] of Object.entries(body)) {
     if (specRoots.has(key) || NON_KNOB_KEYS.has(key)) continue;
-    if (!isKnobScalar(value)) continue;
+    if (!knobValueFits(value)) continue;
     out = setProviderParamValue(out, key, value as JsonValue);
   }
   return out;
 }
 
-function isKnobScalar(value: unknown): boolean {
+/**
+ * A knob value is any scalar or small structure whose every string leaf is
+ * knob-sized. The leaf rule is what keeps content out of structured values — a
+ * `response_format: { type: 'json_object' }` fits, an object smuggling a prompt
+ * in a nested string does not.
+ */
+function knobValueFits(value: unknown): boolean {
+  if (value === null) return true; // an explicit null is part of the raw request
   if (typeof value === 'number' || typeof value === 'boolean') return true;
-  return typeof value === 'string' && value.length <= MAX_KNOB_STRING;
+  if (typeof value === 'string') return value.length <= MAX_KNOB_STRING;
+  if (Array.isArray(value) || isRecord(value)) {
+    if (JSON.stringify(value).length > MAX_KNOB_JSON_CHARS) return false;
+    const leaves = Array.isArray(value) ? value : Object.values(value);
+    return leaves.every(knobValueFits);
+  }
+  return false; // undefined, functions, symbols — not JSON, not a knob
 }
 
 function getPath(values: Record<string, unknown>, path: string): unknown {

--- a/packages/shared/src/request-params-snapshot.ts
+++ b/packages/shared/src/request-params-snapshot.ts
@@ -68,6 +68,7 @@ const NON_KNOB_KEYS = new Set([
   'messages',
   'input',
   'tools',
+  'functions',
   'system',
   'instructions',
   'prompt',
@@ -105,6 +106,9 @@ function addSpeclessKnobs(
   let out = effective;
   for (const [key, value] of Object.entries(body)) {
     if (specRoots.has(key) || NON_KNOB_KEYS.has(key)) continue;
+    // setProviderParamValue reads the key as a dotted path — a literal dotted
+    // key would be recorded as a nested object, so skip rather than mangle.
+    if (key.includes('.')) continue;
     if (!knobValueFits(value)) continue;
     out = setProviderParamValue(out, key, value as JsonValue);
   }


### PR DESCRIPTION
### 💭 Why
`snapshotRequestParams` walks only the MPS catalog specs for the resolved route, so a caller-sent param the catalog has no spec for reaches the provider verbatim but never enters `agent_messages.request_params`. Real case: a caller sent `temperature` to claude-opus-4-8 (whose catalog entry correctly dropped the knob), Anthropic 400'd with "temperature is deprecated for this model", and the recorded snapshot showed only `thinking` + `max_tokens` — the failure evidence Phoenix ingests was missing the exact knob the provider rejected.

### ✨ What changed
- After the spec walk, the snapshot keeps caller-sent top-level scalar knobs (numbers, booleans, strings up to 64 chars) whose key no spec covers.
- Content, identity, and transport keys never qualify (`messages`, `input`, `system`, `instructions`, `prompt`, `tools`, `model`, `metadata`, `user`, `stream`, `stream_options`), and unknown objects or long strings are excluded — the snapshot still never stores content.
- Spec-covered params behave exactly as before.

### 👤 For users
The parameters shown for a failed request now include the one the provider actually complained about, and Phoenix-scraped evidence stops hiding the offending knob.

### 🔧 Notes
Shared-package change only; wire bodies are untouched. New tests cover the opus-4-8 temperature case, the no-spec route, and the content exclusions — shared, backend, and frontend suites all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derive `request-params` snapshots from the raw request body and record caller‑sent knobs without catalog specs (including small structured values). This makes failures show the exact parameter the provider rejected (e.g., `temperature` on `claude-opus-4-8`).

- **Bug Fixes**
  - Build the snapshot from the raw body; the catalog only overlays known params (defaults/applicability). Spec-covered behavior and wire bodies are unchanged.
  - Keep spec‑less knobs if scalar or small structured (strings ≤64 chars; arrays/objects with JSON ≤2 KB and string leaves ≤64 chars).
  - Never include content/identity/transport keys (`messages`, `input`, `system`, `instructions`, `prompt`, `tools`, `functions`, `model`, `metadata`, `user`, `stream`, `stream_options`), dotted keys, or oversized/non‑JSON values.
  - Added tests for the opus‑4‑8 `temperature` case, no‑spec routes, structured knobs, content exclusions, dotted keys, and legacy `functions`.

<sup>Written for commit 1c23869c0fedb95fb041299b0bf3f1ee6158e924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

