### PR TITLE
fix: sync base.digest label with the bumped distroless digest

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,7 @@ LABEL org.opencontainers.image.title="Manifest" \
       org.opencontainers.image.vendor="MNFST Inc." \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.base.name="gcr.io/distroless/nodejs24-debian13:nonroot" \
-      org.opencontainers.image.base.digest="sha256:f16acace4aa70086d4a2caad6c716f01e3e2fe0dd8274c4530c7c17d987bdb1a"
+      org.opencontainers.image.base.digest="sha256:b087b405441cd3e8eab9bd53ae3dd1c2b824e7ce13f25c5e9bb353fbdb3f4544"
 
 ENV NODE_ENV=production
 ENV BIND_ADDRESS=0.0.0.0


### PR DESCRIPTION
Follow-up to #1946: Dependabot bumps the `FROM` digest but doesn't know about the `org.opencontainers.image.base.digest` label, which still recorded the old `f16acac…` digest (cubic's P2 on that PR). One line — the label now matches the actual base image `b087b40…`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the `org.opencontainers.image.base.digest` label with the updated distroless base image, aligning it with the `FROM` digest. This fixes mismatched image metadata so scanners and SBOMs report the correct base.

<sup>Written for commit c77fec4874d2f972c11d1845ffccc9036154412c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

