### PR TITLE
fix: route provider timeouts through fallback

### DIFF
--- a/.changeset/calm-stream-timeouts.md
+++ b/.changeset/calm-stream-timeouts.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Route streaming provider timeouts through configured fallbacks instead of returning M500.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.timeout.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.timeout.spec.ts
@@ -42,8 +42,8 @@ describe('ProviderClient — timeout signal actually aborts the in-flight fetch'
       return new Promise((_resolve, reject) => {
         sig.addEventListener('abort', () => {
           abortObserved = true;
-          // Mirror real fetch behavior: reject with an abort-flavored error.
-          reject(new Error('The operation was aborted'));
+          // Mirror real fetch behavior: reject with the signal's abort reason.
+          reject(sig.reason);
         });
       });
     });
@@ -59,7 +59,7 @@ describe('ProviderClient — timeout signal actually aborts the in-flight fetch'
           body,
           stream: false,
         }),
-      ).rejects.toThrow(/aborted/i);
+      ).rejects.toMatchObject({ name: 'TimeoutError' });
     });
 
     expect(abortObserved).toBe(true);
@@ -117,7 +117,7 @@ describe('ProviderClient — timeout signal actually aborts the in-flight fetch'
       return new Promise((_resolve, reject) => {
         const onAbort = () => {
           abortObserved = true;
-          reject(new Error('The operation was aborted'));
+          reject(sig.reason);
         };
         // Handle both already-aborted (synchronous) and not-yet-aborted (event) cases.
         if (sig.aborted) onAbort();
@@ -140,10 +140,38 @@ describe('ProviderClient — timeout signal actually aborts the in-flight fetch'
       // Yield to the microtask queue so forward() reaches fetch() before we abort.
       await new Promise((r) => setImmediate(r));
       ac.abort();
-      await expect(pending).rejects.toThrow(/aborted/i);
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
     });
 
     expect(abortObserved).toBe(true);
+  }, 5000);
+
+  it('surfaces a streaming response-header timeout as TimeoutError', async () => {
+    process.env.PROVIDER_TIMEOUT_MS = '25';
+
+    mockFetch.mockImplementation((_url: string, init: RequestInit) => {
+      const sig = init.signal as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        sig.addEventListener('abort', () => reject(sig.reason));
+      });
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { ProviderClient: FreshClient } = await import('../provider-client');
+      const fresh = new FreshClient();
+      await expect(
+        fresh.forward({
+          provider: 'openai',
+          apiKey: 'sk-test',
+          model: 'gpt-4o',
+          body,
+          stream: true,
+        }),
+      ).rejects.toMatchObject({
+        name: 'TimeoutError',
+        message: 'Upstream provider request timed out',
+      });
+    });
   }, 5000);
 
   it('does not abort a streaming response body after headers arrive', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1692,6 +1692,35 @@ describe('ProxyService — orchestration', () => {
       expect(result.meta.primaryProvider).toBe('openai');
     });
 
+    it('triggers the fallback chain on a provider timeout response', async () => {
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: new Response('upstream timed out', { status: 504 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      fallbackService.tryFallbacks.mockResolvedValue({
+        success: {
+          forward: {
+            response: okResponse(),
+            isGoogle: false,
+            isAnthropic: true,
+            isChatGpt: false,
+          },
+          model: 'claude',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+        },
+        failures: [],
+      } as never);
+
+      const result = await svc.proxyRequest(baseOpts());
+
+      expect(fallbackService.tryFallbacks).toHaveBeenCalled();
+      expect(result.forward.response.status).toBe(200);
+      expect(result.meta.fallbackFromModel).toBe('gpt-4o');
+    });
+
     it('triggers fallback on provider context length errors', async () => {
       const message =
         "This model's maximum context length is 262144 tokens. However, your messages resulted in 334146 tokens.";

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -713,7 +713,11 @@ export class ProviderClient {
     let timeoutController: AbortController | undefined;
     if (stream) {
       timeoutController = new AbortController();
-      timeout = setTimeout(() => timeoutController?.abort(), PROVIDER_TIMEOUT_MS);
+      timeout = setTimeout(() => {
+        const timeoutError = new Error('Upstream provider request timed out');
+        timeoutError.name = 'TimeoutError';
+        timeoutController?.abort(timeoutError);
+      }, PROVIDER_TIMEOUT_MS);
       fetchSignal = signal
         ? AbortSignal.any([timeoutController.signal, signal])
         : timeoutController.signal;
@@ -734,8 +738,14 @@ export class ProviderClient {
         redirect: 'error',
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(message.replace(/key=[^&\s]+/gi, 'key=***'));
+      const errorLike =
+        err !== null && typeof err === 'object'
+          ? (err as { message?: unknown; name?: unknown })
+          : undefined;
+      const message = typeof errorLike?.message === 'string' ? errorLike.message : String(err);
+      const sanitizedError = new Error(message.replace(/key=[^&\s]+/gi, 'key=***'));
+      if (typeof errorLike?.name === 'string') sanitizedError.name = errorLike.name;
+      throw sanitizedError;
     } finally {
       if (timeout) clearTimeout(timeout);
     }


### PR DESCRIPTION
### ✨ What changed
- Preserve provider timeout identity and route streaming expiry through fallback.
- Cover client aborts, streaming expiry, and 504 fallback behavior.

### 💭 Why
Streaming provider timeouts were reported as M500 and skipped configured fallbacks.

### 👤 For users
Timed-out auto-routed requests now try configured fallback models.

### 📝 Notes
Related to #2571

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route upstream provider timeouts through fallback instead of returning 500s, and preserve timeout/abort error identity for correct routing and telemetry.

- **Bug Fixes**
  - Streaming header timeouts now abort with a `TimeoutError`, triggering the fallback chain.
  - Preserve `Error.name` when sanitizing messages so `AbortError`/`TimeoutError` propagate correctly.
  - `ProxyService` treats provider timeout responses (e.g., 504) as fallback-eligible.
  - Updated tests to assert `AbortError`/`TimeoutError` behavior and verify fallback on timeouts.

<sup>Written for commit c10a89ef091ac5d834da7121ae72c906a7c5dd95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

