### PR TITLE
fix: prevent provider connection name overlap

### DIFF
--- a/packages/frontend/src/pages/AgentProviders.tsx
+++ b/packages/frontend/src/pages/AgentProviders.tsx
@@ -154,9 +154,9 @@ const AgentProviders: Component = () => {
             <colgroup>
               <col style="width: 220px;" />
               <col style="width: 120px;" />
-              <col style="width: 140px;" />
-              <col style="width: 80px;" />
               <col />
+              <col style="width: 56px;" />
+              <col style="width: 64px;" />
             </colgroup>
             <thead>
               <tr>
@@ -209,7 +209,19 @@ const AgentProviders: Component = () => {
                           {AUTH_BADGES[connection.authType] ?? connection.authType}
                         </span>
                       </td>
-                      <td style="color: hsl(var(--muted-foreground));">{connection.label}</td>
+                      <td>
+                        <span
+                          title={connection.label}
+                          style={{
+                            display: 'block',
+                            overflow: 'hidden',
+                            'text-overflow': 'ellipsis',
+                            color: 'hsl(var(--muted-foreground))',
+                          }}
+                        >
+                          {connection.label}
+                        </span>
+                      </td>
                       <td>{connection.models || '-'}</td>
                       <td style="text-align: right;">
                         <button

--- a/packages/frontend/tests/pages/AgentProviders.test.tsx
+++ b/packages/frontend/tests/pages/AgentProviders.test.tsx
@@ -176,6 +176,31 @@ describe('AgentProviders', () => {
     expect(screen.getByLabelText('Enable Anthropic Max')).toBeDefined();
   });
 
+  it('keeps a long connection name within its cell without removing the models column', async () => {
+    const longLabel = 'from MyTrainer LLM Judges and Evaluation Platform';
+    mockGetGlobalProviders.mockResolvedValue({
+      ...providersResponse,
+      providers: providersResponse.providers.map((provider) =>
+        provider.provider === 'openai'
+          ? {
+              ...provider,
+              connections: [{ ...provider.connections[0], label: longLabel }],
+            }
+          : provider,
+      ),
+    });
+
+    render(() => <AgentProviders />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle(longLabel)).toBeDefined();
+    });
+
+    expect(screen.getByTitle(longLabel).style.textOverflow).toBe('ellipsis');
+    expect(screen.getByRole('columnheader', { name: 'Models' })).toBeDefined();
+    expect(screen.getByText('2')).toBeDefined();
+  });
+
   it('enables a provider with PUT', async () => {
     render(() => <AgentProviders />);
 


### PR DESCRIPTION
### ✨ What changed
- Give Connection the remaining table width and keep Models at 56px.
- Truncate long connection labels, with full names available on hover.
- Add regression coverage for a long connection name.

### 💭 Why
Long connection names overlapped the model count in the agent provider table.

### 👤 For users
Long connection names no longer obscure their model count.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents long connection names from overlapping the Models count in the Agent Providers table. Keeps counts visible and shows full names on hover.

- **Bug Fixes**
  - Connection column now takes remaining width; Models fixed to 56px.
  - Long connection labels are truncated with ellipsis and a tooltip.
  - Added regression test for long names to ensure Models column remains.

<sup>Written for commit c14959ec357ec428275a8f34b61a5285eee5ffdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

