### PR TITLE
docs: stop labeling Manifest as beta in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ AI Agents that don't break
 </p>
 
 <p align="center">
-  <span><img src="https://img.shields.io/badge/status-beta-yellow" alt="beta" /></span>
-  &nbsp;
   <a href="https://github.com/mnfst/manifest/stargazers"><img src="https://img.shields.io/github/stars/mnfst/manifest?style=flat" alt="GitHub stars" /></a>
   &nbsp;
   <a href="https://hub.docker.com/r/manifestdotbuild/manifest"><img src="https://img.shields.io/docker/pulls/manifestdotbuild/manifest?color=2496ED&label=docker%20pulls" alt="Docker pulls" /></a>


### PR DESCRIPTION
### 💭 Why
Manifest is well past beta. The badge sat at the top of the README and undersold the project to anyone landing on the repo.

### ✨ What changed
- Removed the `status-beta` shield from the README badge row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the beta badge from the README to reflect Manifest’s current status and avoid underselling the project.

<sup>Written for commit e415db8eefd4ebbe68b88bf76d82b90447d955c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

