### PR TITLE
fix: raise provider connection limit

### DIFF
--- a/.changeset/fifty-provider-connections.md
+++ b/.changeset/fifty-provider-connections.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Raise the per-provider credential safety ceiling from 5 to 50 connections.

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -1,4 +1,4 @@
-import type { ModelRoute } from 'manifest-shared';
+import { MAX_KEYS_PER_PROVIDER, type ModelRoute } from 'manifest-shared';
 import { ProviderService } from '../provider.service';
 import { TenantProvider } from '../../../entities/tenant-provider.entity';
 import { TierAssignment } from '../../../entities/tier-assignment.entity';
@@ -1635,6 +1635,34 @@ describe('ProviderService — symmetric provider↔agent auto-connect', () => {
         { agent: 'agent-1', provider: provider.id },
         { agent: 'agent-2', provider: provider.id },
       ]);
+    });
+
+    it('rejects a new credential only at the 50-key safety ceiling', async () => {
+      const enabled: Array<{ agent: string; provider: string }> = [];
+      const { svc, providerRepo } = build(['agent-1'], enabled);
+      providerRepo.find.mockResolvedValue(
+        Array.from({ length: MAX_KEYS_PER_PROVIDER }, (_, index) => ({
+          id: `provider-${index}`,
+          provider: 'openai',
+          auth_type: 'api_key',
+          label: `Key ${index + 1}`,
+          priority: index,
+          is_active: true,
+        })) as TenantProvider[],
+      );
+
+      await expect(
+        svc.upsertProvider(
+          'agent-1',
+          'tenant-1',
+          'openai',
+          'sk-overflow',
+          'api_key',
+          undefined,
+          'Overflow',
+        ),
+      ).rejects.toThrow(`at most ${MAX_KEYS_PER_PROVIDER}`);
+      expect(providerRepo.insert).not.toHaveBeenCalled();
     });
 
     it('enables a brand-new tokenless subscription provider for every owned agent', async () => {

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -22,7 +22,7 @@ import {
   isManifestUsableProvider,
   isSupportedSubscriptionProvider,
 } from '../../common/utils/subscription-support';
-import type { AuthType, ModelRoute } from 'manifest-shared';
+import { MAX_KEYS_PER_PROVIDER, type AuthType, type ModelRoute } from 'manifest-shared';
 import {
   QWEN_REGION_VALIDATION_MESSAGE,
   detectQwenRegion,
@@ -42,7 +42,6 @@ import {
 } from '../subscription-region';
 import { filterProvidersForDeployment } from '../../common/utils/provider-availability';
 
-const MAX_KEYS_PER_PROVIDER = 5;
 const MAX_LABEL_LENGTH = 50;
 const DEFAULT_LABEL = 'Default';
 // Bounds for withSubscriptionCredentialLock's critical section (the provider

--- a/packages/backend/test/multi-key-providers.e2e-spec.ts
+++ b/packages/backend/test/multi-key-providers.e2e-spec.ts
@@ -1,7 +1,7 @@
 /**
  * Verifies the multi-key-per-provider HTTP surface end to end:
  *
- *  - POST /providers with `label` adds an extra key (cap = 5)
+ *  - POST /providers with `label` adds extra keys
  *  - PATCH /providers/:provider/keys/:label renames a key
  *  - PUT /providers/:provider/keys/order rewrites priorities by index
  *  - DELETE /providers/:provider?label=… removes one key from the chain
@@ -79,21 +79,23 @@ describe('Multi-key per provider — HTTP', () => {
     expect(rows[1].priority).toBeGreaterThan(rows[0].priority);
   });
 
-  it('rejects connecting a 6th key for the same (provider, auth_type)', async () => {
-    for (let i = 1; i <= 5; i++) {
+  it('accepts more than 5 keys for the same (provider, auth_type)', async () => {
+    for (let i = 1; i <= 6; i++) {
       await auth(api().post('/api/v1/routing/test-agent/providers'))
         .send({ provider: 'openai', apiKey: `sk-${i}`, label: `Key ${i}` })
         .expect(201);
     }
-    const res = await auth(api().post('/api/v1/routing/test-agent/providers'))
-      .send({ provider: 'openai', apiKey: 'sk-6', label: 'Key 6' });
-    expect(res.status).toBe(400);
-    expect(res.body.message).toMatch(/at most 5/i);
+
+    expect(await listActiveOpenAi()).toHaveLength(6);
   });
 
   it('accepts custom labels for subscription auth_type', async () => {
-    const res = await auth(api().post('/api/v1/routing/test-agent/providers'))
-      .send({ provider: 'anthropic', apiKey: 'sub-token', authType: 'subscription', label: 'Pro' });
+    const res = await auth(api().post('/api/v1/routing/test-agent/providers')).send({
+      provider: 'anthropic',
+      apiKey: 'sub-token',
+      authType: 'subscription',
+      label: 'Pro',
+    });
     // Multi-key chains apply to subscription too — multiple Anthropic Pro
     // tokens, multiple ChatGPT Plus accounts, etc.
     expect(res.status).toBe(201);
@@ -109,9 +111,7 @@ describe('Multi-key per provider — HTTP', () => {
       .send({ provider: 'openai', apiKey: 'sk-work', label: 'Work' })
       .expect(201);
 
-    const res = await auth(
-      api().patch('/api/v1/routing/test-agent/providers/openai/keys/Work'),
-    )
+    const res = await auth(api().patch('/api/v1/routing/test-agent/providers/openai/keys/Work'))
       .send({ newLabel: 'Office' })
       .expect(200);
     expect(res.body.label).toBe('Office');
@@ -151,8 +151,9 @@ describe('Multi-key per provider — HTTP', () => {
       .send({ provider: 'openai', apiKey: 'sk-del-work', label: 'Work' })
       .expect(201);
 
-    await auth(api().delete('/api/v1/routing/test-agent/providers/openai?label=Default'))
-      .expect(200);
+    await auth(api().delete('/api/v1/routing/test-agent/providers/openai?label=Default')).expect(
+      200,
+    );
 
     const rows = await listActiveOpenAi();
     expect(rows).toHaveLength(1);

--- a/packages/frontend/src/components/CopilotDeviceLogin.tsx
+++ b/packages/frontend/src/components/CopilotDeviceLogin.tsx
@@ -1,4 +1,5 @@
 import { createSignal, For, onCleanup, Show, type Component } from 'solid-js';
+import { MAX_KEYS_PER_PROVIDER } from 'manifest-shared';
 import { providerIcon } from './ProviderIcon.js';
 import {
   copilotDeviceCode,
@@ -35,7 +36,6 @@ interface Props {
 
 const SLOW_DOWN_INCREASE = 5;
 const MAX_POLL_ERRORS = 5;
-const MAX_KEYS_PER_PROVIDER = 5;
 
 const CopilotDeviceLogin: Component<Props> = (props) => {
   const [phase, setPhase] = createSignal<Phase>('idle');

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -10,6 +10,7 @@ import {
   type Accessor,
   type Setter,
 } from 'solid-js';
+import { MAX_KEYS_PER_PROVIDER as SHARED_MAX_KEYS_PER_PROVIDER } from 'manifest-shared';
 import type { ProviderDef, SubscriptionEndpointRegion } from '../services/providers.js';
 import { validateApiKey, validateSubscriptionKey } from '../services/provider-utils.js';
 import {
@@ -27,7 +28,7 @@ import {
 import { suggestNextProviderKeyLabel } from '../services/provider-key-labels.js';
 import { toast } from '../services/toast-store.js';
 
-export const MAX_KEYS_PER_PROVIDER = 5;
+export const MAX_KEYS_PER_PROVIDER = SHARED_MAX_KEYS_PER_PROVIDER;
 const MAX_LABEL_LENGTH = 50;
 const WORKSPACE_ID_PLACEHOLDER = '<workspace-id>';
 

--- a/packages/frontend/tests/components/ProviderDetailView.test.tsx
+++ b/packages/frontend/tests/components/ProviderDetailView.test.tsx
@@ -60,7 +60,7 @@ vi.mock('../../src/components/ProviderKeyForm.js', () => ({
       data-validation-error={props.validationError() ?? ''}
     />
   ),
-  MAX_KEYS_PER_PROVIDER: 5,
+  MAX_KEYS_PER_PROVIDER: 50,
 }));
 
 vi.mock('../../src/components/OAuthDetailView.js', () => ({
@@ -396,6 +396,24 @@ describe('ProviderDetailView', () => {
     const props = createTestProps({ provId: 'anthropic' });
     render(() => <ProviderDetailView {...props} />);
     expect(screen.getByTestId('provider-key-form')).toBeDefined();
+  });
+
+  it('keeps the add-key action available after 5 active keys', () => {
+    const providers: RoutingProvider[] = Array.from({ length: 6 }, (_, index) => ({
+      id: `p${index + 1}`,
+      provider: 'openai',
+      auth_type: 'api_key',
+      is_active: true,
+      has_api_key: true,
+      label: `Key ${index + 1}`,
+      priority: index,
+      connected_at: '2026-01-01',
+    }));
+    const props = createTestProps({ provId: 'openai', providers });
+
+    render(() => <ProviderDetailView {...props} />);
+
+    expect(screen.getByText('Add another key')).toBeDefined();
   });
 
   describe('per-provider refresh button', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -113,6 +113,7 @@ export {
 } from './model-params-scope';
 export type { ModelParamsRoutingScopeInput } from './model-params-scope';
 export { API_KEY_PREFIX } from './api-key';
+export { MAX_KEYS_PER_PROVIDER } from './provider-limits';
 export {
   FALLBACK_KEY_DELIMITER,
   parseFallbackEntry,

--- a/packages/shared/src/provider-limits.ts
+++ b/packages/shared/src/provider-limits.ts
@@ -1,0 +1,7 @@
+/**
+ * Safety ceiling for active credentials on one provider/authentication type.
+ *
+ * This is intentionally high enough not to constrain legitimate multi-account
+ * setups while still guarding against accidental bulk credential creation.
+ */
+export const MAX_KEYS_PER_PROVIDER = 50;


### PR DESCRIPTION
### ✨ What changed
- Raise the per-provider credential safety ceiling from 5 to 50.
- Share one limit across backend, provider forms, and Copilot login.

### 💭 Why
Five connections blocked valid multi-account setups.

### 👤 For users
Users can add up to 50 credentials for each provider and authentication type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the per-provider credential limit from 5 to 50 and centralize the cap in `manifest-shared` so backend and UI use one rule. This enables legitimate multi-account setups while keeping a safety ceiling.

- **New Features**
  - Defined `MAX_KEYS_PER_PROVIDER = 50` in `manifest-shared` (`provider-limits`) and exported via `shared/index`.
  - Backend now imports the shared limit; adds a unit test that rejects the 51st key and updates e2e to accept >5 keys.
  - Frontend (`ProviderKeyForm`, `CopilotDeviceLogin`) uses the shared limit; UI test keeps “Add another key” available after 5 active keys.

<sup>Written for commit c5ef674c7ef5e7c707ebbe2fd5456a71fcd7b618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

