### PR TITLE
fix: stop telemetry send time drifting an hour each day

### DIFF
--- a/.changeset/stable-telemetry-send-hour.md
+++ b/.changeset/stable-telemetry-send-hour.md
@@ -2,4 +2,4 @@
 "manifest": patch
 ---
 
-Self-hosted telemetry now reports at a stable hour each day. The send previously drifted one hour later per report, so roughly every three weeks an install skipped a UTC calendar day and its daily usage stats briefly dropped to zero.
+Self-hosted telemetry now reports at a stable hour each day and declares the exact 24h window it covers (`window_start`/`window_end`). The send previously drifted one hour later per report, so roughly every three weeks an install skipped a UTC calendar day and its daily usage stats briefly dropped to zero. Also replaces the cross-tenant error-scan index with one covering the request-first `failed`/`auto_fixed` statuses, so error queries stay indexed for rows written after the request-first model.

--- a/.changeset/stable-telemetry-send-hour.md
+++ b/.changeset/stable-telemetry-send-hour.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Self-hosted telemetry now reports at a stable hour each day. The send previously drifted one hour later per report, so roughly every three weeks an install skipped a UTC calendar day and its daily usage stats briefly dropped to zero.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -511,6 +511,9 @@ send one aggregate usage report per 24h to `TELEMETRY_ENDPOINT` (default
   cents)
 - Configuration: `agents_total`, `agents_by_platform`
 - Runtime: `platform` (`process.platform`), `arch` (`process.arch`)
+- Coverage: `window_start` / `window_end` — ISO-8601 UTC bounds of the
+  aggregation window (`window_end` = build time), so the ingest can attribute
+  the report to calendar days exactly instead of assuming it ended at arrival
 
 User-facing spec: https://manifest.build/docs/self-hosted#telemetry
 
@@ -532,9 +535,14 @@ duplicate-report window is also 23h, so the guard can never trip it. Hourly
 tick + timestamp check beats a daily cron because it survives restarts without
 missing windows.
 
-**Extending the payload**: bump `TELEMETRY_SCHEMA_VERSION` and add fields
-additively — the ingest (peacock-backend) rejects unknown `schema_version`
-values with 400, so downgrades stay safe.
+**Extending the payload**: add fields additively and keep `schema_version: 1` —
+receivers feature-detect on field presence (see `dto/telemetry-payload.ts`;
+precedent: `cost_usd_total`, `window_start`/`window_end`). The ingest
+(peacock-backend) validates with `forbidNonWhitelisted`, so the new field must
+be whitelisted in peacock's `TelemetryReportDto` **and deployed** before a
+Manifest release ships it, or every report carrying it gets 400'd. Reserve a
+`TELEMETRY_SCHEMA_VERSION` bump for breaking changes — the ingest rejects
+unknown versions with 400, so downgrades stay safe.
 
 ## Error Monitoring (Sentry, opt-in)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,9 +522,15 @@ raw IPs.
 `NODE_ENV !== 'production'` so dev instances never report.
 
 **Cadence**: `@Cron(CronExpression.EVERY_HOUR)` fires once an hour but
-short-circuits unless the last send was ≥24h ago (and the first-send jitter
-window has elapsed). Hourly tick + timestamp check beats a daily cron
-because it survives restarts without missing windows.
+short-circuits unless the last send was ≥23h ago (and the first-send jitter
+window has elapsed). The guard is 23h, not 24h, on purpose: `last_sent_at` is
+stamped just after the tick, so a 24h guard never passed at the same-hour tick
+the next day and every send drifted one hour later per day — when the send hour
+crossed UTC midnight, the install's report skipped a calendar day in
+received-at-binned daily stats. Real cadence stays ~24h; the ingest's
+duplicate-report window is also 23h, so the guard can never trip it. Hourly
+tick + timestamp check beats a daily cron because it survives restarts without
+missing windows.
 
 **Extending the payload**: bump `TELEMETRY_SCHEMA_VERSION` and add fields
 additively — the ingest (peacock-backend) rejects unknown `schema_version`

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -31,6 +31,7 @@ import { ReclassifyPlanRequestLimitMessages1800100000000 } from './migrations/18
 import { AddMessageErrorCode1800200000000 } from './migrations/1800200000000-AddMessageErrorCode';
 import { DropUnusedAgentMessageIndexes1800300000000 } from './migrations/1800300000000-DropUnusedAgentMessageIndexes';
 import { ExtendDashboardCoveringIndex1801200000000 } from './migrations/1801200000000-ExtendDashboardCoveringIndex';
+import { AddErrorFamilyTimestampIndex1801300000000 } from './migrations/1801300000000-AddErrorFamilyTimestampIndex';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -300,4 +301,5 @@ export const migrations = [
   AddRequestsAndProviderAttempts1801000000000,
   AddProviderAttemptOrdering1801100000000,
   ExtendDashboardCoveringIndex1801200000000,
+  AddErrorFamilyTimestampIndex1801300000000,
 ];

--- a/packages/backend/src/database/migrations/1801300000000-AddErrorFamilyTimestampIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1801300000000-AddErrorFamilyTimestampIndex.spec.ts
@@ -1,0 +1,71 @@
+import { AddErrorFamilyTimestampIndex1801300000000 } from './1801300000000-AddErrorFamilyTimestampIndex';
+
+describe('AddErrorFamilyTimestampIndex1801300000000', () => {
+  const migration = new AddErrorFamilyTimestampIndex1801300000000();
+  let queries: string[];
+
+  const mockQueryRunner = {
+    query: jest.fn().mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve([]);
+    }),
+  } as never;
+
+  beforeEach(() => {
+    queries = [];
+    jest.clearAllMocks();
+  });
+
+  it('exposes the expected migration name', () => {
+    expect(migration.name).toBe('AddErrorFamilyTimestampIndex1801300000000');
+  });
+
+  it('runs outside a transaction so the builds can be CONCURRENT', () => {
+    expect(migration.transaction).toBe(false);
+  });
+
+  it('builds the five-status index before dropping the legacy trio index', async () => {
+    await migration.up(mockQueryRunner);
+
+    const create = queries.find((sql) =>
+      sql.startsWith(
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_error_family_timestamp"',
+      ),
+    );
+    expect(create).toBeDefined();
+    expect(create).toContain('ON "agent_messages" ("timestamp")');
+    expect(create).toContain(
+      `WHERE "status" IN ('error', 'fallback_error', 'rate_limited', 'auto_fixed', 'failed')`,
+    );
+
+    // Swap order: build the wider index, then drop the trio one — every trio
+    // query implies the wider predicate, so scans stay index-served throughout.
+    const createAt = queries.indexOf(create as string);
+    const dropLegacyAt = queries.findIndex((sql) =>
+      sql.includes('DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_errors_timestamp"'),
+    );
+    expect(dropLegacyAt).toBeGreaterThan(createAt);
+  });
+
+  it('clears an invalid leftover before creating (interrupted CONCURRENTLY build)', async () => {
+    await migration.up(mockQueryRunner);
+
+    expect(queries[0]).toBe(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_error_family_timestamp"',
+    );
+  });
+
+  it('down drops the family index and restores the legacy trio index', async () => {
+    await migration.down(mockQueryRunner);
+
+    expect(queries[0]).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_error_family_timestamp"',
+    );
+    const recreate = queries.find((sql) =>
+      sql.startsWith(
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_errors_timestamp"',
+      ),
+    );
+    expect(recreate).toContain(`WHERE "status" IN ('error', 'fallback_error', 'rate_limited')`);
+  });
+});

--- a/packages/backend/src/database/migrations/1801300000000-AddErrorFamilyTimestampIndex.ts
+++ b/packages/backend/src/database/migrations/1801300000000-AddErrorFamilyTimestampIndex.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Extends the cross-tenant error-scan index to the request-first status
+ * vocabulary. The request-first model (mnfst/manifest#2485, deployed
+ * 2026-07-21) records failures as `failed` (with Auto-fix marking healed
+ * originals `auto_fixed`), but IDX_agent_messages_errors_timestamp only
+ * covers the legacy trio ('error', 'fallback_error', 'rate_limited'). A
+ * partial index is usable only when the query predicate implies the index
+ * predicate, so any consumer that (correctly) filters the full five-status
+ * error family gets NO index at all and falls back to scanning every row in
+ * the window — the multi-minute cross-tenant scans the trio index was built
+ * to kill (see 1795100000000).
+ *
+ * The five-status replacement is built first, then the legacy trio index is
+ * dropped: every trio query implies the wider predicate, so error scans stay
+ * index-served during and after the swap.
+ *
+ * Built CONCURRENTLY (so `transaction = false`) to avoid the ACCESS EXCLUSIVE
+ * lock that deadlocks against live writes during a deploy.
+ */
+export class AddErrorFamilyTimestampIndex1801300000000 implements MigrationInterface {
+  name = 'AddErrorFamilyTimestampIndex1801300000000';
+  transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Clear any invalid leftover from an interrupted CONCURRENTLY build, since
+    // CREATE ... IF NOT EXISTS would otherwise skip over an invalid index.
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_error_family_timestamp"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_error_family_timestamp" ON "agent_messages" ("timestamp") WHERE "status" IN ('error', 'fallback_error', 'rate_limited', 'auto_fixed', 'failed')`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_errors_timestamp"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "IDX_agent_messages_error_family_timestamp"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_agent_messages_errors_timestamp" ON "agent_messages" ("timestamp") WHERE "status" IN ('error', 'fallback_error', 'rate_limited')`,
+    );
+  }
+}

--- a/packages/backend/src/telemetry/dto/telemetry-payload.ts
+++ b/packages/backend/src/telemetry/dto/telemetry-payload.ts
@@ -48,4 +48,14 @@ export interface TelemetryPayloadV1 {
   // Runtime
   platform: string;
   arch: string;
+
+  /**
+   * ISO-8601 UTC bounds of the 24h window the aggregates cover
+   * (`window_end` = payload build time, `window_start` = 24h earlier).
+   * They make the coverage explicit so the ingest can attribute the report
+   * to calendar days exactly instead of assuming a 24h window ending at
+   * *arrival* time.
+   */
+  window_start?: string;
+  window_end?: string;
 }

--- a/packages/backend/src/telemetry/payload-builder.service.spec.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.spec.ts
@@ -119,6 +119,20 @@ describe('PayloadBuilderService', () => {
     expect(payload.arch).toBe(process.arch);
   });
 
+  it('declares the exact 24h aggregation window it covered', async () => {
+    const service = await makeService({});
+    const before = Date.now();
+
+    const payload = await service.build('inst-123', '5.47.0');
+
+    const after = Date.now();
+    const start = new Date(payload.window_start!).getTime();
+    const end = new Date(payload.window_end!).getTime();
+    expect(end - start).toBe(24 * 60 * 60 * 1000);
+    expect(end).toBeGreaterThanOrEqual(before);
+    expect(end).toBeLessThanOrEqual(after);
+  });
+
   it('aggregates message counts and token totals across the 24h window', async () => {
     const service = await makeService({
       providers: [

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -29,10 +29,13 @@ interface TotalsRow {
   cost: string | null;
 }
 
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Builds the daily telemetry payload by aggregating the last 24h of
- * `agent_messages` plus the total agent count + runtime metadata. All
- * SELECTs are parameterised so the window is consistent across queries.
+ * `agent_messages` plus the total agent count + runtime metadata. One
+ * JS-computed window bounds every SELECT, so the `window_start`/`window_end`
+ * the payload declares are exactly what was aggregated.
  */
 @Injectable()
 export class PayloadBuilderService {
@@ -44,12 +47,14 @@ export class PayloadBuilderService {
   ) {}
 
   async build(installId: string, manifestVersion: string): Promise<TelemetryPayloadV1> {
+    const windowEnd = new Date();
+    const windowStart = new Date(windowEnd.getTime() - WINDOW_MS);
     const [providerRows, tierRows, authRows, totals, agentsTotal, agentPlatformRows] =
       await Promise.all([
-        this.messagesByProvider(),
-        this.messagesByBucket('routing_tier'),
-        this.messagesByBucket('auth_type'),
-        this.totals(),
+        this.messagesByProvider(windowStart),
+        this.messagesByBucket('routing_tier', windowStart),
+        this.messagesByBucket('auth_type', windowStart),
+        this.totals(windowStart),
         this.userAgentsCount(),
         this.agentsByPlatform(),
       ]);
@@ -74,16 +79,18 @@ export class PayloadBuilderService {
       agents_by_platform: this.bucketsToRecord(agentPlatformRows, 'unknown'),
       platform: process.platform,
       arch: process.arch,
+      window_start: windowStart.toISOString(),
+      window_end: windowEnd.toISOString(),
     };
   }
 
-  private async messagesByProvider(): Promise<ProviderAggregateRow[]> {
+  private async messagesByProvider(since: Date): Promise<ProviderAggregateRow[]> {
     return this.messages
       .createQueryBuilder('m')
       .select('m.provider', 'provider')
       .addSelect('COUNT(*)', 'count')
       .addSelect('COALESCE(SUM(m.cost_usd), 0)', 'cost')
-      .where(`m.timestamp >= NOW() - INTERVAL '24 hours'`)
+      .where('m.timestamp >= :since', { since: since.toISOString() })
       .groupBy('m.provider')
       .getRawMany<ProviderAggregateRow>();
   }
@@ -93,12 +100,15 @@ export class PayloadBuilderService {
    * short stable set (`routing_tier`, `auth_type`). We trust the set because
    * the producer — our own proxy — writes known enum strings.
    */
-  private async messagesByBucket(column: 'routing_tier' | 'auth_type'): Promise<BucketRow[]> {
+  private async messagesByBucket(
+    column: 'routing_tier' | 'auth_type',
+    since: Date,
+  ): Promise<BucketRow[]> {
     return this.messages
       .createQueryBuilder('m')
       .select(`m.${column}`, 'bucket')
       .addSelect('COUNT(*)', 'count')
-      .where(`m.timestamp >= NOW() - INTERVAL '24 hours'`)
+      .where('m.timestamp >= :since', { since: since.toISOString() })
       .groupBy(`m.${column}`)
       .getRawMany<BucketRow>();
   }
@@ -142,14 +152,14 @@ export class PayloadBuilderService {
     return Number(result?.count ?? 0);
   }
 
-  private async totals(): Promise<TotalsRow> {
+  private async totals(since: Date): Promise<TotalsRow> {
     const row = await this.messages
       .createQueryBuilder('m')
       .select('COUNT(*)', 'total')
       .addSelect('SUM(m.input_tokens)', 'input_tokens')
       .addSelect('SUM(m.output_tokens)', 'output_tokens')
       .addSelect('COALESCE(SUM(m.cost_usd), 0)', 'cost')
-      .where(`m.timestamp >= NOW() - INTERVAL '24 hours'`)
+      .where('m.timestamp >= :since', { since: since.toISOString() })
       .getRawOne<TotalsRow>();
     return row ?? { total: '0', input_tokens: '0', output_tokens: '0', cost: '0' };
   }

--- a/packages/backend/src/telemetry/telemetry.service.spec.ts
+++ b/packages/backend/src/telemetry/telemetry.service.spec.ts
@@ -166,7 +166,7 @@ describe('TelemetryService', () => {
       expect(install.markSent).toHaveBeenCalledTimes(1);
     });
 
-    it('skips when the last send was less than 24h ago', async () => {
+    it('skips when the last send was less than 23h ago', async () => {
       const { service, install, payloadBuilder } = makeService();
       const now = new Date('2026-04-20T12:00:00');
       const recent = new Date(now.getTime() - 1000).toISOString();
@@ -179,6 +179,62 @@ describe('TelemetryService', () => {
       await service.tick(now);
 
       expect(payloadBuilder.build).not.toHaveBeenCalled();
+    });
+
+    it('skips one millisecond before the 23h interval elapses (boundary)', async () => {
+      const { service, install, payloadBuilder } = makeService();
+      const now = new Date('2026-04-20T12:00:00.000Z');
+      const almost = new Date(now.getTime() - (23 * 60 * 60 * 1000 - 1)).toISOString();
+      install.getOrCreate.mockResolvedValue({
+        ...baseInstall,
+        first_send_at: '2026-04-01T00:00:00',
+        last_sent_at: almost,
+      });
+
+      await service.tick(now);
+
+      expect(payloadBuilder.build).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('sends at exactly 23h since the last send (boundary)', async () => {
+      const { service, install, payloadBuilder } = makeService();
+      const now = new Date('2026-04-20T12:00:00.000Z');
+      const exactly = new Date(now.getTime() - 23 * 60 * 60 * 1000).toISOString();
+      install.getOrCreate.mockResolvedValue({
+        ...baseInstall,
+        first_send_at: '2026-04-01T00:00:00',
+        last_sent_at: exactly,
+      });
+      payloadBuilder.build.mockResolvedValue(payloadStub());
+      fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await service.tick(now);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(install.markSent).toHaveBeenCalledWith(now);
+    });
+
+    it('sends at the same-hour tick the next day even when a hair under 24h has elapsed', async () => {
+      // Regression for the +1h/day send drift: markSent stamps a moment after
+      // the tick, so the same-hour tick the next day sees slightly *less* than
+      // 24h elapsed. A 24h guard skipped it and pushed every send one hour
+      // later per day until it crossed UTC midnight; the 23h guard fires here.
+      const { service, install, payloadBuilder } = makeService();
+      const now = new Date('2026-04-21T12:00:00.000Z');
+      const justUnder24h = new Date(now.getTime() - (24 * 60 * 60 * 1000 - 100)).toISOString();
+      install.getOrCreate.mockResolvedValue({
+        ...baseInstall,
+        first_send_at: '2026-04-01T00:00:00',
+        last_sent_at: justUnder24h,
+      });
+      payloadBuilder.build.mockResolvedValue(payloadStub());
+      fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await service.tick(now);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(install.markSent).toHaveBeenCalledWith(now);
     });
 
     it('sends when no previous send exists and jitter has elapsed', async () => {
@@ -196,7 +252,7 @@ describe('TelemetryService', () => {
       expect(install.markSent).toHaveBeenCalledTimes(1);
     });
 
-    it('sends again when 24h have elapsed since last send', async () => {
+    it('sends again when more than a day has elapsed since last send', async () => {
       const { service, install, payloadBuilder } = makeService();
       const now = new Date('2026-04-20T12:00:00');
       const old = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();

--- a/packages/backend/src/telemetry/telemetry.service.ts
+++ b/packages/backend/src/telemetry/telemetry.service.ts
@@ -4,7 +4,16 @@ import { InstallIdService } from './install-id.service';
 import { PayloadBuilderService } from './payload-builder.service';
 import { buildTelemetryConfig, TELEMETRY_DOCS_URL, type TelemetryConfig } from './telemetry.config';
 
-const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+// One hour under a full day on purpose. The cron ticks at the top of each hour
+// and `markSent` stamps `last_sent_at` a moment *after* the tick, so a >= 24h
+// guard could never pass at the same-hour tick the next day — every send
+// slipped one hour later per day. When that hour crossed UTC midnight, the
+// install's report skipped a calendar day and received-at-binned daily stats
+// dropped its whole volume for that day. A 23h guard keeps the real cadence at
+// ~24h (the next qualifying tick is the same hour the next day) while pinning
+// the send to a stable hour. The ingest's duplicate-report window is also 23h,
+// so a send can never arrive inside it.
+const SEND_INTERVAL_MS = 23 * 60 * 60 * 1000;
 
 /**
  * Drives the once-per-24h telemetry send for self-hosted installs.
@@ -14,7 +23,8 @@ const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
  * local development and tests never report.
  *
  * The cron ticks hourly (not daily) so restarts don't skip windows — each
- * tick checks `last_sent_at + jitter` and fires only when 24h have elapsed.
+ * tick checks `last_sent_at + jitter` and fires once `SEND_INTERVAL_MS` has
+ * elapsed, which lands on the same hour every ~24h.
  */
 @Injectable()
 export class TelemetryService implements OnModuleInit {
@@ -56,7 +66,7 @@ export class TelemetryService implements OnModuleInit {
   private shouldSend(firstSendAt: string | null, lastSentAt: string | null, now: Date): boolean {
     if (firstSendAt && new Date(firstSendAt).getTime() > now.getTime()) return false;
     if (!lastSentAt) return true;
-    return now.getTime() - new Date(lastSentAt).getTime() >= TWENTY_FOUR_HOURS_MS;
+    return now.getTime() - new Date(lastSentAt).getTime() >= SEND_INTERVAL_MS;
   }
 
   private async postPayload(payload: unknown): Promise<boolean> {


### PR DESCRIPTION
### 💭 Why
The telemetry cron ticks hourly and stamps `last_sent_at` just after the tick, so a `>= 24h` guard never passed at the same-hour tick the next day. Every send slipped one hour later per day, and when the send hour crossed UTC midnight the install skipped a whole calendar day of daily stats (its entire volume vanished from that day's "Local" numbers in Peacock, then reappeared). Separately, reports never said which 24h they covered, and the cross-tenant error index predates the request-first statuses.

### ✨ What changed
- Send guard is now 23h (`SEND_INTERVAL_MS`): sends stay pinned to a stable hour while the real cadence stays ~24h. Matches the ingest's 23h duplicate window.
- Payload declares the exact window it covers (`window_start`/`window_end`), and one JS-computed window bounds every aggregate SELECT so the declared bounds are exactly what was aggregated.
- Migration swaps the cross-tenant error index for one covering the request-first `failed`/`auto_fixed` statuses — a partial index only serves queries whose predicate implies its own, so consumers filtering the full five-status family had no index at all.
- Boundary tests for the 23h threshold, a regression test for the next-day same-hour tick, migration + window tests.
- CLAUDE.md: cadence section and payload-extension protocol corrected (additive fields keep `schema_version: 1`; receivers feature-detect).

### 🔧 For operators
Merge mnfst/peacock#211 (whitelists the new payload fields) before cutting the next Docker release — its ingest runs `forbidNonWhitelisted`, so reports carrying undeclared fields get 400'd. The index migration builds CONCURRENTLY on boot; no manual step.

### 📝 Notes
Companion Peacock PR mnfst/peacock#211 makes the recap card compare complete days, flag missing reports from big installs, and consume the declared windows.