### PR TITLE
fix: preserve DeepSeek reasoning effort

### DIFF
--- a/.changeset/preserve-deepseek-reasoning-effort.md
+++ b/.changeset/preserve-deepseek-reasoning-effort.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Preserve configured reasoning effort when forwarding requests to native DeepSeek V4 models.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -64,6 +64,21 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('reasoning_effort', 'high');
     });
 
+    it('should preserve reasoning_effort for DeepSeek', () => {
+      const result = sanitizeOpenAiBody(
+        {
+          messages: [{ role: 'user', content: 'Hi' }],
+          thinking: { type: 'enabled' },
+          reasoning_effort: 'max',
+        },
+        'deepseek',
+        'deepseek-v4-pro',
+      );
+
+      expect(result).toHaveProperty('thinking', { type: 'enabled' });
+      expect(result).toHaveProperty('reasoning_effort', 'max');
+    });
+
     it('should preserve response_format for OpenAI-wire providers', () => {
       const responseFormat = {
         type: 'json_schema',

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -3483,6 +3483,30 @@ describe('ProviderClient', () => {
       expect(sentBody.service_tier).toBeUndefined();
     });
 
+    it('preserves DeepSeek reasoning_effort in the provider-facing request', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'deepseek',
+        apiKey: 'sk-ds',
+        model: 'deepseek-v4-pro',
+        body: {
+          messages: [{ role: 'user', content: 'Solve this carefully.' }],
+          thinking: { type: 'enabled' },
+          reasoning_effort: 'max',
+        },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody).toMatchObject({
+        model: 'deepseek-v4-pro',
+        thinking: { type: 'enabled' },
+        reasoning_effort: 'max',
+      });
+      expect(result.wireRequestBody).toEqual(sentBody);
+    });
+
     it('caps DeepSeek max_tokens at the provider limit', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -387,7 +387,7 @@ export function sanitizeOpenAiBody(
       cleaned[key] = value;
       continue;
     }
-    if (key === 'reasoning_effort' && endpointKey === 'xai') {
+    if (key === 'reasoning_effort' && (endpointKey === 'xai' || endpointKey === 'deepseek')) {
       cleaned[key] = value;
       continue;
     }


### PR DESCRIPTION
### ✨ What changed
- Preserve `reasoning_effort` when forwarding native DeepSeek requests.
- Cover sanitizer output and serialized provider request bodies.

### 💭 Why
Model parameter overrides for DeepSeek V4 were saved but stripped before reaching the provider.

### 👤 For users
DeepSeek V4 thinking effort settings now affect provider requests.

### 📝 Notes
Fixes #2576

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves DeepSeek V4 `reasoning_effort` when forwarding native requests so the model’s thinking effort reaches the provider. Fixes #2576.

- **Bug Fixes**
  - Allow `reasoning_effort` for `deepseek` in `sanitizeOpenAiBody` (previously only `xai`).
  - Add tests verifying preserved fields and the provider-facing serialized body.

<sup>Written for commit 964601e5d5de31e7dd6e67bc15347572a257772e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

