### PR TITLE
fix: heal native Google provider failures

### DIFF
--- a/.changeset/heal-native-google-requests.md
+++ b/.changeset/heal-native-google-requests.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Send native Google provider failures through Auto-fix with their exact request and response bodies.

--- a/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
@@ -89,6 +89,7 @@ function makeParams(overrides: Partial<MaybeHealParams>): MaybeHealParams {
     agentId: 'agent-1',
     tenantId: 'tenant-1',
     provider: 'anthropic',
+    model: 'gpt',
     authType: 'subscription',
     apiMode: 'chat_completions',
     requestBody: { model: 'gpt', max_tokens: 100 },
@@ -714,6 +715,58 @@ describe('AutofixService', () => {
       const healArg = client.heal.mock.calls[0][0] as { request: Record<string, unknown> };
       expect(healArg.request).toBe(requestBody);
       expect(reforward.mock.calls[0][0]).toBe(healedBody);
+    });
+
+    it('keeps native Gemini model metadata outside the exact provider request', async () => {
+      const client = makeHealingClient();
+      const requestBody = {
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        generationConfig: { maxOutputTokens: 32_000, topP: 1 },
+      };
+      const healedBody = {
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        generationConfig: { maxOutputTokens: 32_000 },
+      };
+      client.heal.mockResolvedValue(
+        patchedHeal({
+          status: 'unverified',
+          operations: [{ type: 'drop_param' }],
+          healedBody,
+        }),
+      );
+      const forward = {
+        ...makeForward('{"error":{"message":"topP is unsupported"}}', 400),
+        wireFormat: 'google_generate_content' as const,
+        wireRequestUrl:
+          'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+      };
+      const reforward = reforwardMock('{"ok":true}', 200);
+      const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
+      const service = makeService({ client: client as unknown as HealingClient, repo });
+
+      await service.maybeHeal(
+        makeParams({
+          forward,
+          reforward,
+          provider: 'gemini',
+          model: 'gemini-2.5-flash',
+          requestBody,
+        }),
+      );
+
+      expect(client.heal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gemini-2.5-flash',
+          request: requestBody,
+          providerExchange: expect.objectContaining({
+            format: 'google_generate_content',
+            request: { body: requestBody, redactedFields: [] },
+          }),
+        }),
+      );
+      expect(requestBody).not.toHaveProperty('model');
+      expect(reforward).toHaveBeenCalledWith(healedBody);
+      expect(healedBody).not.toHaveProperty('model');
     });
 
     it('does not mutate the provider body', async () => {

--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -21,6 +21,8 @@ export interface MaybeHealParams {
   agentId: string;
   tenantId: string;
   provider: string;
+  /** Logical model identity when the provider encodes it outside the JSON body. */
+  model: string;
   authType: AuthType;
   apiMode: ProxyApiMode;
   /** The request body that was actually forwarded and failed. */
@@ -375,6 +377,7 @@ export class AutofixService {
         traceId: groupId,
         tenantId: params.tenantId,
         provider: params.provider,
+        model: params.model,
         authType: params.authType,
         api: params.apiMode,
         url: params.url,

--- a/packages/backend/src/routing/autofix/contract/phoenix-openapi.yaml
+++ b/packages/backend/src/routing/autofix/contract/phoenix-openapi.yaml
@@ -325,6 +325,13 @@ components:
             Tenant.id). Optional on the wire; recorded so a failure can be
             attributed to a tenant. Manifest always sends it on the proxy path.
         provider: { type: string, minLength: 1, example: openai }
+        model:
+          type: string
+          minLength: 1
+          maxLength: 1024
+          description: >
+            Logical provider model identity. Native transports may encode it in
+            the URL rather than in the JSON request body.
         authType:
           type: string
           enum: [api_key, subscription, local]

--- a/packages/backend/src/routing/autofix/observation-payload.spec.ts
+++ b/packages/backend/src/routing/autofix/observation-payload.spec.ts
@@ -12,6 +12,7 @@ const baseInput: ObservationInput = {
   tenantId: 'tenant-1',
   agentId: 'agent-1',
   provider: 'openai',
+  model: 'gpt-5.1',
   authType: 'api_key',
   apiMode: 'chat_completions',
   requestBody: { model: 'gpt-5.1', temperature: 5, messages: [{ role: 'user', content: 'hi' }] },
@@ -160,13 +161,17 @@ describe('toObservation', () => {
     const obs = toObservation({
       ...baseInput,
       provider: 'gemini',
-      requestBody: { model: 'gemini-2.5-flash-lite', ...wireBody },
+      model: 'gemini-2.5-flash-lite',
+      requestBody: wireBody,
       providerWire: {
         format: 'google_generate_content',
         url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
         body: wireBody,
       },
     });
+    expect(obs?.model).toBe('gemini-2.5-flash-lite');
+    expect(obs?.request).toEqual(wireBody);
+    expect(obs?.request).not.toHaveProperty('model');
     expect(obs?.providerExchange).toEqual({
       format: 'google_generate_content',
       url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',

--- a/packages/backend/src/routing/autofix/observation-payload.ts
+++ b/packages/backend/src/routing/autofix/observation-payload.ts
@@ -124,6 +124,8 @@ export interface ObservationInput {
    */
   agentId: string;
   provider: string;
+  /** Logical model identity when the provider encodes it in the URL. */
+  model: string;
   authType: AuthType;
   apiMode: ProxyApiMode;
   /**
@@ -165,6 +167,7 @@ export function toObservation(input: ObservationInput): HealRequest | null {
     traceId: input.traceId,
     tenantId: input.tenantId,
     provider: input.provider,
+    model: input.model,
     authType: input.authType,
     api: input.apiMode,
     request: scrubbed,

--- a/packages/backend/src/routing/autofix/observation-reporter.spec.ts
+++ b/packages/backend/src/routing/autofix/observation-reporter.spec.ts
@@ -26,6 +26,7 @@ const input: ObservationInput = {
   tenantId: 'tenant-1',
   agentId: 'agent-1',
   provider: 'openai',
+  model: 'gpt-5.1',
   authType: 'api_key',
   apiMode: 'chat_completions',
   requestBody: { model: 'gpt-5.1', messages: [{ role: 'user', content: 'hi' }] },

--- a/packages/backend/src/routing/autofix/phoenix.types.ts
+++ b/packages/backend/src/routing/autofix/phoenix.types.ts
@@ -53,6 +53,8 @@ export interface HealRequest {
    */
   tenantId: string;
   provider: string;
+  /** Logical model identity; native transports may encode it in the URL. */
+  model?: string;
   authType: AuthType;
   /**
    * Provider-facing wire protocol. `request` uses this shape, and Phoenix must

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -1453,6 +1453,7 @@ describe('ProxyController', () => {
 
     expect(observationReporter.report).toHaveBeenCalledWith(
       expect.objectContaining({
+        model: 'claude-opus-4-8',
         provider: 'Anthropic',
         authType: 'api_key',
         apiMode: 'messages',
@@ -1467,7 +1468,7 @@ describe('ProxyController', () => {
     expect(observationReporter.report.mock.calls[0][0]).not.toHaveProperty('resolvedModel');
   });
 
-  it('reports native Gemini failures even though that wire format is not patchable', async () => {
+  it('reports native Gemini failures with model metadata outside the exact provider body', async () => {
     const wireRequestBody = {
       contents: [{ role: 'user', parts: [{ text: 'test' }] }],
       generationConfig: { maxOutputTokens: 32000, topP: 1, temperature: 1 },
@@ -1500,8 +1501,9 @@ describe('ProxyController', () => {
 
     expect(observationReporter.report).toHaveBeenCalledWith(
       expect.objectContaining({
+        model: 'gemini-2.5-flash-lite',
         apiMode: 'chat_completions',
-        requestBody: { model: 'gemini-2.5-flash-lite', ...wireRequestBody },
+        requestBody: wireRequestBody,
         providerWire: {
           format: 'google_generate_content',
           url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
@@ -1509,6 +1511,7 @@ describe('ProxyController', () => {
         },
       }),
     );
+    expect(observationReporter.report.mock.calls[0][0].requestBody).not.toHaveProperty('model');
   });
 
   it('should handle 500 errors from proxyService as friendly chat message', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -402,11 +402,25 @@ describe('ProxyService — orchestration', () => {
       expect(autofixService.maybeHeal.mock.calls[0][0]).not.toHaveProperty('resolvedModel');
     });
 
-    it('skips Auto-fix when Phoenix cannot represent the provider wire format', async () => {
-      routableResolve();
+    it('sends native Gemini failures to Auto-fix with the exact provider body', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('gemini', 'api_key', 'gemini-2.5-flash'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      const wireRequestBody = {
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        generationConfig: { maxOutputTokens: 32_000, topP: 1 },
+      };
       fallbackService.tryForwardToProvider.mockResolvedValueOnce({
         response: okResponse(400),
-        wireRequestBody: { contents: [{ role: 'user', parts: [{ text: 'hi' }] }] },
+        wireRequestBody,
+        wireRequestUrl:
+          'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+        wireFormat: 'google_generate_content',
         retryWireBody: jest.fn(),
         isGoogle: true,
         isAnthropic: false,
@@ -415,7 +429,15 @@ describe('ProxyService — orchestration', () => {
 
       await svc.proxyRequest(baseOpts());
 
-      expect(autofixService.maybeHeal).not.toHaveBeenCalled();
+      expect(autofixService.maybeHeal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'gemini',
+          model: 'gemini-2.5-flash',
+          apiMode: 'chat_completions',
+          requestBody: wireRequestBody,
+        }),
+      );
+      expect(autofixService.maybeHeal.mock.calls[0][0].requestBody).not.toHaveProperty('model');
     });
 
     it('re-resolves routing and forwards to the newly-resolved route when the heal changes the model (M5)', async () => {

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -362,18 +362,15 @@ export class ProxyController {
         const wireApiMode = forward.wireApiMode;
         const wireFormat = forward.wireFormat;
         if (!alreadyReportedByAutofix && meta.auth_type && wireRequestBody && wireFormat) {
-          const phoenixRequest =
-            wireApiMode || typeof wireRequestBody.model === 'string'
-              ? wireRequestBody
-              : { model: meta.model, ...wireRequestBody };
           this.observationReporter.report({
             traceId: traceId ?? uuid(),
             tenantId,
             agentId: req.ingestionContext.agentId,
             provider: meta.provider,
+            model: meta.model,
             authType: meta.auth_type,
             apiMode: wireApiMode ?? apiMode,
-            requestBody: phoenixRequest,
+            requestBody: wireRequestBody,
             providerWire: {
               format: wireFormat,
               ...(forward.wireRequestUrl ? { url: forward.wireRequestUrl } : {}),

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -411,22 +411,25 @@ export class ProxyService {
     // failed with a repairable status, so successful traffic is untouched.
     const wireRequestBody = forward.wireRequestBody;
     const wireApiMode = forward.wireApiMode;
+    const wireFormat = forward.wireFormat;
     const retryWireBody = forward.retryWireBody;
+    const autofixApiMode = wireApiMode ?? apiMode;
     const autofixAttempt =
-      wireRequestBody && wireApiMode && retryWireBody
+      wireRequestBody && retryWireBody && (wireApiMode || wireFormat)
         ? await this.autofixService.maybeHeal({
             forward,
             agentId,
             tenantId,
             provider: route.provider,
+            model: primaryModel,
             authType: route.authType,
-            apiMode: wireApiMode,
+            apiMode: autofixApiMode,
             requestBody: wireRequestBody,
             reforward: (healedBody) =>
               this.reforwardHealed(healedBody, forward, {
                 agentId,
                 tenantId,
-                apiMode: wireApiMode,
+                apiMode: autofixApiMode,
                 sessionKey,
                 signal,
                 stream,
@@ -1208,6 +1211,7 @@ export class ProxyService {
       // No provider was resolved — fingerprint under the vendor the model id
       // implies (`openrouter/x` → openrouter), or `manifest` for bare names.
       provider: inferProviderFromModel(requestedModel) ?? 'manifest',
+      model: requestedModel,
       // No connection resolved, so there is no real credential type to report.
       // Use the protocol's non-subscription baseline for this synthetic error.
       authType: 'api_key',


### PR DESCRIPTION
## What
- send native Google failures through synchronous Auto-fix
- keep model identity outside the exact provider JSON body
- retry Phoenix healed bodies verbatim
- stop reconstructing native requests in passive observations

## Why
Google forwards had a retryable wire body and format but no OpenAI-style wire API mode, so active Auto-fix skipped them entirely.

## Dependency
Merge and deploy mnfst/phoenix#158 first.

## Test plan
- npm run lint
- npm run build
- npx tsc --noEmit (backend)
- 438 backend unit suites / 7,931 tests
- 43 backend e2e suites / 364 tests against clean PostgreSQL
- focused Auto-fix and proxy suites / 306 tests
- npm run check:changesets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes native Google (Gemini) failures through Auto-fix using the exact provider wire body and URL, and records the model separately from the JSON body. This fixes skipped healing for Gemini and avoids mutating provider requests.

- **Bug Fixes**
  - Auto-fix now heals Google `generateContent` failures using the exact wire request/response (even without a wire API mode).
  - Added a `model` field to Autofix/observation payloads so native transports keep model identity out of the provider JSON.
  - Proxy reports and replays healed requests verbatim; no request reconstruction or body mutation.
  - Updated OpenAPI, controller/service logic, and tests to reflect the new `model` field and Google wire format handling.

- **Dependencies**
  - Requires `mnfst/phoenix#158` to be merged and deployed.

<sup>Written for commit d2a0c79eb72e34a7ef9e669080e563c29a308309. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

