### PR TITLE
fix: do not send self-hosted telemetry from cloud mode

### DIFF
--- a/.changeset/disable-cloud-telemetry.md
+++ b/.changeset/disable-cloud-telemetry.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Stop the cloud deployment from sending self-hosted telemetry reports, which double-counted cloud traffic under Peacock's Local series

--- a/packages/backend/src/telemetry/telemetry.config.spec.ts
+++ b/packages/backend/src/telemetry/telemetry.config.spec.ts
@@ -27,6 +27,18 @@ describe('buildTelemetryConfig', () => {
     ).toBe(false);
   });
 
+  it('is disabled in cloud mode even in production (cloud has its own analytics)', () => {
+    expect(
+      buildTelemetryConfig({ NODE_ENV: 'production', MANIFEST_MODE: 'cloud' }).enabled,
+    ).toBe(false);
+  });
+
+  it('stays enabled for explicit self-hosted production', () => {
+    expect(
+      buildTelemetryConfig({ NODE_ENV: 'production', MANIFEST_MODE: 'selfhosted' }).enabled,
+    ).toBe(true);
+  });
+
   it('ignores unrecognised disable values (opt-out must be explicit)', () => {
     expect(
       buildTelemetryConfig({ NODE_ENV: 'production', MANIFEST_TELEMETRY_DISABLED: 'yes' }).enabled,

--- a/packages/backend/src/telemetry/telemetry.config.ts
+++ b/packages/backend/src/telemetry/telemetry.config.ts
@@ -18,15 +18,26 @@ export interface TelemetryConfig {
  * `manifest_version` as semver, so a misconfigured image without
  * `packages/manifest/package.json` would otherwise spam the endpoint
  * with 400s.
+ *
+ * Cloud (`MANIFEST_MODE=cloud`) never reports: the payload is designed for
+ * anonymous self-hosted fleets, and the cloud deployment already has its
+ * own `agent_messages` analytics. Letting cloud phone home double-counts
+ * the same traffic under Peacock's Local series (the cloud install_id
+ * shows up as the self-hosted "whale").
  */
 export function buildTelemetryConfig(env: NodeJS.ProcessEnv = process.env): TelemetryConfig {
   const disabled = env['MANIFEST_TELEMETRY_DISABLED'];
   const isProd = (env['NODE_ENV'] ?? 'development') === 'production';
   const isDisabled = disabled === '1' || disabled === 'true';
+  // Explicit cloud only — self-hosted (selfhosted/local/auto-detect) keeps
+  // reporting. Do not use isSelfHosted() here: bare-metal self-host without
+  // MANIFEST_MODE defaults to "cloud" detection but should still be able to
+  // opt into telemetry via MANIFEST_MODE=selfhosted or by not setting cloud.
+  const isCloud = env['MANIFEST_MODE'] === 'cloud';
   const manifestVersion = readManifestVersion();
   const versionReadable = manifestVersion !== UNKNOWN_VERSION;
   return {
-    enabled: isProd && !isDisabled && versionReadable,
+    enabled: isProd && !isDisabled && !isCloud && versionReadable,
     endpoint: env['TELEMETRY_ENDPOINT'] ?? DEFAULT_TELEMETRY_ENDPOINT,
     manifestVersion,
   };


### PR DESCRIPTION
### 💭 Why
Manifest Cloud runs with `MANIFEST_MODE=cloud` and `NODE_ENV=production`, so the self-hosted telemetry sender was enabled. It reports daily aggregates under a random `install_id` to Peacock, where that install shows up as the Local "whale". Cloud traffic then appears twice on the platform dashboard (Cloud series + inside Local).

### ✨ What changed
- `buildTelemetryConfig` disables the sender when `MANIFEST_MODE=cloud`.
- Explicit self-hosted (`MANIFEST_MODE=selfhosted` / `local`) and installs without the cloud flag keep reporting.
- Tests cover cloud opt-out and self-hosted stay-on.

### 🔧 How to test
- `npx jest --testPathPattern='telemetry.config.spec'` in `packages/backend`

### 📝 Notes
Historical Peacock rows for the cloud install still need receiver-side exclusion (Peacock PR). This stops new double-counting at the source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable self-hosted telemetry when running with `MANIFEST_MODE=cloud` to stop double-counting cloud traffic in Peacock. Self-hosted installs keep reporting; tests cover both paths.

- **Bug Fixes**
  - `buildTelemetryConfig` now disables the sender when `MANIFEST_MODE=cloud` (even in production).
  - Self-hosted modes (`selfhosted`/`local` or no cloud flag) remain enabled.
  - Added tests for cloud opt-out and self-hosted enabled behavior.

<sup>Written for commit 1fa8d38195c3d35962f60875ed73adb95922f96a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

