### PR TITLE
feat(dashboard): Add By Provider / By Model Groupings to Overview Charts

### DIFF
--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -55,6 +55,11 @@ function mockTimeseries(): Record<string, jest.Mock> {
     getPerModelTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
     getPerModelMessageTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
     getPerModelCostTimeseries: jest.fn().mockResolvedValue({ agents: [], timeseries: [] }),
+    getModelUsageTimeseries: jest.fn().mockResolvedValue({
+      tokenUsage: { agents: [], timeseries: [] },
+      messageUsage: { agents: [], timeseries: [] },
+      costUsage: { agents: [], timeseries: [] },
+    }),
   };
 }
 
@@ -393,6 +398,86 @@ describe('OverviewController', () => {
       const nullCtx = { tenantId: null, userId: 'u1' };
       await controller.getPerAgentTimeseries({ range: '24h' }, nullCtx as never);
       expect(ts.getPerAgentTimeseries).toHaveBeenCalledWith('24h', null, true);
+    });
+  });
+
+  describe('request-level provider/model volume and model usage', () => {
+    function withRequestVolume(rows: Array<Record<string, unknown>>) {
+      const requestVolume = {
+        getVolumeByDimensionTimeseries: jest.fn().mockResolvedValue(rows),
+      };
+      const c = new OverviewController(
+        agg as never,
+        ts as never,
+        { getProviders: mockGetProviders } as never,
+        { resolve: mockResolveAgent } as never,
+        { find: mockAccessFind } as never,
+        undefined,
+        requestVolume as never,
+      );
+      return { c, requestVolume };
+    }
+
+    it('providers/request-usage pivots terminal-attributed volume per provider', async () => {
+      const { c, requestVolume } = withRequestVolume([
+        { hour: '1', provider: 'openai', messages: 5 },
+        { hour: '1', provider: 'anthropic', messages: 3 },
+        { hour: '2', provider: 'openai', messages: 7 },
+      ]);
+      const result = await c.getOverviewProvidersRequestUsage(
+        { range: '24h', agent_name: 'bot-1' },
+        ctx as never,
+      );
+      expect(requestVolume.getVolumeByDimensionTimeseries).toHaveBeenCalledWith(
+        'provider',
+        '24h',
+        'tenant-123',
+        true,
+        'bot-1',
+      );
+      expect(result).toEqual({
+        agents: ['anthropic', 'openai'],
+        timeseries: [
+          { hour: '1', anthropic: 3, openai: 5 },
+          { hour: '2', anthropic: 0, openai: 7 },
+        ],
+      });
+    });
+
+    it('providers/request-usage returns empty shape when volume service absent', async () => {
+      const result = await controller.getOverviewProvidersRequestUsage(
+        { range: '24h' },
+        ctx as never,
+      );
+      expect(result).toEqual({ agents: [], timeseries: [] });
+    });
+
+    it('models/request-usage uses the model dimension and date buckets for 7d', async () => {
+      const { c, requestVolume } = withRequestVolume([
+        { date: '2026-07-01', model: 'gpt-4o', messages: 4 },
+      ]);
+      const result = await c.getOverviewModelsRequestUsage({ range: '7d' }, ctx as never);
+      expect(requestVolume.getVolumeByDimensionTimeseries).toHaveBeenCalledWith(
+        'model',
+        '7d',
+        'tenant-123',
+        false,
+        undefined,
+      );
+      expect(result).toEqual({
+        agents: ['gpt-4o'],
+        timeseries: [{ date: '2026-07-01', 'gpt-4o': 4 }],
+      });
+    });
+
+    it('models/request-usage returns empty shape when volume service absent', async () => {
+      const result = await controller.getOverviewModelsRequestUsage({ range: '24h' }, ctx as never);
+      expect(result).toEqual({ agents: [], timeseries: [] });
+    });
+
+    it('models/usage delegates to combined model usage timeseries', async () => {
+      await controller.getOverviewModelsUsage({ range: '7d', agent_name: 'bot-1' }, ctx as never);
+      expect(ts.getModelUsageTimeseries).toHaveBeenCalledWith('7d', 'tenant-123', false, 'bot-1');
     });
   });
 });

--- a/packages/backend/src/analytics/controllers/overview.controller.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.ts
@@ -14,6 +14,7 @@ import { Repository } from 'typeorm';
 import { AgentEnabledProvider } from '../../entities/agent-enabled-provider.entity';
 import { computeTrend } from '../services/query-helpers';
 import { MessagesQueryService } from '../services/messages-query.service';
+import { RequestVolumeService } from '../services/request-volume.service';
 
 /** Sum the timeseries buckets into current-window totals for the summary cards. */
 function sumTimeseries(tsData: {
@@ -45,6 +46,8 @@ export class OverviewController {
     private readonly enabledProviderRepo: Repository<AgentEnabledProvider>,
     @Optional()
     private readonly messagesQuery?: MessagesQueryService,
+    @Optional()
+    private readonly requestVolume?: RequestVolumeService,
   ) {}
 
   @Get('overview')
@@ -180,6 +183,57 @@ export class OverviewController {
     return this.timeseries.getProviderUsageTimeseries(range, ctx.tenantId, hourly, agentName);
   }
 
+  /**
+   * Request-level volume per provider (terminal attribution): one logical
+   * request counts once, under the provider that served its concluding
+   * attempt — so the Requests chart's By provider view stacks to the same
+   * total as By request status and the Requests KPI. Distinct from
+   * `overview/providers/usage`, which is served-attempt tokens/cost.
+   */
+  @Get('overview/providers/request-usage')
+  async getOverviewProvidersRequestUsage(
+    @Query() query: RangeQueryDto,
+    @TenantCtx() ctx: TenantContext,
+  ) {
+    const { range, hourly, agentName } = this.deriveTimeseriesArgs(query);
+    if (!this.requestVolume) return { agents: [], timeseries: [] };
+    const rows = await this.requestVolume.getVolumeByDimensionTimeseries(
+      'provider',
+      range,
+      ctx.tenantId,
+      hourly,
+      agentName,
+    );
+    return pivotRequestVolume(rows, hourly ? 'hour' : 'date', 'provider');
+  }
+
+  @Get('overview/models/usage')
+  async getOverviewModelsUsage(@Query() query: RangeQueryDto, @TenantCtx() ctx: TenantContext) {
+    const { range, hourly, agentName } = this.deriveTimeseriesArgs(query);
+    return this.timeseries.getModelUsageTimeseries(range, ctx.tenantId, hourly, agentName);
+  }
+
+  /**
+   * Request-level volume per model (terminal attribution), the Requests
+   * chart's By model view. Same contract as providers/request-usage.
+   */
+  @Get('overview/models/request-usage')
+  async getOverviewModelsRequestUsage(
+    @Query() query: RangeQueryDto,
+    @TenantCtx() ctx: TenantContext,
+  ) {
+    const { range, hourly, agentName } = this.deriveTimeseriesArgs(query);
+    if (!this.requestVolume) return { agents: [], timeseries: [] };
+    const rows = await this.requestVolume.getVolumeByDimensionTimeseries(
+      'model',
+      range,
+      ctx.tenantId,
+      hourly,
+      agentName,
+    );
+    return pivotRequestVolume(rows, hourly ? 'hour' : 'date', 'model');
+  }
+
   @Get('overview/per-model-cost-timeseries')
   async getPerModelCostTimeseries(@Query() query: RangeQueryDto, @TenantCtx() ctx: TenantContext) {
     const { range, hourly, agentName } = this.deriveTimeseriesArgs(query);
@@ -232,4 +286,34 @@ export class OverviewController {
       return false;
     }
   }
+}
+
+/**
+ * Pivot RequestVolumeService rows into the { agents, timeseries } shape the
+ * frontend's pivoted-timeseries charts consume: one numeric column per
+ * distinct series key, zero-filled so stacked bars stay aligned.
+ */
+function pivotRequestVolume(
+  rows: Array<Record<string, unknown>>,
+  bucketAlias: string,
+  keyField: string,
+): { agents: string[]; timeseries: Array<Record<string, number | string>> } {
+  const keySet = new Set<string>();
+  for (const r of rows) keySet.add(String(r[keyField]));
+  const keys = [...keySet].sort();
+
+  const byBucket = new Map<string, Record<string, number>>();
+  for (const r of rows) {
+    const bucket = String(r[bucketAlias]);
+    if (!byBucket.has(bucket)) byBucket.set(bucket, {});
+    byBucket.get(bucket)![String(r[keyField])] = Number(r['messages'] ?? 0);
+  }
+
+  const timeseries = [...byBucket.entries()].map(([bucket, map]) => {
+    const row: Record<string, number | string> = { [bucketAlias]: bucket };
+    for (const k of keys) row[k] = map[k] ?? 0;
+    return row;
+  });
+
+  return { agents: keys, timeseries };
 }

--- a/packages/backend/src/analytics/services/request-volume.service.spec.ts
+++ b/packages/backend/src/analytics/services/request-volume.service.spec.ts
@@ -78,6 +78,32 @@ describe('RequestVolumeService (#2511 request-level volume)', () => {
     expect(sql).toContain('AS hour');
   });
 
+  it('keys the per-provider request volume by terminal attribution', async () => {
+    await service.getVolumeByDimensionTimeseries('provider', '7d', 't1', false);
+    const sql = lastSql();
+    // One row per logical request (request-level, not attempt-level).
+    expect(sql).toContain('DISTINCT ON (r.id)');
+    // Zero-attempt conclusions stay visible instead of vanishing.
+    expect(sql).toContain("COALESCE(t.provider, 'No provider') AS provider");
+    expect(sql).toContain('AS date');
+    expect(sql).toContain('COUNT(*)::int AS messages');
+  });
+
+  it('keys the per-model request volume by terminal attribution', async () => {
+    await service.getVolumeByDimensionTimeseries('model', '24h', 't1', true);
+    const sql = lastSql();
+    expect(sql).toContain('DISTINCT ON (r.id)');
+    expect(sql).toContain("COALESCE(t.model, 'No model') AS model");
+    expect(sql).toContain('AS hour');
+  });
+
+  it('scopes the per-dimension request volume to the live agent when given', async () => {
+    await service.getVolumeByDimensionTimeseries('provider', '7d', 't1', false, 'demo-agent');
+    const sql = lastSql();
+    expect(sql).toContain('deleted_at IS NULL');
+    expect(lastParams()).toEqual(['t1', expect.any(String), 'demo-agent']);
+  });
+
   it('computes per-dimension request totals with terminal outcomes', async () => {
     messageRepo.query.mockResolvedValue([
       { key: 'openai', requests: '10', failed: '2', succeeded: '8', healed: '1', fallback: '2' },
@@ -148,6 +174,12 @@ describe('RequestVolumeService (#2511 request-level volume)', () => {
     ).resolves.toEqual([]);
     await expect(service.getVolumeByAgentTimeseries('7d', null, false)).resolves.toEqual([]);
     await expect(service.getVolumeByDimension('model', { tenantId: null })).resolves.toEqual([]);
+    await expect(
+      service.getVolumeByDimensionTimeseries('provider', '7d', null, false),
+    ).resolves.toEqual([]);
+    await expect(
+      service.getVolumeByDimensionTimeseries('model', '7d', null, false),
+    ).resolves.toEqual([]);
     await expect(
       service.getDispositionTotals({ tenantId: null, from: '2026-01-01' }),
     ).resolves.toEqual({ total: 0, success: 0, healed: 0, fallback: 0, error: 0 });

--- a/packages/backend/src/analytics/services/request-volume.service.ts
+++ b/packages/backend/src/analytics/services/request-volume.service.ts
@@ -294,6 +294,39 @@ export class RequestVolumeService {
   }
 
   /**
+   * Request volume per dimension bucket (terminal attribution, requests
+   * level): one request counts once, under its terminal attempt's provider or
+   * model — so the By provider / By model Requests charts stack to the same
+   * total as By request status and the Requests KPI. Requests that concluded
+   * without any provider attempt (zero-attempt rejections) read 'No provider'
+   * / 'No model' instead of vanishing. Deliberately NOT used by usage
+   * (tokens/cost) surfaces, which keep served-only semantics.
+   */
+  async getVolumeByDimensionTimeseries(
+    dim: 'provider' | 'model',
+    range: string,
+    tenantId: string | null,
+    hourly: boolean,
+    agentName?: string,
+  ): Promise<Array<Record<string, unknown>>> {
+    if (!tenantId) return [];
+    const bucketExpr = hourly ? sqlHourBucket('t.ts') : sqlDateBucket('t.ts');
+    const bucketAlias = hourly ? 'hour' : 'date';
+    const keyExpr =
+      dim === 'provider' ? `COALESCE(t.provider, 'No provider')` : `COALESCE(t.model, 'No model')`;
+    const sql = `${this.terminalCte(agentName)}
+      SELECT ${bucketExpr} AS ${bucketAlias},
+        ${keyExpr} AS ${dim},
+        COUNT(*)::int AS messages
+      FROM terminal t
+      GROUP BY 1, 2
+      ORDER BY 1 ASC`;
+    return (await this.messageRepo.query(sql, this.params(tenantId, range, agentName))) as Array<
+      Record<string, unknown>
+    >;
+  }
+
+  /**
    * Request-level totals per dimension for the Overview trio tables
    * (Total requests / Healed / Success rate). `succeeded` counts requests
    * whose terminal outcome is ok (recovered included), so Success rate =

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -1126,6 +1126,30 @@ describe('TimeseriesQueriesService', () => {
       expect(out.timeseries).toEqual([{ hour: '01', 'gpt-4o': 0.9 }]);
     });
 
+    it('getModelUsageTimeseries pivots tokens, messages, and cost from one query', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { hour: '01', model: 'gpt-4o', tokens: 10, messages: 2, cost: 1.5 },
+        { hour: '01', model: 'claude-4', tokens: 5, messages: 1, cost: 0.5 },
+      ]);
+      const out = await service.getModelUsageTimeseries('24h', 'u1', true);
+
+      expect(out.tokenUsage.timeseries[0]).toEqual({ hour: '01', 'claude-4': 5, 'gpt-4o': 10 });
+      expect(out.messageUsage.timeseries[0]).toEqual({ hour: '01', 'claude-4': 1, 'gpt-4o': 2 });
+      expect(out.costUsage.timeseries[0]).toEqual({ hour: '01', 'claude-4': 0.5, 'gpt-4o': 1.5 });
+      expect(mockGetRawMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('getModelUsageTimeseries supports date buckets and agent scope', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { date: '2026-01-01', model: 'gpt-4o', tokens: 10, messages: 2, cost: 1.5 },
+      ]);
+      const out = await service.getModelUsageTimeseries('7d', 'u1', false, 'agent-x');
+
+      expect(out.tokenUsage.timeseries[0]).toEqual({ date: '2026-01-01', 'gpt-4o': 10 });
+      expect(out.messageUsage.timeseries[0]).toEqual({ date: '2026-01-01', 'gpt-4o': 2 });
+      expect(out.costUsage.timeseries[0]).toEqual({ date: '2026-01-01', 'gpt-4o': 1.5 });
+    });
+
     it('zero-fills missing values from null', async () => {
       mockGetRawMany.mockResolvedValue([{ hour: '01', provider: 'openai', tokens: null }]);
       const out = await service.getPerProviderTimeseries('24h', 'u1', true);

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -900,6 +900,43 @@ export class TimeseriesQueriesService {
     return pivotByKey(rows, bucketAlias, 'model', 'cost');
   }
 
+  /**
+   * Per-model tokens/messages/cost from ONE query, like
+   * getProviderUsageTimeseries. Serves the By model lens on the usage tabs.
+   * The Requests tab does NOT read this: its By provider / By model views are
+   * request-level (terminal attribution) and come from the dedicated
+   * endpoints backed by RequestVolumeService.
+   */
+  async getModelUsageTimeseries(
+    range: string,
+    tenantId: string | null,
+    hourly: boolean,
+    agentName?: string,
+  ): Promise<UsageTimeseries> {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly ? sqlHourBucket('at.timestamp') : sqlDateBucket('at.timestamp');
+    const bucketAlias = hourly ? 'hour' : 'date';
+    const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'));
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('at.model', 'model')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
+      .addSelect(sqlCountMessages(), 'messages')
+      .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'cost')
+      .where('at.timestamp >= :cutoff', { cutoff })
+      .andWhere('at.model IS NOT NULL');
+    excludePlaygroundAgents(qb);
+    addTenantFilter(qb, tenantId, agentName);
+    const rows = await qb
+      .groupBy(bucketAlias)
+      .addGroupBy('at.model')
+      .orderBy(bucketAlias, 'ASC')
+      .getRawMany();
+    return pivotUsageRows(rows, bucketAlias, 'model');
+  }
+
   async getAgentNamesByAuthType(authType: string, tenantId: string | null): Promise<string[]> {
     const qb = this.turnRepo
       .createQueryBuilder('at')

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -28,11 +28,14 @@ import {
   getOverview,
   getOverviewAgentUsage,
   getOverviewProviderUsage,
+  getOverviewProviderRequestUsage,
+  getOverviewModelUsage,
+  getOverviewModelRequestUsage,
 } from '../services/api/analytics.js';
 import { getBillingStatus } from '../services/api/billing.js';
 import { formatNumber, formatCost } from '../services/formatters.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
-import { preloadModelDisplayNames } from '../services/model-display.js';
+import { preloadModelDisplayNames, getModelDisplayName } from '../services/model-display.js';
 import { PROVIDERS } from '../services/providers.js';
 import { AGENT_COLORS } from '../components/MultiAgentTokenChart.jsx';
 import InfoTooltip from '../components/InfoTooltip.jsx';
@@ -204,7 +207,7 @@ const GlobalOverview: Component = () => {
   const loadGroup = (): string => {
     try {
       const v = localStorage.getItem(GROUP_STORAGE_KEY);
-      if (v === 'status' || v === 'provider' || v === 'agent') return v;
+      if (v === 'status' || v === 'provider' || v === 'model' || v === 'agent') return v;
     } catch {
       /* ignore */
     }
@@ -385,12 +388,28 @@ const GlobalOverview: Component = () => {
   type UsageTSResult = { tokenUsage: TSResult; messageUsage: TSResult; costUsage: TSResult };
   const usageFetcher = (range: string, group: string): Promise<UsageTSResult> => {
     if (group === 'provider') return getOverviewProviderUsage(range) as Promise<UsageTSResult>;
+    if (group === 'model') return getOverviewModelUsage(range) as Promise<UsageTSResult>;
     return getOverviewAgentUsage(range) as Promise<UsageTSResult>;
   };
 
   const [usageTimeseries] = createResource(
     () => ({ range: effectiveChartRange(), group: groupBy(), _ping: messagePing() }),
     (p) => usageFetcher(p.range, p.group),
+  );
+
+  // Request-level volume for the Requests tab's By provider / By model views
+  // (terminal attribution: one logical request counts once, so these stack to
+  // the Requests KPI total like By request status does).
+  const requestGroupFetcher = (range: string, group: string): Promise<TSResult> => {
+    if (group === 'provider') return getOverviewProviderRequestUsage(range) as Promise<TSResult>;
+    return getOverviewModelRequestUsage(range) as Promise<TSResult>;
+  };
+  const [requestGroupTimeseries] = createResource(
+    () =>
+      groupBy() === 'provider' || groupBy() === 'model'
+        ? { range: effectiveChartRange(), group: groupBy(), _ping: messagePing() }
+        : false,
+    (p) => requestGroupFetcher(p.range, p.group),
   );
 
   // Provider-grouped series key custom providers as 'custom:<uuid>'. Remap
@@ -417,6 +436,7 @@ const GlobalOverview: Component = () => {
   const tokenSeries = createMemo(() => remapCustomSeries(usageTimeseries()?.tokenUsage));
   const messageSeries = createMemo(() => remapCustomSeries(usageTimeseries()?.messageUsage));
   const costSeries = createMemo(() => remapCustomSeries(usageTimeseries()?.costUsage));
+  const requestGroupSeries = createMemo(() => remapCustomSeries(requestGroupTimeseries()));
 
   // ── Harness filter state (sessionStorage) ────────────────────────────
   // Scope the persisted selection by groupBy(): the provider grouping and the
@@ -447,12 +467,17 @@ const GlobalOverview: Component = () => {
     ),
   );
   const allAgents = createMemo(() => {
-    const tokenAgents = tokenSeries()?.agents ?? [];
-    const msgAgents = messageSeries()?.agents ?? [];
-    const costAgents = costSeries()?.agents ?? [];
-    const set = new Set([...tokenAgents, ...msgAgents, ...costAgents]);
+    const set = new Set<string>();
+    for (const s of [tokenSeries(), messageSeries(), costSeries(), requestGroupSeries()]) {
+      for (const a of s?.agents ?? []) set.add(a);
+    }
     return [...set].sort();
   });
+
+  // Model-grouped series carry model slugs; resolve display names for the
+  // filter dropdown so it reads like the Model usage table.
+  const seriesDisplayName = (key: string) =>
+    groupBy() === 'model' ? getModelDisplayName(key) : key;
 
   const agentColorMap = createMemo(() => {
     const map: Record<string, string> = {};
@@ -540,6 +565,22 @@ const GlobalOverview: Component = () => {
     if (sel.size === 0) return raw;
     const filtered_agents = raw.agents.filter((a: string) => sel.has(a));
     const timeseries = raw.timeseries.map((row: Record<string, number | string>) => {
+      const filtered: Record<string, number | string> = {};
+      for (const [k, v] of Object.entries(row)) {
+        if (k === 'hour' || k === 'date' || sel.has(k)) filtered[k] = v;
+      }
+      return filtered;
+    });
+    return { agents: filtered_agents, timeseries };
+  });
+
+  const filteredRequestGroupTimeseries = createMemo(() => {
+    const raw = requestGroupSeries();
+    if (!raw) return undefined;
+    const sel = effectiveSelected();
+    if (sel.size === 0) return raw;
+    const filtered_agents = raw.agents.filter((a) => sel.has(a));
+    const timeseries = raw.timeseries.map((row) => {
       const filtered: Record<string, number | string> = {};
       for (const [k, v] of Object.entries(row)) {
         if (k === 'hour' || k === 'date' || sel.has(k)) filtered[k] = v;
@@ -689,11 +730,17 @@ const GlobalOverview: Component = () => {
         {/* ── 2. Unified Chart Card ─────────────────────────────────── */}
         {(() => {
           const o = () => overview()!;
-          // A request can touch several providers, so the Requests tab only
-          // groups by status or harness; usage tabs (tokens/cost) only group
-          // by provider or harness. One stored groupBy, coerced per tab.
-          const requestsGroup = () => (groupBy() === 'agent' ? 'agent' : 'status');
-          const usageGroup = () => (groupBy() === 'provider' ? 'provider' : 'agent');
+          // Requests groups by status (request grain) or by provider/model
+          // (terminal attribution) or by harness; usage tabs (tokens/cost)
+          // group by provider, model, or harness. One stored groupBy.
+          const requestsGroup = () =>
+            groupBy() === 'provider' || groupBy() === 'model'
+              ? groupBy()
+              : groupBy() === 'agent'
+                ? 'agent'
+                : 'status';
+          const usageGroup = () =>
+            groupBy() === 'provider' || groupBy() === 'model' ? groupBy() : 'agent';
           return (
             <UnifiedChartCard
               activeTab={chartView()}
@@ -723,7 +770,9 @@ const GlobalOverview: Component = () => {
               agentRequestTimeseries={
                 requestsGroup() === 'agent'
                   ? (filteredAgentMessageTimeseries() ?? undefined)
-                  : undefined
+                  : requestsGroup() === 'provider' || requestsGroup() === 'model'
+                    ? (filteredRequestGroupTimeseries() ?? undefined)
+                    : undefined
               }
               agentTimeseries={filteredAgentTimeseries() ?? undefined}
               agentCostTimeseries={filteredAgentCostTimeseries() ?? undefined}
@@ -739,6 +788,22 @@ const GlobalOverview: Component = () => {
                       onClick={() => setGroupBy('status')}
                     >
                       By request status
+                    </button>
+                    <button
+                      class="chart-card__filter-btn"
+                      classList={{
+                        'chart-card__filter-btn--active': requestsGroup() === 'provider',
+                      }}
+                      onClick={() => setGroupBy('provider')}
+                    >
+                      By provider
+                    </button>
+                    <button
+                      class="chart-card__filter-btn"
+                      classList={{ 'chart-card__filter-btn--active': requestsGroup() === 'model' }}
+                      onClick={() => setGroupBy('model')}
+                    >
+                      By model
                     </button>
                     <button
                       class="chart-card__filter-btn"
@@ -760,19 +825,33 @@ const GlobalOverview: Component = () => {
                     </button>
                     <button
                       class="chart-card__filter-btn"
+                      classList={{ 'chart-card__filter-btn--active': usageGroup() === 'model' }}
+                      onClick={() => setGroupBy('model')}
+                    >
+                      By model
+                    </button>
+                    <button
+                      class="chart-card__filter-btn"
                       classList={{ 'chart-card__filter-btn--active': usageGroup() === 'agent' }}
                       onClick={() => setGroupBy('agent')}
                     >
                       By harness
                     </button>
                   </Show>
-                  <Show when={chartView() !== 'requests' || requestsGroup() === 'agent'}>
+                  <Show when={groupBy() !== 'status'}>
                     <div style="min-width: 140px;">
                       <FilterSelect
-                        noun={groupBy() === 'provider' ? 'providers' : 'harnesses'}
+                        noun={
+                          groupBy() === 'provider'
+                            ? 'providers'
+                            : groupBy() === 'model'
+                              ? 'models'
+                              : 'harnesses'
+                        }
                         items={allAgents()}
                         selected={effectiveSelected()}
                         colorMap={agentColorMap()}
+                        displayName={seriesDisplayName}
                         onToggle={toggleAgent}
                         onSelectAll={() => setAllAgents(true)}
                         onUnselectAll={() => setAllAgents(false)}

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -31,8 +31,13 @@ import {
   getPerProviderTimeseries,
   getPerProviderMessageTimeseries,
   getPerProviderCostTimeseries,
+  getPerProviderRequestUsage,
+  getPerModelTimeseries,
+  getPerModelMessageTimeseries,
+  getPerModelCostTimeseries,
+  getPerModelRequestUsage,
 } from '../services/api/analytics.js';
-import { preloadModelDisplayNames } from '../services/model-display.js';
+import { preloadModelDisplayNames, getModelDisplayName } from '../services/model-display.js';
 import { isRecentlyCreated, isSetupPending, clearSetupPending } from '../services/recent-agents.js';
 import { messagePing } from '../services/sse.js';
 import {
@@ -267,6 +272,35 @@ const Overview: Component = () => {
     (p) => getPerProviderCostTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
 
+  // ── Group-by state (status / provider / model) ──────────────────────
+  // A request may touch several providers, so the Requests tab's provider and
+  // model views are request-level (terminal attribution); usage tabs are
+  // served-attempt. One stored groupBy drives both.
+  const [groupBy, setGroupBy] = createSignal<'status' | 'provider' | 'model'>('status');
+  const isGrouped = () => groupBy() !== 'status';
+
+  const [modelTokenTs] = createResource(
+    () => (groupBy() === 'model' && tokenChartRequested() && !billing.loading ? tsKey() : false),
+    (p) => getPerModelTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
+  );
+  const [modelMessageTs] = createResource(
+    () => (groupBy() === 'model' && !billing.loading ? tsKey() : false),
+    (p) => getPerModelMessageTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
+  );
+  const [modelCostTs] = createResource(
+    () => (groupBy() === 'model' && costChartRequested() && !billing.loading ? tsKey() : false),
+    (p) => getPerModelCostTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
+  );
+  // Request-level per-provider / per-model volume (terminal attribution).
+  const [providerRequestTs] = createResource(
+    () => (groupBy() === 'provider' && !billing.loading ? tsKey() : false),
+    (p) => getPerProviderRequestUsage(p.agent, p.range) as Promise<PivotedTimeseries>,
+  );
+  const [modelRequestTs] = createResource(
+    () => (groupBy() === 'model' && !billing.loading ? tsKey() : false),
+    (p) => getPerModelRequestUsage(p.agent, p.range) as Promise<PivotedTimeseries>,
+  );
+
   // ── Auto-fix resources (conditional on tenant cohort) ───────────────
   const [autofixCohort] = createResource(
     () => ({ _ping: messagePing() }),
@@ -324,6 +358,11 @@ const Overview: Component = () => {
       ...(providerTokenTs()?.agents ?? []),
       ...(providerMessageTs()?.agents ?? []),
       ...(providerCostTs()?.agents ?? []),
+      ...(modelTokenTs()?.agents ?? []),
+      ...(modelMessageTs()?.agents ?? []),
+      ...(modelCostTs()?.agents ?? []),
+      ...(providerRequestTs()?.agents ?? []),
+      ...(modelRequestTs()?.agents ?? []),
     ]);
     return [...set].sort();
   });
@@ -372,12 +411,27 @@ const Overview: Component = () => {
       }),
     };
   };
-  const filteredTokenTs = createMemo(() => filterTs(providerTokenTs()));
-  const filteredMessageTs = createMemo(() => filterTs(providerMessageTs()));
-  const filteredCostTs = createMemo(() => filterTs(providerCostTs()));
 
   const providerDisplayName = (provId: string): string =>
     PROVIDERS.find((p) => p.id === provId)?.name ?? provId;
+
+  // The filter dropdown reads provider display names in provider mode and
+  // model display names in model mode.
+  const seriesDisplayName = (key: string): string =>
+    groupBy() === 'model' ? getModelDisplayName(key) : providerDisplayName(key);
+
+  // The chart series for the active grouping: usage tabs read the
+  // served-attempt provider/model series; the Requests tab reads the
+  // request-level provider/model volume.
+  const activeTokenTs = createMemo(() =>
+    filterTs(groupBy() === 'model' ? modelTokenTs() : providerTokenTs()),
+  );
+  const activeCostTs = createMemo(() =>
+    filterTs(groupBy() === 'model' ? modelCostTs() : providerCostTs()),
+  );
+  const activeRequestTs = createMemo(() =>
+    filterTs(groupBy() === 'model' ? modelRequestTs() : providerRequestTs()),
+  );
 
   return (
     <div class="container--lg">
@@ -515,23 +569,59 @@ const Overview: Component = () => {
                         tokensValue={d().summary?.tokens_today?.value ?? 0}
                         tokensTrendPct={d().summary?.tokens_today?.trend_pct ?? 0}
                         range={effectiveRange()}
-                        requestStatusTimeseries={statusTimeseries()}
-                        agentTimeseries={filteredTokenTs() ?? undefined}
-                        agentCostTimeseries={filteredCostTs() ?? undefined}
+                        requestStatusTimeseries={
+                          groupBy() === 'status' ? statusTimeseries() : undefined
+                        }
+                        agentRequestTimeseries={
+                          groupBy() === 'provider' || groupBy() === 'model'
+                            ? (activeRequestTs() ?? undefined)
+                            : undefined
+                        }
+                        agentTimeseries={activeTokenTs() ?? undefined}
+                        agentCostTimeseries={activeCostTs() ?? undefined}
                         colorMap={providerColorMap()}
                         seriesFilters={
-                          <Show when={activeView() !== 'requests' && allProviders().length > 1}>
-                            <FilterSelect
-                              noun="providers"
-                              items={allProviders()}
-                              selected={effectiveSelected()}
-                              colorMap={providerColorMap()}
-                              displayName={providerDisplayName}
-                              onToggle={toggleProvider}
-                              onSelectAll={() => setAllProviders(true)}
-                              onUnselectAll={() => setAllProviders(false)}
-                            />
-                          </Show>
+                          <>
+                            <button
+                              class="chart-card__filter-btn"
+                              classList={{
+                                'chart-card__filter-btn--active': groupBy() === 'status',
+                              }}
+                              onClick={() => setGroupBy('status')}
+                            >
+                              By request status
+                            </button>
+                            <button
+                              class="chart-card__filter-btn"
+                              classList={{
+                                'chart-card__filter-btn--active': groupBy() === 'provider',
+                              }}
+                              onClick={() => setGroupBy('provider')}
+                            >
+                              By provider
+                            </button>
+                            <button
+                              class="chart-card__filter-btn"
+                              classList={{
+                                'chart-card__filter-btn--active': groupBy() === 'model',
+                              }}
+                              onClick={() => setGroupBy('model')}
+                            >
+                              By model
+                            </button>
+                            <Show when={isGrouped() && allProviders().length > 1}>
+                              <FilterSelect
+                                noun={groupBy() === 'model' ? 'models' : 'providers'}
+                                items={allProviders()}
+                                selected={effectiveSelected()}
+                                colorMap={providerColorMap()}
+                                displayName={seriesDisplayName}
+                                onToggle={toggleProvider}
+                                onSelectAll={() => setAllProviders(true)}
+                                onUnselectAll={() => setAllProviders(false)}
+                              />
+                            </Show>
+                          </>
                         }
                       />
                     );

--- a/packages/frontend/src/services/api/analytics.ts
+++ b/packages/frontend/src/services/api/analytics.ts
@@ -203,6 +203,25 @@ export function getOverviewProviderUsage(range = '24h'): UsageTimeseries {
   return fetchJson('/overview/providers/usage', { range }) as UsageTimeseries;
 }
 
+/**
+ * Request-level volume per provider (terminal attribution) for the Requests
+ * chart's By provider view: one logical request counts once, so the view
+ * stacks to the same total as By request status and the Requests KPI.
+ * Distinct from getOverviewProviderUsage (served-attempt tokens/cost).
+ */
+export function getOverviewProviderRequestUsage(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/providers/request-usage', { range }) as PivotedTimeseries;
+}
+
+export function getOverviewModelUsage(range = '24h'): UsageTimeseries {
+  return fetchJson('/overview/models/usage', { range }) as UsageTimeseries;
+}
+
+/** Request-level volume per model (terminal attribution), Requests By model. */
+export function getOverviewModelRequestUsage(range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/models/request-usage', { range }) as PivotedTimeseries;
+}
+
 export function getGlobalPerModelTimeseries(range = '24h'): PivotedTimeseries {
   return fetchJson('/overview/per-model-timeseries', { range }) as PivotedTimeseries;
 }
@@ -234,6 +253,43 @@ export function getPerProviderMessageTimeseries(
 
 export function getPerProviderCostTimeseries(agentName: string, range = '24h'): PivotedTimeseries {
   return fetchJson('/overview/per-provider-cost-timeseries', {
+    agent_name: agentName,
+    range,
+  }) as PivotedTimeseries;
+}
+
+export function getPerModelTimeseries(agentName: string, range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-model-timeseries', {
+    agent_name: agentName,
+    range,
+  }) as PivotedTimeseries;
+}
+
+export function getPerModelMessageTimeseries(agentName: string, range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-model-message-timeseries', {
+    agent_name: agentName,
+    range,
+  }) as PivotedTimeseries;
+}
+
+export function getPerModelCostTimeseries(agentName: string, range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/per-model-cost-timeseries', {
+    agent_name: agentName,
+    range,
+  }) as PivotedTimeseries;
+}
+
+/** Agent-scoped request-level per-provider volume (Requests By provider). */
+export function getPerProviderRequestUsage(agentName: string, range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/providers/request-usage', {
+    agent_name: agentName,
+    range,
+  }) as PivotedTimeseries;
+}
+
+/** Agent-scoped request-level per-model volume (Requests By model). */
+export function getPerModelRequestUsage(agentName: string, range = '24h'): PivotedTimeseries {
+  return fetchJson('/overview/models/request-usage', {
     agent_name: agentName,
     range,
   }) as PivotedTimeseries;

--- a/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
@@ -84,6 +84,14 @@ vi.mock('../../src/services/api/analytics.js', () => ({
   getOverview: (...args: unknown[]) => apiMocks.getOverview(...args),
   getOverviewAgentUsage: (...args: unknown[]) => apiMocks.getOverviewAgentUsage(...args),
   getOverviewProviderUsage: (...args: unknown[]) => apiMocks.getOverviewProviderUsage(...args),
+  getOverviewProviderRequestUsage: () => Promise.resolve({ agents: [], timeseries: [] }),
+  getOverviewModelUsage: () =>
+    Promise.resolve({
+      tokenUsage: { agents: [], timeseries: [] },
+      messageUsage: { agents: [], timeseries: [] },
+      costUsage: { agents: [], timeseries: [] },
+    }),
+  getOverviewModelRequestUsage: () => Promise.resolve({ agents: [], timeseries: [] }),
   getAttemptStats: () =>
     Promise.resolve({
       total_attempts: { value: 20, previous: 10 },

--- a/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
@@ -16,6 +16,9 @@ const apiMocks = vi.hoisted(() => ({
   getOverview: vi.fn(),
   getOverviewAgentUsage: vi.fn(),
   getOverviewProviderUsage: vi.fn(),
+  getOverviewProviderRequestUsage: vi.fn(),
+  getOverviewModelUsage: vi.fn(),
+  getOverviewModelRequestUsage: vi.fn(),
   getBillingStatus: vi.fn(),
 }));
 
@@ -27,9 +30,11 @@ const sseMocks = vi.hoisted(() => ({
 }));
 
 let filterSelectProps: {
+  noun: string;
   onUnselectAll: () => void;
   onSelectAll: () => void;
   items: string[];
+  displayName?: (item: string) => string;
 } | null = null;
 let providerChartProps: Record<string, unknown> | null = null;
 let mockSearchParams: Record<string, string | undefined> = {};
@@ -84,14 +89,11 @@ vi.mock('../../src/services/api/analytics.js', () => ({
   getOverview: (...args: unknown[]) => apiMocks.getOverview(...args),
   getOverviewAgentUsage: (...args: unknown[]) => apiMocks.getOverviewAgentUsage(...args),
   getOverviewProviderUsage: (...args: unknown[]) => apiMocks.getOverviewProviderUsage(...args),
-  getOverviewProviderRequestUsage: () => Promise.resolve({ agents: [], timeseries: [] }),
-  getOverviewModelUsage: () =>
-    Promise.resolve({
-      tokenUsage: { agents: [], timeseries: [] },
-      messageUsage: { agents: [], timeseries: [] },
-      costUsage: { agents: [], timeseries: [] },
-    }),
-  getOverviewModelRequestUsage: () => Promise.resolve({ agents: [], timeseries: [] }),
+  getOverviewProviderRequestUsage: (...args: unknown[]) =>
+    apiMocks.getOverviewProviderRequestUsage(...args),
+  getOverviewModelUsage: (...args: unknown[]) => apiMocks.getOverviewModelUsage(...args),
+  getOverviewModelRequestUsage: (...args: unknown[]) =>
+    apiMocks.getOverviewModelRequestUsage(...args),
   getAttemptStats: () =>
     Promise.resolve({
       total_attempts: { value: 20, previous: 10 },
@@ -176,14 +178,17 @@ vi.mock('../../src/components/Select.jsx', () => ({
 // Stub FilterSelect to surface the otherwise-unreachable onUnselectAll handler.
 vi.mock('../../src/components/FilterSelect.jsx', () => ({
   default: (props: {
+    noun: string;
     items: string[];
     onUnselectAll: () => void;
     onSelectAll: () => void;
     onToggle: (item: string) => void;
+    displayName?: (item: string) => string;
   }) => {
     filterSelectProps = props;
     return (
       <div data-testid="filter-select">
+        <span data-testid="filter-noun">{props.noun}</span>
         <span data-testid="filter-item-count">{props.items.length}</span>
         <button data-testid="filter-unselect-all" onClick={() => props.onUnselectAll()}>
           Unselect all
@@ -338,6 +343,15 @@ beforeEach(() => {
   apiMocks.getOverview.mockResolvedValue(overviewResponse);
   apiMocks.getOverviewAgentUsage.mockResolvedValue(providerUsageTimeseries);
   apiMocks.getOverviewProviderUsage.mockResolvedValue(providerUsageTimeseries);
+  apiMocks.getOverviewProviderRequestUsage.mockResolvedValue({
+    agents: ['openai', 'anthropic'],
+    timeseries: [{ hour: '2026-06-04 10:00:00', openai: 10, anthropic: 8 }],
+  });
+  apiMocks.getOverviewModelUsage.mockResolvedValue(providerUsageTimeseries);
+  apiMocks.getOverviewModelRequestUsage.mockResolvedValue({
+    agents: ['gpt-4o', 'claude-3.5-sonnet'],
+    timeseries: [{ hour: '2026-06-04 10:00:00', 'gpt-4o': 10, 'claude-3.5-sonnet': 8 }],
+  });
   apiMocks.getBillingStatus.mockResolvedValue({
     enabled: false,
     plan: 'free',
@@ -438,5 +452,56 @@ describe('GlobalOverview filter onUnselectAll', () => {
     } finally {
       replaceState.mockRestore();
     }
+  });
+
+  it('fires the request-level provider fetcher when By provider is active on mount', async () => {
+    render(() => <GlobalOverview />);
+    await waitFor(() => expect(apiMocks.getOverviewProviderRequestUsage).toHaveBeenCalled());
+  });
+
+  it('switches the Requests tab to By model and fires getOverviewModelRequestUsage', async () => {
+    const { container } = render(() => <GlobalOverview />);
+    await waitFor(() => expect(apiMocks.getOverviewProviderRequestUsage).toHaveBeenCalled());
+
+    const groupBtn = (label: string) =>
+      [...container.querySelectorAll('.chart-card__filter-btn')].find(
+        (b) => b.textContent === label,
+      ) as HTMLButtonElement | undefined;
+
+    // Wait for the chart-card filter buttons to render.
+    await waitFor(() => expect(groupBtn('By model')).toBeDefined());
+
+    fireEvent.click(groupBtn('By model')!);
+
+    await waitFor(() => expect(apiMocks.getOverviewModelRequestUsage).toHaveBeenCalled());
+    expect(apiMocks.getOverviewModelRequestUsage.mock.calls[0]![0]).toBe('7d');
+  });
+
+  it('fires getOverviewModelUsage for the Tokens tab under By model', async () => {
+    const { container } = render(() => <GlobalOverview />);
+    await waitFor(() => expect(container.querySelector('.chart-card')).not.toBeNull());
+
+    const groupBtn = (label: string) =>
+      [...container.querySelectorAll('.chart-card__filter-btn')].find(
+        (b) => b.textContent === label,
+      ) as HTMLButtonElement | undefined;
+
+    fireEvent.click(groupBtn('By model')!);
+    // The usage resource refetches on groupBy change; model usage fires
+    // regardless of which stat tab is active.
+    await waitFor(() => expect(apiMocks.getOverviewModelUsage).toHaveBeenCalled());
+  });
+
+  it('uses the "models" noun for FilterSelect when grouped By model', async () => {
+    const { container } = render(() => <GlobalOverview />);
+    await waitFor(() => expect(container.querySelector('.chart-card')).not.toBeNull());
+
+    const groupBtn = (label: string) =>
+      [...container.querySelectorAll('.chart-card__filter-btn')].find(
+        (b) => b.textContent === label,
+      ) as HTMLButtonElement | undefined;
+
+    fireEvent.click(groupBtn('By model')!);
+    await waitFor(() => expect(filterSelectProps?.noun).toBe('models'));
   });
 });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -74,6 +74,11 @@ const mockPerProvider = vi.fn(() => Promise.resolve({ agents: [], timeseries: []
 const mockPerProviderTokens = vi.fn((...a: unknown[]) => mockPerProvider(...a));
 const mockPerProviderMessages = vi.fn((...a: unknown[]) => mockPerProvider(...a));
 const mockPerProviderCosts = vi.fn((...a: unknown[]) => mockPerProvider(...a));
+const mockPerModelTokens = vi.fn((...a: unknown[]) => mockPerProvider(...a));
+const mockPerModelMessages = vi.fn((...a: unknown[]) => mockPerProvider(...a));
+const mockPerModelCosts = vi.fn((...a: unknown[]) => mockPerProvider(...a));
+const mockPerProviderRequests = vi.fn((...a: unknown[]) => mockPerProvider(...a));
+const mockPerModelRequests = vi.fn((...a: unknown[]) => mockPerProvider(...a));
 const mockGetAutofixStats = vi.fn();
 let mockAutofixEligible = false;
 vi.mock('../../src/services/api/analytics.js', () => ({
@@ -99,6 +104,11 @@ vi.mock('../../src/services/api/analytics.js', () => ({
   getPerProviderTimeseries: (...a: unknown[]) => mockPerProviderTokens(...a),
   getPerProviderMessageTimeseries: (...a: unknown[]) => mockPerProviderMessages(...a),
   getPerProviderCostTimeseries: (...a: unknown[]) => mockPerProviderCosts(...a),
+  getPerModelTimeseries: (...a: unknown[]) => mockPerModelTokens(...a),
+  getPerModelMessageTimeseries: (...a: unknown[]) => mockPerModelMessages(...a),
+  getPerModelCostTimeseries: (...a: unknown[]) => mockPerModelCosts(...a),
+  getPerProviderRequestUsage: (...a: unknown[]) => mockPerProviderRequests(...a),
+  getPerModelRequestUsage: (...a: unknown[]) => mockPerModelRequests(...a),
   getAttemptStats: () =>
     Promise.resolve({
       total_attempts: { value: 50, previous: 40 },
@@ -505,6 +515,36 @@ describe('Overview', () => {
     expect(mockPerProviderMessages).toHaveBeenCalledTimes(1);
     expect(mockPerProviderTokens).not.toHaveBeenCalled();
     expect(mockPerProviderCosts).not.toHaveBeenCalled();
+  });
+
+  it('fetches request-level provider and model volume when those groupings are chosen', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['openai'],
+      timeseries: [{ hour: '1', openai: 5 }],
+    });
+    const { container } = render(() => <Overview />);
+
+    await vi.waitFor(() => {
+      expect(mockPerProviderMessages).toHaveBeenCalledTimes(1);
+    });
+    expect(mockPerProviderRequests).not.toHaveBeenCalled();
+    expect(mockPerModelRequests).not.toHaveBeenCalled();
+
+    const groupBtn = (label: string) =>
+      [...container.querySelectorAll('.chart-card__filter-btn')].find(
+        (b) => b.textContent === label,
+      ) as HTMLButtonElement;
+
+    fireEvent.click(groupBtn('By provider'));
+    await vi.waitFor(() => {
+      expect(mockPerProviderRequests).toHaveBeenCalledWith('test-agent', '30d');
+    });
+
+    fireEvent.click(groupBtn('By model'));
+    await vi.waitFor(() => {
+      expect(mockPerModelRequests).toHaveBeenCalledWith('test-agent', '30d');
+    });
   });
 
   it('fetches token and cost provider series when those chart views are opened', async () => {

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -547,6 +547,124 @@ describe('Overview', () => {
     });
   });
 
+  it('fires the model token-series fetcher when By model is chosen on the Tokens tab', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['openai', 'anthropic'],
+      timeseries: [{ hour: '1', openai: 5, anthropic: 3 }],
+    });
+    const { container } = render(() => <Overview />);
+
+    await vi.waitFor(() => {
+      expect(mockPerProviderMessages).toHaveBeenCalledTimes(1);
+    });
+
+    const groupBtn = (label: string) =>
+      [...container.querySelectorAll('.chart-card__filter-btn')].find(
+        (b) => b.textContent === label,
+      ) as HTMLButtonElement;
+
+    fireEvent.click(groupBtn('By model'));
+    // Open the Token usage tab so tokenChartRequested() flips true.
+    const tokenStat = [...container.querySelectorAll('.chart-card__stat--clickable')].find((s) =>
+      s.textContent?.includes('Token usage'),
+    ) as HTMLButtonElement;
+    fireEvent.click(tokenStat);
+
+    await vi.waitFor(() => {
+      expect(mockPerModelTokens).toHaveBeenCalledWith('test-agent', '30d');
+    });
+  });
+
+  it('fires the model cost-series fetcher when By model is chosen on the Cost tab', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['openai', 'anthropic'],
+      timeseries: [{ hour: '1', openai: 5, anthropic: 3 }],
+    });
+    const { container } = render(() => <Overview />);
+
+    await vi.waitFor(() => {
+      expect(mockPerProviderMessages).toHaveBeenCalledTimes(1);
+    });
+
+    const groupBtn = (label: string) =>
+      [...container.querySelectorAll('.chart-card__filter-btn')].find(
+        (b) => b.textContent === label,
+      ) as HTMLButtonElement;
+
+    fireEvent.click(groupBtn('By model'));
+    const costStat = [...container.querySelectorAll('.chart-card__stat--clickable')].find((s) =>
+      s.textContent?.includes('Cost'),
+    ) as HTMLButtonElement;
+    fireEvent.click(costStat);
+
+    await vi.waitFor(() => {
+      expect(mockPerModelCosts).toHaveBeenCalledWith('test-agent', '30d');
+    });
+  });
+
+  it('labels the FilterSelect with "models" noun when grouped By model', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    mockPerProvider.mockResolvedValue({
+      agents: ['openai', 'anthropic'],
+      timeseries: [{ hour: '1', openai: 5, anthropic: 3 }],
+    });
+    const { container } = render(() => <Overview />);
+
+    await vi.waitFor(() => {
+      expect(mockPerProviderMessages).toHaveBeenCalledTimes(1);
+    });
+
+    const groupBtn = (label: string) =>
+      [...container.querySelectorAll('.chart-card__filter-btn')].find(
+        (b) => b.textContent === label,
+      ) as HTMLButtonElement;
+
+    fireEvent.click(groupBtn('By model'));
+
+    // The real FilterSelect renders a trigger label containing the noun.
+    await vi.waitFor(() => {
+      const trigger = container.querySelector('.agent-filter-select__trigger');
+      expect(trigger).not.toBeNull();
+      expect(trigger!.textContent).toContain('models');
+    });
+  });
+
+  it('resolves model display names via getModelDisplayName in model mode', async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    // Two model series so FilterSelect renders and displayName is exercised.
+    mockPerProvider.mockResolvedValue({
+      agents: ['gpt-4o', 'claude-3.5-sonnet'],
+      timeseries: [{ hour: '1', 'gpt-4o': 5, 'claude-3.5-sonnet': 3 }],
+    });
+    const { container } = render(() => <Overview />);
+
+    await vi.waitFor(() => {
+      expect(mockPerProviderMessages).toHaveBeenCalledTimes(1);
+    });
+
+    const groupBtn = (label: string) =>
+      [...container.querySelectorAll('.chart-card__filter-btn')].find(
+        (b) => b.textContent === label,
+      ) as HTMLButtonElement;
+
+    fireEvent.click(groupBtn('By model'));
+
+    // Wait for FilterSelect to render, then open its dropdown to read item names.
+    await vi.waitFor(() => {
+      expect(container.querySelector('.agent-filter-select__trigger')).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector('.agent-filter-select__trigger')!);
+
+    await vi.waitFor(() => {
+      const names = container.querySelectorAll('.agent-filter-select__name');
+      expect(names.length).toBeGreaterThanOrEqual(2);
+      expect([...names].some((n) => n.textContent === 'gpt-4o')).toBe(true);
+      expect([...names].some((n) => n.textContent === 'claude-3.5-sonnet')).toBe(true);
+    });
+  });
+
   it('fetches token and cost provider series when those chart views are opened', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     mockPerProvider.mockResolvedValue({

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -21,6 +21,9 @@ const apiMocks = vi.hoisted(() => ({
   getOverview: vi.fn(),
   getOverviewAgentUsage: vi.fn(),
   getOverviewProviderUsage: vi.fn(),
+  getOverviewProviderRequestUsage: vi.fn(),
+  getOverviewModelUsage: vi.fn(),
+  getOverviewModelRequestUsage: vi.fn(),
   getBillingStatus: vi.fn(),
   getConnectionDetail: vi.fn(),
   getProviderAnalytics: vi.fn(),
@@ -101,6 +104,11 @@ vi.mock('../../src/services/api/analytics.js', () => ({
   getOverview: (...args: unknown[]) => apiMocks.getOverview(...args),
   getOverviewAgentUsage: (...args: unknown[]) => apiMocks.getOverviewAgentUsage(...args),
   getOverviewProviderUsage: (...args: unknown[]) => apiMocks.getOverviewProviderUsage(...args),
+  getOverviewProviderRequestUsage: (...args: unknown[]) =>
+    apiMocks.getOverviewProviderRequestUsage(...args),
+  getOverviewModelUsage: (...args: unknown[]) => apiMocks.getOverviewModelUsage(...args),
+  getOverviewModelRequestUsage: (...args: unknown[]) =>
+    apiMocks.getOverviewModelRequestUsage(...args),
   getConnectionDetail: (...args: unknown[]) => apiMocks.getConnectionDetail(...args),
   getProviderAnalytics: (...args: unknown[]) => apiMocks.getProviderAnalytics(...args),
   getPerAgentTimeseries: (...args: unknown[]) => apiMocks.getPerAgentTimeseries(...args),
@@ -638,6 +646,17 @@ const providerUsageTimeseries = {
   costUsage: providerTimeseries,
 };
 
+const modelTimeseries = {
+  agents: ['gpt-5'],
+  timeseries: [{ hour: '2026-06-04 10:00:00', 'gpt-5': 1200 }],
+};
+
+const modelUsageTimeseries = {
+  tokenUsage: modelTimeseries,
+  messageUsage: modelTimeseries,
+  costUsage: modelTimeseries,
+};
+
 const connectionDetail = {
   connection: {
     id: 'conn-openai',
@@ -748,6 +767,9 @@ beforeEach(() => {
   apiMocks.getOverview.mockResolvedValue(overviewResponse);
   apiMocks.getOverviewAgentUsage.mockResolvedValue(agentUsageTimeseries);
   apiMocks.getOverviewProviderUsage.mockResolvedValue(providerUsageTimeseries);
+  apiMocks.getOverviewProviderRequestUsage.mockResolvedValue(providerTimeseries);
+  apiMocks.getOverviewModelUsage.mockResolvedValue(modelUsageTimeseries);
+  apiMocks.getOverviewModelRequestUsage.mockResolvedValue(modelTimeseries);
   apiMocks.getBillingStatus.mockResolvedValue({
     enabled: false,
     plan: 'free',

--- a/packages/frontend/tests/services/api/analytics.test.ts
+++ b/packages/frontend/tests/services/api/analytics.test.ts
@@ -224,9 +224,12 @@ describe('analytics API client', () => {
       [analytics.getGlobalPerProviderMessageTimeseries, 'per-provider-message-timeseries'],
       [analytics.getGlobalPerProviderCostTimeseries, 'per-provider-cost-timeseries'],
       [analytics.getOverviewProviderUsage, 'providers/usage'],
+      [analytics.getOverviewProviderRequestUsage, 'providers/request-usage'],
       [analytics.getGlobalPerModelTimeseries, 'per-model-timeseries'],
       [analytics.getGlobalPerModelMessageTimeseries, 'per-model-message-timeseries'],
       [analytics.getGlobalPerModelCostTimeseries, 'per-model-cost-timeseries'],
+      [analytics.getOverviewModelUsage, 'models/usage'],
+      [analytics.getOverviewModelRequestUsage, 'models/request-usage'],
     ];
     for (const [fn, path] of fns) {
       const fetchMock = setupFetch({ agents: [], timeseries: [] });
@@ -242,6 +245,11 @@ describe('analytics API client', () => {
       [analytics.getPerProviderTimeseries, 'per-provider-timeseries'],
       [analytics.getPerProviderMessageTimeseries, 'per-provider-message-timeseries'],
       [analytics.getPerProviderCostTimeseries, 'per-provider-cost-timeseries'],
+      [analytics.getPerModelTimeseries, 'per-model-timeseries'],
+      [analytics.getPerModelMessageTimeseries, 'per-model-message-timeseries'],
+      [analytics.getPerModelCostTimeseries, 'per-model-cost-timeseries'],
+      [analytics.getPerProviderRequestUsage, 'providers/request-usage'],
+      [analytics.getPerModelRequestUsage, 'models/request-usage'],
     ];
     for (const [fn, path] of fns) {
       const fetchMock = setupFetch({ agents: [], timeseries: [] });


### PR DESCRIPTION
## Summary

Adds series grouping to dashboard overview charts on both the global overview and per-harness overview pages. The **Requests** tab gains "By provider" and "By model" groupings alongside "By request status". The **Cost** and **Tokens** tabs gain "By model" alongside "By provider".

## Implementation

- **Requests grouping** — uses new request-level endpoints backed by `RequestVolumeService.getVolumeByDimensionTimeseries` with terminal-attempt attribution. Per-provider and per-model request stacks now reconcile with the Requests KPI counter.
- **Usage grouping** — reuses the existing served-attempt pivots and adds a combined model usage timeseries.

## Screenshots
<img width="1481" height="584" alt="image" src="https://github.com/user-attachments/assets/f5743aeb-28b5-4aef-ab30-95f6cbd73dac" />
<img width="1471" height="566" alt="image" src="https://github.com/user-attachments/assets/2bdc8421-4995-49f3-adef-f9df6fffc40b" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “By provider” and “By model” groupings to the Overview charts on both the global and per-harness dashboards. Requests stacks now use request-level terminal attribution so totals match the Requests KPI.

- New Features
  - Requests: provider/model stacks use `RequestVolumeService.getVolumeByDimensionTimeseries` (terminal-attempt) for KPI-aligned totals.
  - Usage: added per-model grouping for Tokens and Cost via a single `getModelUsageTimeseries` query (tokens/messages/cost).
  - Endpoints: `'/overview/providers/request-usage'`, `'/overview/models/request-usage'`, `'/overview/models/usage'`; wired in the `analytics` client and UI (grouping buttons, persisted selection, model/provider display names).
  - Tests: frontend tests for global and per-harness dashboards verify request-level fetchers on “By provider”/“By model”, model usage fetchers on Tokens/Cost tabs, and FilterSelect shows the “models” noun and model names.

<sup>Written for commit 8043055eae14ef98e36944f9268e123eca85bbfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



