### PR TITLE
fix: bump seroval to 1.5.6 (critical deserialization advisory)

### DIFF
--- a/.changeset/seroval-critical-bump.md
+++ b/.changeset/seroval-critical-bump.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Security: bump transitive dependency `seroval` 1.5.1 → 1.5.6, fixing a critical deserialization advisory (`fromJSON()` Promise resolver type confusion, GHSA — patched in 1.5.3).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12430,14 +12430,18 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.5.1",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/seroval-plugins": {
-      "version": "1.5.1",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.6.tgz",
+      "integrity": "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10"


### PR DESCRIPTION
Resolves the one **critical** open Dependabot alert (runtime scope): `seroval` ≤ 1.5.2 — `fromJSON()` Promise resolver type confusion that can invoke attacker-controlled methods during deserialization. Patched in 1.5.3.

`seroval` is a transitive dependency of `solid-js` (`~1.5.0`), so Dependabot never opens a PR for it — but the constraint already admits the patched line, so this is a lockfile-only bump: `npm update seroval seroval-plugins`, 1.5.1 → 1.5.6. The diff touches exactly those two lockfile entries; no package.json or override changes.

Verified: full frontend suite (210 files / 4094 tests) green — solid-js is the only consumer.

Changeset included (patch): runtime security fix, ships in the Docker image.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical deserialization vulnerability by bumping transitive `seroval` to 1.5.6 (patches `fromJSON()` Promise resolver type confusion). Lockfile-only update; no app code changes.

- **Dependencies**
  - Update `seroval` and `seroval-plugins` 1.5.1 → 1.5.6.
  - Pulled via `solid-js` (`~1.5.0`); no `package.json` or overrides changed.
  - All frontend tests pass; included in the Docker image.

<sup>Written for commit 04bc1c9e54a8ee4330317ec119bab0957b983869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

