### PR TITLE
fix: walk fallbacks when primary credentials fail to resolve

### DIFF
--- a/.changeset/m100-credential-fallback.md
+++ b/.changeset/m100-credential-fallback.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Walk the fallback chain when the primary route's stored credentials fail to resolve (e.g. a dead OAuth refresh token), instead of failing the whole request with M100

--- a/.changeset/m100-credential-fallback.md
+++ b/.changeset/m100-credential-fallback.md
@@ -2,4 +2,4 @@
 "manifest": patch
 ---
 
-Walk the fallback chain when the primary route's stored credentials fail to resolve (e.g. a dead OAuth refresh token), instead of failing the whole request with M100
+When primary credentials fail to resolve, treat it as a failed attempt and enter the normal fallback chain instead of hard-failing with M100. Dead subscription OAuth (refresh/unwrap failed) now surfaces as M102 rather than the misleading "no API key" M100.

--- a/.changeset/oauth-refresh-row-lock.md
+++ b/.changeset/oauth-refresh-row-lock.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Serialize OAuth subscription token refreshes with a DB row lock (`SELECT … FOR UPDATE` on `tenant_providers`) so multi-replica backends cannot rotate the same refresh token concurrently

--- a/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
+++ b/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
@@ -1,4 +1,5 @@
 import {
+  extractManifestErrorCode,
   formatManifestError,
   MANIFEST_ERRORS,
   MANIFEST_ERRORS_DOCS_BASE,
@@ -70,6 +71,43 @@ describe('formatManifestError', () => {
       const out = formatManifestError(code);
       expect(out.startsWith(`[🦚 Manifest ${code}]`)).toBe(true);
       expect(out.endsWith(`See ${MANIFEST_ERRORS_DOCS_BASE}/${code}`)).toBe(true);
+    }
+  });
+});
+
+describe('extractManifestErrorCode', () => {
+  it('returns null for empty or non-Manifest text', () => {
+    expect(extractManifestErrorCode(null)).toBeNull();
+    expect(extractManifestErrorCode(undefined)).toBeNull();
+    expect(extractManifestErrorCode('')).toBeNull();
+    expect(extractManifestErrorCode('upstream 500')).toBeNull();
+    expect(extractManifestErrorCode('[Manifest M999] unknown')).toBeNull();
+  });
+
+  it('extracts the code from a formatted peacock message', () => {
+    expect(extractManifestErrorCode(formatManifestError('M102', { provider: 'openai' }))).toBe(
+      'M102',
+    );
+    expect(
+      extractManifestErrorCode('[🦚 Manifest M100] No openai API key yet. Add one here: https://x'),
+    ).toBe('M100');
+  });
+
+  it('finds the code when nested inside a JSON error body', () => {
+    const body = JSON.stringify({
+      error: {
+        message: formatManifestError('M102', {
+          provider: 'openai',
+          dashboardUrl: 'https://dash/routing',
+        }),
+      },
+    });
+    expect(extractManifestErrorCode(body)).toBe('M102');
+  });
+
+  it('round-trips every registered code', () => {
+    for (const code of Object.keys(MANIFEST_ERRORS) as ManifestErrorCode[]) {
+      expect(extractManifestErrorCode(formatManifestError(code))).toBe(code);
     }
   });
 });

--- a/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
+++ b/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
@@ -82,6 +82,10 @@ describe('extractManifestErrorCode', () => {
     expect(extractManifestErrorCode('')).toBeNull();
     expect(extractManifestErrorCode('upstream 500')).toBeNull();
     expect(extractManifestErrorCode('[Manifest M999] unknown')).toBeNull();
+    // A provider body that echoes the code text without the peacock must NOT
+    // be mistaken for a Manifest error (guards against provider-error mislabeling).
+    expect(extractManifestErrorCode('[Manifest M100] echoed by an upstream')).toBeNull();
+    expect(extractManifestErrorCode('provider said: Manifest M102 somewhere')).toBeNull();
   });
 
   it('extracts the code from a formatted peacock message', () => {

--- a/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
+++ b/packages/backend/src/common/errors/__tests__/error-codes.spec.ts
@@ -49,6 +49,16 @@ describe('formatManifestError', () => {
     expect(out).toContain('{dashboardUrl}');
   });
 
+  it('renders M102 for unusable subscription credentials', () => {
+    const out = formatManifestError('M102', {
+      provider: 'openai',
+      dashboardUrl: 'https://dash.example/routing',
+    });
+    expect(out).toContain('[🦚 Manifest M102]');
+    expect(out).toContain('openai subscription credentials could not be refreshed');
+    expect(out).toContain('https://dash.example/routing');
+  });
+
   it('appends the docs URL exactly once', () => {
     const out = formatManifestError('M500');
     const matches = out.match(/https:\/\/manifest\.build\/docs\/errors\/M500/g) ?? [];

--- a/packages/backend/src/common/errors/error-codes.ts
+++ b/packages/backend/src/common/errors/error-codes.ts
@@ -85,8 +85,11 @@ export const MANIFEST_ERRORS = {
 
 export type ManifestErrorCode = keyof typeof MANIFEST_ERRORS;
 
-/** Matches the peacock prefix written by formatManifestError, e.g. `[🦚 Manifest M102]`. */
-const MANIFEST_ERROR_CODE_RE = /\[\s*(?:🦚\s*)?Manifest\s+(M\d{3})\s*\]/;
+// Matches the peacock prefix written by formatManifestError, e.g. `[🦚 Manifest M102]`.
+// The 🦚 is REQUIRED: only Manifest emits it, so a provider error body that merely
+// echoes the text "Manifest M100" can never be mis-extracted into a Manifest code
+// (which would then misclassify a provider round-trip as a Manifest config error).
+const MANIFEST_ERROR_CODE_RE = /\[\s*🦚\s*Manifest\s+(M\d{3})\s*\]/;
 
 export function formatManifestError(
   code: ManifestErrorCode,

--- a/packages/backend/src/common/errors/error-codes.ts
+++ b/packages/backend/src/common/errors/error-codes.ts
@@ -35,6 +35,11 @@ export const MANIFEST_ERRORS = {
     title: 'No providers configured',
     template: "You're connected, but no providers are set up yet. Add one here: {dashboardUrl}",
   },
+  M102: {
+    title: 'Provider subscription credentials unusable',
+    template:
+      '{provider} subscription credentials could not be refreshed. Reconnect OAuth here: {dashboardUrl}',
+  },
   M200: {
     title: 'Usage limit exceeded',
     template:

--- a/packages/backend/src/common/errors/error-codes.ts
+++ b/packages/backend/src/common/errors/error-codes.ts
@@ -85,6 +85,9 @@ export const MANIFEST_ERRORS = {
 
 export type ManifestErrorCode = keyof typeof MANIFEST_ERRORS;
 
+/** Matches the peacock prefix written by formatManifestError, e.g. `[🦚 Manifest M102]`. */
+const MANIFEST_ERROR_CODE_RE = /\[\s*(?:🦚\s*)?Manifest\s+(M\d{3})\s*\]/;
+
 export function formatManifestError(
   code: ManifestErrorCode,
   vars: Record<string, string | number> = {},
@@ -95,4 +98,19 @@ export function formatManifestError(
     return value === undefined ? match : String(value);
   });
   return `[${PEACOCK} Manifest ${code}] ${interpolated} See ${MANIFEST_ERRORS_DOCS_BASE}/${code}`;
+}
+
+/**
+ * Pull a registered Manifest error code out of a rendered message or JSON body
+ * that embeds one (provider-attempt rows store the peacock text in
+ * error_message but need error_code for filters/analytics).
+ */
+export function extractManifestErrorCode(
+  text: string | null | undefined,
+): ManifestErrorCode | null {
+  if (!text) return null;
+  const match = text.match(MANIFEST_ERROR_CODE_RE);
+  if (!match) return null;
+  const code = match[1] as ManifestErrorCode;
+  return code in MANIFEST_ERRORS ? code : null;
 }

--- a/packages/backend/src/common/errors/manifest-error.ts
+++ b/packages/backend/src/common/errors/manifest-error.ts
@@ -10,6 +10,7 @@ import { formatManifestError, MANIFEST_ERRORS, type ManifestErrorCode } from './
 export const MANIFEST_BLOCKED_REQUEST_REASONS = [
   'no_provider',
   'no_provider_key',
+  'subscription_credentials_unusable',
   'key_expired',
   'limit_exceeded',
   'plan_request_limit_exceeded',
@@ -48,6 +49,7 @@ export const MANIFEST_CODE_TO_REASON: Record<RecordableManifestCode, ManifestBlo
     M004: 'key_expired',
     M100: 'no_provider_key',
     M101: 'no_provider',
+    M102: 'subscription_credentials_unusable',
     M200: 'limit_exceeded',
     M201: 'manifest_rate_limited',
     M202: 'manifest_ip_rate_limited',

--- a/packages/backend/src/routing/oauth/__tests__/mock-subscription-lock.ts
+++ b/packages/backend/src/routing/oauth/__tests__/mock-subscription-lock.ts
@@ -1,0 +1,37 @@
+/**
+ * Test double for ProviderService.withSubscriptionCredentialLock.
+ * Bridges to the older getFreshSubscriptionCredential / upsertProvider mocks
+ * so existing unwrapToken assertions keep working.
+ */
+export function mockSubscriptionCredentialLock(provider: {
+  getFreshSubscriptionCredential: jest.Mock;
+  upsertProvider: jest.Mock;
+}): jest.Mock {
+  return jest.fn(
+    async (
+      tenantId: string,
+      providerId: string,
+      label: string | undefined,
+      fn: (ops: {
+        readFreshRaw: () => Promise<string | null>;
+        writeRaw: (raw: string) => Promise<void>;
+      }) => Promise<unknown>,
+    ) =>
+      fn({
+        readFreshRaw: () => provider.getFreshSubscriptionCredential(tenantId, providerId, label),
+        writeRaw: async (raw: string) => {
+          // agentId is unused for locked in-place writes in production; null
+          // keeps the upsert shape tests already assert on.
+          await provider.upsertProvider(
+            null,
+            tenantId,
+            providerId,
+            raw,
+            'subscription',
+            undefined,
+            label,
+          );
+        },
+      }),
+  );
+}

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.security.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.security.spec.ts
@@ -1,4 +1,5 @@
 import { ProviderService } from '../../routing-core/provider.service';
+import { mockSubscriptionCredentialLock } from '../__tests__/mock-subscription-lock';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { AnthropicOauthService } from './anthropic-oauth.service';
 import {
@@ -29,11 +30,19 @@ function createProviderService() {
       recalculateTiers,
       nextOAuthLabel,
       getFreshSubscriptionCredential,
+      withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+        getFreshSubscriptionCredential,
+        upsertProvider,
+      }),
     } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     nextOAuthLabel,
     getFreshSubscriptionCredential,
+    withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+      getFreshSubscriptionCredential,
+      upsertProvider,
+    }),
   };
 }
 

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -1,4 +1,5 @@
 import { ProviderService } from '../../routing-core/provider.service';
+import { mockSubscriptionCredentialLock } from '../__tests__/mock-subscription-lock';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import {
   AnthropicOauthExchangeError,
@@ -36,12 +37,20 @@ function createProviderService() {
       recalculateTiersForTenant,
       nextOAuthLabel,
       getFreshSubscriptionCredential,
+      withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+        getFreshSubscriptionCredential,
+        upsertProvider,
+      }),
     } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     recalculateTiersForTenant,
     nextOAuthLabel,
     getFreshSubscriptionCredential,
+    withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+      getFreshSubscriptionCredential,
+      upsertProvider,
+    }),
   };
 }
 
@@ -423,7 +432,7 @@ describe('AnthropicOauthService', () => {
       const token = await svc.unwrapToken(blob, 'agent-1', 'tenant-1', 'Work');
       expect(token).toBe('new');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
-        'agent-1',
+        null,
         'tenant-1',
         'anthropic',
         expect.stringContaining('"t":"new"'),

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -9,6 +9,7 @@ import {
   OAuthPendingFlowStore,
   parseOAuthTokenBlob,
   serializeOAuthTokenBlob,
+  subscriptionCredentialLock,
   type OAuthTokenBlob,
 } from '../core';
 import { ANTHROPIC_OAUTH } from './anthropic-oauth.config';
@@ -222,22 +223,15 @@ export class AnthropicOauthService {
         key: oauthRefreshKey('anthropic', tenantId, keyLabel),
         logger: this.logger,
         callerBlob: blob,
-        readFreshRaw: () =>
-          this.providerService.getFreshSubscriptionCredential(tenantId, 'anthropic', keyLabel),
         parse: parseOAuthTokenBlob,
         refresh: (current) => this.refreshAccessToken(current.r),
-        persist: (refreshed) =>
-          this.providerService
-            .upsertProvider(
-              agentId,
-              tenantId,
-              'anthropic',
-              serializeOAuthTokenBlob(refreshed),
-              'subscription',
-              undefined,
-              keyLabel,
-            )
-            .then(() => undefined),
+        withLock: subscriptionCredentialLock(
+          (t, p, l, fn) => this.providerService.withSubscriptionCredentialLock(t, p, l, fn),
+          tenantId,
+          'anthropic',
+          keyLabel,
+          serializeOAuthTokenBlob,
+        ),
       });
       return resolved.t;
     } catch (err) {

--- a/packages/backend/src/routing/oauth/core/index.ts
+++ b/packages/backend/src/routing/oauth/core/index.ts
@@ -15,11 +15,13 @@ export { oauthDoneHtml } from './callback-page';
 export {
   coordinateOAuthRefresh,
   oauthRefreshKey,
+  subscriptionCredentialLock,
   __resetOAuthRefreshCoordinator,
   REFRESH_EXPIRY_SKEW_MS,
   PERSIST_MAX_ATTEMPTS,
   type RefreshableBlob,
   type CoordinatedRefreshParams,
+  type CredentialLockOps,
 } from './oauth-refresh-coordinator';
 export {
   ABSOLUTE_TIME_THRESHOLD_MS,

--- a/packages/backend/src/routing/oauth/core/oauth-refresh-coordinator.spec.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-refresh-coordinator.spec.ts
@@ -6,6 +6,7 @@ import {
   PERSIST_MAX_ATTEMPTS,
   REFRESH_EXPIRY_SKEW_MS,
   type CoordinatedRefreshParams,
+  type CredentialLockOps,
 } from './oauth-refresh-coordinator';
 
 interface TestBlob {
@@ -21,7 +22,12 @@ function fakeLogger(): Logger {
 const expired = (): TestBlob => ({ t: 'old', e: Date.now() - 1_000, r: 'refresh-old' });
 const valid = (t = 'fresh'): TestBlob => ({ t, e: Date.now() + 5 * 60_000, r: 'refresh-new' });
 
-function makeParams(overrides: Partial<CoordinatedRefreshParams<TestBlob>> = {}): {
+function makeParams(
+  overrides: Partial<CoordinatedRefreshParams<TestBlob>> & {
+    persist?: jest.Mock;
+    readFreshRaw?: jest.Mock;
+  } = {},
+): {
   params: CoordinatedRefreshParams<TestBlob>;
   refresh: jest.Mock;
   persist: jest.Mock;
@@ -30,16 +36,20 @@ function makeParams(overrides: Partial<CoordinatedRefreshParams<TestBlob>> = {})
 } {
   const logger = overrides.logger ?? fakeLogger();
   const refresh = (overrides.refresh as jest.Mock) ?? jest.fn().mockResolvedValue(valid());
-  const persist = (overrides.persist as jest.Mock) ?? jest.fn().mockResolvedValue(undefined);
-  const readFreshRaw = (overrides.readFreshRaw as jest.Mock) ?? jest.fn().mockResolvedValue(null);
+  const persist = overrides.persist ?? jest.fn().mockResolvedValue(undefined);
+  const readFreshRaw = overrides.readFreshRaw ?? jest.fn().mockResolvedValue(null);
+  // Default withLock just runs the critical section with the mock ops — same
+  // as a single-process test without a real DB lock.
+  const withLock =
+    overrides.withLock ??
+    (<R>(fn: (ops: CredentialLockOps<TestBlob>) => Promise<R>) => fn({ readFreshRaw, persist }));
   const params: CoordinatedRefreshParams<TestBlob> = {
     key: overrides.key ?? 'openai:user-1:agent-1:Default',
     logger,
     callerBlob: overrides.callerBlob ?? expired(),
-    readFreshRaw,
     parse: overrides.parse ?? ((raw: string) => JSON.parse(raw) as TestBlob),
     refresh,
-    persist,
+    withLock,
   };
   return { params, refresh, persist, readFreshRaw, logger };
 }
@@ -183,5 +193,32 @@ describe('coordinateOAuthRefresh', () => {
     await coordinateOAuthRefresh(params);
 
     expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the critical section inside withLock', async () => {
+    const order: string[] = [];
+    const withLock: CoordinatedRefreshParams<TestBlob>['withLock'] = async (fn) => {
+      order.push('lock');
+      const result = await fn({
+        readFreshRaw: async () => {
+          order.push('read');
+          return null;
+        },
+        persist: async () => {
+          order.push('persist');
+        },
+      });
+      order.push('unlock');
+      return result;
+    };
+    const refresh = jest.fn(async () => {
+      order.push('refresh');
+      return valid('x');
+    });
+    const { params } = makeParams({ withLock, refresh });
+
+    await coordinateOAuthRefresh(params);
+
+    expect(order).toEqual(['lock', 'read', 'refresh', 'persist', 'unlock']);
   });
 });

--- a/packages/backend/src/routing/oauth/core/oauth-refresh-coordinator.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-refresh-coordinator.ts
@@ -9,35 +9,22 @@
  *   1. Concurrent requests. An agent fires many parallel requests against an
  *      expired token. Each one parsed its own (stale) blob and calls the
  *      provider with the SAME old refresh token. The first rotates it; every
- *      other one gets `refresh_token_invalidated` and fails. A request that
- *      arrives just after a refresh finishes can still hold the pre-refresh
- *      blob (read from the routing cache) and refresh again with the now-dead
- *      token.
+ *      other one gets `refresh_token_invalidated` and fails.
  *
  *   2. Persist-after-rotate failure. If the DB write fails AFTER the provider
  *      already rotated, the only copy of the new refresh token is lost while
  *      the stored one is already dead — the account is bricked until the user
- *      deletes and recreates it (exactly issue #2012).
+ *      reconnects (exactly issue #2012).
  *
- * This coordinator fixes both for a single backend instance (the current
- * deployment shape) without a distributed lock:
+ * Layered protection:
  *
- *   - Concurrent refreshes for the SAME credential coalesce onto one in-flight
- *     promise, keyed by provider+tenant+label. Different credentials never
- *     block each other.
- *   - Before refreshing, it re-reads the freshest persisted blob straight from
- *     the DB (bypassing the routing cache). If another request already
- *     refreshed it, the fresh blob is returned and the redundant rotation is
- *     skipped. The fresh refresh token — not the caller's stale one — is the
- *     refresh source.
- *   - The refreshed blob is persisted with a few retries. The provider has
- *     already rotated, so we NEVER refresh again on a persist failure (that
- *     would just reuse the dead token); we retry persisting the same blob.
- *
- * Multi-replica correctness (two backend instances refreshing the same
- * credential at the same instant) is intentionally out of scope here — it
- * needs an optimistic compare-and-set on persist or a DB lease, tracked as a
- * follow-up. The pending-OAuth store is already documented as single-instance.
+ *   - In-process single-flight (this file): concurrent requests on one
+ *     backend instance coalesce onto one refresh promise.
+ *   - DB row lock (`withLock`, usually SELECT … FOR UPDATE on
+ *     tenant_providers): multi-replica deploys serialize the critical
+ *     section so two instances cannot rotate the same refresh token.
+ *   - Inside the lock: re-read the blob, skip refresh if already valid,
+ *     then refresh + persist with retries (never re-refresh on persist fail).
  */
 import { Logger } from '@nestjs/common';
 
@@ -55,6 +42,14 @@ export const REFRESH_EXPIRY_SKEW_MS = 60_000;
 /** How many times to retry persisting an already-rotated blob before giving up. */
 export const PERSIST_MAX_ATTEMPTS = 3;
 
+/** Locked read/write of one credential row (same DB transaction). */
+export interface CredentialLockOps<T extends RefreshableBlob> {
+  /** Fresh raw credential value under the lock (or null if no row). */
+  readFreshRaw: () => Promise<string | null>;
+  /** Persist a refreshed blob under the same lock. */
+  persist: (refreshed: T) => Promise<void>;
+}
+
 export interface CoordinatedRefreshParams<T extends RefreshableBlob> {
   /** Identity key for single-flight: `${provider}:${tenantId}:${label}`. */
   readonly key: string;
@@ -65,14 +60,16 @@ export interface CoordinatedRefreshParams<T extends RefreshableBlob> {
    * fresh DB read returns nothing.
    */
   readonly callerBlob: T;
-  /** Fresh, cache-bypassing read of the persisted raw credential value. */
-  readonly readFreshRaw: () => Promise<string | null>;
   /** Parse a raw stored value into the provider's blob type. */
   readonly parse: (raw: string) => T | null;
   /** Perform the provider-specific refresh-token exchange. */
   readonly refresh: (current: T) => Promise<T>;
-  /** Persist the refreshed blob (serialize + upsert). */
-  readonly persist: (refreshed: T) => Promise<void>;
+  /**
+   * Exclusive critical section for this credential. Callers pass a DB row
+   * lock (`ProviderService.withSubscriptionCredentialLock`) so multi-replica
+   * refreshes serialize. Tests can use a no-op wrapper around mock ops.
+   */
+  readonly withLock: <R>(fn: (ops: CredentialLockOps<T>) => Promise<R>) => Promise<R>;
 }
 
 /**
@@ -83,6 +80,34 @@ export interface CoordinatedRefreshParams<T extends RefreshableBlob> {
  */
 export function oauthRefreshKey(providerId: string, tenantId: string, label?: string): string {
   return `${providerId}:${tenantId}:${label ?? 'Default'}`;
+}
+
+/**
+ * Build a `withLock` callback that holds the tenant_providers subscription
+ * row for the duration of the refresh critical section.
+ */
+export function subscriptionCredentialLock<T extends RefreshableBlob>(
+  lock: <R>(
+    tenantId: string,
+    provider: string,
+    label: string | undefined,
+    fn: (ops: {
+      readFreshRaw: () => Promise<string | null>;
+      writeRaw: (raw: string) => Promise<void>;
+    }) => Promise<R>,
+  ) => Promise<R>,
+  tenantId: string,
+  provider: string,
+  label: string | undefined,
+  serialize: (blob: T) => string,
+): CoordinatedRefreshParams<T>['withLock'] {
+  return (fn) =>
+    lock(tenantId, provider, label, async (ops) =>
+      fn({
+        readFreshRaw: ops.readFreshRaw,
+        persist: async (refreshed) => ops.writeRaw(serialize(refreshed)),
+      }),
+    );
 }
 
 // Shared across every OAuth service. Each value is the in-flight refresh for
@@ -116,32 +141,36 @@ export async function coordinateOAuthRefresh<T extends RefreshableBlob>(
 async function refreshOnce<T extends RefreshableBlob>(
   params: CoordinatedRefreshParams<T>,
 ): Promise<T> {
-  // The DB is the source of truth: a parallel request (or a previous one that
-  // resolved just before this caller read its cached copy) may have already
-  // rotated the token. Re-read it so we never refresh with a stale token.
-  let current = params.callerBlob;
-  const freshRaw = await params.readFreshRaw();
-  if (freshRaw) {
-    const fresh = params.parse(freshRaw);
-    if (fresh) current = fresh;
-  }
+  // withLock holds the tenant_providers row (FOR UPDATE) for the whole
+  // section so another replica cannot rotate the same refresh token.
+  return params.withLock(async (ops) => {
+    // The DB is the source of truth under the lock: another instance may have
+    // already rotated. Re-read so we never refresh with a stale token.
+    let current = params.callerBlob;
+    const freshRaw = await ops.readFreshRaw();
+    if (freshRaw) {
+      const fresh = params.parse(freshRaw);
+      if (fresh) current = fresh;
+    }
 
-  // Already valid — either it never really expired, or someone just refreshed.
-  if (Date.now() < current.e - REFRESH_EXPIRY_SKEW_MS) return current;
+    // Already valid — either it never really expired, or someone just refreshed.
+    if (Date.now() < current.e - REFRESH_EXPIRY_SKEW_MS) return current;
 
-  const refreshed = await params.refresh(current);
-  await persistWithRetry(params, refreshed);
-  return refreshed;
+    const refreshed = await params.refresh(current);
+    await persistWithRetry(params, ops.persist, refreshed);
+    return refreshed;
+  });
 }
 
 async function persistWithRetry<T extends RefreshableBlob>(
   params: CoordinatedRefreshParams<T>,
+  persist: (refreshed: T) => Promise<void>,
   refreshed: T,
 ): Promise<void> {
   let lastErr: unknown;
   for (let attempt = 1; attempt <= PERSIST_MAX_ATTEMPTS; attempt++) {
     try {
-      await params.persist(refreshed);
+      await persist(refreshed);
       return;
     } catch (err) {
       lastErr = err;
@@ -150,9 +179,9 @@ async function persistWithRetry<T extends RefreshableBlob>(
       );
     }
   }
-  // Surface the failure so the caller's catch runs, but the rotated token is
-  // gone either way — this is the brick window we cannot fully close without a
-  // distributed lease. Retrying the same blob is the best we can do.
+  // Surface the failure so the caller's catch runs. The provider may already
+  // have rotated; retrying the same blob is the best we can do without a
+  // durable outbox.
   throw lastErr;
 }
 

--- a/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.ts
@@ -20,7 +20,11 @@ import { generatePkce, generateState } from './pkce';
 import { oauthDoneHtml } from './callback-page';
 import { PendingStore } from './pending-store';
 import { parseOAuthTokenBlob, serializeOAuthTokenBlob, type OAuthTokenBlob } from './oauth-blob';
-import { coordinateOAuthRefresh, oauthRefreshKey } from './oauth-refresh-coordinator';
+import {
+  coordinateOAuthRefresh,
+  oauthRefreshKey,
+  subscriptionCredentialLock,
+} from './oauth-refresh-coordinator';
 
 export interface RedirectPkceOauthConfig {
   /** Provider id stored on `tenant_providers.provider_id`. */
@@ -289,22 +293,15 @@ export abstract class RedirectPkceOauthBaseService {
         key: oauthRefreshKey(providerId, tenantId, keyLabel),
         logger: this.logger,
         callerBlob: blob,
-        readFreshRaw: () =>
-          this.providerService.getFreshSubscriptionCredential(tenantId, providerId, keyLabel),
         parse: parseOAuthTokenBlob,
         refresh: (current) => this.refreshAccessToken(current.r, current.u),
-        persist: (refreshed) =>
-          this.providerService
-            .upsertProvider(
-              agentId,
-              tenantId,
-              providerId,
-              serializeOAuthTokenBlob(refreshed),
-              'subscription',
-              undefined,
-              keyLabel,
-            )
-            .then(() => undefined),
+        withLock: subscriptionCredentialLock(
+          (t, p, l, fn) => this.providerService.withSubscriptionCredentialLock(t, p, l, fn),
+          tenantId,
+          providerId,
+          keyLabel,
+          serializeOAuthTokenBlob,
+        ),
       });
       return resolved.t;
     } catch (err) {

--- a/packages/backend/src/routing/oauth/gemini/gemini-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/gemini/gemini-oauth.service.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { GeminiOauthService } from './gemini-oauth.service';
 import { ProviderService } from '../../routing-core/provider.service';
+import { mockSubscriptionCredentialLock } from '../__tests__/mock-subscription-lock';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { CodeAssistClientService } from './codeassist-client.service';
 
@@ -32,22 +33,29 @@ function createProviderService(): {
   recalculateTiers: jest.Mock;
   nextOAuthLabel: jest.Mock;
   getFreshSubscriptionCredential: jest.Mock;
+  withSubscriptionCredentialLock: jest.Mock;
 } {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
   const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
+  const withSubscriptionCredentialLock = mockSubscriptionCredentialLock({
+    getFreshSubscriptionCredential,
+    upsertProvider,
+  });
   return {
     svc: {
       upsertProvider,
       recalculateTiers,
       nextOAuthLabel,
       getFreshSubscriptionCredential,
+      withSubscriptionCredentialLock,
     } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     nextOAuthLabel,
     getFreshSubscriptionCredential,
+    withSubscriptionCredentialLock,
   };
 }
 
@@ -338,7 +346,7 @@ describe('GeminiOauthService', () => {
       expect(token).toBe('new');
       // The upserted blob must carry the project id so it survives the refresh.
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
-        'agent-1',
+        null,
         'user-1',
         'gemini',
         expect.stringContaining('"u":"proj-abc"'),
@@ -356,7 +364,7 @@ describe('GeminiOauthService', () => {
       const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1', 'Work');
       expect(token).toBe('new');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
-        'agent-1',
+        null,
         'user-1',
         'gemini',
         expect.stringContaining('"t":"new"'),

--- a/packages/backend/src/routing/oauth/kiro/kiro-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/kiro/kiro-oauth.service.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { KiroOauthService } from './kiro-oauth.service';
 import { ProviderService } from '../../routing-core/provider.service';
+import { mockSubscriptionCredentialLock } from '../__tests__/mock-subscription-lock';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import {
   KiroAuthorizationOptionsError,
@@ -38,6 +39,10 @@ function createProviderService() {
   const recalculateTiersForUser = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue('Kiro 1');
   const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
+  const withSubscriptionCredentialLock = mockSubscriptionCredentialLock({
+    getFreshSubscriptionCredential,
+    upsertProvider,
+  });
   return {
     svc: {
       upsertProvider,
@@ -45,12 +50,14 @@ function createProviderService() {
       recalculateTiersForUser,
       nextOAuthLabel,
       getFreshSubscriptionCredential,
+      withSubscriptionCredentialLock,
     } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     recalculateTiersForUser,
     nextOAuthLabel,
     getFreshSubscriptionCredential,
+    withSubscriptionCredentialLock,
   };
 }
 

--- a/packages/backend/src/routing/oauth/kiro/kiro-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/kiro/kiro-oauth.service.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'node:crypto';
 import { ProviderService } from '../../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { scrubSecrets } from '../../../common/utils/secret-scrub';
-import { coordinateOAuthRefresh, oauthRefreshKey } from '../core';
+import { coordinateOAuthRefresh, oauthRefreshKey, subscriptionCredentialLock } from '../core';
 import {
   KIRO_CLIENT_NAME,
   KIRO_CLIENT_TYPE,
@@ -246,22 +246,15 @@ export class KiroOauthService {
         key: oauthRefreshKey('kiro', tenantId, keyLabel),
         logger: this.logger,
         callerBlob: blob,
-        readFreshRaw: () =>
-          this.providerService.getFreshSubscriptionCredential(tenantId, 'kiro', keyLabel),
         parse: parseKiroOAuthTokenBlob,
         refresh: (current) => this.refreshAccessToken(current),
-        persist: (refreshed) =>
-          this.providerService
-            .upsertProvider(
-              agentId,
-              tenantId,
-              'kiro',
-              serializeKiroOAuthTokenBlob(refreshed),
-              'subscription',
-              undefined,
-              keyLabel,
-            )
-            .then(() => undefined),
+        withLock: subscriptionCredentialLock(
+          (t, p, l, fn) => this.providerService.withSubscriptionCredentialLock(t, p, l, fn),
+          tenantId,
+          'kiro',
+          keyLabel,
+          serializeKiroOAuthTokenBlob,
+        ),
       });
       return resolved.t;
     } catch (err) {

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.coverage.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.coverage.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { MinimaxOauthService } from './minimax-oauth.service';
 import { ProviderService } from '../../routing-core/provider.service';
+import { mockSubscriptionCredentialLock } from '../__tests__/mock-subscription-lock';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 
 const originalFetch = global.fetch;
@@ -40,12 +41,20 @@ function createProviderService() {
       recalculateTiersForUser,
       nextOAuthLabel,
       getFreshSubscriptionCredential,
+      withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+        getFreshSubscriptionCredential,
+        upsertProvider,
+      }),
     } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     recalculateTiersForUser,
     nextOAuthLabel,
     getFreshSubscriptionCredential,
+    withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+      getFreshSubscriptionCredential,
+      upsertProvider,
+    }),
   };
 }
 

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { MinimaxOauthService } from './minimax-oauth.service';
 import { ProviderService } from '../../routing-core/provider.service';
+import { mockSubscriptionCredentialLock } from '../__tests__/mock-subscription-lock';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetchMock = jest.fn() as jest.Mock<Promise<any>>;
@@ -16,11 +17,17 @@ describe('MinimaxOauthService', () => {
 
   beforeEach(() => {
     dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+    const upsertProvider = jest.fn().mockResolvedValue({ provider: {}, isNew: true });
+    const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
     providerService = {
-      upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
+      upsertProvider,
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
       nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
-      getFreshSubscriptionCredential: jest.fn().mockResolvedValue(null),
+      getFreshSubscriptionCredential,
+      withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+        getFreshSubscriptionCredential,
+        upsertProvider,
+      }),
     } as unknown as jest.Mocked<ProviderService>;
 
     configService = {

--- a/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/minimax/minimax-oauth.service.ts
@@ -4,8 +4,12 @@ import { createHash, randomBytes, randomUUID } from 'crypto';
 import { ProviderService } from '../../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { scrubSecrets } from '../../../common/utils/secret-scrub';
-import { coordinateOAuthRefresh, oauthRefreshKey } from '../core';
-import { OAuthTokenBlob } from '../core';
+import {
+  coordinateOAuthRefresh,
+  oauthRefreshKey,
+  subscriptionCredentialLock,
+  type OAuthTokenBlob,
+} from '../core';
 import {
   MinimaxRegion,
   DEFAULT_REGION,
@@ -300,22 +304,15 @@ export class MinimaxOauthService {
         key: oauthRefreshKey('minimax', tenantId, keyLabel),
         logger: this.logger,
         callerBlob: blob,
-        readFreshRaw: () =>
-          this.providerService.getFreshSubscriptionCredential(tenantId, 'minimax', keyLabel),
         parse: parseMinimaxBlob,
         refresh: (current) => this.refreshAccessToken(current.r, current.u),
-        persist: (refreshed) =>
-          this.providerService
-            .upsertProvider(
-              agentId,
-              tenantId,
-              'minimax',
-              JSON.stringify(refreshed),
-              'subscription',
-              undefined,
-              keyLabel,
-            )
-            .then(() => undefined),
+        withLock: subscriptionCredentialLock(
+          (t, p, l, fn) => this.providerService.withSubscriptionCredentialLock(t, p, l, fn),
+          tenantId,
+          'minimax',
+          keyLabel,
+          (refreshed) => JSON.stringify(refreshed),
+        ),
       });
     } catch (err) {
       this.logger.error(`Failed to refresh MiniMax token: ${err}`);

--- a/packages/backend/src/routing/oauth/openai/openai-oauth.service.coverage.spec.ts
+++ b/packages/backend/src/routing/oauth/openai/openai-oauth.service.coverage.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { OpenaiOauthService } from './openai-oauth.service';
 import { ProviderService } from '../../routing-core/provider.service';
+import { mockSubscriptionCredentialLock } from '../__tests__/mock-subscription-lock';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 
 const originalFetch = global.fetch;
@@ -38,12 +39,20 @@ function createProviderService() {
       recalculateTiersForUser,
       nextOAuthLabel,
       getFreshSubscriptionCredential,
+      withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+        getFreshSubscriptionCredential,
+        upsertProvider,
+      }),
     } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     recalculateTiersForUser,
     nextOAuthLabel,
     getFreshSubscriptionCredential,
+    withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+      getFreshSubscriptionCredential,
+      upsertProvider,
+    }),
   };
 }
 
@@ -278,7 +287,7 @@ describe('OpenaiOauthService', () => {
       const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1', 'Work');
       expect(token).toBe('new');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
-        'agent-1',
+        null,
         'user-1',
         'openai',
         expect.stringContaining('"t":"new"'),

--- a/packages/backend/src/routing/oauth/openai/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/openai/openai-oauth.service.spec.ts
@@ -2,6 +2,7 @@ import { createServer } from 'http';
 import { ConfigService } from '@nestjs/config';
 import { OpenaiOauthService, OAuthTokenBlob } from './openai-oauth.service';
 import { ProviderService } from '../../routing-core/provider.service';
+import { mockSubscriptionCredentialLock } from '../__tests__/mock-subscription-lock';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetchMock = jest.fn() as jest.Mock<Promise<any>>;
@@ -31,11 +32,17 @@ describe('OpenaiOauthService', () => {
   let discoveryService: { discoverModels: jest.Mock };
 
   beforeEach(() => {
+    const upsertProvider = jest.fn().mockResolvedValue({ provider: {}, isNew: true });
+    const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
     providerService = {
-      upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
+      upsertProvider,
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
       nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
-      getFreshSubscriptionCredential: jest.fn().mockResolvedValue(null),
+      getFreshSubscriptionCredential,
+      withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+        getFreshSubscriptionCredential,
+        upsertProvider,
+      }),
     } as unknown as jest.Mocked<ProviderService>;
 
     configService = {
@@ -286,7 +293,7 @@ describe('OpenaiOauthService', () => {
 
       expect(result).toBe('new-access');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
-        'agent-1',
+        null,
         'tenant-1',
         'openai',
         expect.any(String),

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
@@ -2,6 +2,7 @@ import { ConfigService } from '@nestjs/config';
 import type { ServerResponse } from 'http';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { ProviderService } from '../../routing-core/provider.service';
+import { mockSubscriptionCredentialLock } from '../__tests__/mock-subscription-lock';
 import { XaiOauthService } from './xai-oauth.service';
 
 const mockHttpControl: {
@@ -69,12 +70,20 @@ function createProviderService() {
       recalculateTiersForUser,
       nextOAuthLabel,
       getFreshSubscriptionCredential,
+      withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+        getFreshSubscriptionCredential,
+        upsertProvider,
+      }),
     } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     recalculateTiersForUser,
     nextOAuthLabel,
     getFreshSubscriptionCredential,
+    withSubscriptionCredentialLock: mockSubscriptionCredentialLock({
+      getFreshSubscriptionCredential,
+      upsertProvider,
+    }),
   };
 }
 
@@ -235,7 +244,7 @@ describe('XaiOauthService', () => {
       expect.objectContaining({ method: 'POST' }),
     );
     expect(providerService.upsertProvider).toHaveBeenCalledWith(
-      'agent-1',
+      null,
       'user-1',
       'xai',
       expect.stringContaining('"t":"new-access"'),

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -1358,7 +1358,7 @@ describe('ProxyFallbackService', () => {
       expect(providerClient.forward).not.toHaveBeenCalled();
     });
 
-    it('skips models with no API key', async () => {
+    it('records a credential failure when a model has no API key', async () => {
       pricingCache.getByModel.mockReturnValue({ provider: 'Anthropic' } as never);
       providerKeyService.getProviderApiKey.mockResolvedValue(null);
 
@@ -1373,7 +1373,15 @@ describe('ProxyFallbackService', () => {
       );
 
       expect(result.success).toBeNull();
-      expect(result.failures).toHaveLength(0);
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toMatchObject({
+        provider: 'Anthropic',
+        model: 'claude-sonnet-4',
+        status: 401,
+        providerCallStarted: true,
+      });
+      expect(result.failures[0].errorBody).toContain('M100');
+      expect(providerClient.forward).not.toHaveBeenCalled();
     });
 
     it('resolves custom provider from model prefix', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -156,6 +156,35 @@ describe('ProxyMessageRecorder', () => {
         expect.objectContaining({
           status: 'failed',
           error_message: 'Request failed without an error message.',
+          error_code: null,
+        }),
+      );
+    });
+
+    it('stamps error_code when completing a pending attempt with a Manifest body', async () => {
+      const attempt: ProviderAttemptRef = {
+        id: 'attempt-m102',
+        attemptNumber: 1,
+        startedAtMs: 1_000,
+        startedAt: '1970-01-01T00:00:01.000Z',
+        completedAtMs: 1_050,
+        pendingWrite: Promise.resolve(true),
+      };
+
+      await recorder.completePendingProviderFailure(
+        attempt,
+        401,
+        '[🦚 Manifest M102] openai subscription credentials could not be refreshed.',
+        true,
+      );
+
+      expect(updateMock).toHaveBeenCalledWith(
+        { id: 'attempt-m102' },
+        expect.objectContaining({
+          status: 'failed',
+          error_code: 'M102',
+          error_http_status: 401,
+          superseded: true,
         }),
       );
     });
@@ -922,6 +951,34 @@ describe('ProxyMessageRecorder', () => {
       );
     });
 
+    it('stamps error_code on mid-chain Manifest credential failures', async () => {
+      const failures = [
+        {
+          model: 'claude-sonnet-4',
+          provider: 'anthropic',
+          status: 401,
+          errorBody: JSON.stringify({
+            error: {
+              message:
+                '[🦚 Manifest M100] No anthropic API key yet. Add one here: https://x/routing See https://manifest.build/docs/errors/M100',
+            },
+          }),
+          fallbackIndex: 0,
+          authType: 'api_key' as const,
+        },
+      ];
+      await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures);
+      expect(insertMock.mock.calls[0][0]).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            error_code: 'M100',
+            error_http_status: 401,
+            provider: 'anthropic',
+          }),
+        ]),
+      );
+    });
+
     it('records all failures and emits SSE event once', async () => {
       const failures = [
         { model: 'gpt-4o', provider: 'openai', status: 500, errorBody: 'fail-1', fallbackIndex: 0 },
@@ -1148,8 +1205,35 @@ describe('ProxyMessageRecorder', () => {
         superseded: true,
         error_origin: 'transport',
         error_class: 'network',
+        error_code: null,
       });
       expect(emitMock).toHaveBeenCalledWith('tenant-1', 'message', 'user-1');
+    });
+
+    it('stamps error_code when the primary body is a Manifest credential failure', async () => {
+      const body = JSON.stringify({
+        error: {
+          message:
+            '[🦚 Manifest M102] openai subscription credentials could not be refreshed. Reconnect OAuth here: https://x/routing See https://manifest.build/docs/errors/M102',
+        },
+      });
+      await recorder.recordPrimaryFailure(
+        ctx,
+        'default',
+        'gpt-5.5',
+        body,
+        '2025-01-01T00:00:00.000Z',
+        'subscription',
+        { provider: 'openai', httpStatus: 401 },
+      );
+      expect(insertMock.mock.calls[0][0]).toMatchObject({
+        status: 'failed',
+        error_code: 'M102',
+        error_http_status: 401,
+        auth_type: 'subscription',
+        provider: 'openai',
+      });
+      expect(insertMock.mock.calls[0][0].error_message).toContain('M102');
     });
 
     it('persists the provider column when passed a provider', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -979,6 +979,39 @@ describe('ProxyMessageRecorder', () => {
       );
     });
 
+    it('classifies a mid-chain credential failure as config origin despite a tier routing_reason', async () => {
+      // The row carries a synthetic 401 and the tier reason ('scored'), but the
+      // stamped M102 must win classification — otherwise a Manifest config error
+      // is bucketed as a provider 401 and inflates provider_error_rate/billing.
+      const failures = [
+        {
+          model: 'claude-sonnet-4',
+          provider: 'anthropic',
+          status: 401,
+          errorBody: JSON.stringify({
+            error: {
+              message:
+                '[🦚 Manifest M102] anthropic subscription credentials could not be refreshed. Reconnect OAuth here: https://x/routing See https://manifest.build/docs/errors/M102',
+            },
+          }),
+          fallbackIndex: 0,
+          authType: 'subscription' as const,
+        },
+      ];
+      await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures, {
+        reason: 'scored',
+      });
+      const rows = insertMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+      expect(rows[0]).toEqual(
+        expect.objectContaining({
+          error_code: 'M102',
+          routing_reason: 'scored', // display keeps the tier reason
+          error_origin: 'config', // …but it classifies as Manifest config, not a provider 401
+          error_class: 'subscription_credentials_unusable',
+        }),
+      );
+    });
+
     it('records all failures and emits SSE event once', async () => {
       const failures = [
         { model: 'gpt-4o', provider: 'openai', status: 500, errorBody: 'fail-1', fallbackIndex: 0 },

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -731,7 +731,7 @@ describe('ProxyService — orchestration', () => {
   });
 
   describe('no credentials', () => {
-    it('returns the M100 friendly response', async () => {
+    it('returns the M100 friendly response when no key exists', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         route: route('openai', 'api_key', 'gpt-4o'),
@@ -744,9 +744,39 @@ describe('ProxyService — orchestration', () => {
       const result = await svc.proxyRequest(baseOpts());
       const body = await result.forward.response.text();
       expect(body).toContain('M100');
+      expect(body).toContain('No openai API key yet');
     });
 
-    it('promotes the first fallback with usable credentials instead of failing', async () => {
+    it('returns M102 when a subscription OAuth blob cannot be refreshed', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'subscription', 'gpt-5.5'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      // Valid compact OAuth blob shape — unwrapToken fails (dead refresh).
+      providerKeyService.selectProviderKey.mockResolvedValue({
+        apiKey: JSON.stringify({ t: 'access', r: 'refresh', e: 0 }),
+        id: 'up-oai',
+        region: null,
+        label: 'Default',
+        priority: 0,
+      });
+      openaiOauth.unwrapToken.mockResolvedValue(null);
+
+      const result = await svc.proxyRequest(baseOpts());
+      const body = await result.forward.response.text();
+
+      expect(body).toContain('M102');
+      expect(body).toContain('subscription credentials could not be refreshed');
+      expect(body).toContain('openai');
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      expect(fallbackService.tryFallbacks).not.toHaveBeenCalled();
+    });
+
+    it('enters the normal fallback chain when primary credentials fail', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         route: route('openai', 'subscription', 'gpt-5.5'),
@@ -758,62 +788,48 @@ describe('ProxyService — orchestration', () => {
         score: 5,
         reason: 'scored',
       });
-      providerKeyService.selectProviderKey.mockImplementation((_tenant, provider) =>
-        Promise.resolve(
-          provider === 'minimax'
-            ? { apiKey: 'mk-key', id: 'up-mm', region: null, label: 'Default', priority: 0 }
-            : null,
-        ),
-      );
-      fallbackService.tryForwardToProvider.mockResolvedValue({
-        response: okResponse(200),
-        isGoogle: false,
-        isAnthropic: false,
-        isChatGpt: false,
+      providerKeyService.selectProviderKey.mockResolvedValue({
+        apiKey: JSON.stringify({ t: 'access', r: 'refresh', e: 0 }),
+        id: 'up-oai',
+        region: null,
+        label: 'Default',
+        priority: 0,
+      });
+      openaiOauth.unwrapToken.mockResolvedValue(null);
+      fallbackService.tryFallbacks.mockResolvedValue({
+        success: {
+          forward: {
+            response: okResponse(200),
+            isGoogle: false,
+            isAnthropic: false,
+            isChatGpt: false,
+          },
+          model: 'MiniMax-M3',
+          provider: 'minimax',
+          fallbackIndex: 0,
+          authType: 'api_key',
+          tenantProviderId: 'up-mm',
+        },
+        failures: [],
       });
 
       const result = await svc.proxyRequest(baseOpts());
 
-      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: 'minimax', model: 'MiniMax-M3', apiKey: 'mk-key' }),
-      );
+      // Primary is not rewritten to minimax — fallback chain is used instead.
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      expect(fallbackService.tryFallbacks).toHaveBeenCalled();
+      const call = fallbackService.tryFallbacks.mock.calls[0];
+      expect(call[2]).toEqual(['MiniMax-M3', 'glm-5']); // fallback models
+      expect(call[6]).toBe('gpt-5.5'); // primary model
+      expect(call[8]).toBe('openai'); // primary provider
+      expect(call[9]).toBe('subscription');
+      expect(result.meta.fallbackFromModel).toBe('gpt-5.5');
+      expect(result.meta.provider).toBe('minimax');
+      expect(result.meta.primaryErrorBody).toContain('M102');
       expect(result.forward.response.status).toBe(200);
     });
 
-    it('skips credential-less fallbacks and promotes the first usable one', async () => {
-      resolveService.resolve.mockResolvedValue({
-        tier: 'standard',
-        route: route('openai', 'subscription', 'gpt-5.5'),
-        fallback_routes: [
-          route('minimax', 'api_key', 'MiniMax-M3'),
-          route('zai', 'api_key', 'glm-5'),
-        ],
-        confidence: 0.9,
-        score: 5,
-        reason: 'scored',
-      });
-      providerKeyService.selectProviderKey.mockImplementation((_tenant, provider) =>
-        Promise.resolve(
-          provider === 'zai'
-            ? { apiKey: 'zai-key', id: 'up-zai', region: null, label: 'Default', priority: 0 }
-            : null,
-        ),
-      );
-      fallbackService.tryForwardToProvider.mockResolvedValue({
-        response: okResponse(200),
-        isGoogle: false,
-        isAnthropic: false,
-        isChatGpt: false,
-      });
-
-      await svc.proxyRequest(baseOpts());
-
-      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: 'zai', model: 'glm-5', apiKey: 'zai-key' }),
-      );
-    });
-
-    it('returns M100 for the primary provider when the whole chain is dry', async () => {
+    it('returns the primary M102 body when the fallback chain is exhausted', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         route: route('openai', 'subscription', 'gpt-5.5'),
@@ -822,13 +838,47 @@ describe('ProxyService — orchestration', () => {
         score: 5,
         reason: 'scored',
       });
-      providerKeyService.selectProviderKey.mockResolvedValue(null);
+      providerKeyService.selectProviderKey.mockResolvedValue({
+        apiKey: JSON.stringify({ t: 'access', r: 'refresh', e: 0 }),
+        id: 'up-oai',
+        region: null,
+        label: 'Default',
+        priority: 0,
+      });
+      openaiOauth.unwrapToken.mockResolvedValue(null);
+      fallbackService.tryFallbacks.mockResolvedValue({ success: null, failures: [] });
 
       const result = await svc.proxyRequest(baseOpts());
       const body = await result.forward.response.text();
 
+      // Exhausted chain keeps the primary synthetic 401 (same as HTTP fallback
+      // exhaustion) — the M102 message is on the body for attempt recording.
+      expect(result.forward.response.status).toBe(401);
+      expect(body).toContain('M102');
+      expect(body).toContain('openai');
+      expect(fallbackService.tryFallbacks).toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+    });
+
+    it('returns the primary M100 body when the whole chain is dry (no keys)', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-5.5'),
+        fallback_routes: [route('minimax', 'api_key', 'MiniMax-M3')],
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      providerKeyService.selectProviderKey.mockResolvedValue(null);
+      fallbackService.tryFallbacks.mockResolvedValue({ success: null, failures: [] });
+
+      const result = await svc.proxyRequest(baseOpts());
+      const body = await result.forward.response.text();
+
+      expect(result.forward.response.status).toBe(401);
       expect(body).toContain('M100');
       expect(body).toContain('openai');
+      expect(fallbackService.tryFallbacks).toHaveBeenCalled();
       expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
     });
   });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -745,6 +745,92 @@ describe('ProxyService — orchestration', () => {
       const body = await result.forward.response.text();
       expect(body).toContain('M100');
     });
+
+    it('promotes the first fallback with usable credentials instead of failing', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'subscription', 'gpt-5.5'),
+        fallback_routes: [
+          route('minimax', 'api_key', 'MiniMax-M3'),
+          route('zai', 'api_key', 'glm-5'),
+        ],
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      providerKeyService.selectProviderKey.mockImplementation((_tenant, provider) =>
+        Promise.resolve(
+          provider === 'minimax'
+            ? { apiKey: 'mk-key', id: 'up-mm', region: null, label: 'Default', priority: 0 }
+            : null,
+        ),
+      );
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(200),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      const result = await svc.proxyRequest(baseOpts());
+
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'minimax', model: 'MiniMax-M3', apiKey: 'mk-key' }),
+      );
+      expect(result.forward.response.status).toBe(200);
+    });
+
+    it('skips credential-less fallbacks and promotes the first usable one', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'subscription', 'gpt-5.5'),
+        fallback_routes: [
+          route('minimax', 'api_key', 'MiniMax-M3'),
+          route('zai', 'api_key', 'glm-5'),
+        ],
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      providerKeyService.selectProviderKey.mockImplementation((_tenant, provider) =>
+        Promise.resolve(
+          provider === 'zai'
+            ? { apiKey: 'zai-key', id: 'up-zai', region: null, label: 'Default', priority: 0 }
+            : null,
+        ),
+      );
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(200),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'zai', model: 'glm-5', apiKey: 'zai-key' }),
+      );
+    });
+
+    it('returns M100 for the primary provider when the whole chain is dry', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'subscription', 'gpt-5.5'),
+        fallback_routes: [route('minimax', 'api_key', 'MiniMax-M3')],
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      providerKeyService.selectProviderKey.mockResolvedValue(null);
+
+      const result = await svc.proxyRequest(baseOpts());
+      const body = await result.forward.response.text();
+
+      expect(body).toContain('M100');
+      expect(body).toContain('openai');
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+    });
   });
 
   describe('explicit OpenAI-compatible model routing', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -747,6 +747,62 @@ describe('ProxyService — orchestration', () => {
       expect(body).toContain('No openai API key yet');
     });
 
+    it('does NOT start a provider attempt when credentials fail with no fallback routes (no orphan row)', async () => {
+      // With no chain to record it, a synthetic attempt would INSERT a pending
+      // agent_messages row that nothing ever completes. The Manifest stub is the
+      // sole record, so no provider attempt must be started.
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      providerKeyService.selectProviderKey.mockResolvedValue(null);
+      const startProviderAttempt = jest.fn(() => ({
+        id: 'attempt-1',
+        attemptNumber: 1,
+        startedAtMs: Date.now(),
+        startedAt: new Date().toISOString(),
+        pendingWrite: Promise.resolve(true),
+      }));
+
+      const result = await svc.proxyRequest(baseOpts({ startProviderAttempt }));
+
+      expect(startProviderAttempt).not.toHaveBeenCalled();
+      expect(await result.forward.response.text()).toContain('M100');
+    });
+
+    it('starts the synthetic primary attempt only when a fallback chain will run', async () => {
+      // Fallback routes exist → the chain records/completes the primary
+      // credential-failure attempt, so starting it here is safe.
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: [route('anthropic', 'api_key', 'claude-sonnet-4')],
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      providerKeyService.selectProviderKey.mockResolvedValue(null);
+      fallbackService.tryFallbacks.mockResolvedValue({ success: null, failures: [] });
+      const startProviderAttempt = jest.fn(() => ({
+        id: 'attempt-1',
+        attemptNumber: 1,
+        startedAtMs: Date.now(),
+        startedAt: new Date().toISOString(),
+        pendingWrite: Promise.resolve(true),
+      }));
+
+      await svc.proxyRequest(baseOpts({ startProviderAttempt }));
+
+      expect(startProviderAttempt).toHaveBeenCalledTimes(1);
+      expect(startProviderAttempt).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'openai', model: 'gpt-4o' }),
+      );
+    });
+
     it('returns M102 when a subscription OAuth blob cannot be refreshed', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',

--- a/packages/backend/src/routing/proxy/__tests__/route-credentials.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/route-credentials.spec.ts
@@ -1,0 +1,192 @@
+import {
+  buildCredentialFailureFallback,
+  buildCredentialFailureForward,
+  credentialFailureCode,
+  presentCredentialFailure,
+  resolveRouteCredentials,
+  CREDENTIAL_FAILURE_HTTP_STATUS,
+} from '../route-credentials';
+import type { OAuthServiceSet } from '../oauth-credentials';
+
+describe('route-credentials', () => {
+  describe('presentCredentialFailure', () => {
+    it('maps missing key to M100', () => {
+      const p = presentCredentialFailure(
+        'no_provider_key',
+        'openai',
+        'https://dash.example/routing',
+      );
+      expect(p.code).toBe('M100');
+      expect(p.reason).toBe('no_provider_key');
+      expect(p.status).toBe(CREDENTIAL_FAILURE_HTTP_STATUS);
+      expect(p.message).toContain('M100');
+      expect(p.message).toContain('No openai API key yet');
+      expect(p.errorBody).toContain('M100');
+    });
+
+    it('maps dead subscription OAuth to M102', () => {
+      const p = presentCredentialFailure(
+        'subscription_credentials_unusable',
+        'anthropic',
+        'https://dash.example/routing',
+      );
+      expect(p.code).toBe('M102');
+      expect(p.reason).toBe('subscription_credentials_unusable');
+      expect(p.message).toContain('subscription credentials could not be refreshed');
+      expect(credentialFailureCode('subscription_credentials_unusable')).toBe('M102');
+    });
+  });
+
+  describe('buildCredentialFailureForward / Fallback', () => {
+    const presentation = presentCredentialFailure(
+      'no_provider_key',
+      'openai',
+      'https://dash.example/routing',
+    );
+
+    it('builds a synthetic primary forward with a recorded attempt', async () => {
+      const startProviderAttempt = jest.fn().mockReturnValue({
+        id: 'att-1',
+        attemptNumber: 1,
+        startedAtMs: 1,
+        startedAt: new Date(1).toISOString(),
+        pendingWrite: Promise.resolve(true),
+      });
+
+      const forward = buildCredentialFailureForward({
+        provider: 'openai',
+        model: 'gpt-5.5',
+        authType: 'api_key',
+        tenantProviderId: null,
+        presentation,
+        startProviderAttempt,
+      });
+
+      expect(forward.response.status).toBe(401);
+      expect(forward.providerCallStarted).toBe(true);
+      expect(forward.attempt?.id).toBe('att-1');
+      expect(forward.attempt?.completedAtMs).toBeDefined();
+      expect(await forward.response.text()).toContain('M100');
+      expect(startProviderAttempt).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'openai', model: 'gpt-5.5' }),
+      );
+    });
+
+    it('builds a mid-chain FailedFallback-shaped entry with the same body policy', () => {
+      const entry = buildCredentialFailureFallback({
+        model: 'MiniMax-M3',
+        provider: 'minimax',
+        fallbackIndex: 0,
+        authType: 'api_key',
+        tenantProviderId: null,
+        presentation,
+      });
+
+      expect(entry).toMatchObject({
+        model: 'MiniMax-M3',
+        provider: 'minimax',
+        fallbackIndex: 0,
+        status: 401,
+        providerCallStarted: true,
+      });
+      expect(entry.errorBody).toBe(presentation.errorBody);
+    });
+  });
+
+  describe('resolveRouteCredentials', () => {
+    const oauth = {
+      openaiOauth: { unwrapToken: jest.fn() },
+      minimaxOauth: { unwrapToken: jest.fn() },
+      anthropicOauth: { unwrapToken: jest.fn() },
+      geminiOauth: { unwrapToken: jest.fn() },
+      kiroOauth: { unwrapToken: jest.fn() },
+      xaiOauth: { unwrapToken: jest.fn() },
+    } as unknown as OAuthServiceSet;
+
+    const providerKeyService = {
+      selectProviderKey: jest.fn(),
+      getProviderApiKey: jest.fn(),
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns no_provider_key when no connection row exists', async () => {
+      providerKeyService.selectProviderKey.mockResolvedValue(null);
+      const result = await resolveRouteCredentials(
+        { providerKeyService, oauth },
+        {
+          agentId: 'a1',
+          tenantId: 't1',
+          provider: 'openai',
+          authType: 'api_key',
+        },
+      );
+      expect(result).toEqual({
+        ok: false,
+        reason: 'no_provider_key',
+        tenantProviderId: null,
+      });
+    });
+
+    it('returns subscription_credentials_unusable when OAuth unwrap fails on a blob', async () => {
+      const blob = JSON.stringify({ t: 'access', r: 'refresh', e: 0 });
+      providerKeyService.selectProviderKey.mockResolvedValue({
+        apiKey: blob,
+        id: 'up-1',
+        region: null,
+        label: 'Default',
+        priority: 0,
+      });
+      (oauth.openaiOauth.unwrapToken as jest.Mock).mockResolvedValue(null);
+
+      const result = await resolveRouteCredentials(
+        { providerKeyService, oauth },
+        {
+          agentId: 'a1',
+          tenantId: 't1',
+          provider: 'openai',
+          authType: 'subscription',
+        },
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        reason: 'subscription_credentials_unusable',
+        tenantProviderId: 'up-1',
+      });
+    });
+
+    it('returns usable credentials for a plain API key', async () => {
+      providerKeyService.selectProviderKey.mockResolvedValue({
+        apiKey: 'sk-live',
+        id: 'up-1',
+        region: 'us',
+        label: 'Work',
+        priority: 0,
+      });
+
+      const result = await resolveRouteCredentials(
+        { providerKeyService, oauth },
+        {
+          agentId: 'a1',
+          tenantId: 't1',
+          provider: 'openai',
+          authType: 'api_key',
+          providerKeyLabel: 'Work',
+        },
+      );
+
+      expect(result).toEqual({
+        ok: true,
+        apiKey: 'sk-live',
+        rawApiKey: 'sk-live',
+        resourceUrl: undefined,
+        providerRegion: 'us',
+        tenantProviderId: 'up-1',
+        keyLabel: 'Work',
+      });
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -46,10 +46,7 @@ interface ForwardProviderOptions {
   startProviderAttempt?: StartProviderAttempt;
 }
 
-import {
-  ProviderKeyService,
-  SYNTHETIC_OLLAMA_PROVIDER_ID,
-} from '../routing-core/provider-key.service';
+import { ProviderKeyService } from '../routing-core/provider-key.service';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
 import { resolveForwardEndpoint } from './forward-endpoint-resolver';
@@ -81,11 +78,13 @@ import type {
   StartProviderAttempt,
 } from './proxy-types';
 import type { ProxyApiMode } from './proxy-types';
+import { refreshRejectedOAuthCredential } from './oauth-credentials';
 import {
-  isRefreshableOAuthCredential,
-  refreshRejectedOAuthCredential,
-  resolveApiKey,
-} from './oauth-credentials';
+  buildCredentialFailureFallback,
+  presentCredentialFailure,
+  resolveRouteCredentials,
+  type RouteCredentialDeps,
+} from './route-credentials';
 
 // Fallback cooldown applied when an upstream 429 carries no usable Retry-After.
 // Kept short (15s) on purpose: many providers rate-limit on brief RPM/burst
@@ -193,6 +192,8 @@ export class ProxyFallbackService {
     paramMergeContext?: ParamMergeContext,
     reasoningContentLookup?: ReasoningContentLookup,
     startProviderAttempt?: StartProviderAttempt,
+    /** Dashboard URL embedded in mid-chain M100/M102 credential failure bodies. */
+    credentialDashboardUrl?: string,
   ): Promise<{
     success: {
       forward: ForwardResult;
@@ -261,67 +262,37 @@ export class ProxyFallbackService {
         )) as AuthType;
       }
       const model = normalizeProviderModel(provider, requestedModel);
-      // Single key selection per attempt: the forwarded apiKey, the stamped
-      // tenant_provider_id, the recorded key label, and the region are all
-      // projected from this one row, so they can never diverge. With no
-      // pinned label this returns the priority-0 (default) key.
-      const key = await this.providerKeyService.selectProviderKey(
+      // Same credential resolution as primary (select key + OAuth unwrap).
+      const credentials = await resolveRouteCredentials(this.routeCredentialDeps(), {
+        agentId,
         tenantId,
         provider,
         authType,
         providerKeyLabel,
-        agentId,
-      );
-      if (!key || key.apiKey === null) {
+      });
+      if (!credentials.ok) {
         this.logger.debug(
-          `Fallback ${i}: skipping model=${model} provider=${provider} (no API key)`,
+          `Fallback ${i}: credential failure model=${model} provider=${provider} reason=${credentials.reason}`,
         );
-        continue;
-      }
-      const apiKey = key.apiKey;
-      // NULL for synthetic Ollama — no persisted row to stamp.
-      const tenantProviderId = key.id === SYNTHETIC_OLLAMA_PROVIDER_ID ? null : key.id;
-      // Resolve an unpinned subscription label to the selected row's label so
-      // OAuth refresh persistence updates the same key the selection used.
-      if (!providerKeyLabel && authType === 'subscription') {
-        providerKeyLabel = key.label;
-      }
-
-      const resolvedCredentials = await resolveApiKey(
-        provider,
-        apiKey,
-        authType,
-        agentId,
-        tenantId,
-        this.openaiOauth,
-        this.minimaxOauth,
-        this.anthropicOauth,
-        this.geminiOauth,
-        this.kiroOauth,
-        this.xaiOauth,
-        providerKeyLabel,
-      );
-      if (resolvedCredentials.apiKey === null) {
-        this.logger.debug(
-          `Fallback ${i}: skipping model=${model} provider=${provider} (OAuth token unavailable)`,
-        );
-        continue;
-      }
-      let rawApiKey = apiKey;
-      if (authType === 'subscription' && isRefreshableOAuthCredential(apiKey)) {
-        // Deliberate re-read: resolveApiKey may have refreshed + persisted a
-        // rotated OAuth blob (which also invalidates the key cache), so the
-        // freshest stored value is fetched for the 401-retry path.
-        rawApiKey =
-          (await this.providerKeyService.getProviderApiKey(
-            tenantId,
+        failures.push(
+          buildCredentialFailureFallback({
+            model,
             provider,
+            fallbackIndex: i,
             authType,
-            providerKeyLabel,
-            agentId,
-          )) ?? apiKey;
+            tenantProviderId: credentials.tenantProviderId,
+            presentation: presentCredentialFailure(
+              credentials.reason,
+              provider,
+              credentialDashboardUrl ?? 'the dashboard',
+            ),
+            startProviderAttempt,
+          }),
+        );
+        continue;
       }
-      const providerRegion = key.region;
+      providerKeyLabel = credentials.keyLabel ?? providerKeyLabel;
+      const tenantProviderId = credentials.tenantProviderId;
 
       this.logger.log(
         `Fallback ${i}: trying model=${model} provider=${provider} auth_type=${authType} (primary=${primaryModel})`,
@@ -329,7 +300,7 @@ export class ProxyFallbackService {
 
       const forward = await this.tryForwardToProvider({
         provider,
-        apiKey: resolvedCredentials.apiKey,
+        apiKey: credentials.apiKey,
         model,
         body,
         chatBody,
@@ -338,12 +309,12 @@ export class ProxyFallbackService {
         signal,
         agentId,
         tenantId,
-        rawApiKey,
+        rawApiKey: credentials.rawApiKey,
         providerKeyLabel,
         authType,
         apiMode,
-        resourceUrl: resolvedCredentials.resourceUrl,
-        providerRegion,
+        resourceUrl: credentials.resourceUrl,
+        providerRegion: credentials.providerRegion,
         signatureLookup,
         thinkingLookup,
         reasoningContentLookup,
@@ -363,7 +334,9 @@ export class ProxyFallbackService {
             // Label of the connection row that served the attempt — stamped
             // alongside its tenant_provider_id so the pair always matches.
             // Synthetic rows (Ollama) keep the pinned label, if any.
-            keyLabel: tenantProviderId ? key.label : providerKeyLabel,
+            keyLabel: tenantProviderId
+              ? (credentials.keyLabel ?? providerKeyLabel)
+              : providerKeyLabel,
             tenantProviderId,
           },
           failures,
@@ -391,6 +364,20 @@ export class ProxyFallbackService {
       if (!shouldTriggerFallback(forward.response.status)) break;
     }
     return { success: null, failures };
+  }
+
+  private routeCredentialDeps(): RouteCredentialDeps {
+    return {
+      providerKeyService: this.providerKeyService,
+      oauth: {
+        openaiOauth: this.openaiOauth,
+        minimaxOauth: this.minimaxOauth,
+        anthropicOauth: this.anthropicOauth,
+        geminiOauth: this.geminiOauth,
+        kiroOauth: this.kiroOauth,
+        xaiOauth: this.xaiOauth,
+      },
+    };
   }
 
   async tryForwardToProvider(opts: ForwardProviderOptions): Promise<ForwardResult> {

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -27,7 +27,11 @@ import { CustomProviderService } from '../custom-provider/custom-provider.servic
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
 import { extractManifestErrorCode, type ManifestErrorCode } from '../../common/errors/error-codes';
-import type { ManifestBlockedRequestReason } from '../../common/errors/manifest-error';
+import {
+  MANIFEST_CODE_TO_REASON,
+  isRecordableManifestCode,
+  type ManifestBlockedRequestReason,
+} from '../../common/errors/manifest-error';
 import {
   getAutofixRetry,
   type AutofixChainEntry,
@@ -372,10 +376,20 @@ function classifyRow(row: Partial<AgentMessage>): {
   if (normalizeStatus(row.status) === PENDING_STATUS) {
     return { error_origin: null, error_class: null, superseded: false };
   }
+  // A stamped Manifest error_code is the authoritative origin signal. A
+  // credential-hop failure (M100/M102) carries a synthetic 401 and rides the
+  // fallback recorder, whose routing_reason is the *tier* reason ('scored',
+  // 'default', …) — classifying off that alone would bucket a Manifest config
+  // error as a provider 401 and inflate provider_error_rate / billing. Derive
+  // the reason from the code so it classifies as config even though
+  // routing_reason keeps the tier reason for display.
+  const code = row.error_code as ManifestErrorCode | null | undefined;
+  const codeReason =
+    code && isRecordableManifestCode(code) ? MANIFEST_CODE_TO_REASON[code] : undefined;
   return classifyMessageError({
     status: row.status ?? 'ok',
     errorHttpStatus: row.error_http_status,
-    routingReason: row.routing_reason,
+    routingReason: codeReason ?? row.routing_reason,
   });
 }
 

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -26,7 +26,7 @@ import type { ProviderAttemptRef, ProviderAttemptStart } from './proxy-types';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
-import type { ManifestErrorCode } from '../../common/errors/error-codes';
+import { extractManifestErrorCode, type ManifestErrorCode } from '../../common/errors/error-codes';
 import type { ManifestBlockedRequestReason } from '../../common/errors/manifest-error';
 import {
   getAutofixRetry,
@@ -575,11 +575,13 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       status: richStatus,
       error_http_status: status,
     });
+    const errorMessage = scrubSecrets(errorBody).trim().slice(0, 2000) || FAILED_WITHOUT_MESSAGE;
     await this.messageRepo.update(
       { id: attempt.id },
       {
         status: normalizeStatus(richStatus),
-        error_message: scrubSecrets(errorBody).trim().slice(0, 2000) || FAILED_WITHOUT_MESSAGE,
+        error_message: errorMessage,
+        error_code: extractManifestErrorCode(errorMessage),
         error_http_status: status,
         duration_ms: Math.max(0, (attempt.completedAtMs ?? Date.now()) - attempt.startedAtMs),
         ...classified,
@@ -827,6 +829,9 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       // Falling back to the primary auth keeps behavior identical for rows
       // that haven't been backfilled with routes.
       const recordedAuth = f.authType ?? authType ?? null;
+      const errorMessage = scrubSecrets(
+        normalizeProviderErrorForStorage(f.status, f.errorBody),
+      ).slice(0, 2000);
       rows.push(
         buildMessageRow(ctx, {
           request_id: requestId,
@@ -837,9 +842,11 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
           trace_id: traceId ?? null,
           timestamp: ts,
           status,
-          error_message: scrubSecrets(
-            normalizeProviderErrorForStorage(f.status, f.errorBody),
-          ).slice(0, 2000),
+          error_message: errorMessage,
+          // Credential hop failures embed M100/M102 in the body; stamp the
+          // code so filters/analytics do not have to parse error_message.
+          error_code:
+            extractManifestErrorCode(errorMessage) ?? extractManifestErrorCode(f.errorBody),
           error_http_status: f.status,
           model: canonical.model,
           provider: canonical.provider,
@@ -914,6 +921,9 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       model,
     );
     const requestId = opts?.requestId ?? uuid();
+    const errorMessage = scrubSecrets(
+      normalizeProviderErrorForStorage(opts?.httpStatus, errorBody),
+    ).slice(0, 2000);
     const row = buildMessageRow(ctx, {
       request_id: requestId,
       ...attemptIdentity(opts?.attempt, opts?.attemptNumber),
@@ -921,9 +931,10 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       duration_ms: opts?.requestDurationMs ?? null,
       status: 'fallback_error',
       ...autofixColumns(opts?.autofix, terminalAutofixRole(opts?.autofix)),
-      error_message: scrubSecrets(
-        normalizeProviderErrorForStorage(opts?.httpStatus, errorBody),
-      ).slice(0, 2000),
+      error_message: errorMessage,
+      // Credential failures (M100/M102) land here with a peacock body; stamp
+      // error_code so Messages filters and analytics can group on it.
+      error_code: extractManifestErrorCode(errorMessage) ?? extractManifestErrorCode(errorBody),
       error_http_status: opts?.httpStatus ?? null,
       model: canonical.model,
       provider: canonical.provider,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -314,12 +314,40 @@ export class ProxyService {
       return this.buildNoProviderResult(stream, agentName);
     }
 
-    const route = resolved.route;
-    const credentials = await this.resolveCredentials(agentId, tenantId, {
+    let route = resolved.route;
+    let credentials = await this.resolveCredentials(agentId, tenantId, {
       provider: route.provider,
       auth_type: route.authType,
       provider_key_label: route.keyLabel ?? undefined,
     });
+    if (credentials === null) {
+      // The resolver elected this primary off the provider-key cache (a row
+      // exists and holds a key), but the stored credential didn't resolve —
+      // typically an OAuth subscription whose refresh token is dead. The
+      // fallback service already skips credential-less routes mid-chain, so
+      // give the configured fallbacks the same chance here instead of failing
+      // the request: promote the first one whose credentials resolve and keep
+      // the remainder as its fallback chain. M100 is reserved for a chain
+      // with no usable credentials anywhere.
+      const fallbacks = resolved.fallback_routes ?? [];
+      for (let i = 0; i < fallbacks.length && credentials === null; i++) {
+        const candidate = fallbacks[i];
+        const candidateCredentials = await this.resolveCredentials(agentId, tenantId, {
+          provider: candidate.provider,
+          auth_type: candidate.authType,
+          provider_key_label: candidate.keyLabel ?? undefined,
+        });
+        if (candidateCredentials === null) continue;
+        this.logger.warn(
+          `Primary ${route.provider}/${route.model} has no usable credentials for ` +
+            `agent=${agentId} — promoting fallback ${candidate.provider}/${candidate.model}`,
+        );
+        route = candidate;
+        credentials = candidateCredentials;
+        resolved.route = candidate;
+        resolved.fallback_routes = fallbacks.slice(i + 1);
+      }
+    }
     if (credentials === null) {
       const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
       const content = formatManifestError('M100', { provider: route.provider, dashboardUrl });

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -2,10 +2,7 @@ import { Injectable, Logger, HttpStatus } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ResolveService } from '../resolve/resolve.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
-import {
-  ProviderKeyService,
-  SYNTHETIC_OLLAMA_PROVIDER_ID,
-} from '../routing-core/provider-key.service';
+import { ProviderKeyService } from '../routing-core/provider-key.service';
 import { OpenaiOauthService } from '../oauth/openai/openai-oauth.service';
 import { MinimaxOauthService } from '../oauth/minimax/minimax-oauth.service';
 import { AnthropicOauthService } from '../oauth/anthropic/anthropic-oauth.service';
@@ -39,7 +36,6 @@ import {
   FailedFallback,
   normalizeProviderModel,
 } from './proxy-fallback.service';
-import { isRefreshableOAuthCredential, resolveApiKey } from './oauth-credentials';
 import {
   ProxyApiMode,
   ProxyRequestOptions,
@@ -57,6 +53,13 @@ import { ProviderParamSpecService } from '../routing-core/provider-param-spec.se
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
 import { formatManifestError, type ManifestErrorCode } from '../../common/errors/error-codes';
 import { ManifestError } from '../../common/errors/manifest-error';
+import {
+  buildCredentialFailureForward,
+  presentCredentialFailure,
+  resolveRouteCredentials,
+  type ResolvedRouteCredentials,
+  type RouteCredentialDeps,
+} from './route-credentials';
 import { peekStream, STREAM_WARMUP_MS } from './stream-warmup';
 import { toChatCompletionsRequest } from './responses-adapter';
 import { messagesToChatCompletionsRequest } from './anthropic-messages-adapter';
@@ -314,45 +317,12 @@ export class ProxyService {
       return this.buildNoProviderResult(stream, agentName);
     }
 
-    let route = resolved.route;
-    let credentials = await this.resolveCredentials(agentId, tenantId, {
+    const route = resolved.route;
+    const credentials = await this.resolveCredentials(agentId, tenantId, {
       provider: route.provider,
       auth_type: route.authType,
       provider_key_label: route.keyLabel ?? undefined,
     });
-    if (credentials === null) {
-      // The resolver elected this primary off the provider-key cache (a row
-      // exists and holds a key), but the stored credential didn't resolve —
-      // typically an OAuth subscription whose refresh token is dead. The
-      // fallback service already skips credential-less routes mid-chain, so
-      // give the configured fallbacks the same chance here instead of failing
-      // the request: promote the first one whose credentials resolve and keep
-      // the remainder as its fallback chain. M100 is reserved for a chain
-      // with no usable credentials anywhere.
-      const fallbacks = resolved.fallback_routes ?? [];
-      for (let i = 0; i < fallbacks.length && credentials === null; i++) {
-        const candidate = fallbacks[i];
-        const candidateCredentials = await this.resolveCredentials(agentId, tenantId, {
-          provider: candidate.provider,
-          auth_type: candidate.authType,
-          provider_key_label: candidate.keyLabel ?? undefined,
-        });
-        if (candidateCredentials === null) continue;
-        this.logger.warn(
-          `Primary ${route.provider}/${route.model} has no usable credentials for ` +
-            `agent=${agentId} — promoting fallback ${candidate.provider}/${candidate.model}`,
-        );
-        route = candidate;
-        credentials = candidateCredentials;
-        resolved.route = candidate;
-        resolved.fallback_routes = fallbacks.slice(i + 1);
-      }
-    }
-    if (credentials === null) {
-      const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
-      const content = formatManifestError('M100', { provider: route.provider, dashboardUrl });
-      return buildFriendlyResponse(content, stream, 'no_provider_key', 'M100');
-    }
 
     const primaryModel = normalizeProviderModel(route.provider, route.model);
     this.logger.log(
@@ -406,6 +376,64 @@ export class ProxyService {
           specs: primarySpecs,
         });
 
+    const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
+
+    // Credential resolution can fail before any provider HTTP call (missing
+    // key, or a subscription OAuth blob whose refresh token is dead). Treat
+    // that as a failed primary attempt with a real error body, then enter the
+    // same fallback chain as HTTP failures — do not silently promote a
+    // fallback to primary.
+    if (!credentials.ok) {
+      const credentialFailure = presentCredentialFailure(
+        credentials.reason,
+        route.provider,
+        dashboardUrl,
+      );
+      this.logger.warn(
+        `Primary ${route.provider}/${primaryModel} credentials unusable for ` +
+          `agent=${agentId} reason=${credentials.reason}`,
+      );
+      const forward = buildCredentialFailureForward({
+        provider: route.provider,
+        model: primaryModel,
+        authType: route.authType,
+        tenantProviderId: credentials.tenantProviderId,
+        presentation: credentialFailure,
+        startProviderAttempt,
+      });
+
+      if (!explicitModelOverride && paramMergeContext) {
+        const fallbackResult = await this.tryFallbackChain({
+          agentId,
+          tenantId,
+          resolved,
+          primaryModel,
+          forward,
+          body,
+          chatBody,
+          stream,
+          sessionKey,
+          signal,
+          signatureLookup,
+          thinkingLookup,
+          reasoningContentLookup,
+          apiMode,
+          paramMergeContext,
+          primaryTenantProviderId: credentials.tenantProviderId,
+          startProviderAttempt,
+          credentialDashboardUrl: dashboardUrl,
+        });
+        if (fallbackResult) return fallbackResult;
+      }
+
+      return buildFriendlyResponse(
+        credentialFailure.message,
+        stream,
+        credentialFailure.reason,
+        credentialFailure.code,
+      );
+    }
+
     let forward = await this.fallbackService.tryForwardToProvider({
       provider: route.provider,
       apiKey: credentials.apiKey,
@@ -418,7 +446,7 @@ export class ProxyService {
       agentId,
       tenantId,
       rawApiKey: credentials.rawApiKey,
-      providerKeyLabel: route.keyLabel ?? undefined,
+      providerKeyLabel: credentials.keyLabel ?? route.keyLabel ?? undefined,
       authType: route.authType,
       apiMode,
       resourceUrl: credentials.resourceUrl,
@@ -507,6 +535,7 @@ export class ProxyService {
         paramMergeContext,
         primaryTenantProviderId: credentials.tenantProviderId,
         startProviderAttempt,
+        credentialDashboardUrl: dashboardUrl,
       });
       if (fallbackResult) {
         return {
@@ -606,6 +635,7 @@ export class ProxyService {
           paramMergeContext,
           primaryTenantProviderId: credentials.tenantProviderId,
           startProviderAttempt,
+          credentialDashboardUrl: dashboardUrl,
         });
         if (fallbackResult) {
           return {
@@ -720,7 +750,7 @@ export class ProxyService {
       auth_type: route.authType,
       provider_key_label: route.keyLabel ?? undefined,
     });
-    if (!credentials) return this.autofixReforwardError('no provider key for the healed model');
+    if (!credentials.ok) return this.autofixReforwardError('no provider key for the healed model');
     const model = normalizeProviderModel(route.provider, route.model);
     ctx.onRouteResolved?.({ resolved, model, tenantProviderId: credentials.tenantProviderId });
     const explicitModelOverride = resolved.explicit_model_override === true;
@@ -881,70 +911,32 @@ export class ProxyService {
     };
   }
 
-  private async resolveCredentials(
+  private routeCredentialDeps(): RouteCredentialDeps {
+    return {
+      providerKeyService: this.providerKeyService,
+      oauth: {
+        openaiOauth: this.openaiOauth,
+        minimaxOauth: this.minimaxOauth,
+        anthropicOauth: this.anthropicOauth,
+        geminiOauth: this.geminiOauth,
+        kiroOauth: this.kiroOauth,
+        xaiOauth: this.xaiOauth,
+      },
+    };
+  }
+
+  private resolveCredentials(
     agentId: string,
     tenantId: string,
     resolved: { provider: string; auth_type?: AuthType; provider_key_label?: string },
-  ): Promise<{
-    apiKey: string;
-    rawApiKey: string;
-    resourceUrl?: string;
-    providerRegion?: string | null;
-    tenantProviderId: string | null;
-  } | null> {
-    // Single key selection per request: apiKey, the stamped tenant_provider_id,
-    // and the region are all projected from this one row, so the forwarded
-    // key and the recorded connection can never come from different rows.
-    const key = await this.providerKeyService.selectProviderKey(
-      tenantId,
-      resolved.provider,
-      resolved.auth_type,
-      resolved.provider_key_label,
-      agentId,
-    );
-    if (!key || key.apiKey === null) return null;
-    const apiKey = key.apiKey;
-    // NULL for the synthetic Ollama tile — it has no persisted row, so
-    // stamping its id would violate the agent_messages FK.
-    const tenantProviderId = key.id === SYNTHETIC_OLLAMA_PROVIDER_ID ? null : key.id;
-
-    const unwrapped = await resolveApiKey(
-      resolved.provider,
-      apiKey,
-      resolved.auth_type,
+  ): Promise<ResolvedRouteCredentials> {
+    return resolveRouteCredentials(this.routeCredentialDeps(), {
       agentId,
       tenantId,
-      this.openaiOauth,
-      this.minimaxOauth,
-      this.anthropicOauth,
-      this.geminiOauth,
-      this.kiroOauth,
-      this.xaiOauth,
-      resolved.provider_key_label,
-    );
-    const unwrappedApiKey = unwrapped.apiKey;
-    if (unwrappedApiKey === null) return null;
-    let rawApiKey = apiKey;
-    if (resolved.auth_type === 'subscription' && isRefreshableOAuthCredential(apiKey)) {
-      // Deliberate re-read: resolveApiKey may have refreshed + persisted a
-      // rotated OAuth blob (which also invalidates the key cache), so the
-      // freshest stored value is fetched for the 401-retry path.
-      rawApiKey =
-        (await this.providerKeyService.getProviderApiKey(
-          tenantId,
-          resolved.provider,
-          resolved.auth_type,
-          resolved.provider_key_label,
-          agentId,
-        )) ?? apiKey;
-    }
-    return {
-      apiKey: unwrappedApiKey,
-      rawApiKey,
-      resourceUrl: unwrapped.resourceUrl,
-      providerRegion: key.region,
-      tenantProviderId,
-    };
+      provider: resolved.provider,
+      authType: resolved.auth_type,
+      providerKeyLabel: resolved.provider_key_label,
+    });
   }
 
   private async tryFallbackChain(args: {
@@ -967,6 +959,8 @@ export class ProxyService {
      * its recorded primary-failure row to the connection that actually failed. */
     primaryTenantProviderId: string | null;
     startProviderAttempt?: StartProviderAttempt;
+    /** Dashboard URL embedded in mid-chain M100/M102 credential failure bodies. */
+    credentialDashboardUrl?: string;
   }): Promise<ProxyResult | null> {
     const {
       agentId,
@@ -1023,6 +1017,7 @@ export class ProxyService {
       args.paramMergeContext,
       args.reasoningContentLookup,
       args.startProviderAttempt,
+      args.credentialDashboardUrl,
     );
 
     this.recordTierIfScoring(sessionKey, resolved.tier);

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -393,16 +393,26 @@ export class ProxyService {
         `Primary ${route.provider}/${primaryModel} credentials unusable for ` +
           `agent=${agentId} reason=${credentials.reason}`,
       );
+      // A synthetic provider attempt is only recorded by the fallback chain
+      // (recordPrimaryFailure completes it). When no chain will run — explicit
+      // model override, no merge context, or zero fallback routes — the Manifest
+      // stub is the sole record (a Manifest rejection has zero provider
+      // attempts), so DON'T start one here: it would INSERT a pending
+      // agent_messages row that nothing ever completes (orphan).
+      const willRunChain =
+        !explicitModelOverride &&
+        !!paramMergeContext &&
+        this.effectiveFallbackRoutes(resolved).length > 0;
       const forward = buildCredentialFailureForward({
         provider: route.provider,
         model: primaryModel,
         authType: route.authType,
         tenantProviderId: credentials.tenantProviderId,
         presentation: credentialFailure,
-        startProviderAttempt,
+        startProviderAttempt: willRunChain ? startProviderAttempt : undefined,
       });
 
-      if (!explicitModelOverride && paramMergeContext) {
+      if (willRunChain && paramMergeContext) {
         const fallbackResult = await this.tryFallbackChain({
           agentId,
           tenantId,
@@ -495,7 +505,12 @@ export class ProxyService {
                 apiKey: credentials.apiKey,
                 rawApiKey: credentials.rawApiKey,
                 model: primaryModel,
-                keyLabel: route.keyLabel ?? undefined,
+                // Use the resolved (unpinned-subscription-pinned) label so the
+                // healed-retry row stamps the same connection its
+                // tenant_provider_id points at — otherwise a null/blank label
+                // rides next to the selected connection id (the divergence the
+                // primary forward already avoids).
+                keyLabel: credentials.keyLabel ?? route.keyLabel ?? undefined,
                 authType: route.authType,
                 resourceUrl: credentials.resourceUrl,
                 providerRegion: credentials.providerRegion,
@@ -771,7 +786,9 @@ export class ProxyService {
       agentId: ctx.agentId,
       tenantId: ctx.tenantId,
       rawApiKey: credentials.rawApiKey,
-      providerKeyLabel: route.keyLabel ?? undefined,
+      // Resolved label (pins an unpinned subscription to the selected row) so
+      // the recorded connection matches credentials.tenantProviderId.
+      providerKeyLabel: credentials.keyLabel ?? route.keyLabel ?? undefined,
       authType: route.authType,
       apiMode: ctx.apiMode,
       resourceUrl: credentials.resourceUrl,
@@ -939,6 +956,29 @@ export class ProxyService {
     });
   }
 
+  /**
+   * The effective fallback routes `tryFallbackChain` will actually attempt,
+   * after response-mode filtering. Empty when nothing remains. Callers use this
+   * to decide whether a chain will run *before* starting work that only the
+   * chain would record (see the credential-failure primary path).
+   */
+  private effectiveFallbackRoutes(
+    resolved: ResolvedRouting,
+  ): NonNullable<ResolvedRouting['fallback_routes']> {
+    let fallbackRoutes = resolved.fallback_routes ?? null;
+    if ((resolved.response_mode ?? DEFAULT_RESPONSE_MODE) === 'stream') {
+      const effectiveRoutes = effectiveRoutesForResponseMode(
+        resolved.response_mode,
+        resolved.route,
+        fallbackRoutes,
+      );
+      fallbackRoutes = (effectiveRoutes.fallbackRoutes ?? []).filter(
+        (route) => !routeEquals(route, resolved.route),
+      );
+    }
+    return fallbackRoutes ?? [];
+  }
+
   private async tryFallbackChain(args: {
     agentId: string;
     tenantId: string;
@@ -980,18 +1020,8 @@ export class ProxyService {
     // promoted to primary. Reloading the persisted tier here would retry that
     // promoted route as its own fallback and could resurrect routes the
     // resolver deliberately skipped.
-    let fallbackRoutes = resolved.fallback_routes ?? null;
-    if ((resolved.response_mode ?? DEFAULT_RESPONSE_MODE) === 'stream') {
-      const effectiveRoutes = effectiveRoutesForResponseMode(
-        resolved.response_mode,
-        resolved.route,
-        fallbackRoutes,
-      );
-      fallbackRoutes = (effectiveRoutes.fallbackRoutes ?? []).filter(
-        (route) => !routeEquals(route, resolved.route),
-      );
-    }
-    if (!fallbackRoutes || fallbackRoutes.length === 0) return null;
+    const fallbackRoutes = this.effectiveFallbackRoutes(resolved);
+    if (fallbackRoutes.length === 0) return null;
     const fallbackModels = fallbackRoutes.map((r) => r.model);
 
     const primaryStatus = forward.response.status;

--- a/packages/backend/src/routing/proxy/route-credentials.ts
+++ b/packages/backend/src/routing/proxy/route-credentials.ts
@@ -1,0 +1,277 @@
+/**
+ * Shared route-credential resolution and local credential-failure attempts.
+ *
+ * Primary proxy and mid-chain fallbacks must agree on:
+ *  - how a route becomes a usable apiKey (or why it cannot)
+ *  - which Manifest code/message that maps to (M100 vs M102)
+ *  - how that failure appears as a recorded attempt on the Manifest request
+ *
+ * Keep new credential failure kinds here — callers should not re-implement
+ * selectProviderKey → resolveApiKey or invent parallel error text.
+ */
+import type { AuthType } from 'manifest-shared';
+import {
+  ProviderKeyService,
+  SYNTHETIC_OLLAMA_PROVIDER_ID,
+} from '../routing-core/provider-key.service';
+import { formatManifestError, type ManifestErrorCode } from '../../common/errors/error-codes';
+import type { ManifestBlockedRequestReason } from '../../common/errors/manifest-error';
+import {
+  isRefreshableOAuthCredential,
+  resolveApiKey,
+  type OAuthServiceSet,
+} from './oauth-credentials';
+import type { ForwardResult } from './provider-client';
+import type { ProviderAttemptRef, StartProviderAttempt } from './proxy-types';
+
+/** Why a route could not produce a usable provider apiKey. */
+export type CredentialFailureReason = Extract<
+  ManifestBlockedRequestReason,
+  'no_provider_key' | 'subscription_credentials_unusable'
+>;
+
+const CREDENTIAL_FAILURE_CODE: Record<
+  CredentialFailureReason,
+  Extract<ManifestErrorCode, 'M100' | 'M102'>
+> = {
+  no_provider_key: 'M100',
+  subscription_credentials_unusable: 'M102',
+};
+
+/** HTTP status for local credential failures so shouldTriggerFallback still fires. */
+export const CREDENTIAL_FAILURE_HTTP_STATUS = 401;
+
+export type ResolvedRouteCredentials =
+  | {
+      ok: true;
+      apiKey: string;
+      rawApiKey: string;
+      resourceUrl?: string;
+      providerRegion?: string | null;
+      tenantProviderId: string | null;
+      /** Effective key label after unpinned subscription resolution. */
+      keyLabel?: string;
+    }
+  | {
+      ok: false;
+      reason: CredentialFailureReason;
+      tenantProviderId: string | null;
+    };
+
+export interface CredentialFailurePresentation {
+  code: Extract<ManifestErrorCode, 'M100' | 'M102'>;
+  reason: CredentialFailureReason;
+  message: string;
+  status: typeof CREDENTIAL_FAILURE_HTTP_STATUS;
+  errorBody: string;
+}
+
+export interface RouteCredentialDeps {
+  providerKeyService: Pick<ProviderKeyService, 'selectProviderKey' | 'getProviderApiKey'>;
+  oauth: OAuthServiceSet;
+}
+
+export function credentialFailureCode(
+  reason: CredentialFailureReason,
+): Extract<ManifestErrorCode, 'M100' | 'M102'> {
+  return CREDENTIAL_FAILURE_CODE[reason];
+}
+
+/**
+ * User-facing Manifest error for a credential miss.
+ * `dashboardUrl` should be a real agent routing URL when available.
+ */
+export function presentCredentialFailure(
+  reason: CredentialFailureReason,
+  provider: string,
+  dashboardUrl: string,
+): CredentialFailurePresentation {
+  const code = credentialFailureCode(reason);
+  const message = formatManifestError(code, { provider, dashboardUrl });
+  return {
+    code,
+    reason,
+    message,
+    status: CREDENTIAL_FAILURE_HTTP_STATUS,
+    errorBody: JSON.stringify({ error: { message } }),
+  };
+}
+
+/** Start + complete a local provider attempt for a credential failure. */
+export function startCredentialFailureAttempt(
+  startProviderAttempt: StartProviderAttempt | undefined,
+  start: {
+    provider: string;
+    model: string;
+    authType?: string;
+    tenantProviderId?: string | null;
+  },
+): ProviderAttemptRef | undefined {
+  const attempt = startProviderAttempt?.(start);
+  if (attempt) attempt.completedAtMs = Date.now();
+  return attempt;
+}
+
+/**
+ * Synthetic primary forward when credentials never reached provider transport.
+ * `providerCallStarted: true` so the attempt is persisted (unlike rate-limit cooldowns).
+ */
+export function buildCredentialFailureForward(opts: {
+  provider: string;
+  model: string;
+  authType?: AuthType;
+  tenantProviderId: string | null;
+  presentation: CredentialFailurePresentation;
+  startProviderAttempt?: StartProviderAttempt;
+}): ForwardResult {
+  const attempt = startCredentialFailureAttempt(opts.startProviderAttempt, {
+    provider: opts.provider,
+    model: opts.model,
+    authType: opts.authType,
+    tenantProviderId: opts.tenantProviderId,
+  });
+  return {
+    response: new Response(opts.presentation.errorBody, {
+      status: opts.presentation.status,
+      headers: { 'content-type': 'application/json' },
+    }),
+    providerCallStarted: true,
+    attempt,
+    isGoogle: false,
+    isAnthropic: false,
+    isChatGpt: false,
+  };
+}
+
+/**
+ * Mid-chain credential failure entry for `FailedFallback[]`.
+ * Shape matches FailedFallback so the fallback service can push it directly.
+ */
+export function buildCredentialFailureFallback(opts: {
+  model: string;
+  provider: string;
+  fallbackIndex: number;
+  authType?: AuthType;
+  tenantProviderId: string | null;
+  presentation: CredentialFailurePresentation;
+  startProviderAttempt?: StartProviderAttempt;
+}): {
+  model: string;
+  provider: string;
+  fallbackIndex: number;
+  status: number;
+  errorBody: string;
+  authType?: AuthType;
+  tenantProviderId: string | null;
+  attempt?: ProviderAttemptRef;
+  providerCallStarted: true;
+} {
+  const attempt = startCredentialFailureAttempt(opts.startProviderAttempt, {
+    provider: opts.provider,
+    model: opts.model,
+    authType: opts.authType,
+    tenantProviderId: opts.tenantProviderId,
+  });
+  return {
+    model: opts.model,
+    provider: opts.provider,
+    fallbackIndex: opts.fallbackIndex,
+    status: opts.presentation.status,
+    errorBody: opts.presentation.errorBody,
+    authType: opts.authType,
+    tenantProviderId: opts.tenantProviderId,
+    attempt,
+    providerCallStarted: true,
+  };
+}
+
+/**
+ * Single key selection + OAuth unwrap for one route hop.
+ * Used by primary proxy and mid-chain fallbacks.
+ */
+export async function resolveRouteCredentials(
+  deps: RouteCredentialDeps,
+  args: {
+    agentId: string;
+    tenantId: string;
+    provider: string;
+    authType?: AuthType;
+    providerKeyLabel?: string;
+  },
+): Promise<ResolvedRouteCredentials> {
+  const { providerKeyService, oauth } = deps;
+  const { agentId, tenantId, provider, authType } = args;
+  let providerKeyLabel = args.providerKeyLabel;
+
+  // Single key selection per hop: apiKey, tenant_provider_id, region, and
+  // label all come from this one row so they can never diverge.
+  const key = await providerKeyService.selectProviderKey(
+    tenantId,
+    provider,
+    authType,
+    providerKeyLabel,
+    agentId,
+  );
+  if (!key || key.apiKey === null) {
+    return { ok: false, reason: 'no_provider_key', tenantProviderId: null };
+  }
+
+  const apiKey = key.apiKey;
+  // NULL for synthetic Ollama — no persisted row to stamp (FK).
+  const tenantProviderId = key.id === SYNTHETIC_OLLAMA_PROVIDER_ID ? null : key.id;
+
+  // Unpinned subscription: pin to the selected row so OAuth refresh updates
+  // the same connection getProviderApiKey / unwrap used.
+  if (!providerKeyLabel && authType === 'subscription') {
+    providerKeyLabel = key.label;
+  }
+
+  const unwrapped = await resolveApiKey(
+    provider,
+    apiKey,
+    authType,
+    agentId,
+    tenantId,
+    oauth.openaiOauth,
+    oauth.minimaxOauth,
+    oauth.anthropicOauth,
+    oauth.geminiOauth,
+    oauth.kiroOauth,
+    oauth.xaiOauth,
+    providerKeyLabel,
+  );
+
+  // resolveApiKey only returns null when a subscription OAuth blob exists
+  // but cannot be unwrapped / refreshed.
+  if (unwrapped.apiKey === null) {
+    return {
+      ok: false,
+      reason: 'subscription_credentials_unusable',
+      tenantProviderId,
+    };
+  }
+
+  let rawApiKey = apiKey;
+  if (authType === 'subscription' && isRefreshableOAuthCredential(apiKey)) {
+    // Deliberate re-read: resolveApiKey may have refreshed + persisted a
+    // rotated OAuth blob (which also invalidates the key cache).
+    rawApiKey =
+      (await providerKeyService.getProviderApiKey(
+        tenantId,
+        provider,
+        authType,
+        providerKeyLabel,
+        agentId,
+      )) ?? apiKey;
+  }
+
+  return {
+    ok: true,
+    apiKey: unwrapped.apiKey,
+    rawApiKey,
+    resourceUrl: unwrapped.resourceUrl,
+    providerRegion: key.region,
+    tenantProviderId,
+    keyLabel: providerKeyLabel,
+  };
+}

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.subscription-lock.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.subscription-lock.spec.ts
@@ -1,0 +1,184 @@
+// withSubscriptionCredentialLock holds a SELECT … FOR UPDATE on the subscription
+// row while the provider OAuth refresh runs, then persists the rotated blob.
+// These tests pin the invariants that keep that safe: the critical section is
+// bounded (SET LOCAL), the label is trimmed+lowercased so it matches the stored
+// row, the write goes through a SAVEPOINT (so a transient failure can be
+// retried under the still-held lock), and the routing cache is invalidated only
+// AFTER commit.
+import { ProviderService } from '../provider.service';
+import { TenantProvider } from '../../../entities/tenant-provider.entity';
+import { TierAssignment } from '../../../entities/tier-assignment.entity';
+import { SpecificityAssignment } from '../../../entities/specificity-assignment.entity';
+import { Agent } from '../../../entities/agent.entity';
+import { HeaderTier } from '../../../entities/header-tier.entity';
+import { AgentEnabledProvider } from '../../../entities/agent-enabled-provider.entity';
+import type { Repository } from 'typeorm';
+import type { RoutingCacheService } from '../routing-cache.service';
+import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
+import { decrypt, encrypt, getEncryptionSecret } from '../../../common/utils/crypto.util';
+
+interface LockRow {
+  id: string;
+  api_key_encrypted: string | null;
+  key_prefix?: string;
+  updated_at?: string;
+}
+
+function makeHarness(row: LockRow | null) {
+  const andWhereCalls: Array<[string, Record<string, unknown> | undefined]> = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const lockQb: any = {
+    setLock: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn((clause: string, params?: Record<string, unknown>) => {
+      andWhereCalls.push([clause, params]);
+      return lockQb;
+    }),
+    getOne: jest.fn().mockResolvedValue(row),
+  };
+  const lockRepo = { createQueryBuilder: jest.fn().mockReturnValue(lockQb) };
+
+  const subUpdate = jest.fn().mockResolvedValue(undefined);
+  const subManager = { getRepository: jest.fn().mockReturnValue({ update: subUpdate }) };
+
+  const outerManager = {
+    query: jest.fn().mockResolvedValue(undefined),
+    getRepository: jest.fn().mockReturnValue(lockRepo),
+    // The SAVEPOINT: writeRaw wraps its update in manager.transaction(...).
+    transaction: jest.fn((cb: (m: typeof subManager) => Promise<unknown>) => cb(subManager)),
+  };
+
+  const providerRepo = {
+    manager: {
+      transaction: jest.fn((cb: (m: typeof outerManager) => Promise<unknown>) => cb(outerManager)),
+    },
+  };
+
+  const routingCache = {
+    getProviders: jest.fn().mockReturnValue(null),
+    setProviders: jest.fn(),
+    invalidateAgent: jest.fn(),
+    invalidateTenant: jest.fn(),
+  };
+
+  const makeRepo = () => ({ find: jest.fn(), findOne: jest.fn() });
+  const svc = new ProviderService(
+    providerRepo as unknown as Repository<TenantProvider>,
+    makeRepo() as unknown as Repository<TierAssignment>,
+    makeRepo() as unknown as Repository<SpecificityAssignment>,
+    makeRepo() as unknown as Repository<Agent>,
+    makeRepo() as unknown as Repository<HeaderTier>,
+    { getByModel: jest.fn() } as unknown as ModelPricingCacheService,
+    routingCache as unknown as RoutingCacheService,
+    makeRepo() as unknown as Repository<AgentEnabledProvider>,
+  );
+
+  return { svc, outerManager, subUpdate, andWhereCalls, routingCache };
+}
+
+describe('ProviderService.withSubscriptionCredentialLock', () => {
+  let originalSecret: string | undefined;
+
+  beforeEach(() => {
+    originalSecret = process.env.BETTER_AUTH_SECRET;
+    process.env.BETTER_AUTH_SECRET = 'a'.repeat(48);
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+    else process.env.BETTER_AUTH_SECRET = originalSecret;
+  });
+
+  it('bounds the section and locks the trimmed, lowercased label', async () => {
+    const { svc, outerManager, andWhereCalls } = makeHarness({
+      id: 'tp-1',
+      api_key_encrypted: null,
+    });
+
+    await svc.withSubscriptionCredentialLock(
+      'tenant-1',
+      'anthropic',
+      '  Work  ',
+      async () => 'done',
+    );
+
+    const statements = outerManager.query.mock.calls.map((c) => String(c[0]));
+    expect(statements.some((s) => /SET LOCAL lock_timeout/.test(s))).toBe(true);
+    expect(statements.some((s) => /SET LOCAL idle_in_transaction_session_timeout/.test(s))).toBe(
+      true,
+    );
+    const labelClause = andWhereCalls.find(([clause]) => clause.includes('LOWER(tp.label)'));
+    expect(labelClause?.[1]).toEqual({ label: 'work' });
+  });
+
+  it('defaults a missing label to the lowercased default', async () => {
+    const { svc, andWhereCalls } = makeHarness({ id: 'tp-1', api_key_encrypted: null });
+    await svc.withSubscriptionCredentialLock('tenant-1', 'kiro', undefined, async () => null);
+    const labelClause = andWhereCalls.find(([clause]) => clause.includes('LOWER(tp.label)'));
+    expect(labelClause?.[1]).toEqual({ label: 'default' });
+  });
+
+  it('readFreshRaw decrypts the locked row (and returns null when undecryptable)', async () => {
+    const stored = encrypt('stored-refresh-blob', getEncryptionSecret());
+    const { svc } = makeHarness({ id: 'tp-1', api_key_encrypted: stored });
+    const fresh = await svc.withSubscriptionCredentialLock('t', 'anthropic', 'Default', (ops) =>
+      ops.readFreshRaw(),
+    );
+    expect(fresh).toBe('stored-refresh-blob');
+
+    const { svc: svc2 } = makeHarness({ id: 'tp-1', api_key_encrypted: 'not-a-valid-ciphertext' });
+    const bad = await svc2.withSubscriptionCredentialLock('t', 'anthropic', 'Default', (ops) =>
+      ops.readFreshRaw(),
+    );
+    expect(bad).toBeNull();
+  });
+
+  it('writeRaw persists via a savepoint and invalidates the cache only after commit', async () => {
+    const { svc, outerManager, subUpdate, routingCache } = makeHarness({
+      id: 'tp-1',
+      api_key_encrypted: null,
+    });
+
+    await svc.withSubscriptionCredentialLock('tenant-1', 'anthropic', 'Default', async (ops) => {
+      await ops.writeRaw('brand-new-blob');
+    });
+
+    // The write went through the nested transaction (SAVEPOINT), not a bare save.
+    expect(outerManager.transaction).toHaveBeenCalledTimes(1);
+    expect(subUpdate).toHaveBeenCalledTimes(1);
+    const [where, patch] = subUpdate.mock.calls[0] as [
+      { id: string },
+      { api_key_encrypted: string; key_prefix: string },
+    ];
+    expect(where).toEqual({ id: 'tp-1' });
+    expect(decrypt(patch.api_key_encrypted, getEncryptionSecret())).toBe('brand-new-blob');
+    expect(patch.key_prefix).toBe('brand-ne');
+
+    // Cache invalidation happens, and strictly AFTER the write (post-commit).
+    expect(routingCache.invalidateTenant).toHaveBeenCalledWith('tenant-1');
+    expect(subUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      routingCache.invalidateTenant.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not invalidate the cache when nothing was written', async () => {
+    const { svc, routingCache } = makeHarness({ id: 'tp-1', api_key_encrypted: null });
+    await svc.withSubscriptionCredentialLock(
+      'tenant-1',
+      'anthropic',
+      'Default',
+      async () => 'noop',
+    );
+    expect(routingCache.invalidateTenant).not.toHaveBeenCalled();
+  });
+
+  it('writeRaw throws when no subscription row was locked', async () => {
+    const { svc, routingCache } = makeHarness(null);
+    await expect(
+      svc.withSubscriptionCredentialLock('tenant-1', 'anthropic', 'Default', async (ops) => {
+        await ops.writeRaw('rotated');
+      }),
+    ).rejects.toThrow(/No subscription credential row/);
+    expect(routingCache.invalidateTenant).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -45,6 +45,12 @@ import { filterProvidersForDeployment } from '../../common/utils/provider-availa
 const MAX_KEYS_PER_PROVIDER = 5;
 const MAX_LABEL_LENGTH = 50;
 const DEFAULT_LABEL = 'Default';
+// Bounds for withSubscriptionCredentialLock's critical section (the provider
+// OAuth refresh HTTP call runs inside it). lock_timeout caps a second replica's
+// wait for the row lock; idle_in_transaction caps how long a hung refresh pins
+// the pooled connection.
+const SUBSCRIPTION_LOCK_TIMEOUT = '5s';
+const SUBSCRIPTION_REFRESH_IDLE_TIMEOUT = '20s';
 
 interface ProviderRouteReference {
   agentId: string;
@@ -253,7 +259,14 @@ export class ProviderService {
    * this lock so two instances cannot rotate the same refresh token.
    *
    * Keep the critical section short: re-read → maybe refresh → write. The
-   * provider HTTP call runs while the lock is held (simple and correct).
+   * provider refresh HTTP call runs while the lock is held (needed so two
+   * replicas cannot both rotate), so the section is BOUNDED: `lock_timeout`
+   * caps how long a second replica waits for the lock, and
+   * `idle_in_transaction_session_timeout` caps how long a hung refresh can pin
+   * this pooled connection — without them a stuck provider could hold a
+   * connection indefinitely and starve the pool. `SET LOCAL` scopes both to
+   * this transaction (the sanctioned pattern under PgBouncer, which strips the
+   * server defaults).
    */
   async withSubscriptionCredentialLock<T>(
     tenantId: string,
@@ -264,9 +277,18 @@ export class ProviderService {
       writeRaw: (raw: string) => Promise<void>;
     }) => Promise<T>,
   ): Promise<T> {
-    const wantedLabel = (label ?? DEFAULT_LABEL).toLowerCase();
-    return this.providerRepo.manager.transaction(async (manager) => {
+    // Trim before lowercasing to match normalizeLabel (which trims at store
+    // time) — a label carrying stray whitespace must still find its stored row,
+    // otherwise the lock misses an existing credential and a rotated token is
+    // discarded (bricking it).
+    const wantedLabel = (label ?? DEFAULT_LABEL).trim().toLowerCase();
+    let didWrite = false;
+    const result = await this.providerRepo.manager.transaction(async (manager) => {
       const repo = manager.getRepository(TenantProvider);
+      await manager.query(`SET LOCAL lock_timeout = '${SUBSCRIPTION_LOCK_TIMEOUT}'`);
+      await manager.query(
+        `SET LOCAL idle_in_transaction_session_timeout = '${SUBSCRIPTION_REFRESH_IDLE_TIMEOUT}'`,
+      );
       // Lock the matching subscription row for this tenant/provider/label.
       // LOWER(label) matches the unique index and pinned-route casing quirks.
       const row =
@@ -294,16 +316,40 @@ export class ProviderService {
               `No subscription credential row to persist for ${provider}/${wantedLabel}`,
             );
           }
-          row.api_key_encrypted = encrypt(raw, getEncryptionSecret());
-          row.key_prefix = raw.substring(0, 8);
-          row.updated_at = new Date().toISOString();
-          await repo.save(row);
-          // Bust key/provider caches so the next hop doesn't refresh from
-          // a pre-rotation blob.
-          this.routingCache.invalidateTenant(tenantId);
+          const encrypted = encrypt(raw, getEncryptionSecret());
+          const keyPrefix = raw.substring(0, 8);
+          const updatedAt = new Date().toISOString();
+          // Write inside a SAVEPOINT (nested transaction) so a transient save
+          // failure rolls back only this statement, not the whole locked
+          // transaction. A bare save on the outer tx would abort it, and the
+          // coordinator's persist retry — running on the same held lock — would
+          // then fail every attempt with "current transaction is aborted",
+          // silently discarding the already-rotated token (a brick).
+          await manager.transaction(async (sub) => {
+            await sub
+              .getRepository(TenantProvider)
+              .update(
+                { id: row.id },
+                { api_key_encrypted: encrypted, key_prefix: keyPrefix, updated_at: updatedAt },
+              );
+          });
+          // Keep the in-memory row consistent for any subsequent readFreshRaw.
+          row.api_key_encrypted = encrypted;
+          row.key_prefix = keyPrefix;
+          row.updated_at = updatedAt;
+          didWrite = true;
+          // Cache invalidation is deferred until AFTER commit (below).
+          // Invalidating here — before COMMIT — opens a window where a
+          // concurrent read re-caches the still-committed pre-rotation blob,
+          // which would then be refreshed again on the next hop.
         },
       });
     });
+    // Post-commit: the rotated blob is durable, so busting the cache now
+    // guarantees the next hop reads the new value and no reader can re-cache the
+    // old one.
+    if (didWrite) this.routingCache.invalidateTenant(tenantId);
+    return result;
   }
 
   async upsertProvider(

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -220,10 +220,9 @@ export class ProviderService {
 
   /**
    * Read the freshest persisted subscription credential straight from the DB,
-   * decrypted, bypassing the routing cache. The OAuth refresh coordinator uses
-   * this so a lazy token refresh never rotates based on a stale cached blob
-   * (see issue #2012). Returns the decrypted raw stored value, or null when
-   * there is no row / no stored credential / it cannot be decrypted.
+   * decrypted, bypassing the routing cache. Prefer
+   * {@link withSubscriptionCredentialLock} for OAuth refresh — that path
+   * holds a row lock so multi-replica refreshes cannot collide.
    */
   async getFreshSubscriptionCredential(
     tenantId: string,
@@ -246,6 +245,65 @@ export class ProviderService {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Run OAuth refresh work while holding a row lock on the subscription
+   * credential (`SELECT … FOR UPDATE`). Multi-replica backends serialize on
+   * this lock so two instances cannot rotate the same refresh token.
+   *
+   * Keep the critical section short: re-read → maybe refresh → write. The
+   * provider HTTP call runs while the lock is held (simple and correct).
+   */
+  async withSubscriptionCredentialLock<T>(
+    tenantId: string,
+    provider: string,
+    label: string | undefined,
+    fn: (ops: {
+      readFreshRaw: () => Promise<string | null>;
+      writeRaw: (raw: string) => Promise<void>;
+    }) => Promise<T>,
+  ): Promise<T> {
+    const wantedLabel = (label ?? DEFAULT_LABEL).toLowerCase();
+    return this.providerRepo.manager.transaction(async (manager) => {
+      const repo = manager.getRepository(TenantProvider);
+      // Lock the matching subscription row for this tenant/provider/label.
+      // LOWER(label) matches the unique index and pinned-route casing quirks.
+      const row =
+        (await repo
+          .createQueryBuilder('tp')
+          .setLock('pessimistic_write')
+          .where('tp.tenant_id = :tenantId', { tenantId })
+          .andWhere('tp.provider = :provider', { provider })
+          .andWhere(`tp.auth_type = 'subscription'`)
+          .andWhere('LOWER(tp.label) = :label', { label: wantedLabel })
+          .getOne()) ?? null;
+
+      return fn({
+        readFreshRaw: async () => {
+          if (!row?.api_key_encrypted) return null;
+          try {
+            return decrypt(row.api_key_encrypted, getEncryptionSecret());
+          } catch {
+            return null;
+          }
+        },
+        writeRaw: async (raw: string) => {
+          if (!row) {
+            throw new Error(
+              `No subscription credential row to persist for ${provider}/${wantedLabel}`,
+            );
+          }
+          row.api_key_encrypted = encrypt(raw, getEncryptionSecret());
+          row.key_prefix = raw.substring(0, 8);
+          row.updated_at = new Date().toISOString();
+          await repo.save(row);
+          // Bust key/provider caches so the next hop doesn't refresh from
+          // a pre-rotation blob.
+          this.routingCache.invalidateTenant(tenantId);
+        },
+      });
+    });
   }
 
   async upsertProvider(

--- a/packages/frontend/src/services/formatters.ts
+++ b/packages/frontend/src/services/formatters.ts
@@ -122,6 +122,7 @@ const ERROR_CLASS_LABELS: Record<string, string> = {
   network: 'Network',
   no_provider: 'No provider configured',
   no_provider_key: 'Missing API key',
+  subscription_credentials_unusable: 'Subscription credentials',
   limit_exceeded: 'Limit exceeded',
   plan_request_limit_exceeded: 'Plan request limit',
   internal: 'Internal error',

--- a/packages/frontend/tests/services/formatters.test.ts
+++ b/packages/frontend/tests/services/formatters.test.ts
@@ -123,6 +123,7 @@ describe('formatErrorClass', () => {
     expect(formatErrorClass('rate_limit')).toBe('Rate limit');
     expect(formatErrorClass('billing')).toBe('Billing');
     expect(formatErrorClass('no_provider_key')).toBe('Missing API key');
+    expect(formatErrorClass('subscription_credentials_unusable')).toBe('Subscription credentials');
     expect(formatErrorClass('limit_exceeded')).toBe('Limit exceeded');
     expect(formatErrorClass('plan_request_limit_exceeded')).toBe('Plan request limit');
     expect(formatErrorClass('server_error')).toBe('Server error');

--- a/packages/shared/__tests__/error-taxonomy.spec.ts
+++ b/packages/shared/__tests__/error-taxonomy.spec.ts
@@ -84,6 +84,7 @@ describe('classifyMessageError', () => {
   it.each([
     ['no_provider', 'config', 'no_provider'],
     ['no_provider_key', 'config', 'no_provider_key'],
+    ['subscription_credentials_unusable', 'config', 'subscription_credentials_unusable'],
     ['local_provider_unavailable', 'config', 'local_provider_unavailable'],
     ['key_expired', 'config', 'auth'],
     ['limit_exceeded', 'policy', 'limit_exceeded'],

--- a/packages/shared/src/error-taxonomy.ts
+++ b/packages/shared/src/error-taxonomy.ts
@@ -144,6 +144,7 @@ export const ERROR_CLASSES = [
   // manifest (config / policy / internal / request)
   'no_provider',
   'no_provider_key',
+  'subscription_credentials_unusable',
   'local_provider_unavailable',
   'limit_exceeded',
   'plan_request_limit_exceeded',
@@ -167,6 +168,10 @@ const MANIFEST_REASON_TO_CLASSIFICATION: Record<
 > = {
   no_provider: { origin: 'config', errorClass: 'no_provider' },
   no_provider_key: { origin: 'config', errorClass: 'no_provider_key' },
+  subscription_credentials_unusable: {
+    origin: 'config',
+    errorClass: 'subscription_credentials_unusable',
+  },
   local_provider_unavailable: {
     origin: 'config',
     errorClass: 'local_provider_unavailable',


### PR DESCRIPTION
### ✨ What changed
- When the elected primary route's stored credentials fail to resolve, the proxy now walks the configured fallback routes and promotes the first one with usable credentials, keeping the remainder as its fallback chain.
- M100 is now returned only when no route in the whole chain has usable credentials.

### 💭 Why
The resolver elects the primary off the provider-key cache (a row exists and holds a key), but the forward path asks the harder question and unwraps the credential. A subscription whose OAuth refresh token died passes the first check and fails the second, and the old code hard-returned M100 without ever trying the fallbacks.

In production this is currently failing about 2,000 requests per day across 23 tenants. One tenant has logged 6,094 M100s in four days with zero provider attempts while holding seven other working connections; another lost an agent entirely on 2026-07-20 while its first fallback route succeeds on every request for a sibling agent.

### 🔧 How to test
- `npx jest routing/proxy` in `packages/backend` covers promotion, dead-fallback skipping, and the dry-chain M100.

### 📝 Notes
The fallback service already skips credential-less routes mid-chain, so this closes the one spot where a dead credential was fatal. Marking rows unhealthy on refresh failure (so the resolver stops electing them) is a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Primary credential failures now create a 401 attempt (M100/M102) and then walk the normal fallback chain; M100 is only returned when no route has usable credentials. OAuth subscription refresh is guarded by a DB row lock and is now retry-safe; credential-hop errors are stamped and classified as config for accurate analytics.

- **Bug Fixes**
  - On primary credential failures, emit a synthetic attempt (M100 missing key, M102 unusable OAuth) and run fallbacks; mid-chain fallbacks record the same 401 body.
  - Only start a synthetic attempt if a fallback chain will run, preventing orphan rows; stamp the resolved `keyLabel` on autofix reforward rows.
  - Stamp `error_code` by extracting the peacock-marked Manifest code and classify these rows as config using `MANIFEST_CODE_TO_REASON`; require the peacock marker to avoid mis-extraction from provider bodies.
  - Added M102 and reason `subscription_credentials_unusable`; updated friendly messages, error taxonomy, and frontend labels.
  - Extracted shared route-credential logic for key selection, OAuth unwrap, and failure construction.
  - Serialized subscription OAuth refresh with a row lock and kept in-process single-flight; made it retry-safe with a SAVEPOINT, deferred cache invalidation until after commit, normalized label matching, and bounded lock/idle timeouts.

<sup>Written for commit 13480c3570a9fc485df85e39be95732882b37232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

