### PR TITLE
fix: make the dev Wingman drawer reach the local gateway again

### DIFF
--- a/packages/frontend/src/components/WingmanDevTools.tsx
+++ b/packages/frontend/src/components/WingmanDevTools.tsx
@@ -39,9 +39,12 @@ const WingmanDevTools: Component = () => {
   const [heightVh, setHeightVh] = createSignal(readStoredHeight());
   const [resizing, setResizing] = createSignal(false);
 
-  // Wingman is a hosted SPA at wingman.manifest.build. A build-time
-  // `VITE_WINGMAN_URL` override still wins so contributors can point the
-  // drawer at a locally-running Wingman build.
+  // `__WINGMAN_URL__` is set by vite.config.ts to a loopback origin in dev: the
+  // Wingman dev proxy republishes the hosted SPA there so the iframe sits in
+  // the same address space as the gateway it calls. Framing the hosted HTTPS
+  // origin directly makes every request a local-network request, which Chrome
+  // blocks (see wingman-dev-proxy.ts). The literal is only a fallback for a
+  // build that didn't define it.
   const HOSTED_WINGMAN_URL = 'https://wingman.manifest.build';
   const deriveWingmanBase = (): string => __WINGMAN_URL__ || HOSTED_WINGMAN_URL;
 
@@ -189,12 +192,18 @@ const WingmanDevTools: Component = () => {
               </button>
             </div>
           </header>
+          {/* `local-network-access` is delegated as a fallback. It is not
+              needed when the drawer points at the loopback proxy (same
+              address space, no permission involved), but if someone points
+              VITE_WINGMAN_URL back at an https origin it's the difference
+              between Chrome offering the permission prompt and denying it
+              outright by permissions policy, with no prompt possible. */}
           <iframe
             src={iframeSrc()}
             class="wingman-drawer__frame"
             title="Wingman gateway tester"
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-clipboard-write"
-            allow="clipboard-read; clipboard-write"
+            allow="clipboard-read; clipboard-write; local-network-access"
           />
         </aside>
       </Show>

--- a/packages/frontend/tests/components/WingmanDevTools.test.tsx
+++ b/packages/frontend/tests/components/WingmanDevTools.test.tsx
@@ -79,6 +79,20 @@ describe("WingmanDevTools", () => {
     );
   });
 
+  // Without this delegation Chrome denies `local-network-access` by
+  // permissions policy inside a cross-origin iframe, so the permission can
+  // never even be prompted for. It is only a fallback — the drawer normally
+  // points at a loopback origin where no permission is involved — but if it
+  // ever frames an https origin again, this is what keeps it recoverable.
+  it("delegates local-network-access to the iframe", () => {
+    localStorage.setItem(STORAGE_OPEN, "1");
+    const { container } = render(() => <WingmanDevTools />);
+    const iframe = container.querySelector(
+      ".wingman-drawer__frame",
+    ) as HTMLIFrameElement;
+    expect(iframe.getAttribute("allow")).toContain("local-network-access");
+  });
+
   it("respects a build-time __WINGMAN_URL__ override", () => {
     globalThis.__WINGMAN_URL__ = "http://wingman.test:5555";
     localStorage.setItem(STORAGE_OPEN, "1");

--- a/packages/frontend/tests/wingman-dev-proxy.test.ts
+++ b/packages/frontend/tests/wingman-dev-proxy.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import {
+  isRemoteWingman,
+  resolveWingmanDrawerUrl,
+} from "../wingman-dev-proxy";
+
+describe("isRemoteWingman", () => {
+  it("treats the hosted SPA as remote", () => {
+    expect(isRemoteWingman("https://wingman.manifest.build")).toBe(true);
+  });
+
+  it("treats a local Wingman checkout as not remote", () => {
+    expect(isRemoteWingman("http://localhost:3002")).toBe(false);
+    expect(isRemoteWingman("http://127.0.0.1:3002")).toBe(false);
+  });
+});
+
+describe("resolveWingmanDrawerUrl", () => {
+  // The regression this whole plugin exists for: framing the hosted HTTPS SPA
+  // makes every call from it to a localhost gateway a local-network request,
+  // which Chrome blocks and reports as a CORS failure.
+  it("never points the drawer at a public https origin", () => {
+    const url = resolveWingmanDrawerUrl("https://wingman.manifest.build", 3002);
+    expect(url).toBe("http://localhost:3002");
+    expect(url.startsWith("https://")).toBe(false);
+  });
+
+  it("uses the configured port", () => {
+    expect(resolveWingmanDrawerUrl("https://wingman.manifest.build", 41999)).toBe(
+      "http://localhost:41999",
+    );
+  });
+
+  it("leaves a loopback upstream alone", () => {
+    expect(resolveWingmanDrawerUrl("http://localhost:3002", 3002)).toBe(
+      "http://localhost:3002",
+    );
+    expect(resolveWingmanDrawerUrl("http://wingman.test:5555", 3002)).toBe(
+      "http://wingman.test:5555",
+    );
+  });
+});

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { defineConfig, type ProxyOptions } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 import { codecovVitePlugin } from '@codecov/vite-plugin';
+import { resolveWingmanDrawerUrl, wingmanDevProxy } from './wingman-dev-proxy';
 
 // Dial the backend on 127.0.0.1, not `localhost`. The dev backend binds
 // 127.0.0.1 (IPv4), but on dual-stack machines `localhost` can resolve to
@@ -47,6 +48,14 @@ const manifestVersion = (() => {
   }
 })();
 
+// The hosted Wingman SPA, and the loopback port the dev proxy republishes it
+// on. `WINGMAN_PORT` is the same knob the backend reads for its dev CORS
+// allow-list and CSP `frame-src`, so the three stay in step.
+const HOSTED_WINGMAN_URL = 'https://wingman.manifest.build';
+const wingmanUpstream = process.env.VITE_WINGMAN_URL || HOSTED_WINGMAN_URL;
+const wingmanPort = Number(process.env.WINGMAN_PORT || process.env.VITE_WINGMAN_PORT || 3002);
+const wingmanDrawerUrl = resolveWingmanDrawerUrl(wingmanUpstream, wingmanPort);
+
 export default defineConfig(({ command }) => ({
   define: {
     __MANIFEST_VERSION__: JSON.stringify(manifestVersion),
@@ -56,12 +65,16 @@ export default defineConfig(({ command }) => ({
     // cloud, anything else — gets `__DEV_MODE__ = false`, so esbuild
     // dead-code-eliminates the FAB, drawer, and badge.
     __DEV_MODE__: JSON.stringify(command === 'serve'),
-    // Optional build-time override for the Wingman drawer; otherwise it
-    // points at the hosted SPA at https://wingman.manifest.build.
-    __WINGMAN_URL__: JSON.stringify(process.env.VITE_WINGMAN_URL || ''),
+    // Where the drawer's iframe points. In dev this is the loopback origin the
+    // Wingman dev proxy serves on, so the iframe and the gateway share an
+    // address space — a public HTTPS iframe cannot reach a localhost gateway
+    // (see wingman-dev-proxy.ts). Empty in a production build, where the
+    // drawer is dead-code-eliminated anyway.
+    __WINGMAN_URL__: JSON.stringify(command === 'serve' ? wingmanDrawerUrl : ''),
   },
   plugins: [
     solidPlugin(),
+    wingmanDevProxy({ port: wingmanPort, upstream: wingmanUpstream }),
     codecovVitePlugin({
       enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
       bundleName: 'manifest-frontend',

--- a/packages/frontend/wingman-dev-proxy.ts
+++ b/packages/frontend/wingman-dev-proxy.ts
@@ -1,0 +1,104 @@
+import http from 'node:http';
+import https from 'node:https';
+import type { Plugin } from 'vite';
+
+/**
+ * Serves the hosted Wingman SPA from a loopback origin during `vite serve`.
+ *
+ * The drawer used to iframe `https://wingman.manifest.build` directly and pass
+ * it the dashboard's own origin as the gateway to test. That stopped working:
+ * a public HTTPS page reaching `http://localhost:<port>` is a local-network
+ * request, which Chrome (≥ 138) gates behind the Local Network Access
+ * permission. Inside a cross-origin iframe that permission is denied by
+ * permissions policy unless the embedder delegates it, so no prompt ever
+ * appeared and every call failed with `Failed to fetch` — reported by the
+ * browser as a CORS error, which is what sent us auditing the allow-list
+ * repeatedly. Local Network Access also replaced Private Network Access, so
+ * the `Access-Control-Allow-Private-Network` header the backend still sends
+ * can no longer satisfy it.
+ *
+ * Reverse-proxying the SPA onto `127.0.0.1:<wingmanPort>` puts the iframe in
+ * the same address space as the gateway, which sidesteps the permission
+ * entirely — and works the same way in Safari and Firefox, neither of which
+ * implements the Chrome permission. It is mounted at the port root so
+ * Wingman's absolute asset paths (`/assets/…`, `/icons/…`) resolve unchanged.
+ *
+ * Dev only: `apply: 'serve'` keeps it out of every production build, matching
+ * the drawer it exists to serve.
+ */
+/** True when the upstream is a remote HTTPS SPA that has to be republished on loopback. */
+export function isRemoteWingman(upstream: string): boolean {
+  return upstream.startsWith('https://');
+}
+
+/**
+ * The origin the drawer's iframe should point at.
+ *
+ * A remote HTTPS SPA is replaced by the loopback origin the proxy serves it
+ * on — framing it directly would make every gateway call a blocked
+ * local-network request. An upstream that is already on loopback (a
+ * contributor's own `npm run dev` Wingman) is framed as-is.
+ */
+export function resolveWingmanDrawerUrl(upstream: string, port: number): string {
+  return isRemoteWingman(upstream) ? `http://localhost:${port}` : upstream;
+}
+
+export function wingmanDevProxy(options: { port: number; upstream: string }): Plugin {
+  return {
+    name: 'manifest:wingman-dev-proxy',
+    apply: 'serve',
+    configureServer(server) {
+      // Only proxy a remote SPA. A contributor who points VITE_WINGMAN_URL at
+      // their own Wingman checkout is already on a loopback origin.
+      if (!isRemoteWingman(options.upstream)) return;
+      const upstream = new URL(options.upstream);
+
+      const proxy = http.createServer((req, res) => {
+        const upstreamReq = https.request(
+          {
+            host: upstream.hostname,
+            port: 443,
+            path: req.url,
+            method: req.method,
+            headers: {
+              ...req.headers,
+              host: upstream.hostname,
+              // Pass through undecoded so we can stream the body untouched.
+              'accept-encoding': 'identity',
+            },
+          },
+          (upstreamRes) => {
+            const headers = { ...upstreamRes.headers };
+            // The upstream CSP and framing headers are written for the hosted
+            // origin; on loopback they'd only block the drawer.
+            delete headers['content-security-policy'];
+            delete headers['x-frame-options'];
+            res.writeHead(upstreamRes.statusCode ?? 502, headers);
+            upstreamRes.pipe(res);
+          },
+        );
+        upstreamReq.on('error', (err: Error) => {
+          if (res.headersSent) return;
+          res.writeHead(502, { 'content-type': 'text/plain' });
+          res.end(`Wingman dev proxy could not reach ${options.upstream}: ${err.message}`);
+        });
+        req.pipe(upstreamReq);
+      });
+
+      proxy.on('error', (err: NodeJS.ErrnoException) => {
+        // A stale proxy from a previous run already owns the port — harmless,
+        // the drawer still resolves. Anything else is worth surfacing.
+        const detail = err.code === 'EADDRINUSE' ? 'port already in use' : err.message;
+        server.config.logger.warn(`[wingman] dev proxy not started (${detail})`);
+      });
+
+      proxy.listen(options.port, '127.0.0.1', () => {
+        server.config.logger.info(
+          `  ➜  Wingman drawer: http://localhost:${options.port} (proxying ${options.upstream})`,
+        );
+      });
+
+      server.httpServer?.on('close', () => proxy.close());
+    },
+  };
+}


### PR DESCRIPTION
The Wingman drawer in the dev dashboard cannot call the gateway. Every request fails with `Failed to fetch`, and the health badge reads `CORS blocked`.

It is not a CORS bug. That is why it keeps coming back.

## Root cause

The drawer iframes `https://wingman.manifest.build` and hands it the dashboard's own origin to test against. A public HTTPS page calling `http://localhost:<port>` is a **local-network request**, which Chrome (138+) gates behind the Local Network Access permission. Inside a cross-origin iframe that permission is denied by *permissions policy* unless the embedder delegates it — so no prompt could ever appear.

Measured in Chrome 148, from the drawer's iframe:

| iframe `allow` | `navigator.permissions` state | policy allows | fetch to localhost |
|---|---|---|---|
| today's drawer | **denied** | false | blocked |
| `local-network-access` | prompt | true | promptable |

And the decisive one — same request, same server, only the browser flag differs:

```
LNA enforcement ON  (default): TypeError: Failed to fetch
LNA enforcement OFF (--disable-features=LocalNetworkAccessChecks): 200 {"status":"healthy"}
```

Two consequences worth recording:

1. The browser reports this as a CORS error, so it reads as a server bug. The allow-list was correct the whole time.
2. Local Network Access **replaced** Private Network Access, so the `Access-Control-Allow-Private-Network: true` we still echo on the preflight no longer satisfies anything. That mechanism is dead, which is why a fix that worked stopped working without anyone changing it.

## The fix

Stop crossing the address-space boundary rather than chase a permission model that has now changed twice.

`vite serve` republishes the hosted SPA on `http://localhost:$WINGMAN_PORT`, and the drawer frames that. The iframe and the gateway are then in the same address space, so no permission is involved at all — and it works in Safari and Firefox too, which don't implement the Chrome permission but block the HTTPS-to-localhost call in their own ways.

`WINGMAN_PORT` is the port the backend *already* reads for its dev CORS allow-list and CSP `frame-src`, so most of the wiring was in place; it was only ever usable by someone with a local Wingman checkout.

`allow="local-network-access"` is added to the iframe as a fallback. It's unused on the loopback path, but if anyone points `VITE_WINGMAN_URL` back at an https origin it's the difference between Chrome offering the prompt and refusing outright.

Dev-only: `apply: 'serve'` keeps the proxy out of every production build, matching the drawer it serves. A local Wingman checkout in `VITE_WINGMAN_URL` is already on loopback and is framed directly (the proxy skips it).

## Verification

Full `/serve` stack, real Chrome, login → dashboard → drawer → paste gateway key → send:

- Before: `Failed to fetch`, `CORS blocked` badge, request never leaves the browser.
- After: `reachable · 5ms`, **200 OK** with a real gateway response, **zero console errors and zero non-2xx responses** across the whole session.

Exercised with the hosted SPA through the proxy (the default path) and with a local Wingman checkout framed directly.

Tests: frontend 4094 pass (5 new for the drawer URL resolution, 1 new asserting the permission delegation); backend 7953 unit + 364 e2e pass, including `cors.e2e-spec.ts` and `csp.e2e-spec.ts`.

Pairs with mnfst/wingman#9, which fixes Wingman's side — it was reporting this as "CORS blocked" and telling people to edit an allow-list that was already correct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dev Wingman drawer so it can reach the local gateway by rehosting the SPA on `http://localhost:$WINGMAN_PORT` during `vite serve` and pointing the iframe to that loopback origin. Adds `allow="local-network-access"` as a fallback if someone targets an HTTPS origin.

- **Bug Fixes**
  - Added `wingmanDevProxy` to `vite` dev server to proxy `https://wingman.manifest.build` to `http://localhost:$WINGMAN_PORT`; sets `__WINGMAN_URL__` accordingly in dev.
  - Updated `WingmanDevTools` to use `__WINGMAN_URL__` and delegate `local-network-access` on the iframe.
  - Tests added for URL resolution and permission delegation.
  - Dev-only; no change to production builds.

<sup>Written for commit 36b8471976107836de54302441242f8d3eac4b11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

