### PR TITLE
docs: mark Private Network Access support as legacy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,6 +1612,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1628,6 +1629,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1644,6 +1646,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1660,6 +1663,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1676,6 +1680,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1692,6 +1697,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1708,6 +1714,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1724,6 +1731,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1740,6 +1748,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1756,6 +1765,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1772,6 +1782,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1788,6 +1799,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1804,6 +1816,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1820,6 +1833,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1836,6 +1850,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1852,6 +1867,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1883,6 +1899,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1899,6 +1916,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1915,6 +1933,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1931,6 +1950,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1947,6 +1967,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1963,6 +1984,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1979,6 +2001,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1995,6 +2018,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2011,6 +2035,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4200,7 +4225,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.0",
@@ -4213,7 +4239,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.0",
@@ -4226,7 +4253,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.0",
@@ -4239,7 +4267,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.0",
@@ -4252,7 +4281,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.0",
@@ -4265,7 +4295,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.0",
@@ -4278,7 +4309,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.0",
@@ -4291,7 +4323,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.0",
@@ -4304,7 +4337,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.0",
@@ -4317,7 +4351,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.0",
@@ -4330,7 +4365,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.0",
@@ -4343,7 +4379,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.0",
@@ -4356,7 +4393,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.0",
@@ -4369,7 +4407,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.0",
@@ -4382,7 +4421,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.0",
@@ -4395,7 +4435,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.0",
@@ -4406,7 +4447,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.0",
@@ -4417,7 +4459,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.0",
@@ -4430,7 +4473,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.0",
@@ -4443,7 +4487,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.0",
@@ -4456,7 +4501,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.0",
@@ -4469,7 +4515,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.0",
@@ -4482,7 +4529,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.0",
@@ -4495,7 +4543,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
@@ -12505,7 +12554,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/rou3": {
       "version": "0.7.12",
@@ -14385,6 +14435,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/packages/backend/src/cors-csp-config.ts
+++ b/packages/backend/src/cors-csp-config.ts
@@ -108,7 +108,7 @@ export function createCorsOriginHandler(allowedOrigins: string[]): CorsOriginHan
 
 // Preflight cache lifetime (seconds), shared by the dev and production CORS
 // paths. Without a max-age the browser re-runs the preflight — including the
-// dev Private Network Access preflight — roughly every 5s, so every dashboard
+// legacy dev Private Network Access preflight — roughly every 5s, so every dashboard
 // reload (dev) or burst of Wingman requests (production) re-issues one. Each
 // round trip is another chance for a transient blip to surface as a spurious
 // CORS error. Caching the preflight collapses those repeats. 7200s (2h) is the
@@ -138,12 +138,26 @@ export function buildCorsOptions(allowedOrigins: string[]): CorsOptions {
   };
 }
 
-// Chrome's Private Network Access blocks public HTTPS origins (e.g. the
-// hosted Wingman SPA at https://wingman.manifest.build) from reaching
-// loopback addresses unless the server echoes back
-// `Access-Control-Allow-Private-Network: true` on the preflight. Only
-// echo for origins that already passed the CORS allow-list so this
-// header isn't a free pass for arbitrary callers.
+// LEGACY — kept for old browsers only. Do not reach for this when debugging a
+// blocked loopback request; it will not help, and believing it does has cost
+// us the same bug more than once.
+//
+// Chrome's Private Network Access let a server opt in to public-HTTPS →
+// loopback requests by echoing `Access-Control-Allow-Private-Network: true` on
+// the preflight. Chrome ≥ 138 replaced PNA with **Local Network Access**, which
+// is a *user permission* — no response header can grant it, and in a
+// cross-origin iframe it's denied by permissions policy unless the embedder
+// sends `allow="local-network-access"`, so the prompt never even appears.
+//
+// The browser still reports the block as a CORS error, which is exactly why it
+// keeps being mistaken for one. Verified on Chrome 148: the request fails with
+// this header present and succeeds with
+// `--disable-features=LocalNetworkAccessChecks`.
+//
+// The fix is not to send another header — it's to not cross the address-space
+// boundary. The dashboard's dev drawer serves Wingman from a loopback origin
+// for that reason (see packages/frontend/wingman-dev-proxy.ts). This header
+// stays because pre-138 Chrome still honours it and it costs nothing.
 //
 // Shape kept narrow on purpose: takes only the request fields read and
 // a setHeader callback so it composes with Express middleware and unit

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -94,12 +94,15 @@ export async function bootstrap() {
         wingmanPort,
       })
     : buildProdAllowedOrigins({ extraOrigins: process.env['WINGMAN_CORS_ORIGINS'] });
-  // Chrome's Private Network Access preflight must be answered before the cors
-  // middleware ends the OPTIONS response, so register this first. It only echoes
-  // the allow-private-network header for already-allow-listed origins, so it's a
-  // no-op for a public gateway and only matters when a browser-hosted Wingman
-  // targets a gateway on a loopback / LAN address (local dev, or a self-hosted
-  // gateway on a private network).
+  // Legacy Private Network Access support, for browsers older than Chrome 138.
+  // Newer Chrome replaced PNA with Local Network Access, a user permission that
+  // no response header can satisfy — so this does *not* fix a blocked
+  // public-HTTPS → loopback request on a current browser, however much the
+  // browser's "CORS error" wording suggests it should. See the note on
+  // `applyPrivateNetworkAllow` before reaching for it. Registered ahead of the
+  // cors middleware because the preflight has to be answered before that
+  // middleware ends the OPTIONS response; it only echoes the header for
+  // already-allow-listed origins, so it's a no-op for a public gateway.
   app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
     applyPrivateNetworkAllow(req, corsAllowedOrigins, (name, value) => res.setHeader(name, value));
     next();


### PR DESCRIPTION
No behaviour change. Comments only.

The comments around `applyPrivateNetworkAllow` still presented `Access-Control-Allow-Private-Network` as the mechanism that lets the hosted Wingman SPA reach a loopback gateway. It hasn't been since Chrome 138 replaced Private Network Access with **Local Network Access** — a user permission that no response header can grant, and which a cross-origin iframe can't even prompt for without `allow="local-network-access"`.

This is worth more than a normal stale-comment cleanup. Chrome reports the block **as a CORS error**, so the natural debugging path is: audit CORS → find the allow-list correct → notice the PNA header → conclude the server side is already handled → look elsewhere. That loop cost the same bug several times before #2579 diagnosed it, and the comment is what closes it each time.

Keeping the header (pre-138 Chrome still honours it, and it costs nothing), but the comments now state:

- it's legacy, for browsers older than Chrome 138
- what actually gates the request now
- how to verify it in one command — `--disable-features=LocalNetworkAccessChecks` flips it on Chrome 148
- where the real fix lives (`packages/frontend/wingman-dev-proxy.ts`)

`cors-csp-config.spec.ts` unchanged and passing (32 tests) — the behaviour it pins is deliberately untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark Private Network Access (`Access-Control-Allow-Private-Network`) as legacy in backend comments and clarify that Chrome 138+ uses Local Network Access, which cannot be granted by a response header. No behavior change; the header stays for older Chrome, and comments now point to the real fix in `packages/frontend/wingman-dev-proxy.ts`.

<sup>Written for commit 9719c925eed3dc5d00cedde7d6150ea8724f8a6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

