### PR TITLE
fix: scope harness Overview to that harness's own routing

### DIFF
--- a/.changeset/wise-moons-repeat.md
+++ b/.changeset/wise-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Scope a harness's Overview to that harness's own routing: requests where the caller pinned an explicit model in the request body (`direct`) no longer appear in its Recent Messages, charts, cost breakdown or summary cards. They stay fully visible on the global Overview and the Messages log, so total spend still reconciles.

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -106,6 +106,9 @@ describe('OverviewController', () => {
       undefined,
       undefined,
       true,
+      undefined,
+      undefined,
+      false,
     );
   });
 
@@ -145,6 +148,9 @@ describe('OverviewController', () => {
       undefined,
       undefined,
       true,
+      undefined,
+      undefined,
+      false,
     );
   });
 
@@ -174,8 +180,29 @@ describe('OverviewController', () => {
       include_total: false,
       include_filter_options: false,
       exclude_playground: true,
+      exclude_direct: true,
     });
     expect(ts.getRecentActivity).not.toHaveBeenCalled();
+  });
+
+  it('keeps direct requests in the recent-activity query on the global overview', async () => {
+    // Recent activity is served by the request log, which is also what backs the
+    // Requests page — so the exclusion has to be opt-in per call, not baked in.
+    const messagesQuery = { getMessages: jest.fn().mockResolvedValue({ items: [] }) };
+    const requestAwareController = new OverviewController(
+      agg as never,
+      ts as never,
+      { getProviders: mockGetProviders } as never,
+      { resolve: mockResolveAgent } as never,
+      { find: mockAccessFind } as never,
+      messagesQuery as never,
+    );
+
+    await requestAwareController.getOverview({ range: '24h' }, ctx as never);
+
+    expect(messagesQuery.getMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_name: undefined, exclude_direct: false }),
+    );
   });
 
   it('returns combined agent usage timeseries', async () => {
@@ -191,14 +218,32 @@ describe('OverviewController', () => {
   it('defaults range to 24h when not specified', async () => {
     await controller.getOverview({}, ctx as never);
 
-    expect(agg.getPreviousWindowMetrics).toHaveBeenCalledWith('24h', 'tenant-123', undefined, true);
+    expect(agg.getPreviousWindowMetrics).toHaveBeenCalledWith(
+      '24h',
+      'tenant-123',
+      undefined,
+      true,
+      false,
+    );
   });
 
   it('passes agent_name and tenantId to all calls, excluding Playground everywhere', async () => {
     await controller.getOverview({ range: '24h', agent_name: 'bot-1' }, ctx as never);
 
-    expect(agg.getPreviousWindowMetrics).toHaveBeenCalledWith('24h', 'tenant-123', 'bot-1', true);
-    expect(agg.getRequestReliability).toHaveBeenCalledWith('24h', 'tenant-123', 'bot-1', true);
+    expect(agg.getPreviousWindowMetrics).toHaveBeenCalledWith(
+      '24h',
+      'tenant-123',
+      'bot-1',
+      true,
+      true,
+    );
+    expect(agg.getRequestReliability).toHaveBeenCalledWith(
+      '24h',
+      'tenant-123',
+      'bot-1',
+      true,
+      true,
+    );
     expect(ts.getTimeseries).toHaveBeenCalledWith(
       '24h',
       'tenant-123',
@@ -207,11 +252,32 @@ describe('OverviewController', () => {
       undefined,
       undefined,
       true,
+      undefined,
+      undefined,
+      true,
     );
-    expect(ts.getCostByModel).toHaveBeenCalledWith('24h', 'tenant-123', 'bot-1', true);
-    expect(ts.getRecentActivity).toHaveBeenCalledWith('24h', 'tenant-123', 5, 'bot-1', true);
-    expect(ts.getActiveSkills).toHaveBeenCalledWith('24h', 'tenant-123', 'bot-1', true);
-    expect(agg.hasAnyData).toHaveBeenCalledWith('tenant-123', 'bot-1', true);
+    expect(ts.getCostByModel).toHaveBeenCalledWith('24h', 'tenant-123', 'bot-1', true, true);
+    expect(ts.getRecentActivity).toHaveBeenCalledWith('24h', 'tenant-123', 5, 'bot-1', true, true);
+    expect(ts.getActiveSkills).toHaveBeenCalledWith('24h', 'tenant-123', 'bot-1', true, true);
+    expect(agg.hasAnyData).toHaveBeenCalledWith('tenant-123', 'bot-1', true, true);
+  });
+
+  it('keeps client-pinned (direct) requests on the global overview', async () => {
+    // No agent_name => the cross-harness view, which must stay complete: it is
+    // where direct requests are accounted for and where total spend reconciles.
+    await controller.getOverview({ range: '24h' }, ctx as never);
+
+    expect(ts.getRecentActivity).toHaveBeenCalledWith(
+      '24h',
+      'tenant-123',
+      5,
+      undefined,
+      true,
+      false,
+    );
+    expect(ts.getCostByModel).toHaveBeenCalledWith('24h', 'tenant-123', undefined, true, false);
+    expect(ts.getActiveSkills).toHaveBeenCalledWith('24h', 'tenant-123', undefined, true, false);
+    expect(agg.hasAnyData).toHaveBeenCalledWith('tenant-123', undefined, true, false);
   });
 
   it('includes services_hit placeholder in summary', async () => {
@@ -237,7 +303,7 @@ describe('OverviewController', () => {
     const nullCtx = { tenantId: null, userId: 'u1' };
     await controller.getOverview({ range: '24h' }, nullCtx as never);
 
-    expect(agg.getPreviousWindowMetrics).toHaveBeenCalledWith('24h', null, undefined, true);
+    expect(agg.getPreviousWindowMetrics).toHaveBeenCalledWith('24h', null, undefined, true, false);
   });
 
   it('returns has_providers true when agent has active providers', async () => {

--- a/packages/backend/src/analytics/controllers/overview.controller.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.ts
@@ -53,6 +53,12 @@ export class OverviewController {
     const agentName = query.agent_name;
     const hourly = isHourlyRange(range);
     const tenantId = ctx.tenantId;
+    // Scoped to one harness => show only what that harness's routing did. A
+    // `direct` row is a model the caller pinned in the request body, which
+    // bypassed routing entirely, so it is not this harness's traffic. The
+    // unscoped (global) Overview and the Messages log stay complete — that is
+    // where direct requests are accounted for and where spend reconciles.
+    const excludeDirect = !!agentName;
 
     const [
       prevMetrics,
@@ -72,14 +78,28 @@ export class OverviewController {
       // never disagree (a Playground-only tenant reads as empty, not a populated
       // state painted over blank charts).
       //
+      // `excludeDirect` rides along on exactly the same rule: every widget on
+      // this page has to drop it or none of them can.
+      //
       // The current-window summary is derived from the timeseries buckets
       // below (which scan the same Playground-excluded rows), so we only query
       // the previous window here for the trend arrows instead of repeating the
       // full current+previous double-scan.
-      this.aggregation.getPreviousWindowMetrics(range, tenantId, agentName, true),
-      this.aggregation.getRequestReliability(range, tenantId, agentName, true),
-      this.timeseries.getTimeseries(range, tenantId, hourly, agentName, undefined, undefined, true),
-      this.timeseries.getCostByModel(range, tenantId, agentName, true),
+      this.aggregation.getPreviousWindowMetrics(range, tenantId, agentName, true, excludeDirect),
+      this.aggregation.getRequestReliability(range, tenantId, agentName, true, excludeDirect),
+      this.timeseries.getTimeseries(
+        range,
+        tenantId,
+        hourly,
+        agentName,
+        undefined,
+        undefined,
+        true,
+        undefined,
+        undefined,
+        excludeDirect,
+      ),
+      this.timeseries.getCostByModel(range, tenantId, agentName, true, excludeDirect),
       this.messagesQuery
         ? this.messagesQuery
             .getMessages({
@@ -90,11 +110,12 @@ export class OverviewController {
               include_total: false,
               include_filter_options: false,
               exclude_playground: true,
+              exclude_direct: excludeDirect,
             })
             .then((result) => result.items)
-        : this.timeseries.getRecentActivity(range, tenantId, 5, agentName, true),
-      this.timeseries.getActiveSkills(range, tenantId, agentName, true),
-      this.aggregation.hasAnyData(tenantId, agentName, true),
+        : this.timeseries.getRecentActivity(range, tenantId, 5, agentName, true, excludeDirect),
+      this.timeseries.getActiveSkills(range, tenantId, agentName, true, excludeDirect),
+      this.aggregation.hasAnyData(tenantId, agentName, true, excludeDirect),
       this.hasActiveProviders(tenantId, agentName),
     ]);
 

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -3,7 +3,10 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Brackets } from 'typeorm';
 import { AggregationService } from './aggregation.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
-import { EXCLUDE_PLAYGROUND_AGENTS_PREDICATE } from './query-helpers';
+import {
+  EXCLUDE_PLAYGROUND_AGENTS_PREDICATE,
+  EXCLUDE_DIRECT_ATTEMPTS_PREDICATE,
+} from './query-helpers';
 
 describe('AggregationService', () => {
   let service: AggregationService;
@@ -156,6 +159,20 @@ describe('AggregationService', () => {
       await service.hasAnyData('tenant-1');
       const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
       expect(clauses).not.toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
+    });
+
+    it('excludes client-pinned (direct) requests when excludeDirect=true', async () => {
+      mockGetRawOne.mockResolvedValueOnce({ '?column?': 1 });
+      await service.hasAnyData('tenant-1', 'bot-1', true, true);
+      const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+      expect(clauses).toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+    });
+
+    it('keeps direct requests by default', async () => {
+      mockGetRawOne.mockResolvedValueOnce({ '?column?': 1 });
+      await service.hasAnyData('tenant-1', 'bot-1', true);
+      const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+      expect(clauses).not.toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
     });
   });
 
@@ -349,6 +366,20 @@ describe('AggregationService', () => {
         clauses.some((c: unknown) => typeof c === 'string' && c.includes('is_playground')),
       ).toBe(true);
     });
+
+    it('excludes client-pinned (direct) requests when excludeDirect=true', async () => {
+      mockGetRawOne.mockResolvedValueOnce({ msg_count: 8, tokens: 120, cost: 0.8 });
+      await service.getPreviousWindowMetrics('7d', 'tenant-123', 'bot-1', true, true);
+      const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+      expect(clauses).toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+    });
+
+    it('keeps direct requests by default', async () => {
+      mockGetRawOne.mockResolvedValueOnce({ msg_count: 8, tokens: 120, cost: 0.8 });
+      await service.getPreviousWindowMetrics('7d', 'tenant-123', 'bot-1', true);
+      const clauses = mockQb.andWhere.mock.calls.map((c: unknown[]) => c[0]);
+      expect(clauses).not.toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+    });
   });
 
   describe('getRequestReliability', () => {
@@ -395,6 +426,31 @@ describe('AggregationService', () => {
         'agent-1',
       ]);
       expect(query.mock.calls[0][0]).toContain('playag.is_playground = true');
+    });
+
+    it('excludes client-pinned (direct) traffic from both scoped_requests branches', async () => {
+      const query = jest.fn().mockResolvedValue([]);
+      const requestAware = new AggregationService({ query } as never, {} as never);
+
+      await requestAware.getRequestReliability('24h', 'tenant-1', 'agent-1', true, true);
+
+      const sql = query.mock.calls[0][0] as string;
+      // Linked requests are dropped via NOT EXISTS over their attempts...
+      expect(sql).toContain('direct_attempt.request_id = r.id');
+      // ...and unlinked legacy attempts, which are their own synthetic request,
+      // are tested on the attempt row itself.
+      expect(sql).toContain("pa.routing_reason IS DISTINCT FROM 'direct'");
+    });
+
+    it('keeps direct traffic by default', async () => {
+      const query = jest.fn().mockResolvedValue([]);
+      const requestAware = new AggregationService({ query } as never, {} as never);
+
+      await requestAware.getRequestReliability('24h', 'tenant-1', 'agent-1', true);
+
+      const sql = query.mock.calls[0][0] as string;
+      expect(sql).not.toContain('direct_attempt');
+      expect(sql).not.toContain('routing_reason');
     });
 
     it('avoids division by zero when no scoped rows exist', async () => {

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -8,6 +8,8 @@ import {
   computeTrend,
   addTenantFilter,
   excludePlaygroundAgents,
+  excludeDirectAttempts,
+  sqlExcludeDirectRequests,
   scopeToConnection,
   sqlCountMessages,
   sqlExcludePlayground,
@@ -39,6 +41,7 @@ export class AggregationService {
     tenantId: string | null,
     agentName?: string,
     excludePlayground = false,
+    excludeDirect = false,
   ): Promise<boolean> {
     const attemptQb = this.turnRepo.createQueryBuilder('at').select('1').limit(1);
     addTenantFilter(attemptQb, tenantId, agentName);
@@ -46,6 +49,9 @@ export class AggregationService {
     // must read as empty, or has_data=true paints a non-empty state over cards
     // and charts that all dropped Playground and so render blank.
     if (excludePlayground) excludePlaygroundAgents(attemptQb);
+    // Same reasoning for client-pinned (direct) traffic on a harness Overview:
+    // a harness whose only traffic bypassed its routing must read as empty.
+    if (excludeDirect) excludeDirectAttempts(attemptQb);
 
     let requestRow: Promise<unknown> = Promise.resolve(null);
     if (this.requestRepo) {
@@ -64,6 +70,7 @@ export class AggregationService {
         );
       }
       if (excludePlayground) requestQb.andWhere(sqlExcludePlayground('r'));
+      if (excludeDirect) requestQb.andWhere(sqlExcludeDirectRequests('r'));
       requestRow = requestQb.getRawOne();
     }
 
@@ -176,6 +183,7 @@ export class AggregationService {
     tenantId: string | null,
     agentName?: string,
     excludePlayground = false,
+    excludeDirect = false,
   ): Promise<{ tokens: number; cost: number; messages: number }> {
     const { cutoff, prevCutoff } = this.computeWindow(range);
     const safeCost = sqlSanitizeCost('at.cost_usd');
@@ -187,6 +195,9 @@ export class AggregationService {
       undefined,
       undefined,
       excludePlayground,
+      undefined,
+      undefined,
+      excludeDirect,
     )
       .select(sqlCountMessages(), 'msg_count')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
@@ -205,6 +216,7 @@ export class AggregationService {
     tenantId: string | null,
     agentName?: string,
     excludePlayground = false,
+    excludeDirect = false,
   ): Promise<{
     total: number;
     successful: number;
@@ -244,6 +256,14 @@ export class AggregationService {
     const unlinkedPlaygroundPredicate = excludePlayground
       ? `AND ${sqlExcludePlayground('pa')}`
       : '';
+    // `routing_reason` lives on the attempt, so a linked request is dropped via
+    // NOT EXISTS over its attempts while an unlinked legacy attempt is tested
+    // directly. This feeds the Overview's *messages* card, so it has to drop the
+    // same traffic as the token/cost cards beside it.
+    const directPredicate = excludeDirect ? `AND ${sqlExcludeDirectRequests('r')}` : '';
+    const unlinkedDirectPredicate = excludeDirect
+      ? `AND pa.routing_reason IS DISTINCT FROM 'direct'`
+      : '';
     const queryParams = agentName
       ? [tenantId, prevCutoff, cutoff, agentName]
       : [tenantId, prevCutoff, cutoff];
@@ -256,6 +276,7 @@ export class AggregationService {
            AND ${sqlIsCompletedStatus('r.status')}
            ${agentPredicate}
            ${playgroundPredicate}
+           ${directPredicate}
          UNION ALL
          SELECT 'unlinked:' || pa.id, pa.timestamp, pa.status
          FROM agent_messages pa
@@ -265,6 +286,7 @@ export class AggregationService {
            AND ${sqlIsCompletedStatus('pa.status')}
            ${unlinkedAgentPredicate}
            ${unlinkedPlaygroundPredicate}
+           ${unlinkedDirectPredicate}
        ), attempt_stats AS (
          SELECT pa.request_id,
                 COUNT(*) FILTER (WHERE ${sqlIsCompletedStatus('pa.status')}) AS attempts,
@@ -367,6 +389,7 @@ export class AggregationService {
     excludePlayground = false,
     label?: string,
     tenantProviderId?: string,
+    excludeDirect = false,
   ): SelectQueryBuilder<AgentMessage> {
     const qb = this.turnRepo
       .createQueryBuilder('at')
@@ -376,6 +399,7 @@ export class AggregationService {
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
     if (excludePlayground) excludePlaygroundAgents(qb);
+    if (excludeDirect) excludeDirectAttempts(qb);
     scopeToConnection(qb, tenantProviderId, label);
     return qb;
   }

--- a/packages/backend/src/analytics/services/messages-query.requests.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.requests.spec.ts
@@ -465,4 +465,53 @@ describe('MessagesQueryService request-first queries', () => {
 
     expect(requestQb.andWhere).toHaveBeenCalled();
   });
+
+  describe('exclude_direct', () => {
+    function runWith(params: Record<string, unknown>) {
+      const requestQb = makeQb();
+      requestQb.clone.mockReturnValue(makeQb());
+      const legacyBase = makeQb();
+      legacyBase.clone.mockReturnValueOnce(makeQb()).mockReturnValueOnce(makeQb());
+      const service = new MessagesQueryService(
+        {
+          createQueryBuilder: jest.fn(() => legacyBase),
+          query: jest.fn().mockResolvedValue([]),
+        } as never,
+        { find: jest.fn() } as never,
+        { createQueryBuilder: jest.fn(() => requestQb) } as never,
+      );
+      return service
+        .getMessages({
+          tenantId: 'tenant-1',
+          limit: 10,
+          include_total: false,
+          include_filter_options: false,
+          ...params,
+        })
+        .then(() => ({
+          requestClauses: requestQb.andWhere.mock.calls.map((c) => String(c[0])),
+          legacyClauses: legacyBase.andWhere.mock.calls.map((c) => String(c[0])),
+        }));
+    }
+
+    it('drops client-pinned requests from both the request and legacy branches', async () => {
+      const { requestClauses, legacyClauses } = await runWith({ exclude_direct: true });
+
+      // Parent requests carry no routing_reason, so they are tested through
+      // their attempts; an unlinked legacy attempt is tested directly.
+      expect(requestClauses).toContainEqual(
+        expect.stringContaining('direct_attempt.request_id = r.id'),
+      );
+      expect(legacyClauses).toContainEqual(
+        expect.stringContaining("at.routing_reason IS DISTINCT FROM 'direct'"),
+      );
+    });
+
+    it('is opt-in, so the Requests log keeps showing them', async () => {
+      const { requestClauses, legacyClauses } = await runWith({});
+
+      expect(requestClauses.join(' ')).not.toContain('direct_attempt');
+      expect(legacyClauses.join(' ')).not.toContain('routing_reason');
+    });
+  });
 });

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -15,6 +15,8 @@ import {
   CUSTOM_PROVIDER_JOIN_CONDITION,
   excludePlaygroundAgents,
   sqlExcludePlayground,
+  excludeDirectAttempts,
+  sqlExcludeDirectRequests,
   sqlIsFailedStatus,
   sqlIsSuccessStatus,
 } from './query-helpers';
@@ -99,6 +101,14 @@ interface MessageQueryParams extends MessageFilterParams {
   include_total?: boolean;
   include_filter_options?: boolean;
   exclude_playground?: boolean;
+  /**
+   * Drop requests whose model the caller pinned in the request body, so the
+   * agent's routing never chose it (`routing_reason='direct'` on the attempt).
+   * Opt-in and used ONLY by the harness Overview's Recent Messages panel — the
+   * Requests log itself must keep showing them, which is where they are
+   * accounted for. See `sqlExcludeDirectRequests` in query-helpers.
+   */
+  exclude_direct?: boolean;
 }
 
 interface ConnectionIdentity {
@@ -252,6 +262,9 @@ export class MessagesQueryService {
     }
     if (params.exclude_playground) {
       qb.andWhere(sqlExcludePlayground('r'));
+    }
+    if (params.exclude_direct) {
+      qb.andWhere(sqlExcludeDirectRequests('r'));
     }
     if (params.status === 'failed' || params.status === 'errors') {
       // "Not a success" across both vocabularies: a normalized `success` row must
@@ -490,6 +503,9 @@ export class MessagesQueryService {
       }
     }
     if (params.exclude_playground) excludePlaygroundAgents(legacyBase);
+    // An unlinked attempt is its own synthetic request here, so `direct` is read
+    // off the attempt row itself rather than through NOT EXISTS on a parent.
+    if (params.exclude_direct) excludeDirectAttempts(legacyBase);
     const legacyCountQb = legacyBase.clone().select('COUNT(*)', 'total');
     const legacyDataQb = selectMessageRowColumns(
       legacyBase.clone(),

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -6,6 +6,9 @@ import {
   selectMessageRowColumns,
   excludePlaygroundAgents,
   EXCLUDE_PLAYGROUND_AGENTS_PREDICATE,
+  excludeDirectAttempts,
+  EXCLUDE_DIRECT_ATTEMPTS_PREDICATE,
+  sqlExcludeDirectRequests,
   CUSTOM_PROVIDER_JOIN_CONDITION,
   PROVIDER_SERIES_KEY_EXPR,
   filterByKeyLabel,
@@ -247,6 +250,55 @@ describe('excludePlaygroundAgents', () => {
   it('returns the query builder for chaining', () => {
     const { qb } = makeMockQb();
     expect(excludePlaygroundAgents(qb)).toBe(qb);
+  });
+});
+
+describe('excludeDirectAttempts', () => {
+  function makeMockQb() {
+    const mockAndWhere = jest.fn();
+    const qb = { andWhere: mockAndWhere.mockImplementation(() => qb) };
+    return { qb: qb as unknown as SelectQueryBuilder<never>, mockAndWhere };
+  }
+
+  it('drops rows the caller pinned a model on', () => {
+    const { qb, mockAndWhere } = makeMockQb();
+    excludeDirectAttempts(qb);
+    expect(mockAndWhere).toHaveBeenCalledWith(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+  });
+
+  it('uses IS DISTINCT FROM so NULL-reason rows survive', () => {
+    // A pending/cancelled row is stamped before a route is chosen, so its
+    // routing_reason is NULL. Under `!= 'direct'` NULL compares to NULL and the
+    // row would silently vanish from the harness Overview.
+    expect(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE).toBe("at.routing_reason IS DISTINCT FROM 'direct'");
+  });
+
+  it('returns the query builder for chaining', () => {
+    const { qb } = makeMockQb();
+    expect(excludeDirectAttempts(qb)).toBe(qb);
+  });
+});
+
+describe('sqlExcludeDirectRequests', () => {
+  it('tests the parent request through its attempts, where routing_reason lives', () => {
+    // `requests` carries no routing_reason column, so a request-level aggregate
+    // has to reach into agent_messages by request_id.
+    const sql = sqlExcludeDirectRequests('r');
+    expect(sql).toContain('NOT EXISTS');
+    expect(sql).toContain('FROM agent_messages direct_attempt');
+    expect(sql).toContain('direct_attempt.request_id = r.id');
+    expect(sql).toContain("direct_attempt.routing_reason = 'direct'");
+  });
+
+  it('honours the caller alias', () => {
+    expect(sqlExcludeDirectRequests('req')).toContain('direct_attempt.request_id = req.id');
+  });
+
+  it('keeps a request that has no attempts at all', () => {
+    // NOT EXISTS over an empty attempt set is true: a request recorded before any
+    // provider was contacted has nothing claiming `direct`, so it survives —
+    // matching how the attempt-level predicate keeps NULL routing_reason rows.
+    expect(sqlExcludeDirectRequests('r').startsWith('NOT EXISTS')).toBe(true);
   });
 });
 

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -215,6 +215,43 @@ export function excludePlaygroundAgents<T extends ObjectLiteral>(
 }
 
 /**
+ * Exclude `direct` traffic — the requests where the caller pinned an explicit
+ * model in the request body, so the agent's configured routing never chose
+ * anything (the proxy stamps `routing_tier`/`routing_reason` = `direct` on the
+ * attempt, see `buildBaseMeta` in `proxy.service.ts`).
+ *
+ * A harness's own Overview answers "what did MY routing do", and a client-pinned
+ * model is not that harness's routing — it bypassed it. The global Overview and
+ * the Messages log stay complete, so those requests are still visible and total
+ * spend still reconciles there; these predicates are only for agent-scoped
+ * Overview widgets.
+ *
+ * `routing_reason` lives on the ATTEMPT (`agent_messages`), never on the parent
+ * request, so there are two predicates:
+ *
+ *  - `EXCLUDE_DIRECT_ATTEMPTS_PREDICATE` filters an attempt-level aggregate
+ *    directly. `IS DISTINCT FROM` rather than `!=` because an attempt recorded
+ *    before a route was chosen (pending/cancelled) carries a NULL
+ *    `routing_reason`, which `!=` would drop (NULL comparison yields NULL).
+ *  - `sqlExcludeDirectRequests(alias)` filters a request-level aggregate via
+ *    `NOT EXISTS` on its attempts — mirroring how `getRequests` applies every
+ *    other attempt-level facet. A request with no attempts at all (recorded
+ *    before any provider was contacted) has nothing claiming `direct`, so it
+ *    correctly survives.
+ */
+export const EXCLUDE_DIRECT_ATTEMPTS_PREDICATE = "at.routing_reason IS DISTINCT FROM 'direct'";
+
+export function excludeDirectAttempts<T extends ObjectLiteral>(
+  qb: SelectQueryBuilder<T>,
+): SelectQueryBuilder<T> {
+  return qb.andWhere(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+}
+
+export function sqlExcludeDirectRequests(alias: string): string {
+  return `NOT EXISTS (SELECT 1 FROM agent_messages direct_attempt WHERE direct_attempt.request_id = ${alias}.id AND direct_attempt.routing_reason = 'direct')`;
+}
+
+/**
  * Match a connection's key label case-insensitively, treating a legacy NULL
  * `provider_key_label` as the canonical `'Default'`. A connection is identified
  * by (tenant, provider, auth_type, label); without the label filter two keys

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -6,6 +6,7 @@ import { Agent } from '../../entities/agent.entity';
 import {
   MESSAGE_ROW_SELECT_ALIASES,
   EXCLUDE_PLAYGROUND_AGENTS_PREDICATE,
+  EXCLUDE_DIRECT_ATTEMPTS_PREDICATE,
   CUSTOM_PROVIDER_JOIN_CONDITION,
   PROVIDER_SERIES_KEY_EXPR,
 } from './query-helpers';
@@ -338,6 +339,87 @@ describe('TimeseriesQueriesService', () => {
       await service.getRecentActivity('24h', 'tenant-1', 5);
       const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0] as string);
       expect(clauses).not.toContain(EXCLUDE_PLAYGROUND_AGENTS_PREDICATE);
+    });
+
+    it('excludes client-pinned (direct) requests when excludeDirect=true', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getRecentActivity('24h', 'tenant-1', 5, 'bot-1', true, true);
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0] as string);
+      expect(clauses).toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+    });
+
+    it('keeps direct requests by default', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getRecentActivity('24h', 'tenant-1', 5, 'bot-1', true);
+      const clauses = mockTurnQb.andWhere.mock.calls.map((c) => c[0] as string);
+      expect(clauses).not.toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+    });
+  });
+
+  describe('direct-request exclusion', () => {
+    const clauses = () => mockTurnQb.andWhere.mock.calls.map((c) => c[0] as string);
+
+    it.each([
+      [
+        'getTimeseries',
+        () =>
+          service.getTimeseries(
+            '24h',
+            't1',
+            true,
+            'bot-1',
+            undefined,
+            undefined,
+            true,
+            undefined,
+            undefined,
+            true,
+          ),
+      ],
+      ['getActiveSkills', () => service.getActiveSkills('24h', 't1', 'bot-1', true, true)],
+      ['getCostByModel', () => service.getCostByModel('24h', 't1', 'bot-1', true, true)],
+    ])('%s applies the predicate when excludeDirect=true', async (_name, call) => {
+      await call();
+      expect(clauses()).toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+    });
+
+    it.each([
+      [
+        'getTimeseries',
+        () => service.getTimeseries('24h', 't1', true, 'bot-1', undefined, undefined, true),
+      ],
+      ['getActiveSkills', () => service.getActiveSkills('24h', 't1', 'bot-1', true)],
+      ['getCostByModel', () => service.getCostByModel('24h', 't1', 'bot-1', true)],
+    ])('%s keeps direct requests by default', async (_name, call) => {
+      await call();
+      expect(clauses()).not.toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+    });
+
+    // The per-provider charts render on the SAME harness Overview page as the
+    // KPI cards (they feed the card sparklines), so they follow the page's rule
+    // implicitly: agent-scoped => this harness's routing only. Their only caller
+    // is OverviewController, which passes agentName exactly when the request is
+    // for one harness.
+    it.each([
+      [
+        'getPerProviderTimeseries',
+        (agent?: string) => service.getPerProviderTimeseries('24h', 't1', true, agent),
+      ],
+      [
+        'getPerProviderMessageTimeseries',
+        (agent?: string) => service.getPerProviderMessageTimeseries('24h', 't1', true, agent),
+      ],
+      [
+        'getPerProviderCostTimeseries',
+        (agent?: string) => service.getPerProviderCostTimeseries('24h', 't1', true, agent),
+      ],
+    ])('%s excludes direct when agent-scoped and keeps it globally', async (_name, call) => {
+      await call('bot-1');
+      expect(clauses()).toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
+
+      mockTurnQb.andWhere.mockClear();
+      await call(undefined);
+      expect(clauses()).not.toContain(EXCLUDE_DIRECT_ATTEMPTS_PREDICATE);
     });
   });
 

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -9,6 +9,7 @@ import {
   addTenantFilter,
   selectMessageRowColumns,
   excludePlaygroundAgents,
+  excludeDirectAttempts,
   scopeToConnection,
   sqlCountMessages,
   CUSTOM_PROVIDER_JOIN_CONDITION,
@@ -73,6 +74,7 @@ export class TimeseriesQueriesService {
     excludePlayground = false,
     label?: string,
     tenantProviderId?: string,
+    excludeDirect = false,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -91,6 +93,7 @@ export class TimeseriesQueriesService {
     if (authType) qb.andWhere('at.auth_type = :authType', { authType });
     if (provider) qb.andWhere('at.provider = :provider', { provider });
     if (excludePlayground) excludePlaygroundAgents(qb);
+    if (excludeDirect) excludeDirectAttempts(qb);
     // Scope to this connection: pin to the tenant_providers id when present,
     // else the provider+auth_type+label tuple (see scopeToConnection).
     scopeToConnection(qb, tenantProviderId, label);
@@ -187,6 +190,7 @@ export class TimeseriesQueriesService {
     tenantId: string | null,
     agentName?: string,
     excludePlayground = false,
+    excludeDirect = false,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -201,6 +205,7 @@ export class TimeseriesQueriesService {
       .andWhere('at.skill_name IS NOT NULL');
     addTenantFilter(qb, tenantId, agentName);
     if (excludePlayground) excludePlaygroundAgents(qb);
+    if (excludeDirect) excludeDirectAttempts(qb);
     const rows = await qb.groupBy('at.skill_name').orderBy('run_count', 'DESC').getRawMany();
     return rows.map((r: Record<string, unknown>) => ({
       name: String(r['name']),
@@ -217,6 +222,7 @@ export class TimeseriesQueriesService {
     limit = 5,
     agentName?: string,
     excludePlayground = false,
+    excludeDirect = false,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -229,6 +235,7 @@ export class TimeseriesQueriesService {
     );
     addTenantFilter(qb, tenantId, agentName);
     if (excludePlayground) excludePlaygroundAgents(qb);
+    if (excludeDirect) excludeDirectAttempts(qb);
     return qb.orderBy('at.timestamp', 'DESC').limit(limit).getRawMany();
   }
 
@@ -237,6 +244,7 @@ export class TimeseriesQueriesService {
     tenantId: string | null,
     agentName?: string,
     excludePlayground = false,
+    excludeDirect = false,
   ) {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
@@ -256,6 +264,7 @@ export class TimeseriesQueriesService {
       .andWhere("at.model != ''");
     addTenantFilter(qb, tenantId, agentName);
     if (excludePlayground) excludePlaygroundAgents(qb);
+    if (excludeDirect) excludeDirectAttempts(qb);
     const rows = await qb
       .groupBy('at.model')
       .addGroupBy('at.auth_type')
@@ -693,6 +702,12 @@ export class TimeseriesQueriesService {
     // addTenantFilter also scopes to the LIVE agent owning the slug (id-based),
     // so a soft-deleted agent sharing the name doesn't leak its old rows.
     addTenantFilter(qb, tenantId, agentName);
+    // Scoped to one harness => that harness's routing only; a client-pinned
+    // model bypassed it (see excludeDirectAttempts). These per-provider series
+    // feed the KPI card sparklines on the harness Overview, so they must drop
+    // exactly what the /overview widgets drop or a card and its sparkline
+    // disagree. Unscoped (global Overview) keeps everything.
+    if (agentName) excludeDirectAttempts(qb);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -727,6 +742,8 @@ export class TimeseriesQueriesService {
     // addTenantFilter also scopes to the LIVE agent owning the slug (id-based),
     // so a soft-deleted agent sharing the name doesn't leak its old rows.
     addTenantFilter(qb, tenantId, agentName);
+    // Agent-scoped => this harness's routing only (see getPerProviderTimeseries).
+    if (agentName) excludeDirectAttempts(qb);
 
     const rows = await qb
       .groupBy(bucketAlias)
@@ -828,6 +845,8 @@ export class TimeseriesQueriesService {
     // addTenantFilter also scopes to the LIVE agent owning the slug (id-based),
     // so a soft-deleted agent sharing the name doesn't leak its old rows.
     addTenantFilter(qb, tenantId, agentName);
+    // Agent-scoped => this harness's routing only (see getPerProviderTimeseries).
+    if (agentName) excludeDirectAttempts(qb);
     const rows = await qb
       .groupBy(bucketAlias)
       .addGroupBy(PROVIDER_SERIES_KEY_EXPR)

--- a/packages/backend/test/overview.e2e-spec.ts
+++ b/packages/backend/test/overview.e2e-spec.ts
@@ -6,6 +6,11 @@ import { createTestApp, TEST_API_KEY, TEST_TENANT_ID, TEST_AGENT_ID } from './he
 
 let app: INestApplication;
 
+/** Only ever used by the unlinked `direct` attempt — an unambiguous signal. */
+const DIRECT_ONLY_MODEL = 'client-pinned-only-model';
+/** Only ever used by the `direct` attempt hanging off a real `requests` row. */
+const LINKED_DIRECT_MODEL = 'client-pinned-linked-model';
+
 beforeAll(async () => {
   app = await createTestApp();
 
@@ -16,13 +21,102 @@ beforeAll(async () => {
   await ds.query(
     `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
-    [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, 'ok', 'claude-opus-4-6', 2000, 1000, 0, 0, 'User query processed', 'agent', 'test-agent', 'test-user-001'],
+    [
+      uuid(),
+      TEST_TENANT_ID,
+      TEST_AGENT_ID,
+      now,
+      'ok',
+      'claude-opus-4-6',
+      2000,
+      1000,
+      0,
+      0,
+      'User query processed',
+      'agent',
+      'test-agent',
+      'test-user-001',
+    ],
   );
 
   await ds.query(
     `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
-    [uuid(), TEST_TENANT_ID, TEST_AGENT_ID, now, 'ok', 'gpt-4o', 500, 300, 0, 0, 'Browser task completed', 'browser', 'test-agent', 'test-user-001'],
+    [
+      uuid(),
+      TEST_TENANT_ID,
+      TEST_AGENT_ID,
+      now,
+      'ok',
+      'gpt-4o',
+      500,
+      300,
+      0,
+      0,
+      'Browser task completed',
+      'browser',
+      'test-agent',
+      'test-user-001',
+    ],
+  );
+
+  // A request whose model the CALLER pinned in the request body: Manifest's
+  // routing never chose it (routing_reason='direct'). It must stay visible on
+  // the cross-harness overview but disappear from the harness's own.
+  await ds.query(
+    `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id, routing_tier, routing_reason)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+    [
+      uuid(),
+      TEST_TENANT_ID,
+      TEST_AGENT_ID,
+      now,
+      'ok',
+      DIRECT_ONLY_MODEL,
+      7777,
+      0,
+      0,
+      0,
+      'Client-pinned model',
+      'agent',
+      'test-agent',
+      'test-user-001',
+      'direct',
+      'direct',
+    ],
+  );
+
+  // The same thing in the request-first shape: a parent `requests` row with a
+  // linked attempt. `routing_reason` lives only on the attempt, so this is the
+  // row that exercises the NOT EXISTS path rather than the legacy unlinked one.
+  const linkedRequestId = uuid();
+  await ds.query(
+    `INSERT INTO requests (id, tenant_id, agent_id, agent_name, user_id, timestamp, status)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [linkedRequestId, TEST_TENANT_ID, TEST_AGENT_ID, 'test-agent', 'test-user-001', now, 'success'],
+  );
+  await ds.query(
+    `INSERT INTO agent_messages (id, tenant_id, agent_id, request_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, description, service_type, agent_name, user_id, routing_tier, routing_reason)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+    [
+      uuid(),
+      TEST_TENANT_ID,
+      TEST_AGENT_ID,
+      linkedRequestId,
+      now,
+      'success',
+      LINKED_DIRECT_MODEL,
+      1234,
+      0,
+      0,
+      0,
+      'Client-pinned model on a linked request',
+      'agent',
+      'test-agent',
+      'test-user-001',
+      'direct',
+      'direct',
+    ],
   );
 });
 
@@ -91,8 +185,53 @@ describe('GET /api/v1/overview', () => {
   });
 
   it('rejects request without API key with 401', async () => {
-    await request(app.getHttpServer())
-      .get('/api/v1/overview?range=24h')
-      .expect(401);
+    await request(app.getHttpServer()).get('/api/v1/overview?range=24h').expect(401);
+  });
+});
+
+describe('GET /api/v1/overview — client-pinned (direct) requests', () => {
+  const get = (qs: string) =>
+    request(app.getHttpServer())
+      .get(`/api/v1/overview?range=24h${qs}`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+  const models = (body: { cost_by_model?: { model: string }[] }) =>
+    (body.cost_by_model ?? []).map((r) => r.model);
+  const activityModels = (body: { recent_activity?: { model: string }[] }) =>
+    (body.recent_activity ?? []).map((r) => r.model);
+
+  it('hides them from the harness overview — rows, breakdown and totals alike', async () => {
+    const { body } = await get('&agent_name=test-agent');
+
+    // The harness overview answers "what did MY routing do", so a model the
+    // caller pinned (routing never chose it) is not this harness's traffic.
+    // Both shapes must go: the unlinked attempt and the linked request whose
+    // `direct` marker only exists on its child attempt.
+    expect(activityModels(body)).not.toContain(DIRECT_ONLY_MODEL);
+    expect(activityModels(body)).not.toContain(LINKED_DIRECT_MODEL);
+    expect(models(body)).not.toContain(DIRECT_ONLY_MODEL);
+    expect(models(body)).not.toContain(LINKED_DIRECT_MODEL);
+    // ...and the cards must agree with the rows, or the page contradicts itself:
+    // neither direct row's tokens may reach the summary.
+    expect(body.summary.tokens_today.value).toBe(3800); // 2000+1000 + 500+300
+  });
+
+  it('keeps them on the cross-harness overview, where spend reconciles', async () => {
+    const { body } = await get('');
+
+    expect(activityModels(body)).toEqual(
+      expect.arrayContaining([DIRECT_ONLY_MODEL, LINKED_DIRECT_MODEL]),
+    );
+    expect(models(body)).toEqual(expect.arrayContaining([DIRECT_ONLY_MODEL, LINKED_DIRECT_MODEL]));
+    expect(body.summary.tokens_today.value).toBe(12811); // 3800 + 7777 + 1234
+  });
+
+  it('keeps rows recorded before a route was chosen (NULL routing_reason)', async () => {
+    // Pending/cancelled rows carry no routing_reason. A naive `!= 'direct'`
+    // would drop them (NULL comparison yields NULL); the predicate uses
+    // IS DISTINCT FROM so they survive on the harness overview.
+    const { body } = await get('&agent_name=test-agent');
+    expect(activityModels(body)).toEqual(expect.arrayContaining(['claude-opus-4-6', 'gpt-4o']));
   });
 });


### PR DESCRIPTION
A harness's Overview was listing requests whose model the **caller pinned in the request body** (`routing_reason='direct'`), which bypass the agent's configured routing entirely — so a harness configured for `kimi-k3` appeared to be routing to models its config never mentions. This drops that traffic from every widget on the per-harness Overview when `agent_name` is passed (the request log behind Recent Messages, request reliability, the token/cost timeseries, cost-by-model, active skills, `has_data`, and the three per-provider series feeding the KPI sparklines) — they all have to drop it or a card ends up disagreeing with the rows beside it. The global Overview and the Requests log are deliberately untouched: direct traffic stays fully visible there and total spend still reconciles, and routing behavior itself is unchanged.

`routing_reason` lives on the attempt and never on the parent request, so there are two predicates: attempt-level aggregates use `IS DISTINCT FROM 'direct'` rather than `!=` so an attempt recorded before a route was chosen (NULL `routing_reason`) isn't silently dropped (verified against production — 4 such rows survive, 0 under `!=`), while request-level aggregates use `NOT EXISTS` over the request's attempts, mirroring how `getRequests` applies every other attempt-level facet. `getMessages` gains `exclude_direct` as an **opt-in**, since that same method also backs the Requests page.

Covered by unit tests on both predicates and each call site, plus e2e tests over both row shapes — an unlinked legacy attempt and a linked `requests` row whose `direct` marker exists only on its child attempt — asserting each is absent from the harness Overview but present on the global one. Both e2e assertions were confirmed to fail with their respective exclusion disabled.