### PR TITLE
perf: avoid redundant protocol conversions

### DIFF
--- a/.changeset/lazy-native-protocol-conversion.md
+++ b/.changeset/lazy-native-protocol-conversion.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Preserve native Responses and Anthropic Messages requests until cross-protocol conversion is required.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -498,7 +498,10 @@ describe('ProviderClient', () => {
           reasoning: { effort: 'low' },
           stream: false,
         },
-        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        resolveChatBody: async () => ({
+          messages: [{ role: 'user', content: 'Hello' }],
+          stream: false,
+        }),
         stream: false,
         apiMode: 'responses',
       });
@@ -599,13 +602,16 @@ describe('ProviderClient', () => {
 
     it('routes public Responses API requests for OpenAI to /v1/responses', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const resolveChatBody = jest
+        .fn()
+        .mockResolvedValue({ messages: [{ role: 'user', content: 'Hello' }], stream: false });
 
       const result = await client.forward({
         provider: 'openai',
         apiKey: 'sk-test',
         model: 'gpt-4o',
         body: { input: 'Hello', stream: false },
-        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        resolveChatBody,
         stream: false,
         apiMode: 'responses',
       });
@@ -625,6 +631,28 @@ describe('ProviderClient', () => {
       expect(sentBody.instructions).toBeUndefined();
       expect(result.isResponses).toBe(true);
       expect(result.isChatGpt).toBe(false);
+      expect(resolveChatBody).not.toHaveBeenCalled();
+    });
+
+    it('resolves a Responses conversion once for a Chat Completions endpoint', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const resolveChatBody = jest
+        .fn()
+        .mockResolvedValue({ messages: [{ role: 'user', content: 'Hello' }], stream: false });
+
+      await client.forward({
+        provider: 'openrouter',
+        apiKey: 'sk-or-test',
+        model: 'openai/gpt-4o',
+        body: { input: 'Hello', stream: false },
+        resolveChatBody,
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+      expect(resolveChatBody).toHaveBeenCalledTimes(1);
     });
 
     it('adds default instructions for subscription Responses requests', async () => {
@@ -635,7 +663,10 @@ describe('ProviderClient', () => {
         apiKey: 'oauth-token',
         model: 'gpt-5.4',
         body: { input: 'Hello', stream: false },
-        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        resolveChatBody: async () => ({
+          messages: [{ role: 'user', content: 'Hello' }],
+          stream: false,
+        }),
         stream: false,
         authType: 'subscription',
         apiMode: 'responses',
@@ -651,12 +682,19 @@ describe('ProviderClient', () => {
       expect(sentBody.stream).toBe(true);
     });
 
-    it('uses translated chatBody, not the raw Anthropic Messages body, when forwarding /v1/messages to a chatgpt-format endpoint', async () => {
+    it('resolves Anthropic Messages conversion for a Responses endpoint', async () => {
       // Regression: previously the chatgpt branch passed `body` directly into
       // toResponsesRequest, so a /v1/messages request hitting an
       // openai-responses endpoint would forward Anthropic-shaped tools and
       // drop the top-level system prompt.
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const resolveChatBody = jest.fn().mockResolvedValue({
+        messages: [
+          { role: 'system', content: 'be brief' },
+          { role: 'user', content: 'hi' },
+        ],
+        model: 'o1-pro',
+      });
 
       await client.forward({
         provider: 'openai',
@@ -669,22 +707,17 @@ describe('ProviderClient', () => {
           system: 'be brief',
           messages: [{ role: 'user', content: 'hi' }],
         },
-        chatBody: {
-          messages: [
-            { role: 'system', content: 'be brief' },
-            { role: 'user', content: 'hi' },
-          ],
-          model: 'o1-pro',
-        },
+        resolveChatBody,
         stream: false,
         apiMode: 'messages',
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       // toResponsesRequest pulls instructions out of chat-completions system
-      // messages — proves we forwarded chatBody, not the raw Anthropic body.
+      // messages, proving the lazy conversion, not the raw Anthropic body, was forwarded.
       expect(sentBody.instructions).toBe('be brief');
       expect(sentBody.system).toBeUndefined();
+      expect(resolveChatBody).toHaveBeenCalledTimes(1);
     });
 
     it('forwards Anthropic-Messages inbound to an Anthropic upstream without OpenAI translation (issue #1886)', async () => {
@@ -701,8 +734,8 @@ describe('ProviderClient', () => {
         ],
         top_k: 40,
       };
-      // chatBody is what the routing layer would have produced — we pass it
-      // in to prove the wire path ignores it and reads the raw body instead.
+      // This is what the routing layer would derive. Pass it as a resolver to
+      // prove the native wire path never asks for it.
       const lossyChatBody = {
         messages: [
           { role: 'system', content: 'Be concise.' },
@@ -714,13 +747,14 @@ describe('ProviderClient', () => {
         ],
         max_tokens: 1024,
       };
+      const resolveChatBody = jest.fn().mockResolvedValue(lossyChatBody);
 
       const result = await client.forward({
         provider: 'anthropic',
         apiKey: 'sk-ant-test',
         model: 'claude-sonnet-4-5-20250929',
         body: anthropicBody,
-        chatBody: lossyChatBody,
+        resolveChatBody,
         stream: false,
         apiMode: 'messages',
       });
@@ -746,6 +780,7 @@ describe('ProviderClient', () => {
       expect((anthropicBody.tools[1] as Record<string, unknown>).cache_control).toBeUndefined();
       expect(result.wireApiMode).toBe('messages');
       expect(result.wireRequestBody).toEqual(sent);
+      expect(resolveChatBody).not.toHaveBeenCalled();
     });
 
     it('still uses toAnthropicRequest for chat_completions inbound forwarded to an Anthropic upstream', async () => {
@@ -800,7 +835,7 @@ describe('ProviderClient', () => {
             },
           },
         },
-        chatBody: {
+        resolveChatBody: async () => ({
           messages: [{ role: 'user', content: 'Return JSON.' }],
           response_format: {
             type: 'json_schema',
@@ -811,7 +846,7 @@ describe('ProviderClient', () => {
               strict: true,
             },
           },
-        },
+        }),
         stream: false,
         apiMode: 'responses',
       });
@@ -842,10 +877,10 @@ describe('ProviderClient', () => {
           input: 'Return JSON.',
           text: { format: { type: 'json_object' } },
         },
-        chatBody: {
+        resolveChatBody: async () => ({
           messages: [{ role: 'user', content: 'Return JSON.' }],
           response_format: { type: 'json_object' },
-        },
+        }),
         stream: false,
         apiMode: 'responses',
       });
@@ -873,10 +908,10 @@ describe('ProviderClient', () => {
           input: 'Return text.',
           text: { format: { type: 'text' } },
         },
-        chatBody: {
+        resolveChatBody: async () => ({
           messages: [{ role: 'user', content: 'Return text.' }],
           response_format: { type: 'text' },
-        },
+        }),
         stream: false,
         apiMode: 'responses',
       });
@@ -906,7 +941,7 @@ describe('ProviderClient', () => {
           ],
           stream: false,
         },
-        chatBody: {
+        resolveChatBody: async () => ({
           messages: [
             {
               role: 'user',
@@ -917,7 +952,7 @@ describe('ProviderClient', () => {
             },
           ],
           stream: false,
-        },
+        }),
         stream: false,
         apiMode: 'responses',
       });
@@ -993,7 +1028,10 @@ describe('ProviderClient', () => {
         apiKey: 'sk-test',
         model: 'deepseek-chat',
         body: { input: 'Hello', stream: false },
-        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        resolveChatBody: async () => ({
+          messages: [{ role: 'user', content: 'Hello' }],
+          stream: false,
+        }),
         stream: false,
         apiMode: 'responses',
       });
@@ -1812,7 +1850,10 @@ describe('ProviderClient', () => {
         apiKey: 'tid=abc',
         model: 'gpt-5.4',
         body: { input: 'Hello', stream: false },
-        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        resolveChatBody: async () => ({
+          messages: [{ role: 'user', content: 'Hello' }],
+          stream: false,
+        }),
         stream: false,
         apiMode: 'responses',
       });
@@ -1833,7 +1874,10 @@ describe('ProviderClient', () => {
         apiKey: 'tid=abc',
         model: 'claude-sonnet-4.6',
         body: { input: 'Hello', stream: false },
-        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        resolveChatBody: async () => ({
+          messages: [{ role: 'user', content: 'Hello' }],
+          stream: false,
+        }),
         stream: false,
         apiMode: 'responses',
       });
@@ -2116,7 +2160,10 @@ describe('ProviderClient', () => {
           input: [{ role: 'user', content: 'Hello' }],
           stream: false,
         },
-        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        resolveChatBody: async () => ({
+          messages: [{ role: 'user', content: 'Hello' }],
+          stream: false,
+        }),
         stream: false,
         authType: 'subscription',
         apiMode: 'responses',

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -2319,6 +2319,39 @@ describe('ProviderClient', () => {
       expect(result.isChatGpt).toBe(false);
       expect(result.response.headers.get('Content-Type')).toBe('text/event-stream');
     });
+
+    it('converts Responses input once before forwarding to Kiro', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+      const resolveChatBody = jest
+        .fn()
+        .mockResolvedValue({ messages: [{ role: 'user', content: 'Hello from Responses' }] });
+
+      await client.forward({
+        provider: 'kiro',
+        apiKey: 'ksk_test',
+        model: 'kiro/auto',
+        body: { input: 'Hello from Responses' },
+        resolveChatBody,
+        stream: true,
+        authType: 'subscription',
+        apiMode: 'responses',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.conversationState.currentMessage.userInputMessage.content).toBe(
+        'Hello from Responses',
+      );
+      expect(resolveChatBody).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('OpenCode Go provider', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1350,6 +1350,27 @@ describe('ProviderClient', () => {
       expect(sentBody.stream).toBeUndefined();
     });
 
+    it('resolves a Responses conversion once for a Gemini endpoint', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const resolveChatBody = jest
+        .fn()
+        .mockResolvedValue({ messages: [{ role: 'user', content: 'Hello' }] });
+
+      await client.forward({
+        provider: 'google',
+        apiKey: 'AIza-test',
+        model: 'gemini-2.0-flash',
+        body: { input: 'Hello' },
+        resolveChatBody,
+        apiMode: 'responses',
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.contents).toEqual([{ role: 'user', parts: [{ text: 'Hello' }] }]);
+      expect(resolveChatBody).toHaveBeenCalledTimes(1);
+    });
+
     it('maps image parts onto the Google request body', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -589,6 +589,42 @@ describe('ProxyFallbackService', () => {
       );
     });
 
+    it('merges params into a lazy cross-protocol body once per attempt', async () => {
+      const convertedBody = { messages: [{ role: 'user', content: 'hi' }] };
+      const resolveChatBody = jest.fn().mockResolvedValue(convertedBody);
+      modelParamsService.get.mockResolvedValue({ thinking: { type: 'disabled' } });
+      providerClient.forward.mockImplementation(async (options) => {
+        const first = await options.resolveChatBody!();
+        const second = await options.resolveChatBody!();
+        expect(second).toBe(first);
+        expect(first).toEqual({
+          ...convertedBody,
+          thinking: { type: 'disabled' },
+        });
+        return {
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        };
+      });
+
+      await service.tryForwardToProvider({
+        provider: 'deepseek',
+        apiKey: 'sk-test',
+        model: 'deepseek-v4-flash',
+        body: { input: 'hi' },
+        resolveChatBody,
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'api_key',
+        apiMode: 'responses',
+        paramMergeContext: { agentId: 'agent-1', scopeKey: 'tier:default' },
+      });
+
+      expect(resolveChatBody).toHaveBeenCalledTimes(1);
+    });
+
     it('per-attempt lookup leaves other providers untouched (no cross-provider leak)', async () => {
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -261,6 +261,19 @@ describe('ProxyService — orchestration', () => {
       ).rejects.toMatchObject({ code: 'M300', status: 400 });
     });
 
+    it('accepts string and object items in Responses input arrays', () => {
+      const validatePayload = (
+        svc as unknown as {
+          validatePayload: (body: Record<string, unknown>, apiMode: string) => void;
+        }
+      ).validatePayload.bind(svc);
+
+      expect(() => validatePayload({ input: ['Hello'] }, 'responses')).not.toThrow();
+      expect(() =>
+        validatePayload({ input: [{ role: 'user', content: 'Hello' }] }, 'responses'),
+      ).not.toThrow();
+    });
+
     it('forwards long message arrays unchanged', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
@@ -2530,6 +2543,46 @@ describe('ProxyService — orchestration', () => {
 
       expect(resolveService.resolveForTier).toHaveBeenCalledWith('agent-1', 'tenant-1', 'simple');
       expect(convertSpy).not.toHaveBeenCalled();
+    });
+
+    it('detects Responses heartbeats across native input item shapes', () => {
+      const detectHeartbeatBody = (
+        svc as unknown as {
+          detectHeartbeatBody: (body: Record<string, unknown>, apiMode: string) => boolean;
+        }
+      ).detectHeartbeatBody.bind(svc);
+
+      expect(detectHeartbeatBody({}, 'responses')).toBe(false);
+      expect(detectHeartbeatBody({ input: ['HEARTBEAT_OK'] }, 'responses')).toBe(true);
+      expect(
+        detectHeartbeatBody({ input: [{ role: 'user', content: 'HEARTBEAT_OK' }] }, 'responses'),
+      ).toBe(true);
+      expect(
+        detectHeartbeatBody(
+          {
+            input: [
+              null,
+              [],
+              { type: 'function_call' },
+              { type: 'function_call_output' },
+              { role: 'assistant', content: 'HEARTBEAT_OK' },
+              {
+                role: 'user',
+                content: [null, 'ignored', [], { text: 'HEARTBEAT_OK' }],
+              },
+            ],
+          },
+          'responses',
+        ),
+      ).toBe(true);
+      expect(
+        detectHeartbeatBody(
+          {
+            input: [{ type: 'function_call' }, { role: 'assistant', content: 'HEARTBEAT_OK' }],
+          },
+          'responses',
+        ),
+      ).toBe(false);
     });
 
     it('detects HEARTBEAT_OK in array-content user messages', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -259,6 +259,12 @@ describe('ProxyService — orchestration', () => {
       await expect(
         svc.proxyRequest(baseOpts({ apiMode: 'responses', body: {} } as never)),
       ).rejects.toMatchObject({ code: 'M300', status: 400 });
+
+      await expect(
+        svc.proxyRequest(
+          baseOpts({ apiMode: 'responses', body: { instructions: '   ' } } as never),
+        ),
+      ).rejects.toMatchObject({ code: 'M300', status: 400 });
     });
 
     it('accepts string and object items in Responses input arrays', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -85,7 +85,7 @@ const specCatalog: ProviderParamSpecCatalog = [
 
 describe('ProxyService — orchestration', () => {
   let resolveService: jest.Mocked<
-    Pick<ResolveService, 'resolve' | 'resolveForTier' | 'resolveHeaderTier'>
+    Pick<ResolveService, 'resolve' | 'resolveLazy' | 'resolveForTier' | 'resolveHeaderTier'>
   >;
   let providerKeyService: jest.Mocked<
     Pick<
@@ -122,8 +122,21 @@ describe('ProxyService — orchestration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    const resolve = jest.fn();
     resolveService = {
-      resolve: jest.fn(),
+      resolve,
+      resolveLazy: jest.fn(async (agentId, tenantId, resolveInput, ...rest) => {
+        const input = await resolveInput();
+        return resolve(
+          agentId,
+          tenantId,
+          input.messages,
+          input.tools,
+          input.tool_choice,
+          input.max_tokens,
+          ...rest,
+        );
+      }),
       resolveForTier: jest.fn(),
       resolveHeaderTier: jest.fn().mockResolvedValue(null),
     };
@@ -240,6 +253,12 @@ describe('ProxyService — orchestration', () => {
       await expect(
         svc.proxyRequest(baseOpts({ body: { messages: [] } as never })),
       ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it('rejects Responses requests without input or instructions', async () => {
+      await expect(
+        svc.proxyRequest(baseOpts({ apiMode: 'responses', body: {} } as never)),
+      ).rejects.toMatchObject({ code: 'M300', status: 400 });
     });
 
     it('forwards long message arrays unchanged', async () => {
@@ -1468,7 +1487,7 @@ describe('ProxyService — orchestration', () => {
       expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body).toBe(body);
     });
 
-    it('reuses converted Responses bodies for routing when no separate routing body is provided', async () => {
+    it('reuses one converted Responses body for routing and forwarding', async () => {
       const body = {
         input: 'Describe this image',
         stream: false,
@@ -1491,13 +1510,23 @@ describe('ProxyService — orchestration', () => {
         svc as unknown as { validatePayload: (body: Record<string, unknown>) => void },
         'validatePayload',
       );
+      const convertSpy = jest.spyOn(
+        svc as unknown as {
+          toChatBody: (apiMode: string, body: Record<string, unknown>) => Record<string, unknown>;
+        },
+        'toChatBody',
+      );
 
       await svc.proxyRequest(baseOpts({ body, apiMode: 'responses' } as never));
 
-      const forwardedBody = fallbackService.tryForwardToProvider.mock.calls[0][0].chatBody;
+      const resolveChatBody = fallbackService.tryForwardToProvider.mock.calls[0][0].resolveChatBody;
+      expect(resolveChatBody).toBeDefined();
+      const forwardedBody = await resolveChatBody!();
+      const repeatedBody = await resolveChatBody!();
       expect(validateSpy).toHaveBeenCalledTimes(1);
-      expect(forwardedBody).toBeDefined();
-      expect(forwardedBody?.messages).toEqual([{ role: 'user', content: 'Describe this image' }]);
+      expect(convertSpy).toHaveBeenCalledTimes(1);
+      expect(repeatedBody).toBe(forwardedBody);
+      expect(forwardedBody.messages).toEqual([{ role: 'user', content: 'Describe this image' }]);
     });
 
     it('returns the forward result and records tier momentum on a 200 non-stream response', async () => {
@@ -2406,6 +2435,45 @@ describe('ProxyService — orchestration', () => {
   });
 
   describe('routing dispatch', () => {
+    it('keeps native Messages unconverted when routing does not request scorer input', async () => {
+      resolveService.resolveLazy.mockResolvedValue({
+        tier: 'default',
+        route: route('anthropic', 'api_key', 'claude-sonnet-4-5'),
+        fallback_routes: null,
+        confidence: 1,
+        score: 0,
+        reason: 'default',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+      const convertSpy = jest.spyOn(
+        svc as unknown as {
+          toChatBody: (apiMode: string, body: Record<string, unknown>) => Record<string, unknown>;
+        },
+        'toChatBody',
+      );
+
+      await svc.proxyRequest(
+        baseOpts({
+          apiMode: 'messages',
+          body: {
+            model: 'claude-sonnet-4-5',
+            messages: [{ role: 'user', content: 'Hello' }],
+          },
+        } as never),
+      );
+
+      expect(convertSpy).not.toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body).toEqual({
+        model: 'claude-sonnet-4-5',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+    });
+
     it('invokes resolveForTier with simple when the last user message contains HEARTBEAT_OK', async () => {
       resolveService.resolveForTier.mockResolvedValue({
         tier: 'simple',
@@ -2429,6 +2497,39 @@ describe('ProxyService — orchestration', () => {
       );
       expect(resolveService.resolveForTier).toHaveBeenCalledWith('agent-1', 'tenant-1', 'simple');
       expect(resolveService.resolve).not.toHaveBeenCalled();
+    });
+
+    it('detects Responses heartbeats without resolving a Chat Completions body', async () => {
+      resolveService.resolveForTier.mockResolvedValue({
+        tier: 'simple',
+        route: route('openai', 'api_key', 'gpt-4o-mini'),
+        fallback_routes: null,
+        confidence: 1,
+        score: 0,
+        reason: 'heartbeat',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      const convertSpy = jest.spyOn(
+        svc as unknown as {
+          toChatBody: (apiMode: string, body: Record<string, unknown>) => Record<string, unknown>;
+        },
+        'toChatBody',
+      );
+
+      await svc.proxyRequest(
+        baseOpts({
+          apiMode: 'responses',
+          body: { input: 'HEARTBEAT_OK' },
+        } as never),
+      );
+
+      expect(resolveService.resolveForTier).toHaveBeenCalledWith('agent-1', 'tenant-1', 'simple');
+      expect(convertSpy).not.toHaveBeenCalled();
     });
 
     it('detects HEARTBEAT_OK in array-content user messages', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1509,6 +1509,13 @@ describe('ProxyService — orchestration', () => {
     it('reuses one converted Responses body for routing and forwarding', async () => {
       const body = {
         input: 'Describe this image',
+        tools: [
+          {
+            type: 'function',
+            name: 'inspect_image',
+            parameters: { type: 'object', properties: {} },
+          },
+        ],
         stream: false,
       };
       resolveService.resolve.mockResolvedValue({
@@ -1546,6 +1553,15 @@ describe('ProxyService — orchestration', () => {
       expect(convertSpy).toHaveBeenCalledTimes(1);
       expect(repeatedBody).toBe(forwardedBody);
       expect(forwardedBody.messages).toEqual([{ role: 'user', content: 'Describe this image' }]);
+      expect(resolveService.resolve.mock.calls[0][3]).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'inspect_image',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ]);
     });
 
     it('returns the forward result and records tier momentum on a 200 non-stream response', async () => {
@@ -2454,6 +2470,44 @@ describe('ProxyService — orchestration', () => {
   });
 
   describe('routing dispatch', () => {
+    it('treats non-array messages from a healed body as empty scorer input', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      const resolveRouting = (
+        svc as unknown as {
+          resolveRouting: (
+            agentId: string,
+            tenantId: string,
+            body: Record<string, unknown>,
+            resolveChatBody: undefined,
+            sessionKey: string,
+            specificityOverride: undefined,
+            headers: undefined,
+            apiMode: 'chat_completions',
+          ) => Promise<unknown>;
+        }
+      ).resolveRouting.bind(svc);
+
+      await resolveRouting(
+        'agent-1',
+        'tenant-1',
+        { messages: { malformed: true } },
+        undefined,
+        'session-1',
+        undefined,
+        undefined,
+        'chat_completions',
+      );
+
+      expect(resolveService.resolve.mock.calls[0][2]).toEqual([]);
+    });
+
     it('keeps native Messages unconverted when routing does not request scorer input', async () => {
       resolveService.resolveLazy.mockResolvedValue({
         tier: 'default',
@@ -2559,10 +2613,19 @@ describe('ProxyService — orchestration', () => {
       ).detectHeartbeatBody.bind(svc);
 
       expect(detectHeartbeatBody({}, 'responses')).toBe(false);
+      expect(detectHeartbeatBody({ messages: 'invalid' }, 'chat_completions')).toBe(false);
       expect(detectHeartbeatBody({ input: ['HEARTBEAT_OK'] }, 'responses')).toBe(true);
+      expect(detectHeartbeatBody({ input: ['HEARTBEAT_OK', 42] }, 'responses')).toBe(true);
+      expect(detectHeartbeatBody({ input: [{ content: 'HEARTBEAT_OK' }] }, 'responses')).toBe(true);
       expect(
         detectHeartbeatBody({ input: [{ role: 'user', content: 'HEARTBEAT_OK' }] }, 'responses'),
       ).toBe(true);
+      expect(
+        detectHeartbeatBody(
+          { input: [{ role: 'user', content: { custom: 'object' } }] },
+          'responses',
+        ),
+      ).toBe(false);
       expect(
         detectHeartbeatBody(
           {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -283,8 +283,7 @@ export class ProviderClient {
 
     const bareModel = stripModelPrefix(model, endpointKey);
     if (endpoint.format === 'kiro') {
-      const requestSource =
-        opts.apiMode && opts.apiMode !== 'chat_completions' ? (chatBody ?? body) : body;
+      const requestSource = chatBody ?? body;
       const response = await forwardKiroChat({
         apiKey,
         model: bareModel,

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -269,13 +269,11 @@ export class ProviderClient {
     const textFormat = responsesTextFormat(body, opts.apiMode);
     const resolvedWireApiMode = wireApiMode(endpoint);
     const resolvedWireFormat = wireFormat(endpoint);
-    const nativeTarget =
-      (opts.apiMode === 'messages' && endpoint.format === 'anthropic') ||
-      (opts.apiMode === 'responses' && endpoint.format === 'chatgpt');
-    const chatBody =
-      opts.apiMode && opts.apiMode !== 'chat_completions' && !nativeTarget
-        ? await opts.resolveChatBody?.()
-        : undefined;
+    const needsChatBody =
+      opts.apiMode !== undefined &&
+      opts.apiMode !== 'chat_completions' &&
+      opts.apiMode !== resolvedWireApiMode;
+    const chatBody = needsChatBody ? await opts.resolveChatBody?.() : undefined;
 
     const bareModel = stripModelPrefix(model, endpointKey);
     if (endpoint.format === 'kiro') {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -92,6 +92,12 @@ function wireFormat(endpoint: ProviderEndpoint): ProviderWireFormat | undefined 
   return undefined;
 }
 
+function inputWireFormat(apiMode: ProxyApiMode): ProviderWireFormat {
+  if (apiMode === 'responses') return 'openai_responses';
+  if (apiMode === 'messages') return 'anthropic_messages';
+  return 'openai_chat_completions';
+}
+
 interface BuiltProviderRequest {
   url: string;
   headers: Record<string, string>;
@@ -272,7 +278,7 @@ export class ProviderClient {
     const needsChatBody =
       opts.apiMode !== undefined &&
       opts.apiMode !== 'chat_completions' &&
-      opts.apiMode !== resolvedWireApiMode;
+      inputWireFormat(opts.apiMode) !== resolvedWireFormat;
     const chatBody = needsChatBody ? await opts.resolveChatBody?.() : undefined;
 
     const bareModel = stripModelPrefix(model, endpointKey);

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -92,11 +92,11 @@ function wireFormat(endpoint: ProviderEndpoint): ProviderWireFormat | undefined 
   return undefined;
 }
 
-function inputWireFormat(apiMode: ProxyApiMode): ProviderWireFormat {
-  if (apiMode === 'responses') return 'openai_responses';
-  if (apiMode === 'messages') return 'anthropic_messages';
-  return 'openai_chat_completions';
-}
+const INPUT_WIRE_FORMATS: Record<ProxyApiMode, ProviderWireFormat> = {
+  chat_completions: 'openai_chat_completions',
+  messages: 'anthropic_messages',
+  responses: 'openai_responses',
+};
 
 interface BuiltProviderRequest {
   url: string;
@@ -278,7 +278,7 @@ export class ProviderClient {
     const needsChatBody =
       opts.apiMode !== undefined &&
       opts.apiMode !== 'chat_completions' &&
-      inputWireFormat(opts.apiMode) !== resolvedWireFormat;
+      INPUT_WIRE_FORMATS[opts.apiMode] !== resolvedWireFormat;
     const chatBody = needsChatBody ? await opts.resolveChatBody?.() : undefined;
 
     const bareModel = stripModelPrefix(model, endpointKey);
@@ -540,8 +540,7 @@ export class ProviderClient {
     const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
     // Native matching targets read `body` directly. Cross-protocol targets
     // receive the lazily resolved Chat Completions view as `chatBody`.
-    const requestSource =
-      ctx.apiMode && ctx.apiMode !== 'chat_completions' ? (chatBody ?? body) : body;
+    const requestSource = chatBody ?? body;
 
     if (endpoint.format === 'google') {
       // Google accepts the API key via header (set by buildHeaders below) so

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -269,11 +269,18 @@ export class ProviderClient {
     const textFormat = responsesTextFormat(body, opts.apiMode);
     const resolvedWireApiMode = wireApiMode(endpoint);
     const resolvedWireFormat = wireFormat(endpoint);
+    const nativeTarget =
+      (opts.apiMode === 'messages' && endpoint.format === 'anthropic') ||
+      (opts.apiMode === 'responses' && endpoint.format === 'chatgpt');
+    const chatBody =
+      opts.apiMode && opts.apiMode !== 'chat_completions' && !nativeTarget
+        ? await opts.resolveChatBody?.()
+        : undefined;
 
     const bareModel = stripModelPrefix(model, endpointKey);
     if (endpoint.format === 'kiro') {
       const requestSource =
-        opts.apiMode && opts.apiMode !== 'chat_completions' ? (opts.chatBody ?? body) : body;
+        opts.apiMode && opts.apiMode !== 'chat_completions' ? (chatBody ?? body) : body;
       const response = await forwardKiroChat({
         apiKey,
         model: bareModel,
@@ -300,7 +307,7 @@ export class ProviderClient {
       apiKey,
       authType,
       body,
-      chatBody: opts.chatBody,
+      chatBody,
       apiMode: opts.apiMode,
       stream,
       signatureLookup: opts.signatureLookup,
@@ -527,10 +534,8 @@ export class ProviderClient {
     sessionKey?: string;
   }): BuiltProviderRequest {
     const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
-    // For non-chat_completions inbound modes ('responses', 'messages'), the
-    // routing layer pre-translated the request into chat_completions form
-    // (`chatBody`). Provider adapters all consume chat_completions, so prefer
-    // `chatBody` when present.
+    // Native matching targets read `body` directly. Cross-protocol targets
+    // receive the lazily resolved Chat Completions view as `chatBody`.
     const requestSource =
       ctx.apiMode && ctx.apiMode !== 'chat_completions' ? (chatBody ?? body) : body;
 
@@ -571,9 +576,8 @@ export class ProviderClient {
       // (`POST /v1/messages`) and the resolved upstream is also Anthropic,
       // skip the OpenAI translation round-trip and apply only the additive
       // mutations cache_control + subscription identity + max_tokens
-      // default + thinking-block replay. `chatBody` is still used for the
-      // routing/scoring layer earlier in the pipeline; only the wire body
-      // bypasses translation. This closes the lossy-roundtrip class of
+      // default + thinking-block replay. The wire body bypasses translation.
+      // This closes the lossy-roundtrip class of
       // bugs that previously dropped Anthropic-native fields (server tool
       // `type` tags, cache_control placement, etc.) — see #1886.
       const requestBody =

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -26,7 +26,7 @@ interface ForwardProviderOptions {
   apiKey: string;
   model: string;
   body: Record<string, unknown>;
-  chatBody?: Record<string, unknown>;
+  resolveChatBody?: ResolveChatBody;
   stream: boolean;
   sessionKey: string;
   signal?: AbortSignal;
@@ -74,6 +74,7 @@ import type {
   SignatureLookup,
   ThinkingBlockLookup,
   ReasoningContentLookup,
+  ResolveChatBody,
   ProviderAttemptRef,
   StartProviderAttempt,
 } from './proxy-types';
@@ -187,7 +188,7 @@ export class ProxyFallbackService {
     signatureLookup?: SignatureLookup,
     thinkingLookup?: ThinkingBlockLookup,
     apiMode?: ProxyApiMode,
-    chatBody?: Record<string, unknown>,
+    resolveChatBody?: ResolveChatBody,
     fallbackRoutes?: ModelRoute[] | null,
     paramMergeContext?: ParamMergeContext,
     reasoningContentLookup?: ReasoningContentLookup,
@@ -303,7 +304,7 @@ export class ProxyFallbackService {
         apiKey: credentials.apiKey,
         model,
         body,
-        chatBody,
+        resolveChatBody,
         stream,
         sessionKey,
         signal,
@@ -639,16 +640,6 @@ export class ProxyFallbackService {
       authType,
       opts.model,
     );
-    let chatBody = opts.chatBody
-      ? await this.applyParamMerge(
-          opts.chatBody,
-          opts.paramMergeContext,
-          provider,
-          authType,
-          opts.model,
-        )
-      : undefined;
-
     const extraHeaders = buildProviderExtraHeaders(provider, opts.sessionKey);
 
     // Copilot: exchange the stored GitHub OAuth token for a short-lived API token
@@ -687,6 +678,31 @@ export class ProxyFallbackService {
         : customEndpoint
           ? 'custom'
           : resolveEndpointKey(provider);
+    let resolvedChatBody: Promise<Record<string, unknown>> | undefined;
+    const resolveChatBody = opts.resolveChatBody
+      ? () => {
+          resolvedChatBody ??= (async () => {
+            let resolved = await opts.resolveChatBody!();
+            resolved = await this.applyParamMerge(
+              resolved,
+              opts.paramMergeContext,
+              provider,
+              authType,
+              opts.model,
+            );
+            if (this.reasoningCache) {
+              resolved = await this.reasoningCache.reinjectMissingReasoningContent(
+                resolved,
+                opts.sessionKey,
+                reasoningEndpointKey,
+                forwardModel,
+              );
+            }
+            return resolved;
+          })();
+          return resolvedChatBody;
+        }
+      : undefined;
     if (this.reasoningCache) {
       body = await this.reasoningCache.reinjectMissingReasoningContent(
         body,
@@ -694,14 +710,6 @@ export class ProxyFallbackService {
         reasoningEndpointKey,
         forwardModel,
       );
-      if (chatBody) {
-        chatBody = await this.reasoningCache.reinjectMissingReasoningContent(
-          chatBody,
-          opts.sessionKey,
-          reasoningEndpointKey,
-          forwardModel,
-        );
-      }
     }
 
     // For Gemini OAuth, the OAuth blob's `u` field is the
@@ -722,7 +730,7 @@ export class ProxyFallbackService {
         apiKey: effectiveKey,
         model: forwardModel,
         body,
-        chatBody,
+        resolveChatBody,
         stream,
         signal,
         extraHeaders,

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -29,6 +29,9 @@ export type ReasoningContentLookup = (firstToolCallId: string) => string | null;
 
 export type ProxyApiMode = 'chat_completions' | 'responses' | 'messages';
 
+/** Lazily derive the Chat Completions view used by legacy routing or cross-protocol adapters. */
+export type ResolveChatBody = () => Promise<Record<string, unknown>>;
+
 /** The protocol shape actually emitted at the provider transport boundary. */
 export type ProviderWireFormat =
   | 'openai_chat_completions'
@@ -79,7 +82,7 @@ export interface ForwardOptions {
   apiKey: string;
   model: string;
   body: Record<string, unknown>;
-  chatBody?: Record<string, unknown>;
+  resolveChatBody?: ResolveChatBody;
   apiMode?: ProxyApiMode;
   /** Stable Manifest conversation/session key for provider prompt-cache affinity. */
   sessionKey?: string;

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -848,7 +848,7 @@ export class ProxyService {
     if (apiMode === 'chat_completions') return undefined;
     let resolved: Promise<Record<string, unknown>> | undefined;
     return () => {
-      resolved ??= Promise.resolve(this.toChatBody(apiMode, body) ?? body);
+      resolved ??= Promise.resolve(this.toChatBody(apiMode, body)!);
       return resolved;
     };
   }

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -42,6 +42,7 @@ import {
   SignatureLookup,
   ThinkingBlockLookup,
   ReasoningContentLookup,
+  ResolveChatBody,
   ProviderAttemptRef,
   StartProviderAttempt,
 } from './proxy-types';
@@ -262,30 +263,24 @@ export class ProxyService {
     } = opts;
     const apiMode = opts.apiMode ?? 'chat_completions';
     const routingSource = opts.routingBody ?? body;
-    const chatBody = this.toChatBody(apiMode, body);
-    const forwardingBody = chatBody ?? body;
-    let routingBody = forwardingBody;
-    if (routingSource !== body) {
-      const routingChatBody = this.toChatBody(apiMode, routingSource);
-      routingBody = routingChatBody ?? routingSource;
-    }
-    this.validatePayload(forwardingBody);
-    if (routingBody !== forwardingBody) this.validatePayload(routingBody);
+    const resolveChatBody = this.createChatBodyResolver(apiMode, body);
+    const resolveRoutingChatBody =
+      routingSource === body
+        ? resolveChatBody
+        : this.createChatBodyResolver(apiMode, routingSource);
+    this.validatePayload(body, apiMode);
+    if (routingSource !== body) this.validatePayload(routingSource, apiMode);
 
     const limitMessage = await this.enforceLimits(tenantId, agentName);
     if (limitMessage) {
-      return buildFriendlyResponse(
-        limitMessage,
-        routingBody.stream === true,
-        'limit_exceeded',
-        'M200',
-      );
+      return buildFriendlyResponse(limitMessage, body.stream === true, 'limit_exceeded', 'M200');
     }
 
     const resolved = await this.resolveRouting(
       agentId,
       tenantId,
-      routingBody,
+      routingSource,
+      resolveRoutingChatBody,
       sessionKey,
       specificityOverride,
       headers,
@@ -371,7 +366,7 @@ export class ProxyService {
     const primaryRequestParams = explicitModelOverride
       ? null
       : snapshotRequestParams({
-          body: routingBody as Record<string, unknown>,
+          body,
           modelParams: primaryModelParams,
           specs: primarySpecs,
         });
@@ -420,7 +415,7 @@ export class ProxyService {
           primaryModel,
           forward,
           body,
-          chatBody,
+          resolveChatBody,
           stream,
           sessionKey,
           signal,
@@ -449,7 +444,7 @@ export class ProxyService {
       apiKey: credentials.apiKey,
       model: primaryModel,
       body,
-      chatBody,
+      resolveChatBody,
       stream,
       sessionKey,
       signal,
@@ -539,7 +534,7 @@ export class ProxyService {
         primaryModel,
         forward,
         body,
-        chatBody,
+        resolveChatBody,
         stream,
         sessionKey,
         signal,
@@ -639,7 +634,7 @@ export class ProxyService {
           primaryModel,
           forward: syntheticForward,
           body,
-          chatBody,
+          resolveChatBody,
           stream,
           sessionKey,
           signal,
@@ -748,11 +743,12 @@ export class ProxyService {
     healedBody: Record<string, unknown>,
     ctx: ResolvedHealContext,
   ): Promise<ForwardResult> {
-    const routingBody = this.toChatBody(ctx.apiMode, healedBody) ?? healedBody;
+    const resolveChatBody = this.createChatBodyResolver(ctx.apiMode, healedBody);
     const resolved = await this.resolveRouting(
       ctx.agentId,
       ctx.tenantId,
-      routingBody,
+      healedBody,
+      resolveChatBody,
       ctx.sessionKey,
       ctx.specificityOverride,
       ctx.headers,
@@ -779,7 +775,7 @@ export class ProxyService {
       apiKey: credentials.apiKey,
       model,
       body: healedBody,
-      chatBody: this.toChatBody(ctx.apiMode, healedBody),
+      resolveChatBody,
       stream: ctx.stream,
       sessionKey: ctx.sessionKey,
       signal: ctx.signal,
@@ -817,7 +813,22 @@ export class ProxyService {
     };
   }
 
-  private validatePayload(body: ProxyRequestOptions['body']): void {
+  private validatePayload(body: ProxyRequestOptions['body'], apiMode: ProxyApiMode): void {
+    if (apiMode === 'responses') {
+      const hasInstructions =
+        typeof body.instructions === 'string' && body.instructions.trim().length > 0;
+      const hasInput =
+        typeof body.input === 'string' ||
+        (Array.isArray(body.input) &&
+          body.input.some(
+            (item) =>
+              typeof item === 'string' ||
+              (!!item && typeof item === 'object' && !Array.isArray(item)),
+          ));
+      if (hasInstructions || hasInput) return;
+      throw new ManifestError('M300', HttpStatus.BAD_REQUEST);
+    }
+
     const messages = body.messages;
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
       // A ManifestError, not a bare BadRequestException: the proxy needs to tell
@@ -825,13 +836,28 @@ export class ProxyService {
       // row lands in agent_messages blamed on the provider.
       throw new ManifestError('M300', HttpStatus.BAD_REQUEST);
     }
-    sanitizeNullContent(messages as Record<string, unknown>[]);
+    if (apiMode === 'chat_completions') {
+      sanitizeNullContent(messages as Record<string, unknown>[]);
+    }
+  }
+
+  private createChatBodyResolver(
+    apiMode: ProxyApiMode,
+    body: ProxyRequestOptions['body'],
+  ): ResolveChatBody | undefined {
+    if (apiMode === 'chat_completions') return undefined;
+    let resolved: Promise<Record<string, unknown>> | undefined;
+    return () => {
+      resolved ??= Promise.resolve(this.toChatBody(apiMode, body) ?? body);
+      return resolved;
+    };
   }
 
   private async resolveRouting(
     agentId: string,
     tenantId: string,
     body: ProxyRequestOptions['body'],
+    resolveChatBody: ResolveChatBody | undefined,
     sessionKey: string,
     specificityOverride: ProxyRequestOptions['specificityOverride'],
     headers: ProxyRequestOptions['headers'],
@@ -855,26 +881,29 @@ export class ProxyService {
       };
     }
 
-    // Not guaranteed to be an array here: a healed body reaches this path from
-    // forwardResolvedHealed, which never runs it past validatePayload. An
-    // explicit model used to return before this line, so the fall-through is
-    // what newly exposes it to a body Phoenix rewrote.
-    const messages = (Array.isArray(body.messages) ? body.messages : []) as ScorerMessage[];
-    const scoringMessages = this.filterScoringMessages(messages);
-    const scoringTools = Array.isArray(body.tools) ? body.tools : undefined;
-    const isHeartbeat = this.detectHeartbeat(scoringMessages);
+    const isHeartbeat = this.detectHeartbeatBody(body, apiMode);
     const recentTiers = this.momentum.getRecentTiers(sessionKey);
     const recentCategories = this.momentum.getRecentCategories(sessionKey);
 
     const baseResolved = await (isHeartbeat
       ? this.resolveService.resolveForTier(agentId, tenantId, 'simple')
-      : this.resolveService.resolve(
+      : this.resolveService.resolveLazy(
           agentId,
           tenantId,
-          scoringMessages,
-          scoringTools,
-          body.tool_choice,
-          body.max_tokens as number | undefined,
+          async () => {
+            const scoringBody = resolveChatBody ? await resolveChatBody() : body;
+            // Not guaranteed to be an array here: a healed body reaches this
+            // path without validatePayload after Phoenix rewrites it.
+            const messages = (
+              Array.isArray(scoringBody.messages) ? scoringBody.messages : []
+            ) as ScorerMessage[];
+            return {
+              messages: this.filterScoringMessages(messages),
+              tools: Array.isArray(scoringBody.tools) ? scoringBody.tools : undefined,
+              tool_choice: scoringBody.tool_choice,
+              max_tokens: scoringBody.max_tokens as number | undefined,
+            };
+          },
           recentTiers,
           specificityOverride,
           recentCategories,
@@ -986,7 +1015,7 @@ export class ProxyService {
     primaryModel: string;
     forward: ForwardResult;
     body: ProxyRequestOptions['body'];
-    chatBody?: ProxyRequestOptions['body'];
+    resolveChatBody?: ResolveChatBody;
     stream: boolean;
     sessionKey: string;
     signal?: AbortSignal;
@@ -1009,7 +1038,7 @@ export class ProxyService {
       primaryModel,
       forward,
       body,
-      chatBody,
+      resolveChatBody,
       stream,
       sessionKey,
       signal,
@@ -1042,7 +1071,7 @@ export class ProxyService {
       args.signatureLookup,
       args.thinkingLookup,
       apiMode,
-      chatBody,
+      resolveChatBody,
       fallbackRoutes,
       args.paramMergeContext,
       args.reasoningContentLookup,
@@ -1220,6 +1249,38 @@ export class ProxyService {
     return messages
       .filter((m) => !SCORING_EXCLUDED_ROLES.has(m.role))
       .slice(-SCORING_RECENT_MESSAGES);
+  }
+
+  private detectHeartbeatBody(body: ProxyRequestOptions['body'], apiMode: ProxyApiMode): boolean {
+    if (apiMode !== 'responses') {
+      const messages = (Array.isArray(body.messages) ? body.messages : []) as ScorerMessage[];
+      return this.detectHeartbeat(this.filterScoringMessages(messages));
+    }
+
+    if (typeof body.input === 'string') return body.input.includes('HEARTBEAT_OK');
+    if (!Array.isArray(body.input)) return false;
+    for (let i = body.input.length - 1; i >= 0; i--) {
+      const item = body.input[i];
+      if (typeof item === 'string') return item.includes('HEARTBEAT_OK');
+      if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+      const record = item as Record<string, unknown>;
+      if (record.type === 'function_call' || record.type === 'function_call_output') continue;
+      const role = typeof record.role === 'string' ? record.role : 'user';
+      if (role !== 'user') continue;
+      if (typeof record.content === 'string') {
+        return record.content.includes('HEARTBEAT_OK');
+      }
+      if (!Array.isArray(record.content)) return false;
+      return record.content.some(
+        (part) =>
+          !!part &&
+          typeof part === 'object' &&
+          !Array.isArray(part) &&
+          typeof (part as Record<string, unknown>).text === 'string' &&
+          ((part as Record<string, unknown>).text as string).includes('HEARTBEAT_OK'),
+      );
+    }
+    return false;
   }
 
   private detectHeartbeat(scoringMessages: ScorerMessage[]): boolean {

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -134,6 +134,30 @@ describe('ResolveService', () => {
     });
   });
 
+  describe('resolveLazy', () => {
+    it('does not resolve scorer input when complexity routing is disabled', async () => {
+      agentRepo.findOne.mockResolvedValue({
+        id: 'agent-1',
+        complexity_routing_enabled: false,
+      });
+      const resolveInput = jest.fn().mockResolvedValue({ messages });
+
+      const result = await svc.resolveLazy('agent-1', 'user-1', resolveInput);
+
+      expect(result.reason).toBe('default');
+      expect(resolveInput).not.toHaveBeenCalled();
+    });
+
+    it('resolves scorer input once when scoring runs', async () => {
+      const resolveInput = jest.fn().mockResolvedValue({ messages });
+
+      await svc.resolveLazy('agent-1', 'user-1', resolveInput);
+
+      expect(resolveInput).toHaveBeenCalledTimes(1);
+      expect(mockedScore).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('resolve — header tier match', () => {
     it('returns the header-tier route when the rule matches', async () => {
       const tier = {

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -87,6 +87,26 @@ export class ResolveService {
     recentCategories?: readonly SpecificityCategory[],
     headers?: IncomingHttpHeaders,
   ): Promise<ResolveResponse> {
+    return this.resolveLazy(
+      agentId,
+      tenantId,
+      async () => ({ messages, tools, tool_choice: toolChoice, max_tokens: maxTokens }),
+      recentTiers,
+      specificityOverride,
+      recentCategories,
+      headers,
+    );
+  }
+
+  async resolveLazy(
+    agentId: string,
+    tenantId: string,
+    resolveInput: () => Promise<ScorerInput>,
+    recentTiers?: MomentumInput['recentTiers'],
+    specificityOverride?: string,
+    recentCategories?: readonly SpecificityCategory[],
+    headers?: IncomingHttpHeaders,
+  ): Promise<ResolveResponse> {
     if (headers) {
       const headerTierResult = await this.resolveHeaderTier(agentId, tenantId, headers);
       if (headerTierResult) return headerTierResult;
@@ -97,6 +117,12 @@ export class ResolveService {
       return this.resolveForTier(agentId, tenantId, 'default', 'default');
     }
 
+    const {
+      messages,
+      tools,
+      tool_choice: toolChoice,
+      max_tokens: maxTokens,
+    } = await resolveInput();
     const specificityResult = await this.resolveSpecificity(
       agentId,
       tenantId,


### PR DESCRIPTION
### ✨ What changed
- Keep Responses and Anthropic Messages bodies native for matching provider endpoints.
- Derive and memoize a Chat Completions view only when legacy scoring or cross-protocol forwarding needs it.

### 💭 Why
Avoid lossy protocol round trips and preserve protocol-native request fields.

### 👤 For users
Native fields now reach matching providers without Chat Completions translation.

### 📝 Notes
Closes #2501

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves native `responses` and Anthropic `messages` bodies end-to-end, deriving a Chat Completions view only when scoring runs or the provider wire format differs. Adds lazy conversion, mode-aware validation, and heartbeat detection to cut redundant translations; addresses #2501.

- **Refactors**
  - Replaced eager `chatBody` with a lazy, memoized `resolveChatBody` used only for scoring or cross‑protocol forwarding across `ProxyService` → `ProxyFallbackService` → `ProviderClient`.
  - `ProviderClient` now compares input and target wire formats and resolves conversion only when they differ; native bodies are forwarded unchanged.
  - Added `ResolveService.resolveLazy` to compute scorer input only when complexity routing runs; resolved once and reused.
  - Moved param merge and reasoning‑content reinjection into the lazy path; executed once per attempt and reused for routing and forwarding.
  - Made payload validation mode‑aware; `responses` now requires `input` or `instructions` and accepts input arrays with string or object items.
  - Heartbeat detection is mode‑aware and uses native `responses` shapes without resolving a Chat Completions body; routing keeps native `messages` when scorer input isn’t needed.

- **Bug Fixes**
  - Detects `responses` heartbeats from native inputs (string or object items) without forcing conversion and ignores tool items.
  - Forwards Anthropic `messages` natively to preserve fields like `cache_control` and server tool `type`; prevents redundant conversions by memoizing the lazy conversion.

<sup>Written for commit fec14c4e627e9c21bf19445cf3dcb1696e066762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

