### PR TITLE
fix: deactivate subscription on permanent OAuth refresh failure

### DIFF
--- a/.changeset/oauth-mark-dead-credential.md
+++ b/.changeset/oauth-mark-dead-credential.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Deactivate a subscription connection when its OAuth refresh token fails permanently, so routing stops electing the dead primary

--- a/packages/backend/src/routing/oauth/core/index.ts
+++ b/packages/backend/src/routing/oauth/core/index.ts
@@ -22,6 +22,10 @@ export {
   type CoordinatedRefreshParams,
 } from './oauth-refresh-coordinator';
 export {
+  OAuthRefreshError,
+  isPermanentOAuthRefreshFailure,
+} from './oauth-refresh-errors';
+export {
   ABSOLUTE_TIME_THRESHOLD_MS,
   toAbsoluteExpiryTimestamp,
   toPollIntervalMs,

--- a/packages/backend/src/routing/oauth/core/oauth-refresh-errors.spec.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-refresh-errors.spec.ts
@@ -1,0 +1,37 @@
+import { isPermanentOAuthRefreshFailure, OAuthRefreshError } from './oauth-refresh-errors';
+
+describe('isPermanentOAuthRefreshFailure', () => {
+  it('is false for non-OAuthRefreshError values (e.g. persist failures)', () => {
+    expect(isPermanentOAuthRefreshFailure(new Error('Token refresh failed'))).toBe(false);
+    expect(isPermanentOAuthRefreshFailure(new Error('db write failed'))).toBe(false);
+    expect(isPermanentOAuthRefreshFailure(null)).toBe(false);
+  });
+
+  it.each([
+    ['invalid_refresh_token', '{"error":"invalid_refresh_token","error_description":"Could not validate your refresh token"}'],
+    ['refresh_token_reused', '{"error":"refresh_token_reused","error_description":"Your refresh token has already been used to generate a new access token"}'],
+    ['refresh_token_invalidated', 'error=refresh_token_invalidated'],
+    ['invalid_grant', '{"error":"invalid_grant","error_description":"Bad Request"}'],
+    ['expired or revoked', 'Token has been expired or revoked'],
+  ])('is true for permanent provider failure: %s', (_name, body) => {
+    expect(isPermanentOAuthRefreshFailure(new OAuthRefreshError('Token refresh failed', body, 400))).toBe(
+      true,
+    );
+  });
+
+  it('is false for transient provider failures', () => {
+    expect(
+      isPermanentOAuthRefreshFailure(
+        new OAuthRefreshError('Token refresh failed', '{"error":"server_error"}', 500),
+      ),
+    ).toBe(false);
+    expect(
+      isPermanentOAuthRefreshFailure(
+        new OAuthRefreshError('Token refresh failed', '{"error":"temporarily_unavailable"}', 503),
+      ),
+    ).toBe(false);
+    expect(
+      isPermanentOAuthRefreshFailure(new OAuthRefreshError('Token refresh failed', 'rate limited', 429)),
+    ).toBe(false);
+  });
+});

--- a/packages/backend/src/routing/oauth/core/oauth-refresh-errors.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-refresh-errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Classification helpers for OAuth token-refresh failures.
+ *
+ * Rotating refresh tokens (OpenAI and friends) die permanently under a few
+ * well-known error codes. Transient failures (network, 5xx, rate limit) must
+ * NOT deactivate the stored credential — the next request may still recover.
+ */
+
+/** Thrown by refreshAccessToken when the provider rejects the refresh grant. */
+export class OAuthRefreshError extends Error {
+  constructor(
+    message: string,
+    readonly responseBody: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'OAuthRefreshError';
+  }
+}
+
+/**
+ * Provider error codes / phrases that mean the stored refresh token can never
+ * mint a new access token. Matching is case-insensitive on the raw body.
+ */
+const PERMANENT_REFRESH_FAILURE_PATTERNS: readonly RegExp[] = [
+  /invalid_refresh_token/i,
+  /refresh_token_reused/i,
+  /refresh_token_invalidated/i,
+  /"error"\s*:\s*"invalid_grant"/i,
+  /could not validate your refresh token/i,
+  /refresh token has already been used/i,
+  /token has been expired or revoked/i,
+];
+
+export function isPermanentOAuthRefreshFailure(err: unknown): boolean {
+  if (!(err instanceof OAuthRefreshError)) return false;
+  const body = err.responseBody ?? '';
+  return PERMANENT_REFRESH_FAILURE_PATTERNS.some((re) => re.test(body));
+}

--- a/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/core/redirect-pkce-oauth.base.ts
@@ -21,6 +21,7 @@ import { oauthDoneHtml } from './callback-page';
 import { PendingStore } from './pending-store';
 import { parseOAuthTokenBlob, serializeOAuthTokenBlob, type OAuthTokenBlob } from './oauth-blob';
 import { coordinateOAuthRefresh, oauthRefreshKey } from './oauth-refresh-coordinator';
+import { isPermanentOAuthRefreshFailure, OAuthRefreshError } from './oauth-refresh-errors';
 
 export interface RedirectPkceOauthConfig {
   /** Provider id stored on `tenant_providers.provider_id`. */
@@ -246,7 +247,10 @@ export abstract class RedirectPkceOauthBaseService {
       this.logger.error(
         `${this.oauthConfig.providerId} token refresh failed: ${scrubSecrets(text)}`,
       );
-      throw new Error('Token refresh failed');
+      // Keep the body on the error so the caller can tell permanent grant
+      // failures (invalid/reused refresh token) from transient 5xx / rate
+      // limits — only the permanent class should deactivate the stored row.
+      throw new OAuthRefreshError('Token refresh failed', text, response.status);
     }
     const data = (await response.json()) as OAuthTokenResponse;
     return {
@@ -309,6 +313,31 @@ export abstract class RedirectPkceOauthBaseService {
       return resolved.t;
     } catch (err) {
       this.logger.error(`Failed to refresh ${providerId} token for agent=${agentId}: ${err}`);
+      if (isPermanentOAuthRefreshFailure(err)) {
+        // The stored refresh token can never mint a new access token. Flip the
+        // row inactive so resolve/proxy stop electing this dead primary (and
+        // so the dashboard shows the connection as disconnected). Persist
+        // failures after a successful rotate intentionally do NOT take this
+        // path — those throw a plain Error from the coordinator.
+        try {
+          const deactivated = await this.providerService.markSubscriptionCredentialDead(
+            tenantId,
+            providerId,
+            keyLabel,
+          );
+          if (deactivated > 0) {
+            this.logger.warn(
+              `Deactivated ${deactivated} dead ${providerId} subscription ` +
+                `credential(s) for tenant=${tenantId} label=${keyLabel ?? 'Default'} ` +
+                `after permanent refresh failure`,
+            );
+          }
+        } catch (markErr) {
+          this.logger.error(
+            `Failed to deactivate dead ${providerId} credential for tenant=${tenantId}: ${markErr}`,
+          );
+        }
+      }
       return null;
     }
   }

--- a/packages/backend/src/routing/oauth/openai/openai-oauth.service.coverage.spec.ts
+++ b/packages/backend/src/routing/oauth/openai/openai-oauth.service.coverage.spec.ts
@@ -31,6 +31,7 @@ function createProviderService() {
   const recalculateTiersForUser = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
   const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
+  const markSubscriptionCredentialDead = jest.fn().mockResolvedValue(0);
   return {
     svc: {
       upsertProvider,
@@ -38,12 +39,14 @@ function createProviderService() {
       recalculateTiersForUser,
       nextOAuthLabel,
       getFreshSubscriptionCredential,
+      markSubscriptionCredentialDead,
     } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     recalculateTiersForUser,
     nextOAuthLabel,
     getFreshSubscriptionCredential,
+    markSubscriptionCredentialDead,
   };
 }
 
@@ -292,6 +295,35 @@ describe('OpenaiOauthService', () => {
       const blob = { t: 'old', r: 'rf', e: Date.now() + 1000 };
       fetchMock.mockRejectedValue(new Error('network'));
       expect(await svc.unwrapToken(JSON.stringify(blob), 'a', 'u')).toBeNull();
+      expect(providerService.markSubscriptionCredentialDead).not.toHaveBeenCalled();
+    });
+
+    it('deactivates the credential on permanent refresh-token failures', async () => {
+      const blob = { t: 'old', r: 'rf', e: Date.now() + 1000 };
+      fetchMock.mockResolvedValue(
+        mockResponse(400, {
+          error: 'invalid_refresh_token',
+          error_description: 'Could not validate your refresh token',
+        }),
+      );
+      providerService.getFreshSubscriptionCredential.mockResolvedValue(JSON.stringify(blob));
+      providerService.markSubscriptionCredentialDead.mockResolvedValue(1);
+
+      expect(await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'tenant-1', 'Work')).toBeNull();
+      expect(providerService.markSubscriptionCredentialDead).toHaveBeenCalledWith(
+        'tenant-1',
+        'openai',
+        'Work',
+      );
+    });
+
+    it('does not deactivate on transient provider refresh failures', async () => {
+      const blob = { t: 'old', r: 'rf', e: Date.now() + 1000 };
+      fetchMock.mockResolvedValue(mockResponse(503, { error: 'temporarily_unavailable' }));
+      providerService.getFreshSubscriptionCredential.mockResolvedValue(JSON.stringify(blob));
+
+      expect(await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'tenant-1')).toBeNull();
+      expect(providerService.markSubscriptionCredentialDead).not.toHaveBeenCalled();
     });
 
     // Regression: a still-valid access token must be returned even when the

--- a/packages/backend/src/routing/oauth/openai/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/openai/openai-oauth.service.spec.ts
@@ -36,6 +36,7 @@ describe('OpenaiOauthService', () => {
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
       nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
       getFreshSubscriptionCredential: jest.fn().mockResolvedValue(null),
+      markSubscriptionCredentialDead: jest.fn().mockResolvedValue(0),
     } as unknown as jest.Mocked<ProviderService>;
 
     configService = {

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -671,6 +671,45 @@ describe('ProviderService — route-only cleanup paths', () => {
     });
   });
 
+  describe('markSubscriptionCredentialDead', () => {
+    it('deactivates the matching active subscription row and invalidates caches', async () => {
+      const row = {
+        id: 'sub-1',
+        provider: 'openai',
+        auth_type: 'subscription',
+        label: 'Work',
+        priority: 0,
+        is_active: true,
+      } as unknown as TenantProvider;
+      const sibling = {
+        id: 'sub-2',
+        provider: 'openai',
+        auth_type: 'subscription',
+        label: 'Default',
+        priority: 1,
+        is_active: true,
+      } as unknown as TenantProvider;
+      providerRepo.find.mockResolvedValueOnce([row, sibling]);
+
+      const count = await svc.markSubscriptionCredentialDead('tenant-1', 'openai', 'Work');
+
+      expect(count).toBe(1);
+      expect(row.is_active).toBe(false);
+      expect(sibling.is_active).toBe(true);
+      expect(providerRepo.save).toHaveBeenCalledWith([row]);
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+      expect(routingCache.invalidateTenant).toHaveBeenCalledWith('tenant-1');
+    });
+
+    it('returns 0 when no active matching subscription exists', async () => {
+      providerRepo.find.mockResolvedValueOnce([]);
+      await expect(svc.markSubscriptionCredentialDead('tenant-1', 'openai', 'Work')).resolves.toBe(
+        0,
+      );
+      expect(providerRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
   describe('deactivateAllProviders', () => {
     it('updates providers and invalidates cache when no routes reference them', async () => {
       providerRepo.find.mockResolvedValueOnce([

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -1023,6 +1023,49 @@ export class ProviderService {
     return { notifications: [] };
   }
 
+  /**
+   * Soft-deactivate a subscription credential whose OAuth refresh token is
+   * permanently dead (invalid_refresh_token / refresh_token_reused / …).
+   *
+   * Unlike removeProvider / deactivateAllProviders this does NOT require routes
+   * to be cleared first — the credential can no longer authenticate, so leaving
+   * it active only causes the resolver to keep electing a dead primary. Cache
+   * is invalidated so the next resolve/proxy path stops selecting the row.
+   * Returns the number of rows flipped to inactive (0 when already gone).
+   */
+  async markSubscriptionCredentialDead(
+    tenantId: string,
+    provider: string,
+    label?: string,
+  ): Promise<number> {
+    const resolvedLabel = label ?? 'Default';
+    const activeRows = await this.providerRepo.find({
+      where: {
+        tenant_id: tenantId,
+        provider,
+        auth_type: 'subscription',
+        is_active: true,
+      },
+    });
+    const targets = activeRows.filter(
+      (row) => row.label.toLowerCase() === resolvedLabel.toLowerCase(),
+    );
+    if (targets.length === 0) return 0;
+
+    const now = new Date().toISOString();
+    for (const row of targets) {
+      row.is_active = false;
+      row.updated_at = now;
+    }
+    await this.providerRepo.save(targets);
+
+    for (const ownedAgentId of await this.listOwnedAgentIds(tenantId)) {
+      this.routingCache.invalidateAgent(ownedAgentId);
+    }
+    this.routingCache.invalidateTenant(tenantId);
+    return targets.length;
+  }
+
   async deactivateAllProviders(agentId: string, tenantId: string): Promise<void> {
     const activeProviders = await this.providerRepo.find({
       where: { tenant_id: tenantId, is_active: true },


### PR DESCRIPTION
### 💭 Why
When an OAuth subscription's refresh token dies permanently (`invalid_refresh_token`, `refresh_token_reused`, …), Manifest logged the failure and returned null — but left `tenant_providers.is_active = true`. The resolver keeps electing that dead primary, and until #2600 the proxy hard-returned M100 without trying fallbacks. Rows stay green in the UI forever with no reconnect signal.

### ✨ What changed
- `OAuthRefreshError` carries the provider response body; `isPermanentOAuthRefreshFailure` classifies permanent grant failures.
- On permanent refresh failure, `markSubscriptionCredentialDead` flips the matching subscription row inactive and invalidates routing caches (no route-clear precondition — the credential cannot authenticate).
- Transient failures (5xx, rate limit, network) and post-rotate persist errors do **not** deactivate the row.

### 🔧 How to test
- `npx jest --testPathPattern='oauth-refresh-errors|openai-oauth.service.coverage|provider.service.spec'` in `packages/backend`

### 📝 Notes
Pairs with #2600 (walk fallbacks when primary credentials fail). That PR recovers traffic immediately; this one stops the dead primary from being re-elected and surfaces the connection as inactive so users can reconnect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deactivate OAuth subscription credentials when a refresh token is permanently invalid so routing stops re-electing a dead primary and the UI shows the connection as disconnected. Permanent errors (e.g., `invalid_refresh_token`, `refresh_token_reused`) flip the matching `tenant_providers.is_active` to false and clear routing caches; transient errors do not.

- **Bug Fixes**
  - Added `OAuthRefreshError` and `isPermanentOAuthRefreshFailure` to classify provider responses.
  - On permanent refresh failures, call `markSubscriptionCredentialDead` to deactivate the matching subscription and invalidate agent/tenant routing caches (no route-clear needed).
  - Skip deactivation for transient failures (5xx, rate limit, network) and post-rotate persist errors.

<sup>Written for commit 232aad3ee396c502678c1b568f722676fd606a0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

