### PR TITLE
fix: capture provider wire exchanges

### DIFF
--- a/.changeset/capture-provider-wire-exchanges.md
+++ b/.changeset/capture-provider-wire-exchanges.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Report provider-native failed request parameters and response bodies directly to Phoenix diagnostics.

--- a/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
@@ -526,6 +526,70 @@ describe('AutofixService', () => {
   // maybeHeal — happy heal on the single attempt
   // -------------------------------------------------------------------------
   describe('maybeHeal happy path', () => {
+    it('sends the provider exchange to Phoenix and preserves provider response headers', async () => {
+      const client = makeHealingClient();
+      client.heal.mockResolvedValue({ status: 'no_patch', issueId: 'issue-wire' });
+      const forward = {
+        ...makeForward('{"error":{"message":"invalid thinking"}}', 400),
+        response: new Response('{"error":{"message":"invalid thinking"}}', {
+          status: 400,
+          headers: { 'x-provider-request-id': 'provider-request-1' },
+        }),
+        wireFormat: 'anthropic_messages' as const,
+        wireRequestUrl: 'https://api.anthropic.com/v1/messages?key=provider-secret',
+      };
+      const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
+      const service = makeService({ client: client as unknown as HealingClient, repo });
+
+      const result = await service.maybeHeal(makeParams({ forward }));
+
+      expect(client.heal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerExchange: {
+            format: 'anthropic_messages',
+            url: 'https://api.anthropic.com/v1/messages?key=%5BREDACTED%5D',
+            request: {
+              body: { model: 'gpt', max_tokens: 100 },
+              redactedFields: [],
+            },
+            response: {
+              statusCode: 400,
+              body: { error: { message: 'invalid thinking' } },
+            },
+          },
+        }),
+      );
+      expect(result!.forward.response.headers.get('x-provider-request-id')).toBe(
+        'provider-request-1',
+      );
+    });
+
+    it('keeps a plain-text provider response and omits an absent provider URL', async () => {
+      const client = makeHealingClient();
+      client.heal.mockResolvedValue({ status: 'no_patch', issueId: 'issue-wire-text' });
+      const forward = {
+        ...makeForward('invalid thinking', 400),
+        wireFormat: 'anthropic_messages' as const,
+      };
+      const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
+      const service = makeService({ client: client as unknown as HealingClient, repo });
+
+      await service.maybeHeal(makeParams({ forward }));
+
+      expect(client.heal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerExchange: {
+            format: 'anthropic_messages',
+            request: {
+              body: { model: 'gpt', max_tokens: 100 },
+              redactedFields: [],
+            },
+            response: { statusCode: 400, body: 'invalid thinking' },
+          },
+        }),
+      );
+    });
+
     it('heals on the patched retry, reports the cleared retry, and records the chain', async () => {
       const client = makeHealingClient();
       const heal = patchedHeal();

--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -11,6 +11,8 @@ import type { ProxyApiMode } from '../proxy/proxy-types';
 import type { AuthType } from 'manifest-shared';
 import { HEALING_CLIENT, HealContractError, type HealingClient } from './healing-client';
 import { normalizeProviderError } from './provider-error-normalizer';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
+import { scrubProviderUrl } from './observation-payload';
 import type { AutofixChainEntry, AutofixRecord } from './autofix.types';
 import type { HealOutcome, HealResponse } from './phoenix.types';
 
@@ -83,6 +85,15 @@ function headersToObject(headers: Headers): Record<string, string> {
     out[key] = value;
   });
   return out;
+}
+
+function parseProviderBody(raw: string): unknown {
+  const scrubbed = scrubSecrets(raw);
+  try {
+    return JSON.parse(scrubbed) as unknown;
+  } catch {
+    return scrubbed;
+  }
 }
 
 function rebuildForward(base: ForwardResult, body: string, status: number): ForwardResult {
@@ -369,6 +380,21 @@ export class AutofixService {
         url: params.url,
         request: params.requestBody,
         response: { statusCode: status, error: normalized },
+        ...(originalForward.wireFormat
+          ? {
+              providerExchange: {
+                format: originalForward.wireFormat,
+                ...(originalForward.wireRequestUrl
+                  ? { url: scrubProviderUrl(originalForward.wireRequestUrl) }
+                  : {}),
+                request: { body: params.requestBody, redactedFields: [] },
+                response: {
+                  statusCode: status,
+                  body: parseProviderBody(originalText),
+                },
+              },
+            }
+          : {}),
       });
     } catch (err) {
       if (err instanceof HealContractError) {

--- a/packages/backend/src/routing/autofix/contract/phoenix-openapi.yaml
+++ b/packages/backend/src/routing/autofix/contract/phoenix-openapi.yaml
@@ -343,6 +343,32 @@ components:
           properties:
             statusCode: { type: integer, example: 400 }
             error: { $ref: '#/components/schemas/ProviderError' }
+        providerExchange:
+          type: object
+          description: Final provider-native transport exchange, separate from the patch input.
+          required: [format, request, response]
+          properties:
+            format:
+              type: string
+              enum:
+                - openai_chat_completions
+                - openai_responses
+                - anthropic_messages
+                - google_generate_content
+                - google_code_assist
+            url: { type: string, format: uri }
+            request:
+              type: object
+              required: [body]
+              properties:
+                body: { type: object, additionalProperties: true }
+                redactedFields: { type: array, items: { type: string } }
+            response:
+              type: object
+              required: [statusCode, body]
+              properties:
+                statusCode: { type: integer }
+                body: {}
         responseTimeMs: { type: integer, minimum: 0 }
         responseSizeBytes: { type: integer, minimum: 0 }
 

--- a/packages/backend/src/routing/autofix/observation-payload.spec.ts
+++ b/packages/backend/src/routing/autofix/observation-payload.spec.ts
@@ -2,6 +2,7 @@ import {
   MAX_BODY_BYTES,
   isReportableStatus,
   scrubBody,
+  scrubProviderUrl,
   toObservation,
   type ObservationInput,
 } from './observation-payload';
@@ -98,6 +99,18 @@ describe('scrubBody', () => {
   });
 });
 
+describe('scrubProviderUrl', () => {
+  it('keeps routing query parameters but removes credentials', () => {
+    expect(scrubProviderUrl('https://provider.test/generate?alt=sse&key=secret-value')).toBe(
+      'https://provider.test/generate?alt=sse&key=%5BREDACTED%5D',
+    );
+  });
+
+  it('scrubs secrets even when the provider URL is malformed', () => {
+    expect(scrubProviderUrl('not-a-url sk-ant-abcdefghijklmno')).toBe('not-a-url [REDACTED]');
+  });
+});
+
 describe('toObservation', () => {
   it('builds the observe payload with the normalized provider error', () => {
     const obs = toObservation(baseInput);
@@ -137,6 +150,64 @@ describe('toObservation', () => {
       model: 'claude-opus-4-8',
       thinking: { type: 'adaptive', budget_tokens: 8192 },
     });
+  });
+
+  it('keeps a native Gemini provider exchange separate from Phoenix patch identity', () => {
+    const wireBody = {
+      generationConfig: { maxOutputTokens: 32000, topP: 1, temperature: 1 },
+      contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+    };
+    const obs = toObservation({
+      ...baseInput,
+      provider: 'gemini',
+      requestBody: { model: 'gemini-2.5-flash-lite', ...wireBody },
+      providerWire: {
+        format: 'google_generate_content',
+        url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
+        body: wireBody,
+      },
+    });
+    expect(obs?.providerExchange).toEqual({
+      format: 'google_generate_content',
+      url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
+      request: { body: wireBody, redactedFields: [] },
+      response: {
+        statusCode: 400,
+        body: { error: { message: 'temperature must be <= 2', code: 'bad_param' } },
+      },
+    });
+  });
+
+  it('omits an absent provider URL from the exchange', () => {
+    const obs = toObservation({
+      ...baseInput,
+      providerWire: {
+        format: 'openai_chat_completions',
+        body: { model: 'gpt-5.1', max_tokens: 128 },
+      },
+      errorBody: 'plain provider failure',
+    });
+
+    expect(obs?.providerExchange).toEqual({
+      format: 'openai_chat_completions',
+      request: {
+        body: { model: 'gpt-5.1', max_tokens: 128 },
+        redactedFields: [],
+      },
+      response: { statusCode: 400, body: 'plain provider failure' },
+    });
+  });
+
+  it('returns null when the provider-native body is too large to ship', () => {
+    expect(
+      toObservation({
+        ...baseInput,
+        providerWire: {
+          format: 'google_generate_content',
+          body: { contents: [{ text: 'x'.repeat(MAX_BODY_BYTES) }] },
+        },
+      }),
+    ).toBeNull();
   });
 
   it('carries the response time when measured', () => {

--- a/packages/backend/src/routing/autofix/observation-payload.ts
+++ b/packages/backend/src/routing/autofix/observation-payload.ts
@@ -1,5 +1,5 @@
 import { scrubSecrets } from '../../common/utils/secret-scrub';
-import type { ProxyApiMode } from '../proxy/proxy-types';
+import type { ProviderWireFormat, ProxyApiMode } from '../proxy/proxy-types';
 import type { AuthType } from 'manifest-shared';
 import { normalizeProviderError } from './provider-error-normalizer';
 import type { HealRequest } from './phoenix.types';
@@ -56,6 +56,21 @@ function normalizeKey(key: string): string {
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Keep the resolved endpoint while removing credentials from query parameters. */
+export function scrubProviderUrl(raw: string): string {
+  try {
+    const url = new URL(raw);
+    for (const key of [...url.searchParams.keys()]) {
+      if (/key|token|secret|signature|credential/i.test(key)) {
+        url.searchParams.set(key, '[REDACTED]');
+      }
+    }
+    return url.toString();
+  } catch {
+    return scrubSecrets(raw);
+  }
 }
 
 /**
@@ -116,6 +131,11 @@ export interface ObservationInput {
    * observation is evidence only and no Phoenix operation needs the image bytes.
    */
   requestBody: Record<string, unknown>;
+  providerWire?: {
+    format: ProviderWireFormat;
+    url?: string;
+    body: Record<string, unknown>;
+  };
   status: number;
   /** Raw text of the provider's error response. */
   errorBody: string;
@@ -130,6 +150,16 @@ export function toObservation(input: ObservationInput): HealRequest | null {
   if (!isReportableStatus(input.status)) return null;
   const scrubbed = scrubBody(input.requestBody);
   if (!scrubbed) return null;
+  const scrubbedProviderBody = input.providerWire ? scrubBody(input.providerWire.body) : null;
+  if (input.providerWire && !scrubbedProviderBody) return null;
+
+  const safeErrorBody = scrubSecrets(input.errorBody);
+  let providerResponseBody: unknown = safeErrorBody;
+  try {
+    providerResponseBody = JSON.parse(safeErrorBody) as unknown;
+  } catch {
+    // Plain-text provider responses remain plain text.
+  }
 
   return {
     traceId: input.traceId,
@@ -139,6 +169,16 @@ export function toObservation(input: ObservationInput): HealRequest | null {
     api: input.apiMode,
     request: scrubbed,
     response: { statusCode: input.status, error: normalizeProviderError(input.errorBody) },
+    ...(input.providerWire
+      ? {
+          providerExchange: {
+            format: input.providerWire.format,
+            ...(input.providerWire.url ? { url: scrubProviderUrl(input.providerWire.url) } : {}),
+            request: { body: scrubbedProviderBody!, redactedFields: [] },
+            response: { statusCode: input.status, body: providerResponseBody },
+          },
+        }
+      : {}),
     ...(input.responseTimeMs != null ? { responseTimeMs: input.responseTimeMs } : {}),
   };
 }

--- a/packages/backend/src/routing/autofix/phoenix.types.ts
+++ b/packages/backend/src/routing/autofix/phoenix.types.ts
@@ -1,4 +1,4 @@
-import type { ProxyApiMode } from '../proxy/proxy-types';
+import type { ProviderWireFormat, ProxyApiMode } from '../proxy/proxy-types';
 import type { AuthType } from 'manifest-shared';
 
 /**
@@ -20,6 +20,20 @@ export interface PhoenixProviderError {
 export interface PhoenixProviderResponse {
   statusCode: number;
   error: PhoenixProviderError;
+}
+
+/** Final provider-side exchange, separate from the request shape Phoenix patches. */
+export interface PhoenixProviderExchange {
+  format: ProviderWireFormat;
+  url?: string;
+  request: {
+    body: Record<string, unknown>;
+    redactedFields?: string[];
+  };
+  response: {
+    statusCode: number;
+    body: unknown;
+  };
 }
 
 /** POST /api/heal request body. Route identity scopes Phoenix's fingerprint. */
@@ -48,6 +62,7 @@ export interface HealRequest {
   url?: string;
   request: Record<string, unknown>;
   response: PhoenixProviderResponse;
+  providerExchange?: PhoenixProviderExchange;
   responseTimeMs?: number;
   responseSizeBytes?: number;
 }

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1274,6 +1274,9 @@ describe('ProviderClient', () => {
       expect(result.isGoogle).toBe(true);
       expect(result.isAnthropic).toBe(false);
       expect(result.wireApiMode).toBeUndefined();
+      expect(result.wireFormat).toBe('google_generate_content');
+      expect(result.wireRequestUrl).toBe(url);
+      expect(result.wireRequestBody).toEqual(JSON.parse(mockFetch.mock.calls[0][1].body));
     });
 
     it('adds alt=sse for streaming', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -1425,6 +1425,8 @@ describe('ProxyController', () => {
       forward: {
         response: new Response('{"error":"invalid thinking"}', { status: 400 }),
         wireRequestBody,
+        wireRequestUrl: 'https://api.anthropic.com/v1/messages',
+        wireFormat: 'anthropic_messages',
         wireApiMode: 'messages',
         retryWireBody: jest.fn(),
         isGoogle: false,
@@ -1455,9 +1457,58 @@ describe('ProxyController', () => {
         authType: 'api_key',
         apiMode: 'messages',
         requestBody: wireRequestBody,
+        providerWire: {
+          format: 'anthropic_messages',
+          url: 'https://api.anthropic.com/v1/messages',
+          body: wireRequestBody,
+        },
       }),
     );
     expect(observationReporter.report.mock.calls[0][0]).not.toHaveProperty('resolvedModel');
+  });
+
+  it('reports native Gemini failures even though that wire format is not patchable', async () => {
+    const wireRequestBody = {
+      contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+      generationConfig: { maxOutputTokens: 32000, topP: 1, temperature: 1 },
+    };
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: {
+        response: new Response('{"error":{"message":"model unavailable"}}', { status: 404 }),
+        wireRequestBody,
+        wireRequestUrl:
+          'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
+        wireFormat: 'google_generate_content',
+        wireApiMode: undefined,
+        isGoogle: true,
+        isAnthropic: false,
+        isChatGpt: false,
+      },
+      meta: {
+        tier: 'standard',
+        model: 'gemini-2.5-flash-lite',
+        provider: 'Gemini',
+        auth_type: 'api_key',
+        confidence: 0.8,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ model: 'auto', messages: [{ role: 'user', content: 'test' }] });
+    const { res } = mockResponse();
+    await controller.chatCompletions(req as never, res as never);
+
+    expect(observationReporter.report).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiMode: 'chat_completions',
+        requestBody: { model: 'gemini-2.5-flash-lite', ...wireRequestBody },
+        providerWire: {
+          format: 'google_generate_content',
+          url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
+          body: wireRequestBody,
+        },
+      }),
+    );
   });
 
   it('should handle 500 errors from proxyService as friendly chat message', async () => {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -24,7 +24,12 @@ import {
   createAnthropicTransformer,
   createReasoningContentStreamTransformer as reasoningContentStreamTransformer,
 } from './provider-client-converters';
-import { ForwardOptions, ProxyApiMode, type ProviderAttemptRef } from './proxy-types';
+import {
+  ForwardOptions,
+  ProxyApiMode,
+  ProviderWireFormat,
+  type ProviderAttemptRef,
+} from './proxy-types';
 import { CodexSessionAffinity } from './codex-session-affinity';
 import { toNativeResponsesRequest } from './responses-adapter';
 import { forwardKiroChat } from './kiro-adapter';
@@ -38,6 +43,10 @@ export interface ForwardResult {
   response: Response;
   /** Exact JSON body sent to the resolved provider transport. */
   wireRequestBody?: Record<string, unknown>;
+  /** Exact URL used by the resolved provider transport. */
+  wireRequestUrl?: string;
+  /** Provider-native protocol emitted at the transport boundary. */
+  wireFormat?: ProviderWireFormat;
   /** Provider-facing API shape of {@link wireRequestBody}. */
   wireApiMode?: ProxyApiMode;
   /** Re-send a healed wire body through the already-resolved transport. */
@@ -70,6 +79,16 @@ function wireApiMode(endpoint: ProviderEndpoint): ProxyApiMode | undefined {
   if (endpoint.format === 'openai') return 'chat_completions';
   if (endpoint.format === 'anthropic') return 'messages';
   if (endpoint.format === 'chatgpt') return 'responses';
+  return undefined;
+}
+
+function wireFormat(endpoint: ProviderEndpoint): ProviderWireFormat | undefined {
+  if (endpoint.format === 'openai') return 'openai_chat_completions';
+  if (endpoint.format === 'anthropic') return 'anthropic_messages';
+  if (endpoint.format === 'chatgpt') return 'openai_responses';
+  if (endpoint.format === 'google') {
+    return endpoint.codeAssistEnvelope ? 'google_code_assist' : 'google_generate_content';
+  }
   return undefined;
 }
 
@@ -248,6 +267,7 @@ export class ProviderClient {
     const isCodeAssist = !!endpoint.codeAssistEnvelope;
     const textFormat = responsesTextFormat(body, opts.apiMode);
     const resolvedWireApiMode = wireApiMode(endpoint);
+    const resolvedWireFormat = wireFormat(endpoint);
 
     const bareModel = stripModelPrefix(model, endpointKey);
     if (endpoint.format === 'kiro') {
@@ -340,6 +360,8 @@ export class ProviderClient {
       return {
         ...qualifiedResult,
         wireRequestBody,
+        wireRequestUrl: url,
+        wireFormat: resolvedWireFormat,
         wireApiMode: resolvedWireApiMode,
         retryWireBody,
       };

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -29,6 +29,14 @@ export type ReasoningContentLookup = (firstToolCallId: string) => string | null;
 
 export type ProxyApiMode = 'chat_completions' | 'responses' | 'messages';
 
+/** The protocol shape actually emitted at the provider transport boundary. */
+export type ProviderWireFormat =
+  | 'openai_chat_completions'
+  | 'openai_responses'
+  | 'anthropic_messages'
+  | 'google_generate_content'
+  | 'google_code_assist';
+
 export interface ProviderAttemptStart {
   provider: string;
   model: string;

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -359,15 +359,25 @@ export class ProxyController {
         const alreadyReportedByAutofix = Boolean(autofix) && !meta.fallbackFromModel;
         const wireRequestBody = forward.wireRequestBody;
         const wireApiMode = forward.wireApiMode;
-        if (!alreadyReportedByAutofix && meta.auth_type && wireRequestBody && wireApiMode) {
+        const wireFormat = forward.wireFormat;
+        if (!alreadyReportedByAutofix && meta.auth_type && wireRequestBody && wireFormat) {
+          const phoenixRequest =
+            wireApiMode || typeof wireRequestBody.model === 'string'
+              ? wireRequestBody
+              : { model: meta.model, ...wireRequestBody };
           this.observationReporter.report({
             traceId: traceId ?? uuid(),
             tenantId,
             agentId: req.ingestionContext.agentId,
             provider: meta.provider,
             authType: meta.auth_type,
-            apiMode: wireApiMode,
-            requestBody: wireRequestBody,
+            apiMode: wireApiMode ?? apiMode,
+            requestBody: phoenixRequest,
+            providerWire: {
+              format: wireFormat,
+              ...(forward.wireRequestUrl ? { url: forward.wireRequestUrl } : {}),
+              body: wireRequestBody,
+            },
             status: providerResponse.status,
             errorBody,
             responseTimeMs: Date.now() - startTime,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -476,6 +476,11 @@ export class ProxyService {
           isCodeAssist: forward.isCodeAssist,
           structuredOutputToolName: forward.structuredOutputToolName,
           responsesTextFormat: forward.responsesTextFormat,
+          wireRequestBody: forward.wireRequestBody,
+          wireRequestUrl: forward.wireRequestUrl,
+          wireFormat: forward.wireFormat,
+          wireApiMode: forward.wireApiMode,
+          retryWireBody: forward.retryWireBody,
           providerCallStarted: forward.providerCallStarted,
         };
         this.recordTierIfScoring(sessionKey, resolved.tier);
@@ -511,6 +516,11 @@ export class ProxyService {
         isCodeAssist: forward.isCodeAssist,
         structuredOutputToolName: forward.structuredOutputToolName,
         responsesTextFormat: forward.responsesTextFormat,
+        wireRequestBody: forward.wireRequestBody,
+        wireRequestUrl: forward.wireRequestUrl,
+        wireFormat: forward.wireFormat,
+        wireApiMode: forward.wireApiMode,
+        retryWireBody: forward.retryWireBody,
         providerCallStarted: forward.providerCallStarted,
       };
       if (!explicitModelOverride && paramMergeContext) {


### PR DESCRIPTION
### ✨ What changed
- Capture the final provider URL, wire format, and translated request parameters.
- Send credential-scrubbed provider exchanges directly to Phoenix on live failures.
- Include native Gemini failures without persisting wire exchanges in Manifest.

### 💭 Why
Phoenix was receiving Manifest's normalized parameters instead of what the provider received.

### 👤 For users
Phoenix can show the live provider-native request beside the real provider response.

### 🔧 For operators
Deploy Phoenix migration `1700000000035` before this change.

### 📝 Notes
Phoenix: https://github.com/mnfst/phoenix/pull/152
