### PR TITLE
Fix request drawer when no provider attempts

### DIFF
--- a/.changeset/895be6f75eea.md
+++ b/.changeset/895be6f75eea.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Clean up request drawer when no provider attempts: hide the sidebar, show "-" for blank provider/model fields in attempt details, and show "No provider" in the attempt list.

--- a/packages/frontend/src/components/RequestDrawer.tsx
+++ b/packages/frontend/src/components/RequestDrawer.tsx
@@ -314,13 +314,10 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
 
               {/* ── Body: sidebar + content ── */}
               <div class="drawer__split">
-                {/* Attempts sidebar */}
-                <div class="drawer__sidebar">
-                  <div class="drawer__sidebar-title">Attempts</div>
-                  <Show
-                    when={attempts().length > 0}
-                    fallback={<div class="drawer__empty">No provider attempts</div>}
-                  >
+                {/* Attempts sidebar — hidden when no attempts */}
+                <Show when={attempts().length > 0}>
+                  <div class="drawer__sidebar">
+                    <div class="drawer__sidebar-title">Attempts</div>
                     <For each={attempts()}>
                       {(att, idx) => (
                         <button
@@ -355,7 +352,7 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
                               </svg>
                             )}
                           </span>
-                          <span class="attempt-item__model">{att.model}</span>
+                          <span class="attempt-item__model">{att.model ?? 'No provider'}</span>
                           <span
                             class={`attempt-code ${isSuccessStatus(att.status) ? 'attempt-code--ok' : 'attempt-code--error'}`}
                           >
@@ -364,8 +361,8 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
                         </button>
                       )}
                     </For>
-                  </Show>
-                </div>
+                  </div>
+                </Show>
 
                 {/* Attempt content */}
                 <div class="drawer__content">
@@ -418,7 +415,7 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
                                 <span class="drawer-kv__key">Provider</span>
                                 <span style="display: inline-flex; align-items: center; gap: 6px;">
                                   {providerIcon(att().provider, 14)}
-                                  {att().provider}
+                                  {att().provider ?? '-'}
                                 </span>
                               </div>
                               <Show when={att().auth_type}>
@@ -429,7 +426,7 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
                               </Show>
                               <div class="drawer-kv">
                                 <span class="drawer-kv__key">Model</span>
-                                <span>{att().model}</span>
+                                <span>{att().model ?? '-'}</span>
                               </div>
                               <Show when={att().model_id && att().model_id !== att().model}>
                                 <div class="drawer-kv">

--- a/packages/frontend/tests/components/RequestDrawer.test.tsx
+++ b/packages/frontend/tests/components/RequestDrawer.test.tsx
@@ -209,11 +209,13 @@ describe('RequestDrawer', () => {
       <RequestDrawer messageId="zero-attempt" onClose={vi.fn()} />
     ));
 
-    await waitFor(() => expect(screen.getByText('No provider attempts')).toBeDefined());
+    await waitFor(() =>
+      expect(
+        screen.getByText('Manifest rejected this request before contacting a provider.'),
+      ).toBeDefined(),
+    );
     expect(container.querySelector('.attempt-item')).toBeNull();
-    expect(
-      screen.getByText('Manifest rejected this request before contacting a provider.'),
-    ).toBeDefined();
+    expect(container.querySelector('.drawer__sidebar')).toBeNull();
   });
 
   it('shows loading state while an open request is unresolved and stays closed for null', () => {


### PR DESCRIPTION
✨ What changed
- The attempts sidebar is now hidden entirely when a request has no provider attempts
- Provider and Model fields in attempt details show "-" instead of blank
- The attempt list shows "No provider" instead of blank when the model is unknown

💭 Why
When Manifest rejects a request before reaching any provider (bad model name, no providers configured, missing messages array, etc.) the drawer showed an empty sidebar next to the rejection message. The two-column layout with a near-empty left panel looked broken.

👤 For users
Opening a failed request with no provider attempts now shows only the rejection message, full-width, with no empty sidebar alongside it.

🔧 For operators
No operator impact.

🧪 How to test
1. Send a request to Manifest with an invalid model name (anything that is not `auto` or a known model)
2. Open the Requests log and click the failed row
3. The drawer should show only the rejection message, no sidebar
4. For a request that did reach a provider but had no provider set: open it and check Provider and Model rows show "-"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the empty sidebar in the request drawer when a request never reached a provider, and clarifies missing Provider/Model values for better readability.

- **Bug Fixes**
  - Hide the attempts sidebar when there are no provider attempts; rejection message is full-width.
  - Show "-" for Provider and Model in attempt details when absent.
  - Display "No provider" in the attempt list when the model is unknown.

<sup>Written for commit f1e0dc78fd5e978d310b8ddafdf462fbf2853d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

