### PR TITLE
feat: add Claude Opus 5 subscription support

### DIFF
--- a/.changeset/bright-lions-spark.md
+++ b/.changeset/bright-lions-spark.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add Claude Opus 5 to the Anthropic subscription model catalog.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1632,6 +1632,7 @@ describe('ModelDiscoveryService', () => {
         'claude-fable-5',
         'claude-haiku-4',
         'claude-opus-4',
+        'claude-opus-5',
         'claude-sonnet-4',
         'claude-sonnet-5',
       ]);
@@ -1946,14 +1947,15 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Should only include models matching knownModels prefixes (claude-opus-4, claude-sonnet-4, claude-haiku-4)
-      // and NOT claude-2.1 or openai models. claude-fable-5 and claude-sonnet-5
-      // have no OpenRouter pricing entry, so they are appended directly as
-      // zero-cost known models.
-      expect(result).toHaveLength(5);
+      // and NOT claude-2.1 or openai models. Claude Fable 5, Opus 5, and
+      // Sonnet 5 have no OpenRouter pricing entry, so they are appended
+      // directly as zero-cost known models.
+      expect(result).toHaveLength(6);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
         'claude-haiku-4-20260301',
         'claude-opus-4-20260301',
+        'claude-opus-5',
         'claude-sonnet-4-20260301',
         'claude-sonnet-5',
       ]);
@@ -2150,11 +2152,12 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Even without pricingSync, knownModels are returned directly
-      expect(result).toHaveLength(5);
+      expect(result).toHaveLength(6);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
         'claude-haiku-4',
         'claude-opus-4',
+        'claude-opus-5',
         'claude-sonnet-4',
         'claude-sonnet-5',
       ]);
@@ -2531,11 +2534,12 @@ describe('ModelDiscoveryService', () => {
       const result = buildSubscriptionFallbackModels(null as never, 'anthropic');
 
       // No OpenRouter data, but knownModels are added directly
-      expect(result).toHaveLength(5);
+      expect(result).toHaveLength(6);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
         'claude-haiku-4',
         'claude-opus-4',
+        'claude-opus-5',
         'claude-sonnet-4',
         'claude-sonnet-5',
       ]);

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -350,6 +350,37 @@ describe('buildSubscriptionFallbackModels', () => {
     expect(model!.contextWindow).toBe(1000000);
   });
 
+  it('uses the Anthropic Opus 5 subscription context override', () => {
+    const cache = new Map([
+      [
+        'anthropic/claude-opus-5',
+        {
+          input: 0.005,
+          output: 0.025,
+          contextWindow: 200000,
+          displayName: 'Claude Opus 5',
+        },
+      ],
+    ]);
+
+    const model = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic').find(
+      (m) => m.id === 'claude-opus-5',
+    );
+
+    expect(model).toBeDefined();
+    expect(model!.contextWindow).toBe(1000000);
+  });
+
+  it('surfaces claude-opus-5 even when the pricing cache lacks it', () => {
+    // The 5 generation dropped the claude-opus-4 prefix, so Opus 5 reaches the
+    // curated catalog only via its own knownModels entry.
+    const ids = buildSubscriptionFallbackModels(makePricingSync(new Map()), 'anthropic').map(
+      (m) => m.id,
+    );
+
+    expect(ids).toContain('claude-opus-5');
+  });
+
   it('surfaces claude-fable-5 even when the pricing cache lacks it', () => {
     // claude-fable-5 is a valid Anthropic subscription model with no pricing
     // cache entry; the knownModels fallback must still offer it.

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -63,6 +63,18 @@ describe('getSubscriptionProviderConfig', () => {
     });
   });
 
+  it('lists claude-opus-5 explicitly — the claude-opus-4 prefix does not cover it', () => {
+    const config = getSubscriptionProviderConfig('anthropic');
+    const knownModels = config?.knownModels ?? [];
+    expect(knownModels).toContain('claude-opus-5');
+    // Anthropic matches by prefix, so claude-opus-4-8 rides on 'claude-opus-4'.
+    // The 5 generation dropped that prefix — without its own entry, an Opus 5
+    // subscription model would be filtered out of the curated catalog.
+    expect(knownModels.some((m) => 'claude-opus-5'.startsWith(m) && m !== 'claude-opus-5')).toBe(
+      false,
+    );
+  });
+
   it('returns config for openai', () => {
     const config = getSubscriptionProviderConfig('openai');
     expect(config).toMatchObject({
@@ -508,6 +520,8 @@ describe('getSubscriptionCapabilities', () => {
       supportsBatching: false,
     });
     expect(caps?.modelContextWindows?.['claude-opus-4-8']).toBe(1000000);
+    // Opus 5 is 1M too; without an entry it would fall back to the 200k default.
+    expect(caps?.modelContextWindows?.['claude-opus-5']).toBe(1000000);
   });
 
   it('returns capabilities for OpenAI subscription', () => {

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -16,7 +16,9 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       'claude-sonnet-4',
       'claude-haiku-4',
       // claude-opus-4-6 / claude-haiku-4-5 are already matched by the
-      // claude-opus-4 / claude-haiku-4 prefixes above.
+      // claude-opus-4 / claude-haiku-4 prefixes above. claude-opus-5 is not —
+      // the 5 generation dropped the 4.x prefix, so it needs its own entry.
+      'claude-opus-5',
       'claude-sonnet-5',
     ]),
     // `claude-*-fast` ids exist in the OpenRouter pricing cache but 404 at
@@ -28,6 +30,7 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       maxContextWindow: 200000,
       modelContextWindows: Object.freeze({
         'claude-opus-4-8': 1000000,
+        'claude-opus-5': 1000000,
         'claude-sonnet-5': 1000000,
       }),
       supportsPromptCaching: true,


### PR DESCRIPTION
### ✨ What changed
- Adds Claude Opus 5 to the Anthropic subscription catalog.
- Applies its 1M context window to fallback models.

### 💭 Why
The Opus 4 prefix does not match the new model ID.

### 👤 For users
Anthropic subscription users can select Claude Opus 5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `claude-opus-5` to the Anthropic subscription catalog with a 1M context window. Ensures it appears in the curated list and in fallback discovery even when there’s no pricing cache entry.

- **New Features**
  - Added `claude-opus-5` to Anthropic `knownModels`.
  - Set `claude-opus-5` context window to 1,000,000 tokens (including fallback models).
  - Added tests for curated listing, missing-pricing fallback, and the 1M context override.

<sup>Written for commit b818675d8eacc9670bb7e93fd8392e210d05549d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

