### PR TITLE
fix: correct n8n node codex metadata

### DIFF
--- a/integrations/n8n-nodes-manifest/CHANGELOG.md
+++ b/integrations/n8n-nodes-manifest/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.4
+
+- Correct the node codex identifier and category for n8n verification.
+- Remove unsupported node codex metadata.
+
 ## 0.1.3
 
 - Respect the response mode configured by Manifest routing.

--- a/integrations/n8n-nodes-manifest/dist/nodes/Manifest/Manifest.node.json
+++ b/integrations/n8n-nodes-manifest/dist/nodes/Manifest/Manifest.node.json
@@ -1,11 +1,8 @@
 {
-    "node": "n8n-nodes-manifest",
+    "node": "n8n-nodes-manifest.manifest",
     "nodeVersion": "1.0",
     "codexVersion": "1.0",
-    "categories": ["Core Nodes"],
-    "subcategories": {
-        "Core Nodes": ["Helpers"]
-    },
+    "categories": ["Development"],
     "resources": {
         "credentialDocumentation": [
             {

--- a/integrations/n8n-nodes-manifest/dist/package.json
+++ b/integrations/n8n-nodes-manifest/dist/package.json
@@ -1,6 +1,6 @@
 {
     "name": "n8n-nodes-manifest",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Use Manifest's OpenAI-compatible model router from n8n workflows.",
     "license": "MIT",
     "homepage": "https://manifest.build",

--- a/integrations/n8n-nodes-manifest/nodes/Manifest/Manifest.node.json
+++ b/integrations/n8n-nodes-manifest/nodes/Manifest/Manifest.node.json
@@ -1,11 +1,8 @@
 {
-	"node": "n8n-nodes-manifest",
+	"node": "n8n-nodes-manifest.manifest",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
-	"categories": ["Core Nodes"],
-	"subcategories": {
-		"Core Nodes": ["Helpers"]
-	},
+	"categories": ["Development"],
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/integrations/n8n-nodes-manifest/package-lock.json
+++ b/integrations/n8n-nodes-manifest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-manifest",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-manifest",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@n8n/node-cli": "^0.38.7",

--- a/integrations/n8n-nodes-manifest/package.json
+++ b/integrations/n8n-nodes-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-manifest",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Use Manifest's OpenAI-compatible model router from n8n workflows.",
   "license": "MIT",
   "homepage": "https://manifest.build",

--- a/integrations/n8n-nodes-manifest/test/manifest-node.test.js
+++ b/integrations/n8n-nodes-manifest/test/manifest-node.test.js
@@ -1,4 +1,6 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const {
@@ -7,6 +9,31 @@ const {
 	parseServerSentEvents,
 	withoutRouteManagedStream,
 } = require('../dist/nodes/Manifest/Manifest.node.js');
+
+test('keeps codex metadata valid in package and repository files', () => {
+	const expectedNode = `${require('../package.json').name}.${new Manifest().description.name}`;
+	const allowedFields = new Set([
+		'alias',
+		'categories',
+		'codexVersion',
+		'node',
+		'nodeVersion',
+		'resources',
+	]);
+	const codexFiles = [
+		'../nodes/Manifest/Manifest.node.json',
+		'../dist/nodes/Manifest/Manifest.node.json',
+		'../../../nodes/Manifest/Manifest.node.json',
+	];
+
+	for (const relativePath of codexFiles) {
+		const codex = JSON.parse(fs.readFileSync(path.join(__dirname, relativePath), 'utf8'));
+
+		assert.equal(codex.node, expectedNode);
+		assert.deepEqual(codex.categories, ['Development']);
+		assert.ok(Object.keys(codex).every((field) => allowedFields.has(field)));
+	}
+});
 
 function executionContext(parameters, response, requests) {
 	return {

--- a/nodes/Manifest/Manifest.node.json
+++ b/nodes/Manifest/Manifest.node.json
@@ -1,11 +1,8 @@
 {
-	"node": "n8n-nodes-manifest",
+	"node": "n8n-nodes-manifest.manifest",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
-	"categories": ["Core Nodes"],
-	"subcategories": {
-		"Core Nodes": ["Helpers"]
-	},
+	"categories": ["Development"],
 	"resources": {
 		"credentialDocumentation": [
 			{


### PR DESCRIPTION
### ✨ What changed
- use the fully qualified Manifest node identifier
- move the node to the Development category
- remove unsupported codex metadata and add regression coverage
- prepare n8n-nodes-manifest 0.1.4

### 💭 Why
n8n's Creator Portal review blocks approval on the current codex metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes n8n codex metadata for the Manifest node to meet Creator Portal requirements and unblock verification. Uses the fully qualified node ID and correct category, with regression coverage added.

- **Bug Fixes**
  - Set `node` to `n8n-nodes-manifest.manifest`, move category to "Development", and remove unsupported `subcategories`.
  - Add a test that enforces allowed codex fields and expected node ID across `nodes/`, `dist/`, and repo files.
  - Bump `n8n-nodes-manifest` to `0.1.4` and update the changelog.

<sup>Written for commit e332e0e98d49a5a15adf52df73810d338cb46bad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

