### PR TITLE
fix: let a failed self-host install be retried

### DIFF
--- a/.changeset/resume-self-host-install.md
+++ b/.changeset/resume-self-host-install.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Self-hosting fixes. The install script now resumes instead of failing when the install directory already exists, so a run that died at `docker compose up` can be retried without losing the generated secret. Adds `--port` for installing on a port other than 2099, and generates `MANIFEST_ENCRYPTION_KEY` so provider credentials are no longer encrypted with the session-signing secret by default. The bundled compose file now forwards 16 documented variables it was silently dropping, including `TELEMETRY_ENDPOINT` and `MANIFEST_DISABLE_HSTS`. Blank values for `TELEMETRY_ENDPOINT` and the provider OAuth client IDs fall back to their defaults instead of being treated as an override.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -13,12 +13,15 @@ BETTER_AUTH_SECRET=
 
 # ─── Deployment URL + port ─────────────────────────────────────────────────
 
-# App port on the host. Default: 2099 (current dashboard port).
-# Existing installs upgrading from an older image can pin PORT=3001 here
-# to keep reverse-proxy, OAuth callback, and bookmarked URLs working
-# without a reconfiguration. The compose file reads ${PORT:-2099} for
-# both the port binding and the internal backend listener.
-# PORT=3001
+# App port. Default: 2099. This is the one knob for changing the port —
+# the compose file reads ${PORT:-2099} for both the published host port and
+# the backend's internal listener, and BETTER_AUTH_URL below defaults to
+# http://localhost:${PORT:-2099}. No YAML edit needed.
+#
+# Also how existing installs upgrading from an older image stay on the
+# previous port (PORT=3001), keeping reverse-proxy, OAuth callback, and
+# bookmarked URLs working without a reconfiguration.
+# PORT=8080
 
 # Override when deploying to a domain (e.g., https://manifest.example.com).
 # Default: http://localhost:${PORT:-2099}
@@ -92,6 +95,41 @@ BETTER_AUTH_SECRET=
 # DISCORD_CLIENT_SECRET=
 
 
+# ─── Serving over plain HTTP ───────────────────────────────────────────────
+#
+# On boot Manifest warns when BETTER_AUTH_URL is not an https:// origin,
+# because it can't send HSTS. Set this to 1 to silence the warning on an
+# HTTP-only LAN deployment. Anywhere reachable from the internet, put a real
+# https:// URL in BETTER_AUTH_URL instead of setting this.
+# MANIFEST_DISABLE_HSTS=1
+
+
+# ─── Rate limiting + database tuning (optional) ────────────────────────────
+
+# Rate limit: max requests per window, and the window in ms.
+# THROTTLE_LIMIT=100
+# THROTTLE_TTL=60000
+
+# PostgreSQL pool sizes. DB_POOL_MAX is the app's pool; Better Auth opens a
+# second, smaller one of its own.
+# DB_POOL_MAX=30
+# AUTH_DB_POOL_MAX=10
+
+# Set false for multi-replica deploys where only one instance should run
+# migrations on boot. A single-container compose install wants the default.
+# RUN_MIGRATIONS_ON_BOOT=true
+
+
+# ─── Error monitoring (optional) ───────────────────────────────────────────
+#
+# Sentry stays completely uninitialised unless SENTRY_DSN is set. Error
+# capture only — performance tracing, request bodies, headers, and user data
+# are all disabled in code.
+# SENTRY_DSN=
+# SENTRY_ENVIRONMENT=production
+# SENTRY_RELEASE=
+
+
 # ─── Anonymous usage telemetry (optional, opt-out) ─────────────────────────
 #
 # Manifest sends one small anonymous usage report per 24h so the maintainers
@@ -101,3 +139,6 @@ BETTER_AUTH_SECRET=
 #
 # To disable, uncomment the line below.
 # MANIFEST_TELEMETRY_DISABLED=1
+
+# Or keep telemetry on and send it to your own collector instead.
+# TELEMETRY_ENDPOINT=https://telemetry.example.internal/v1/report

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -34,8 +34,10 @@ Manifest is a smart model router for **AI agents** like OpenClaw, Hermes, or any
   - [Option 1: Quickstart install script (recommended)](#option-1-quickstart-install-script-recommended)
   - [Option 2: Docker Compose (manual)](#option-2-docker-compose-manual)
   - [Option 3: Docker Run (bring your own PostgreSQL)](#option-3-docker-run-bring-your-own-postgresql)
+  - [First request](#first-request)
   - [Verifying the image signature](#verifying-the-image-signature)
   - [Custom port](#custom-port)
+  - [Exposing on the LAN](#exposing-on-the-lan)
 - [Image tags](#image-tags)
 - [Upgrading](#upgrading)
 - [Backup & persistence](#backup--persistence)
@@ -63,11 +65,11 @@ Works with 300+ models across OpenAI, Anthropic, Google Gemini, DeepSeek, xAI, M
 
 Three paths, ordered from fastest to most hands-on. All three end in the same place: a running stack at [http://localhost:2099](http://localhost:2099) where you sign up. The first account you create becomes the admin. No demo credentials are pre-seeded.
 
-> **Heads up on network binding.** The bundled compose file binds port 2099 to `127.0.0.1` only, so the dashboard is reachable on the host machine but not over the LAN. See [Custom port](#custom-port) to expose it beyond localhost.
+> **Heads up on network binding.** The bundled compose file binds port 2099 to `127.0.0.1` only, so the dashboard is reachable on the host machine but not over the LAN. See [Exposing on the LAN](#exposing-on-the-lan) to expose it beyond localhost.
 
 ### Option 1: Quickstart install script (recommended)
 
-One command. The installer downloads the compose file, generates a secret, and brings up the stack. Give it about 30 seconds to boot.
+One command. The installer downloads the compose file, generates the secrets, and brings up the stack. First boot pulls the app image and Postgres, so give it up to a couple of minutes.
 
 ```bash
 bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/install.sh)
@@ -96,7 +98,9 @@ bash install.sh
 
 </details>
 
-Useful flags: `--dir <path>` to install elsewhere, `--dry-run` to preview, `--yes` to skip the confirmation prompt.
+Useful flags: `--dir <path>` to install elsewhere, `--port <n>` to serve on a port other than 2099, `--dry-run` to preview, `--yes` to skip the confirmation prompt.
+
+Re-running the installer against an existing install directory resumes it — the compose file and your generated secrets are left untouched and the stack is brought back up.
 
 ### Option 2: Docker Compose (manual)
 
@@ -110,11 +114,17 @@ curl -O https://raw.githubusercontent.com/mnfst/manifest/main/docker/.env.exampl
 cp .env.example .env
 ```
 
-2. Open `.env` in your editor and set `BETTER_AUTH_SECRET` to a random string. You can generate one with:
+2. Open `.env` in your editor and set `BETTER_AUTH_SECRET` and
+   `MANIFEST_ENCRYPTION_KEY` to two **different** random strings. Generate each with:
 
 ```bash
 openssl rand -hex 32
 ```
+
+`MANIFEST_ENCRYPTION_KEY` encrypts the provider API keys and OAuth tokens
+Manifest stores. Left unset it falls back to `BETTER_AUTH_SECRET`, which means
+one leaked session-signing secret also decrypts every stored credential. Set it
+before first boot — adding it later means re-encrypting what is already stored.
 
 (Optional: to use a stronger database password, set BOTH `POSTGRES_PASSWORD` and `DATABASE_URL` in `.env`, they must agree, and any special characters in the password need to be percent-encoded in the URL.)
 
@@ -124,9 +134,11 @@ openssl rand -hex 32
 docker compose up -d
 ```
 
-Give it about 30 seconds to boot.
+Give it up to a couple of minutes on a cold pull — you can watch startup with `docker compose logs -f manifest`.
 
 4. Open [http://localhost:2099](http://localhost:2099) and sign up. The first account you create becomes the admin.
+
+5. Connect a provider and send your first request — see [First request](#first-request).
 
 To stop:
 
@@ -187,6 +199,38 @@ docker run -d ^
 
 TypeORM migrations run automatically on every boot — fresh installs come up with the schema in place. Then visit [http://localhost:2099](http://localhost:2099) and complete the setup wizard to create your admin account.
 
+### First request
+
+Signing up leaves you with an empty instance. Three steps to a routed request:
+
+1. **Connect a provider.** In the sidebar, **Providers → Usage-based** to paste
+   an API key (OpenAI, Anthropic, Gemini, …), **Subscriptions** to reuse a plan
+   you already pay for, or **Local** for Ollama / LM Studio / llama.cpp.
+   Manifest discovers the available models as soon as the connection is saved.
+
+2. **Copy your agent's key.** Each agent has its own key, shown when you create
+   it and under the agent's **Settings**. It starts with `mnfst_`.
+
+3. **Point something at it.** The endpoint is OpenAI-compatible, so any SDK or
+   agent that takes a base URL works — use `http://localhost:2099/v1` and the
+   `mnfst_` key. To check it end to end:
+
+```bash
+curl -X POST http://localhost:2099/v1/chat/completions \
+  -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "auto", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+`"model": "auto"` asks Manifest to route. Any other model name is treated as an
+explicit choice and falls back to your routing config if it matches nothing.
+
+Errors from Manifest itself carry an `M###` code, a plain-English cause, and a
+link to the matching page under
+[manifest.build/docs/errors](https://manifest.build/docs/errors) — including
+`M100` (no provider connected yet) and `M003`/`M005` (bad or unknown key), the
+three you are most likely to hit on a fresh install.
+
 ### Verifying the image signature
 
 Published images are signed with cosign keyless signing (Sigstore). Verify before pulling:
@@ -199,7 +243,19 @@ cosign verify manifestdotbuild/manifest:<version> \
 
 ### Custom port
 
-If port 2099 is taken, change both the mapping and `BETTER_AUTH_URL`:
+**Compose installs — set `PORT` in `.env`, and nothing else:**
+
+```env
+PORT=8080
+```
+
+The compose file reads `${PORT:-2099}` for both the published host port and
+the backend's internal listener, and `BETTER_AUTH_URL` defaults to
+`http://localhost:${PORT:-2099}`, so one line covers all three. No YAML edit.
+The install script does this for you with `--port 8080`.
+
+**`docker run` installs** have no `.env`, so pass the mapping and the URL
+explicitly. Here the container keeps listening on 2099 and Docker remaps it:
 
 ```bash
 docker run -d \
@@ -208,18 +264,8 @@ docker run -d \
   ...
 ```
 
-Or in docker-compose.yml:
-
-```yaml
-ports:
-  - '127.0.0.1:8080:2099'
-```
-
-…and in `.env`:
-
-```env
-BETTER_AUTH_URL=http://localhost:8080
-```
+`BETTER_AUTH_URL` must match the URL you type in the browser — host and port
+both. A mismatch fails the login with "Invalid origin".
 
 ### Exposing on the LAN
 
@@ -350,15 +396,25 @@ sets this automatically).
 | -------------------- | -------- | ----------------------- | --------------------------------------------- |
 | `DATABASE_URL`       | Yes      | --                      | PostgreSQL connection string                  |
 | `BETTER_AUTH_SECRET` | Yes      | --                      | Session signing secret (min 32 chars)         |
-| `BETTER_AUTH_URL`    | No       | `http://localhost:2099` | Public URL. Set this when using a custom port |
-| `PORT`               | No       | `2099`                  | Internal server port                          |
-| `NODE_ENV`           | No       | `production`            | Runtime mode. Leave as `production` for Docker |
-| `SEED_DATA`          | No       | `false`                 | Seed demo data on startup                     |
+| `MANIFEST_ENCRYPTION_KEY` | Recommended | falls back to `BETTER_AUTH_SECRET` | Separate 32+ char key encrypting stored provider keys and OAuth tokens. The install script generates one; set it before first boot, since introducing it later means re-encrypting what is already stored. |
+| `BETTER_AUTH_URL`    | No       | `http://localhost:${PORT}` | Public URL. Must match the URL in the browser |
+| `PORT`               | No       | `2099`                  | Dashboard port — sets both the published host port and the internal listener |
 | `OLLAMA_HOST`        | No       | `http://host.docker.internal:11434` | Ollama endpoint for the built-in tile. Override to point at a LAN-hosted Ollama. |
 | `MANIFEST_MODE`      | No       | auto (Docker → selfhosted) | `selfhosted` or `cloud`. `local` is a legacy alias. Self-hosted mode allows private/http URLs for custom providers. |
+| `MANIFEST_DISABLE_HSTS` | No    | unset                   | Set `1` to silence the boot warning about serving over plain HTTP on a LAN |
+| `THROTTLE_LIMIT` / `THROTTLE_TTL` | No | `100` / `60000`   | Rate limit: requests per window, window in ms  |
+| `DB_POOL_MAX` / `AUTH_DB_POOL_MAX` | No | `30` / `10`      | PostgreSQL pool sizes (app pool, Better Auth pool) |
+| `SENTRY_DSN`         | No       | unset                   | Opt-in error monitoring. Sentry is not initialised unless set |
 | `MANIFEST_TELEMETRY_DISABLED` | No | `0`               | Set `1` to disable anonymous usage telemetry  |
+| `TELEMETRY_ENDPOINT` | No       | `https://telemetry.manifest.build/v1/report` | Send the usage report to your own collector instead |
 
-Full env var reference: [github.com/mnfst/manifest](https://github.com/mnfst/manifest)
+`NODE_ENV` and `SEED_DATA` are deliberately fixed by the compose file and are
+not knobs here: the image is a production artifact, and the demo-data seeder
+refuses to run under `NODE_ENV=production` regardless of `SEED_DATA`. Use the
+first-run setup wizard to create your admin account.
+
+Full env var reference:
+[manifest.build/docs/reference/environment-variables](https://manifest.build/docs/reference/environment-variables)
 
 ## Anonymous usage telemetry
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -68,6 +68,11 @@ services:
       - PROVIDER_TIMEOUT_MS=${PROVIDER_TIMEOUT_MS:-180000}
       - STREAM_WARMUP_MS=${STREAM_WARMUP_MS:-15000}
       - CODEX_SEMANTIC_OUTPUT_TIMEOUT_MS=${CODEX_SEMANTIC_OUTPUT_TIMEOUT_MS:-60000}
+      # Both are deliberately hardcoded, not `${VAR:-default}`. The image is a
+      # production artifact: NODE_ENV=production is what makes it one, and the
+      # seeder refuses to run under it anyway (database-seeder.service.ts logs
+      # "SEED_DATA=true is ignored in production"). Exposing either as a knob
+      # would only offer a setting that cannot take effect.
       - SEED_DATA=false
       - NODE_ENV=production
       # Force self-hosted semantics regardless of the container runtime.
@@ -91,9 +96,45 @@ services:
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
       - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID:-}
       - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET:-}
-      # Anonymous usage telemetry (opt-out). Set to 1 to disable. See
-      # https://manifest.build/telemetry for the exact payload shape.
+      # Provider OAuth client overrides (optional). Only needed if you have
+      # registered your own OAuth app with these providers instead of using
+      # the defaults shipped with Manifest.
+      - OPENAI_OAUTH_CLIENT_ID=${OPENAI_OAUTH_CLIENT_ID:-}
+      - MINIMAX_OAUTH_CLIENT_ID=${MINIMAX_OAUTH_CLIENT_ID:-}
+      # Programmatic API access via the X-API-Key header. Optional — the
+      # dashboard uses cookie sessions and agents use their own mnfst_* keys.
+      - API_KEY=${API_KEY:-}
+      # Rate limiting. Window in ms + max requests per window per client.
+      - THROTTLE_TTL=${THROTTLE_TTL:-60000}
+      - THROTTLE_LIMIT=${THROTTLE_LIMIT:-100}
+      # Database tuning. DB_POOL_MAX sizes the app pool, AUTH_DB_POOL_MAX the
+      # separate pool Better Auth opens for itself.
+      - DB_POOL_MAX=${DB_POOL_MAX:-30}
+      - AUTH_DB_POOL_MAX=${AUTH_DB_POOL_MAX:-10}
+      - DB_TUNE_SESSION=${DB_TUNE_SESSION:-}
+      # Set false for multi-replica deploys where only one instance should run
+      # migrations. A single-container compose install wants the default.
+      - RUN_MIGRATIONS_ON_BOOT=${RUN_MIGRATIONS_ON_BOOT:-true}
+      # Grace period (ms) to finish in-flight requests on SIGTERM. Spelled with
+      # a real default rather than `:-` because the app reads it as
+      # `Number(env ?? 10000)` — an empty string would coerce to 0, not 10000.
+      - SHUTDOWN_DRAIN_MS=${SHUTDOWN_DRAIN_MS:-10000}
+      # Suppresses the boot warning about HSTS on plain-HTTP deployments. Set
+      # to 1 for HTTP-only LAN installs; prefer a real https:// BETTER_AUTH_URL
+      # anywhere reachable from the internet.
+      - MANIFEST_DISABLE_HSTS=${MANIFEST_DISABLE_HSTS:-}
+      # Extra browser origins allowed to call the gateway (comma-separated).
+      - WINGMAN_CORS_ORIGINS=${WINGMAN_CORS_ORIGINS:-}
+      # Error monitoring (opt-in). Sentry stays completely uninitialised
+      # unless SENTRY_DSN is set.
+      - SENTRY_DSN=${SENTRY_DSN:-}
+      - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-}
+      - SENTRY_RELEASE=${SENTRY_RELEASE:-}
+      # Anonymous usage telemetry (opt-out). Set MANIFEST_TELEMETRY_DISABLED=1
+      # to disable, or point TELEMETRY_ENDPOINT at your own collector. See
+      # https://manifest.build/docs/self-hosted#telemetry for the payload shape.
       - MANIFEST_TELEMETRY_DISABLED=${MANIFEST_TELEMETRY_DISABLED:-0}
+      - TELEMETRY_ENDPOINT=${TELEMETRY_ENDPOINT:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -2,9 +2,9 @@
 # Manifest — self-host quick install
 #
 # Downloads the Docker Compose file and the `.env.example` template,
-# generates a BETTER_AUTH_SECRET, writes it into a local `.env`, then
-# brings up the stack. Designed for first-time self-hosters who want a
-# one-command setup. Give it up to a couple of minutes on first boot —
+# generates a BETTER_AUTH_SECRET and a MANIFEST_ENCRYPTION_KEY, writes them
+# into a local `.env`, then brings up the stack. Designed for first-time
+# self-hosters who want a one-command setup. Give it a couple of minutes —
 # Docker needs to pull the app image and Postgres on a cold cache.
 # Once healthy, visit http://localhost:2099 and the setup wizard will
 # walk you through creating the first admin account.
@@ -12,8 +12,13 @@
 # Usage:
 #   bash install.sh                  # install into $HOME/manifest
 #   bash install.sh --dir /opt/mnfst # install into a custom directory
+#   bash install.sh --port 8080      # serve the dashboard on a different port
 #   bash install.sh --dry-run        # print what would happen, do nothing
 #   bash install.sh --yes            # skip confirmation prompt (non-interactive)
+#
+# Re-running against an existing install directory resumes it: the compose
+# file and the generated secrets are left alone and the stack is brought
+# back up. Nothing is overwritten.
 #
 # Review before running:
 #   curl -sSLO https://raw.githubusercontent.com/mnfst/manifest/main/docker/install.sh
@@ -54,19 +59,26 @@ run() {
 }
 
 usage() {
-  sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+  # Print the header comment block: every line from line 2 up to (but not
+  # including) the first non-comment line. Computed rather than a hardcoded
+  # range so editing the header above can't silently truncate --help.
+  awk 'NR>1 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
   exit 0
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dir)     INSTALL_DIR="${2:?--dir requires a path}"; shift 2 ;;
+    --port)    HOST_PORT="${2:?--port requires a port number}"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     --yes|-y)  ASSUME_YES=1; shift ;;
     -h|--help) usage ;;
     *)         die "Unknown flag: $1 (use --help)" ;;
   esac
 done
+
+[[ "$HOST_PORT" =~ ^[0-9]+$ ]] && (( HOST_PORT >= 1 && HOST_PORT <= 65535 )) \
+  || die "--port must be a number between 1 and 65535 (got: $HOST_PORT)"
 
 command -v docker >/dev/null 2>&1 \
   || die "docker not found. Install Docker first: https://docs.docker.com/get-docker/"
@@ -83,23 +95,41 @@ else
   die "Need either openssl or /dev/urandom to generate a secret."
 fi
 
+# An existing install directory is a resume, not an error. The common way to
+# land here is a first run that downloaded the files and then failed at
+# `docker compose up` (no disk space, a Docker daemon hiccup, an exhausted
+# network address pool). Re-running used to hard-fail with "already exists",
+# which pointed at --dir or `rm -rf` — and `rm -rf` throws away the generated
+# BETTER_AUTH_SECRET, invalidating every session and, if the volume survived,
+# every provider credential encrypted with it. So: keep what's there and
+# just bring the stack up.
+RESUME=0
 if [[ -e "$INSTALL_DIR" && -n "$(ls -A "$INSTALL_DIR" 2>/dev/null || true)" ]]; then
-  die "$INSTALL_DIR already exists and is not empty. Pass --dir to choose another location or remove it first."
+  if [[ -f "$INSTALL_DIR/docker-compose.yml" && -f "$INSTALL_DIR/.env" ]]; then
+    RESUME=1
+  else
+    die "$INSTALL_DIR already exists, is not empty, and does not look like a Manifest install (no docker-compose.yml + .env). Pass --dir to choose another location, or remove it first."
+  fi
 fi
 
-# Nothing we install will start if 2099 is already taken; surface that
-# now with a pointer to the fix, rather than letting `docker compose up`
-# fail with a less obvious message below.
-if [[ "$DRY_RUN" -eq 0 ]]; then
+# Nothing we install will start if the host port is already taken; surface
+# that now with a pointer to the fix, rather than letting `docker compose up`
+# fail with a less obvious message below. Skipped when resuming — the port is
+# very likely held by this install's own container.
+if [[ "$DRY_RUN" -eq 0 && "$RESUME" -eq 0 ]]; then
   if command -v ss >/dev/null 2>&1 && ss -ltn 2>/dev/null | grep -qE "[: ]${HOST_PORT}\\b"; then
-    die "Port ${HOST_PORT} is already in use on this host. Stop whatever is bound to it, or pick a different host port by editing the ports line in $INSTALL_DIR/docker-compose.yml after the install."
+    die "Port ${HOST_PORT} is already in use on this host. Stop whatever is bound to it, or re-run with a different port: bash install.sh --port 8080"
   fi
 fi
 
 log "Manifest self-host installer"
 printf '    Install directory: %s\n' "$INSTALL_DIR"
+printf '    Dashboard port:    %s\n' "$HOST_PORT"
 printf '    Source:            %s\n' "$REPO_RAW"
 printf '    Mode:              %s\n' "$([[ $DRY_RUN -eq 1 ]] && echo 'dry-run (no changes)' || echo 'live install')"
+if [[ "$RESUME" -eq 1 ]]; then
+  printf '    Existing install:  resuming (compose file and .env left untouched)\n'
+fi
 echo
 
 if [[ "$ASSUME_YES" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
@@ -117,56 +147,90 @@ if [[ "$ASSUME_YES" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
   [[ "$reply" =~ ^[Yy]$ ]] || { warn "Aborted."; exit 1; }
 fi
 
-log "Creating install directory"
-run mkdir -p "$INSTALL_DIR"
-
-log "Downloading compose file"
-if [[ "$DRY_RUN" -eq 1 ]]; then
-  printf '    \033[2m$ curl -sSLf %s/docker-compose.yml -o %s/docker-compose.yml\033[0m\n' "$REPO_RAW" "$INSTALL_DIR"
-else
-  curl -sSLf "$REPO_RAW/docker-compose.yml" -o "$INSTALL_DIR/docker-compose.yml" \
-    || die "Failed to download docker-compose.yml"
-fi
-
-log "Downloading .env.example"
 ENV_PATH="$INSTALL_DIR/.env"
-if [[ "$DRY_RUN" -eq 1 ]]; then
-  printf '    \033[2m$ curl -sSLf %s/.env.example -o %s\033[0m\n' "$REPO_RAW" "$ENV_PATH"
-else
-  curl -sSLf "$REPO_RAW/.env.example" -o "$ENV_PATH" \
-    || die "Failed to download .env.example"
-fi
 
-log "Generating BETTER_AUTH_SECRET"
-if [[ "$DRY_RUN" -eq 1 ]]; then
-  SECRET="<generated-at-install-time>"
-  printf '    \033[2m$ openssl rand -hex 32\033[0m\n'
-else
+gen_secret() {
   case "$SECRET_TOOL" in
-    openssl) SECRET="$(openssl rand -hex 32)" ;;
-    urandom) SECRET="$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')" ;;
+    openssl) openssl rand -hex 32 ;;
+    urandom) head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
   esac
-fi
+}
 
-log "Writing secret into .env"
-if [[ "$DRY_RUN" -eq 1 ]]; then
-  printf '    \033[2m$ replace "BETTER_AUTH_SECRET=" → "BETTER_AUTH_SECRET=<generated>" in %s\033[0m\n' "$ENV_PATH"
+if [[ "$RESUME" -eq 1 ]]; then
+  log "Reusing existing install (skipping download and secret generation)"
+  printf '    Keeping %s and %s as they are.\n' "$INSTALL_DIR/docker-compose.yml" "$ENV_PATH"
 else
-  if ! grep -qE '^BETTER_AUTH_SECRET=$' "$ENV_PATH"; then
-    die "Expected empty BETTER_AUTH_SECRET= line not found in $ENV_PATH — refusing to proceed."
+  log "Creating install directory"
+  run mkdir -p "$INSTALL_DIR"
+
+  log "Downloading compose file"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '    \033[2m$ curl -sSLf %s/docker-compose.yml -o %s/docker-compose.yml\033[0m\n' "$REPO_RAW" "$INSTALL_DIR"
+  else
+    curl -sSLf "$REPO_RAW/docker-compose.yml" -o "$INSTALL_DIR/docker-compose.yml" \
+      || die "Failed to download docker-compose.yml"
   fi
-  # Line-based rewrite — no sed, no quoting edge cases. openssl rand -hex
-  # produces only [0-9a-f], so interpolation into the line is safe.
-  new_content=""
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    if [[ "$line" == "BETTER_AUTH_SECRET=" ]]; then
-      new_content+="BETTER_AUTH_SECRET=$SECRET"$'\n'
-    else
-      new_content+="$line"$'\n'
+
+  log "Downloading .env.example"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '    \033[2m$ curl -sSLf %s/.env.example -o %s\033[0m\n' "$REPO_RAW" "$ENV_PATH"
+  else
+    curl -sSLf "$REPO_RAW/.env.example" -o "$ENV_PATH" \
+      || die "Failed to download .env.example"
+  fi
+
+  log "Generating BETTER_AUTH_SECRET and MANIFEST_ENCRYPTION_KEY"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    SECRET="<generated-at-install-time>"
+    ENCRYPTION_KEY="<generated-at-install-time>"
+    printf '    \033[2m$ openssl rand -hex 32   # BETTER_AUTH_SECRET\033[0m\n'
+    printf '    \033[2m$ openssl rand -hex 32   # MANIFEST_ENCRYPTION_KEY\033[0m\n'
+  else
+    SECRET="$(gen_secret)"
+    # A second, independent key. Left unset the backend falls back to
+    # BETTER_AUTH_SECRET for at-rest encryption and warns about it on every
+    # boot — which means one leaked session-signing secret also decrypts every
+    # stored provider key and OAuth token. It costs nothing to generate here,
+    # and after first boot it can never be introduced without re-encrypting
+    # what is already in the database.
+    ENCRYPTION_KEY="$(gen_secret)"
+  fi
+
+  log "Writing secrets into .env"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '    \033[2m$ replace "BETTER_AUTH_SECRET=" → "BETTER_AUTH_SECRET=<generated>" in %s\033[0m\n' "$ENV_PATH"
+    printf '    \033[2m$ replace "# MANIFEST_ENCRYPTION_KEY=" → "MANIFEST_ENCRYPTION_KEY=<generated>" in %s\033[0m\n' "$ENV_PATH"
+  else
+    if ! grep -qE '^BETTER_AUTH_SECRET=$' "$ENV_PATH"; then
+      die "Expected empty BETTER_AUTH_SECRET= line not found in $ENV_PATH — refusing to proceed."
     fi
-  done < "$ENV_PATH"
-  printf '%s' "$new_content" > "$ENV_PATH"
-  chmod 600 "$ENV_PATH"
+    if ! grep -qE '^# MANIFEST_ENCRYPTION_KEY=$' "$ENV_PATH"; then
+      die "Expected commented # MANIFEST_ENCRYPTION_KEY= line not found in $ENV_PATH — refusing to proceed."
+    fi
+    # Line-based rewrite — no sed, no quoting edge cases. openssl rand -hex
+    # produces only [0-9a-f], so interpolation into the line is safe.
+    new_content=""
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ "$line" == "BETTER_AUTH_SECRET=" ]]; then
+        new_content+="BETTER_AUTH_SECRET=$SECRET"$'\n'
+      elif [[ "$line" == "# MANIFEST_ENCRYPTION_KEY=" ]]; then
+        new_content+="MANIFEST_ENCRYPTION_KEY=$ENCRYPTION_KEY"$'\n'
+      else
+        new_content+="$line"$'\n'
+      fi
+    done < "$ENV_PATH"
+    printf '%s' "$new_content" > "$ENV_PATH"
+
+    # The compose file reads ${PORT:-2099} for both the published host port and
+    # the backend's own listener, and BETTER_AUTH_URL defaults to
+    # http://localhost:${PORT:-2099} — so pinning PORT is the whole job. Only
+    # written when it differs from the default, to keep .env close to stock.
+    if [[ "$HOST_PORT" -ne 2099 ]]; then
+      printf 'PORT=%s\n' "$HOST_PORT" >> "$ENV_PATH"
+    fi
+
+    chmod 600 "$ENV_PATH"
+  fi
 fi
 
 log "Starting the stack"
@@ -189,15 +253,21 @@ for _ in $(seq 1 24); do
     cat <<EOF
 
   Open:   http://localhost:${HOST_PORT}
-  Setup:  the first visit walks you through creating your admin account.
-  Config: $INSTALL_DIR/.env  (BETTER_AUTH_SECRET, OAuth keys, email provider)
 
+  Next:   1. Create your admin account — the first visit walks you through it.
+          2. Connect a provider: Providers → Usage-based (API key) or
+             Subscriptions, in the dashboard sidebar.
+          3. Copy your agent's mnfst_ key and point your agent at
+             http://localhost:${HOST_PORT}/v1
+
+  Config: $INSTALL_DIR/.env  (secrets, OAuth keys, email provider)
   Verify: curl -sSf http://localhost:${HOST_PORT}/api/v1/health
 
   Note:   Port ${HOST_PORT} is bound to 127.0.0.1 only. To expose on your LAN,
           edit $INSTALL_DIR/docker-compose.yml and change the ports line
-          from "127.0.0.1:${HOST_PORT}:${HOST_PORT}" to "${HOST_PORT}:${HOST_PORT}", then update
-          BETTER_AUTH_URL in .env to match the host you'll access it on.
+          from "127.0.0.1:\${PORT:-2099}:\${PORT:-2099}" to "\${PORT:-2099}:\${PORT:-2099}",
+          then set BETTER_AUTH_URL in .env to the host you'll reach it on
+          (e.g. http://192.168.1.20:${HOST_PORT}) — it must match the browser URL.
 
   Stop:  (cd $INSTALL_DIR && docker compose down)
   Wipe:  (cd $INSTALL_DIR && docker compose down -v)

--- a/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.spec.ts
+++ b/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.spec.ts
@@ -86,6 +86,44 @@ function buildSvc(): TestPkceOauthService {
   );
 }
 
+describe('RedirectPkceOauthBaseService — client id resolution', () => {
+  // The env var reaches the service through ConfigService. docker-compose
+  // forwards unset optional vars as an empty string, so `''` must mean
+  // "not configured" and fall back to the shipped default client id —
+  // otherwise the authorize redirect goes out with a blank client_id.
+  function buildWithEnvClientId(value: string | undefined): TestPkceOauthService {
+    const configService = {
+      get: (key: string) => {
+        if (key === 'app.nodeEnv') return 'production';
+        if (key === 'TEST_OAUTH_CLIENT_ID') return value;
+        return undefined;
+      },
+    } as unknown as ConfigService;
+    return new TestPkceOauthService(createProviderService(), configService, createDiscovery());
+  }
+
+  async function clientIdInAuthorizeUrl(svc: TestPkceOauthService): Promise<string | null> {
+    const url = await svc.generateAuthorizationUrl('a', 'u', 'http://localhost:3001');
+    return new URL(url).searchParams.get('client_id');
+  }
+
+  it('uses the env override when it holds a real value', async () => {
+    expect(await clientIdInAuthorizeUrl(buildWithEnvClientId('custom-client-id'))).toBe(
+      'custom-client-id',
+    );
+  });
+
+  it('falls back to the default when the env var is unset, empty, or whitespace', async () => {
+    for (const value of [undefined, '', '   ']) {
+      expect(await clientIdInAuthorizeUrl(buildWithEnvClientId(value))).toBe('test-client-id');
+    }
+  });
+
+  it('trims a padded env override', async () => {
+    expect(await clientIdInAuthorizeUrl(buildWithEnvClientId('  padded-id  '))).toBe('padded-id');
+  });
+});
+
 describe('RedirectPkceOauthBaseService — backendUrl validation', () => {
   beforeEach(() => {
     jest.useFakeTimers();

--- a/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.ts
@@ -114,11 +114,15 @@ export abstract class RedirectPkceOauthBaseService {
     protected readonly oauthConfig: RedirectPkceOauthConfig,
   ) {
     this.logger = new Logger(oauthConfig.serviceName);
+    // `||`, not `??`: docker-compose forwards unset optional vars as an empty
+    // string, and `??` would take `''` as a deliberate override — leaving the
+    // provider with a blank client id and an OAuth flow that fails at the
+    // authorize redirect instead of falling back to the shipped default.
     this.clientId =
-      configService.get<string>(oauthConfig.clientIdEnvVar) ?? oauthConfig.defaultClientId;
+      configService.get<string>(oauthConfig.clientIdEnvVar)?.trim() || oauthConfig.defaultClientId;
     this.clientSecret = oauthConfig.clientSecretEnvVar
-      ? (configService.get<string>(oauthConfig.clientSecretEnvVar) ??
-        oauthConfig.defaultClientSecret)
+      ? configService.get<string>(oauthConfig.clientSecretEnvVar)?.trim() ||
+        oauthConfig.defaultClientSecret
       : oauthConfig.defaultClientSecret;
     this.redirectUri =
       oauthConfig.redirectUri ?? `http://localhost:${oauthConfig.callbackPort}/auth/callback`;

--- a/packages/backend/src/telemetry/telemetry.config.spec.ts
+++ b/packages/backend/src/telemetry/telemetry.config.spec.ts
@@ -41,6 +41,26 @@ describe('buildTelemetryConfig', () => {
     expect(cfg.endpoint).toBe('http://127.0.0.1:9999/ingest');
   });
 
+  it('falls back to the default endpoint when TELEMETRY_ENDPOINT is blank', () => {
+    // docker-compose forwards unset optional vars as an empty string
+    // (`- TELEMETRY_ENDPOINT=${TELEMETRY_ENDPOINT:-}`). Treating `''` as a
+    // deliberate override would silently POST every report to nowhere.
+    for (const blank of ['', '   ']) {
+      expect(
+        buildTelemetryConfig({ NODE_ENV: 'production', TELEMETRY_ENDPOINT: blank }).endpoint,
+      ).toBe(DEFAULT_TELEMETRY_ENDPOINT);
+    }
+  });
+
+  it('trims a padded TELEMETRY_ENDPOINT', () => {
+    expect(
+      buildTelemetryConfig({
+        NODE_ENV: 'production',
+        TELEMETRY_ENDPOINT: '  http://127.0.0.1:9999/ingest  ',
+      }).endpoint,
+    ).toBe('http://127.0.0.1:9999/ingest');
+  });
+
   it('is disabled when the Manifest version cannot be read', () => {
     // Simulates a misconfigured image that ships without
     // packages/manifest/package.json. readManifestVersion() falls back to

--- a/packages/backend/src/telemetry/telemetry.config.ts
+++ b/packages/backend/src/telemetry/telemetry.config.ts
@@ -27,7 +27,10 @@ export function buildTelemetryConfig(env: NodeJS.ProcessEnv = process.env): Tele
   const versionReadable = manifestVersion !== UNKNOWN_VERSION;
   return {
     enabled: isProd && !isDisabled && versionReadable,
-    endpoint: env['TELEMETRY_ENDPOINT'] ?? DEFAULT_TELEMETRY_ENDPOINT,
+    // `||`, not `??`: docker-compose passes unset optional vars through as an
+    // empty string (`- TELEMETRY_ENDPOINT=${TELEMETRY_ENDPOINT:-}`), and `??`
+    // would accept `''` as a deliberate override and POST reports to nowhere.
+    endpoint: env['TELEMETRY_ENDPOINT']?.trim() || DEFAULT_TELEMETRY_ENDPOINT,
     manifestVersion,
   };
 }


### PR DESCRIPTION
### 💭 Why
Re-running `install.sh` against an existing directory failed with "already exists and is not empty" and pointed at `--dir` or `rm -rf`. That is the exact state a run leaves behind when `docker compose up` dies (out of disk, daemon hiccup, exhausted network pool). `rm -rf` then throws away the generated `BETTER_AUTH_SECRET`, which invalidates every session and, if the volume survives, every provider credential encrypted with it.

### ✨ What changed
Installer:
- Resumes an existing install instead of failing. Secrets untouched.
- New `--port`, so 2099 being taken is no longer a dead end.
- Port-conflict error no longer names a file it never created.
- Generates `MANIFEST_ENCRYPTION_KEY` alongside `BETTER_AUTH_SECRET`.
- `--help` computes its own line range instead of a hardcoded one.

Compose:
- Forwards 16 documented variables it was silently dropping, including `TELEMETRY_ENDPOINT`, `MANIFEST_DISABLE_HSTS`, `THROTTLE_*`, `DB_POOL_MAX`, `SENTRY_*`.
- Comments why `NODE_ENV` and `SEED_DATA` stay fixed.
- Fixes a 404 link to `manifest.build/telemetry`.

Empty-string handling, which the new passthroughs would otherwise have exposed:
- `TELEMETRY_ENDPOINT=""` no longer blanks the endpoint and posts reports to nowhere.
- Blank provider OAuth client ids fall back to the shipped default.

### 🔧 For operators
Nothing required. New installs get a dedicated `MANIFEST_ENCRYPTION_KEY` and stop warning about it on boot. Existing installs are unaffected: adding that key later would mean re-encrypting stored credentials, so it is generated only on a fresh install.

### 📝 Notes
Found by installing from the published docs on a clean machine and following them literally.
Docs side is mnfst/docs#41.
Verified end to end: fresh install, resume with secret preserved, `--port 8080`, dry-run, and the non-Manifest-directory guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retrying a self-host install now works without losing secrets. The installer resumes safely, adds `--port`, generates a dedicated encryption key, and compose/backend handle blank env vars correctly.

- **New Features**
  - Installer resumes an existing directory; secrets are preserved.
  - Add `--port` and write `PORT` to `.env` for non-2099 installs.
  - Generate `MANIFEST_ENCRYPTION_KEY` alongside `BETTER_AUTH_SECRET`.
  - Compose now forwards missing envs (e.g., `TELEMETRY_ENDPOINT`, `MANIFEST_DISABLE_HSTS`, `THROTTLE_*`, `DB_POOL_MAX`, `SENTRY_*`).

- **Bug Fixes**
  - Blank `TELEMETRY_ENDPOINT` falls back to the default endpoint.
  - Blank/whitespace OAuth client IDs fall back to built-in defaults.
  - Port-conflict check points to `--port`; fixed 404 telemetry doc link.

<sup>Written for commit e3bb269a3641edcf35e3202bdf79a5ae273d5a30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

