### PR TITLE
fix: show current model names when connecting a provider

### DIFF
--- a/.changeset/current-provider-catalogs.md
+++ b/.changeset/current-provider-catalogs.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Refresh the model lists shown on provider tiles and in the README so they match the catalogs providers actually serve today

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 <p align="center">
-Plug your AI agents into any provider
+AI Agents that don't break
 </p>
 
 ![manifest-gh](https://github.com/user-attachments/assets/7dd74fc2-f7d6-4558-a95a-014ed754a125)
@@ -42,12 +42,12 @@ Plug your AI agents into any provider
 
 ## What is Manifest?
 
-Manifest is an open-source model router for AI agents and apps. Connect your API keys, subscriptions, and local models to one OpenAI-compatible endpoint, and each query goes to the right model. No single-provider lock-in.
+Manifest is an open-source LLM gateway for AI agents and apps. Connect your API keys, subscriptions, and local models to one OpenAI-compatible endpoint, and each query goes to the right model. No single-provider lock-in.
 
-- 🔀 Routing based on complexity, specificity and custom HTTP headers
-- 🎛️ Mix your providers: API keys, Subscriptions, Local models, Custom providers
+- 🔀 Custom Routing: API keys, Subscriptions, Local models, Custom providers
+- 💾 Full Body Logs for Success and Error Messages
 - 📊 Track every single dollar, setup notifications and limits
-- 🚑 Fallback on different models when queries fails
+- 🚑 Fallback on different models when queries fails, Self-heals your bad requests
 
 ## Quick start
 
@@ -67,13 +67,13 @@ Open [http://localhost:2099](http://localhost:2099) and sign up — the first ac
 
 ### Deploy with one click
 
-| Platform | Notes |
-| --- | --- |
-| [Railway](https://railway.com/deploy/wild-wild) | Best path. Template includes Manifest and PostgreSQL. |
-| [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Blueprint includes Manifest and Render PostgreSQL. |
-| [DigitalOcean](deploy/digitalocean/TUTORIAL.md) | App Platform button includes Manifest and a Dev PostgreSQL database. |
-| [AWS](deploy/aws/TUTORIAL.md) | CloudFormation quick-create for ECS, RDS, and Secrets Manager. |
-| [GCP](deploy/gcp/TUTORIAL.md) | Cloud Shell guided deploy for Cloud Run, Cloud SQL, and Secret Manager. |
+| Platform                                                                   | Notes                                                                   |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [Railway](https://railway.com/deploy/wild-wild)                            | Best path. Template includes Manifest and PostgreSQL.                   |
+| [Render](https://render.com/deploy?repo=https://github.com/mnfst/manifest) | Blueprint includes Manifest and Render PostgreSQL.                      |
+| [DigitalOcean](deploy/digitalocean/TUTORIAL.md)                            | App Platform button includes Manifest and a Dev PostgreSQL database.    |
+| [AWS](deploy/aws/TUTORIAL.md)                                              | CloudFormation quick-create for ECS, RDS, and Secrets Manager.          |
+| [GCP](deploy/gcp/TUTORIAL.md)                                              | Cloud Shell guided deploy for Cloud Run, Cloud SQL, and Secret Manager. |
 
 Full deployment guides: [Railway](https://manifest.build/docs/deploy/railway), [Render](https://manifest.build/docs/deploy/render), [DigitalOcean](https://manifest.build/docs/deploy/digitalocean), [AWS](https://manifest.build/docs/deploy/aws), [GCP](https://manifest.build/docs/deploy/gcp), [Fly.io](https://manifest.build/docs/deploy/fly), [Coolify](https://manifest.build/docs/deploy/coolify), [Easypanel](https://manifest.build/docs/deploy/easypanel), [Heroku](https://manifest.build/docs/deploy/heroku), and [Koyeb](https://manifest.build/docs/deploy/koyeb).
 
@@ -81,43 +81,43 @@ Full deployment guides: [Railway](https://manifest.build/docs/deploy/railway), [
 
 ## Providers
 
-Manifest connects to **300+ models through 31 built-in provider connections** plus any custom OpenAI/Anthropic-compatible endpoint. Bring your own API key, reuse one of **18 subscription flows**, or run models locally. Everything is routed through the same `/auto` endpoint.
+Manifest connects to **300+ models through 31 built-in provider connections** plus any custom OpenAI/Anthropic-compatible endpoint. Bring your own API key, reuse one of **18 subscription flows**, or run models locally. Everything is routed through the same OpenAI-compatible endpoint — send `"model": "auto"` and Manifest picks the model.
 
 Provider catalogs are discovered dynamically when credentials are connected. The examples below are representative, not exhaustive.
 
-| Provider | API key / local | Subscription | Model catalog |
-| --- | :---: | :--- | --- |
-| [**OpenAI**](https://platform.openai.com/) | ✅ | ✅ ChatGPT Plus / Pro / Team | GPT-5 family, o-series, Codex / Responses models |
-| [**Anthropic**](https://www.anthropic.com/) | ✅ | ✅ Claude Max / Pro | Claude Opus, Sonnet, Haiku, Fable |
-| [**Google**](https://ai.google.dev/) | ✅ | ✅ Sign in with Google | Gemini 3.1, Gemini 3, Gemini 2.5 |
-| [**xAI**](https://x.ai/) | ✅ | ✅ Grok subscription | Grok, Grok Code Fast |
-| [**AWS Bedrock**](https://aws.amazon.com/bedrock/) | ✅ | — | Claude, Llama, Mistral, Nova via Bedrock |
-| [**Alibaba Cloud / Qwen**](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) | ✅ | ✅ Qwen Token Plan | Qwen, DeepSeek, Kimi, GLM via Alibaba Cloud |
-| [**DeepSeek**](https://www.deepseek.com/) | ✅ | — | DeepSeek V3, DeepSeek R1 |
-| [**Mistral**](https://mistral.ai/) | ✅ | ✅ Mistral Vibe | Mistral Large, Codestral, Pixtral |
-| [**Moonshot** (Kimi)](https://kimi.ai/) | ✅ | ✅ Kimi Coding Plan | Kimi K2, Kimi for Coding, Moonshot v1 |
-| [**MiniMax**](https://www.minimax.io/) | ✅ | ✅ MiniMax Coding Plan | MiniMax M3, M2.7, M2.5 |
-| [**Xiaomi MiMo**](https://platform.xiaomimimo.com/) | ✅ | ✅ MiMo Token Plan | MiMo V2.5 Pro, V2.5, Flash |
-| [**Z.ai**](https://z.ai/) | ✅ | ✅ GLM Coding Plan | GLM 5.2, GLM 5.1, GLM 5 Turbo |
-| [**BytePlus**](https://www.byteplus.com/en/activity/codingplan) | — | ✅ ModelArk Coding Plan | Ark Code, Seed Code, GLM, Kimi, DeepSeek |
-| [**GitHub Copilot**](https://github.com/features/copilot) | — | ✅ Copilot subscription | Claude, GPT, Gemini, Grok via Copilot |
-| [**Kiro**](https://kiro.dev/) | — | ✅ Kiro subscription | `kiro/auto`, Claude, DeepSeek, MiniMax, GLM, Qwen |
-| [**Command Code**](https://commandcode.ai/studio) | — | ✅ Command Code subscription | Claude, GPT, Kimi, DeepSeek, Qwen |
-| [**ClinePass**](https://app.cline.bot/) | — | ✅ ClinePass subscription | `cline-pass/glm-5.2`, Kimi, DeepSeek, MiMo, MiniMax, Qwen |
-| [**NousResearch**](https://portal.nousresearch.com/) | — | ✅ NousResearch subscription | NousResearch Portal model catalog |
-| [**OpenCode Go**](https://opencode.ai/) | — | ✅ OpenCode Go | GLM, Kimi, MiMo, MiniMax |
-| [**Ollama / Ollama Cloud**](https://ollama.com/) | 🖥️ Local | ✅ Ollama Cloud | Local or cloud tags: Llama, Qwen, DeepSeek, Gemma |
-| [**LM Studio**](https://lmstudio.ai/) | 🖥️ Local | — | Local GGUF models, port `1234` |
-| [**llama.cpp**](https://github.com/ggml-org/llama.cpp) | 🖥️ Local | — | Local GGUF models, port `8080` |
-| [**OpenRouter**](https://openrouter.ai/) | ✅ | — | 300+ models across labs |
-| [**OpenCode Zen**](https://opencode.ai/) | ✅ | — | Claude, GPT, Gemini, Qwen, GLM, MiniMax |
-| [**Kilo**](https://kilo.ai/) | ✅ | — | Kilo Gateway catalog |
-| [**Cerebras**](https://www.cerebras.ai/) | ✅ | — | GPT OSS, GLM on Cerebras inference |
-| [**Fireworks AI**](https://fireworks.ai/) | ✅ | — | GLM 5.2, DeepSeek, Kimi, Qwen, Llama |
-| [**Groq**](https://groq.com/) | ✅ | — | Llama, Gemma, Mixtral |
-| [**NVIDIA NIM**](https://build.nvidia.com/) | ✅ | — | Nemotron, Llama, Mistral |
-| [**Pioneer**](https://pioneer.ai/) | ✅ | — | OpenAI-compatible and fine-tuned Pioneer models |
-| **Custom** | ✅ | — | Any `/v1/chat/completions` or `/v1/messages` endpoint |
+| Provider                                                                                 | API key / local | Subscription                 | Model catalog                                                   |
+| ---------------------------------------------------------------------------------------- | :-------------: | :--------------------------- | --------------------------------------------------------------- |
+| [**OpenAI**](https://platform.openai.com/)                                               |       ✅        | ✅ ChatGPT Plus / Pro / Team | GPT-5.6 (Sol / Terra / Luna), GPT-5.5, GPT-5.4, Codex, o-series |
+| [**Anthropic**](https://www.anthropic.com/)                                              |       ✅        | ✅ Claude Max / Pro          | Claude Opus 5, Sonnet 5, Fable 5, Haiku 4.5                     |
+| [**Google**](https://ai.google.dev/)                                                     |       ✅        | ✅ Sign in with Google       | Gemini 3.6 Flash, 3.5 Flash, 3.1 Pro, Gemini 2.5                |
+| [**xAI**](https://x.ai/)                                                                 |       ✅        | ✅ Grok subscription         | Grok 4.5, Grok 4.3, Grok Build, Grok 4.20                       |
+| [**AWS Bedrock**](https://aws.amazon.com/bedrock/)                                       |       ✅        | —                            | Claude, GPT, Kimi, MiniMax, Nemotron, Nova via Bedrock          |
+| [**Alibaba Cloud / Qwen**](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) |       ✅        | ✅ Qwen Token Plan           | Qwen 3.7 Max / Plus / Flash, DeepSeek, Kimi, GLM                |
+| [**DeepSeek**](https://www.deepseek.com/)                                                |       ✅        | —                            | DeepSeek V4 Pro, V4 Flash, V3.2, R1                             |
+| [**Mistral**](https://mistral.ai/)                                                       |       ✅        | ✅ Mistral Vibe              | Mistral Large, Medium 3.5, Devstral, Codestral                  |
+| [**Moonshot** (Kimi)](https://kimi.ai/)                                                  |       ✅        | ✅ Kimi Coding Plan          | Kimi K3, K2.7 Code, Kimi for Coding                             |
+| [**MiniMax**](https://www.minimax.io/)                                                   |       ✅        | ✅ MiniMax Coding Plan       | MiniMax M3, M2.7, M2.5                                          |
+| [**Xiaomi MiMo**](https://platform.xiaomimimo.com/)                                      |       ✅        | ✅ MiMo Token Plan           | MiMo V2.5 Pro, V2.5, Flash                                      |
+| [**Z.ai**](https://z.ai/)                                                                |       ✅        | ✅ GLM Coding Plan           | GLM 5.2, GLM 5.1, GLM 5 Turbo                                   |
+| [**BytePlus**](https://www.byteplus.com/en/activity/codingplan)                          |        —        | ✅ ModelArk Coding Plan      | Ark Code, Seed Code, GLM, Kimi, DeepSeek, GPT-OSS               |
+| [**GitHub Copilot**](https://github.com/features/copilot)                                |        —        | ✅ Copilot subscription      | Claude, GPT, Gemini, Grok via Copilot                           |
+| [**Kiro**](https://kiro.dev/)                                                            |        —        | ✅ Kiro subscription         | `kiro/auto`, Claude, DeepSeek, MiniMax, GLM, Qwen               |
+| [**Command Code**](https://commandcode.ai/studio)                                        |        —        | ✅ Command Code subscription | Claude, DeepSeek V4, Qwen 3.7, Gemini, Kimi                     |
+| [**ClinePass**](https://app.cline.bot/)                                                  |        —        | ✅ ClinePass subscription    | `cline-pass/glm-5.2`, Kimi, DeepSeek, MiMo, MiniMax, Qwen       |
+| [**NousResearch**](https://portal.nousresearch.com/)                                     |        —        | ✅ NousResearch subscription | NousResearch Portal model catalog                               |
+| [**OpenCode Go**](https://opencode.ai/)                                                  |        —        | ✅ OpenCode Go               | DeepSeek V4, Qwen 3.7, GLM, Kimi, MiMo                          |
+| [**Ollama / Ollama Cloud**](https://ollama.com/)                                         |    🖥️ Local     | ✅ Ollama Cloud              | Local tags: Llama, Qwen, Gemma. Cloud: DeepSeek V4, GLM, Kimi   |
+| [**LM Studio**](https://lmstudio.ai/)                                                    |    🖥️ Local     | —                            | Local GGUF models, port `1234`                                  |
+| [**llama.cpp**](https://github.com/ggml-org/llama.cpp)                                   |    🖥️ Local     | —                            | Local GGUF models, port `8080`                                  |
+| [**OpenRouter**](https://openrouter.ai/)                                                 |       ✅        | —                            | 300+ models across labs                                         |
+| [**OpenCode Zen**](https://opencode.ai/)                                                 |       ✅        | —                            | Curated Claude, GPT, DeepSeek, MiMo, Nemotron                   |
+| [**Kilo**](https://kilo.ai/)                                                             |       ✅        | —                            | Kilo Gateway catalog                                            |
+| [**Cerebras**](https://www.cerebras.ai/)                                                 |       ✅        | —                            | GPT-OSS, GLM, Gemma on Cerebras inference                       |
+| [**Fireworks AI**](https://fireworks.ai/)                                                |       ✅        | —                            | DeepSeek V4, Kimi K2.7, Qwen 3.7, Nemotron                      |
+| [**Groq**](https://groq.com/)                                                            |       ✅        | —                            | Llama 4, Qwen 3.6, GPT-OSS, Gemma                               |
+| [**NVIDIA NIM**](https://build.nvidia.com/)                                              |       ✅        | —                            | Nemotron 3, GLM, Kimi, MiniMax, Qwen                            |
+| [**Pioneer**](https://pioneer.ai/)                                                       |       ✅        | —                            | OpenAI-compatible and fine-tuned Pioneer models                 |
+| **Custom**                                                                               |       ✅        | —                            | Any `/v1/chat/completions` or `/v1/messages` endpoint           |
 
 ## Quick links
 

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -111,7 +111,7 @@ interface ProviderUIOverlay {
 const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   qwen: {
     initial: 'Al',
-    subtitle: 'Qwen, DeepSeek, Kimi, GLM via Alibaba Cloud',
+    subtitle: 'Qwen 3.7, DeepSeek, Kimi, GLM via Alibaba Cloud',
     apiKeyEndpointRegions: [
       { value: 'auto', label: 'Auto-detect' },
       { value: 'beijing', label: 'China (Beijing)' },
@@ -152,7 +152,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   anthropic: {
     initial: 'A',
-    subtitle: 'Claude Opus 4, Sonnet 4.5, Haiku',
+    subtitle: 'Claude Opus 5, Sonnet 5, Fable 5, Haiku 4.5',
     supportsSubscription: true,
     subscriptionLabel: 'Claude Max / Pro subscription',
     subscriptionAuthMode: 'popup_paste',
@@ -160,7 +160,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   bedrock: {
     initial: 'AWS',
-    subtitle: 'Claude, Llama, Mistral, Nova via Amazon Bedrock',
+    subtitle: 'Claude, GPT, Kimi, MiniMax, Nova via Amazon Bedrock',
     apiKeyEndpointRegions: [
       { value: 'us-east-1', label: 'US East (N. Virginia)' },
       { value: 'us-east-2', label: 'US East (Ohio)' },
@@ -180,7 +180,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   byteplus: {
     initial: 'Bp',
-    subtitle: 'Ark Code, Seed Code, GLM, Kimi',
+    subtitle: 'Ark Code, Seed Code, DeepSeek, GLM, Kimi',
     supportsSubscription: true,
     subscriptionOnly: true,
     subscriptionLabel: 'ModelArk Coding Plan',
@@ -192,7 +192,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   cerebras: {
     initial: 'Cb',
-    subtitle: 'GPT OSS and GLM on Cerebras inference',
+    subtitle: 'GPT-OSS, GLM, Gemma on Cerebras inference',
     models: [],
   },
   'cline-pass': {
@@ -215,17 +215,17 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   deepseek: {
     initial: 'D',
-    subtitle: 'DeepSeek V3, R1',
+    subtitle: 'DeepSeek V4 Pro, V4 Flash, V3.2, R1',
     models: [],
   },
   fireworks: {
     initial: 'Fw',
-    subtitle: 'DeepSeek, Kimi, Qwen, Llama',
+    subtitle: 'DeepSeek V4, Kimi, Qwen 3.7, Nemotron',
     models: [],
   },
   copilot: {
     initial: 'GH',
-    subtitle: 'Claude, GPT, Gemini via Copilot',
+    subtitle: 'Claude, GPT, Gemini, Grok via Copilot',
     supportsSubscription: true,
     subscriptionLabel: 'GitHub Copilot subscription',
     subscriptionAuthMode: 'device_code',
@@ -247,7 +247,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   commandcode: {
     initial: 'CC',
-    subtitle: 'Claude, GPT, Kimi, DeepSeek, Qwen',
+    subtitle: 'Claude, DeepSeek, Qwen, Gemini, Kimi',
     supportsSubscription: true,
     subscriptionOnly: true,
     subscriptionLabel: 'Command Code subscription',
@@ -259,7 +259,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   gemini: {
     initial: 'G',
-    subtitle: 'Gemini 2.5, Gemini 2.0 Flash',
+    subtitle: 'Gemini 3.6 Flash, 3.1 Pro, Gemini 2.5',
     supportsSubscription: true,
     subscriptionLabel: 'Sign in with Google',
     subscriptionAuthMode: 'popup_oauth',
@@ -277,7 +277,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   groq: {
     initial: 'Gq',
-    subtitle: 'Llama, Gemma, Mixtral. Fast inference',
+    subtitle: 'Llama 4, Qwen, GPT-OSS. Fast inference',
     models: [],
   },
   kilo: {
@@ -301,7 +301,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   minimax: {
     initial: 'Mm',
-    subtitle: 'MiniMax M2.7, M2.5, M1',
+    subtitle: 'MiniMax M3, M2.7, M2.5',
     supportsSubscription: true,
     subscriptionLabel: 'MiniMax Coding Plan',
     subscriptionAuthMode: 'device_code',
@@ -330,7 +330,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   mistral: {
     initial: 'M',
-    subtitle: 'Mistral Large, Codestral, Pixtral',
+    subtitle: 'Mistral Large, Medium 3.5, Devstral, Codestral',
     supportsSubscription: true,
     subscriptionLabel: 'Mistral Vibe subscription',
     subscriptionAuthMode: 'token',
@@ -341,7 +341,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   moonshot: {
     initial: 'Mo',
-    subtitle: 'Kimi k2, Moonshot v1',
+    subtitle: 'Kimi K3, K2.7 Code, Kimi for Coding',
     supportsSubscription: true,
     subscriptionLabel: 'Kimi Coding Plan',
     subscriptionAuthMode: 'token',
@@ -363,18 +363,18 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   nvidia: {
     initial: 'Nv',
-    subtitle: 'Nemotron, Llama, Mistral via NVIDIA NIM',
+    subtitle: 'Nemotron 3, GLM, Kimi, Qwen via NVIDIA NIM',
     models: [],
   },
   ollama: {
     initial: 'Ol',
-    subtitle: 'Llama, Mistral, Gemma, and more',
+    subtitle: 'Llama, Qwen, Gemma, and more',
     noKeyRequired: true,
     models: [],
   },
   'ollama-cloud': {
     initial: 'Oc',
-    subtitle: 'DeepSeek, Qwen, Gemma, Llama in the cloud',
+    subtitle: 'DeepSeek V4, GLM, Kimi, MiniMax in the cloud',
     supportsSubscription: true,
     subscriptionOnly: true,
     subscriptionLabel: 'Ollama Cloud subscription',
@@ -385,7 +385,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   openai: {
     initial: 'O',
-    subtitle: 'GPT-4o, GPT-4.1, o3, o4',
+    subtitle: 'GPT-5.6, GPT-5.5, GPT-5.4, Codex',
     supportsSubscription: true,
     subscriptionLabel: 'ChatGPT Plus/Pro/Team',
     subscriptionAuthMode: 'popup_oauth',
@@ -409,7 +409,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   'opencode-go': {
     initial: 'OG',
-    subtitle: 'GLM, Kimi, MiMo, MiniMax',
+    subtitle: 'DeepSeek, Qwen, GLM, Kimi, MiMo',
     supportsSubscription: true,
     subscriptionLabel: 'OpenCode Go (beta)',
     subscriptionAuthMode: 'token',
@@ -423,7 +423,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   'opencode-zen': {
     initial: 'OZ',
-    subtitle: 'Curated Claude, GPT, Gemini, Qwen, GLM, MiniMax',
+    subtitle: 'Curated Claude, GPT, DeepSeek, MiMo, Nemotron',
     models: [],
   },
   openrouter: {
@@ -433,7 +433,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   xai: {
     initial: 'X',
-    subtitle: 'Grok 3, Grok 2',
+    subtitle: 'Grok 4.5, Grok 4.3, Grok Build',
     supportsSubscription: true,
     subscriptionLabel: 'Grok subscription',
     subscriptionAuthMode: 'popup_oauth',
@@ -441,7 +441,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   zai: {
     initial: 'Z',
-    subtitle: 'GLM 5.1, GLM 5, GLM 4.7',
+    subtitle: 'GLM 5.2, GLM 5.1, GLM 5 Turbo',
     supportsSubscription: true,
     subscriptionLabel: 'GLM Coding Plan',
     subscriptionAuthMode: 'token',


### PR DESCRIPTION
### 💭 Why

The provider tiles in the dashboard still listed models from 2024. OpenAI said "GPT-4o, GPT-4.1, o3, o4", xAI said "Grok 3, Grok 2", Moonshot said "Kimi k2", Groq said "Mixtral". Someone picking a provider was reading a catalog that no longer matches what they get. The README provider table had the same drift.

### ✨ What changed

- Refreshed all 22 provider tile subtitles to current catalogs.
- Refreshed the model column of the README provider table (17 rows).
- Fixed the README claim that everything routes through an `/auto` endpoint. Routing is triggered by `"model": "auto"` on the OpenAI-compatible endpoint.
- Reworded the README intro (LLM gateway, full body logs, self-healing).

### 👤 For users

Connect-provider tiles now show models that exist. Copy only, no behavior change.

### 📝 Notes

Model lists came from two sources, not guesswork: the OpenRouter catalog (the same feed `PricingSyncService` syncs) and the top models actually served per provider in production over the last 21 days. That second source is what caught the non-obvious ones, like Bedrock now serving GPT, Kimi and MiniMax, and NVIDIA NIM serving GLM and Kimi rather than Llama.

Left alone on purpose: `SUBSCRIPTION_PROVIDER_CONFIGS.gemini.knownModels` omits Gemini 3.5 and 3.6 Flash. That looks like drift but the list is deliberately restricted to models the CodeAssist route accepts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale model names in provider tiles and syncs the README provider table so users see current catalogs when connecting a provider. Copy-only change; no runtime behavior impact.

- **Bug Fixes**
  - Updated 22 provider tile subtitles to match current catalogs.
  - Synced README provider table (17 rows) and corrected routing docs: send `"model": "auto"` on the OpenAI‑compatible endpoint (not a `/auto` path).
  - Tightened README intro copy for clarity.

<sup>Written for commit ed712ab5b2f5edd3466840a02d70bf11f09c68b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

