### PR TITLE
fix: notify the account holder on duplicate email signup

### DIFF
--- a/.changeset/existing-account-signup-email.md
+++ b/.changeset/existing-account-signup-email.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Email the account holder when someone signs up with an email that already has an account, instead of showing "check your email" and sending nothing.

--- a/packages/backend/src/auth/auth.instance.spec.ts
+++ b/packages/backend/src/auth/auth.instance.spec.ts
@@ -22,6 +22,9 @@ jest.mock('../notifications/emails/verify-email', () => ({
 jest.mock('../notifications/emails/reset-password', () => ({
   ResetPasswordEmail: jest.fn().mockReturnValue('reset-password-element'),
 }));
+jest.mock('../notifications/emails/existing-account', () => ({
+  ExistingAccountEmail: jest.fn().mockReturnValue('existing-account-element'),
+}));
 jest.mock('../notifications/services/email-providers/send-email', () => ({
   sendEmail: jest.fn(),
 }));
@@ -293,6 +296,68 @@ describe('auth.instance', () => {
         subject: 'Reset your password',
         html: '<html>rendered</html>',
         text: 'plain text version',
+      });
+    });
+  });
+
+  describe('onExistingUserSignUp callback', () => {
+    // Better Auth answers a duplicate sign-up with a synthetic 200 rather than an
+    // error, so this hook is the only thing standing between the account holder
+    // and a "check your email" screen for a mail that was never sent.
+    it('emails the existing account holder a sign-in link', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { ExistingAccountEmail } = require('../notifications/emails/existing-account') as {
+        ExistingAccountEmail: jest.Mock;
+      };
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { sendEmail } = require('../notifications/services/email-providers/send-email') as {
+        sendEmail: jest.Mock;
+      };
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { render } = require('@react-email/render') as { render: jest.Mock };
+      process.env.BETTER_AUTH_URL = 'https://app.manifest.build';
+
+      loadModule();
+
+      const config = mockBetterAuth.mock.calls[0][0];
+      const mockUser = { name: 'Jane Doe', email: 'jane@example.com' };
+
+      await config.emailAndPassword.onExistingUserSignUp({ user: mockUser });
+
+      expect(ExistingAccountEmail).toHaveBeenCalledWith({
+        userName: 'Jane Doe',
+        signInUrl: 'https://app.manifest.build/login',
+        resetPasswordUrl: 'https://app.manifest.build/reset-password',
+      });
+      expect(render).toHaveBeenCalledWith('existing-account-element');
+      expect(render).toHaveBeenCalledWith('existing-account-element', { plainText: true });
+      expect(sendEmail).toHaveBeenCalledWith({
+        to: 'jane@example.com',
+        subject: 'You already have a Manifest account',
+        html: '<html>rendered</html>',
+        text: 'plain text version',
+      });
+    });
+
+    it('builds the links from the local port when BETTER_AUTH_URL is unset', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { ExistingAccountEmail } = require('../notifications/emails/existing-account') as {
+        ExistingAccountEmail: jest.Mock;
+      };
+      delete process.env.BETTER_AUTH_URL;
+      process.env.PORT = '4242';
+
+      loadModule();
+
+      const config = mockBetterAuth.mock.calls[0][0];
+      await config.emailAndPassword.onExistingUserSignUp({
+        user: { name: 'Jane Doe', email: 'jane@example.com' },
+      });
+
+      expect(ExistingAccountEmail).toHaveBeenCalledWith({
+        userName: 'Jane Doe',
+        signInUrl: 'http://localhost:4242/login',
+        resetPasswordUrl: 'http://localhost:4242/reset-password',
       });
     });
   });

--- a/packages/backend/src/auth/auth.instance.ts
+++ b/packages/backend/src/auth/auth.instance.ts
@@ -4,6 +4,7 @@ import { stripe as stripePlugin } from '@better-auth/stripe';
 import { render } from '@react-email/render';
 import { VerifyEmailEmail } from '../notifications/emails/verify-email';
 import { ResetPasswordEmail } from '../notifications/emails/reset-password';
+import { ExistingAccountEmail } from '../notifications/emails/existing-account';
 import { sendEmail } from '../notifications/services/email-providers/send-email';
 import { isBillingEnabled, getStripeClient } from '../billing/billing.config';
 import {
@@ -14,6 +15,7 @@ import {
 } from '../billing/subscription-webhook-emails';
 
 const port = process.env['PORT'] ?? '3001';
+const appBaseUrl = process.env['BETTER_AUTH_URL'] ?? `http://localhost:${port}`;
 const isDev = (process.env['NODE_ENV'] ?? '') !== 'production';
 const hasEmailProvider = !!(
   (process.env['EMAIL_PROVIDER'] && process.env['EMAIL_API_KEY']) ||
@@ -101,7 +103,7 @@ function buildPlugins() {
 
 export const auth = betterAuth({
   database,
-  baseURL: process.env['BETTER_AUTH_URL'] ?? `http://localhost:${port}`,
+  baseURL: appBaseUrl,
   basePath: '/api/auth',
   secret: betterAuthSecret,
   logger: { level: 'debug' },
@@ -117,6 +119,27 @@ export const auth = betterAuth({
     enabled: true,
     minPasswordLength: 8,
     requireEmailVerification: !isDev && hasEmailProvider,
+    // With `requireEmailVerification` on, Better Auth answers a sign-up for an
+    // existing email with a synthetic 200 instead of an error, so the address is
+    // never confirmed to whoever submitted the form. That anti-enumeration
+    // response is also a dead end: the browser shows "check your email" and no
+    // email is ever sent. This hook closes the loop for the one party entitled to
+    // know — the account holder — without leaking anything to the submitter.
+    onExistingUserSignUp: async ({ user }) => {
+      const element = ExistingAccountEmail({
+        userName: user.name,
+        signInUrl: `${appBaseUrl}/login`,
+        resetPasswordUrl: `${appBaseUrl}/reset-password`,
+      });
+      const html = await render(element);
+      const text = await render(element, { plainText: true });
+      void sendEmail({
+        to: user.email,
+        subject: 'You already have a Manifest account',
+        html,
+        text,
+      });
+    },
     sendResetPassword: async ({ user, url }) => {
       const element = ResetPasswordEmail({
         userName: user.name,

--- a/packages/backend/src/notifications/emails/existing-account.tsx
+++ b/packages/backend/src/notifications/emails/existing-account.tsx
@@ -1,0 +1,211 @@
+import * as React from 'react';
+import {
+  Html,
+  Head,
+  Body,
+  Container,
+  Section,
+  Text,
+  Button,
+  Preview,
+  Hr,
+  Img,
+  Link,
+} from '@react-email/components';
+
+export interface ExistingAccountProps {
+  userName: string;
+  signInUrl: string;
+  resetPasswordUrl: string;
+  logoUrl?: string;
+}
+
+export function ExistingAccountEmail(props: ExistingAccountProps) {
+  const {
+    userName,
+    signInUrl,
+    resetPasswordUrl,
+    logoUrl = 'https://app.manifest.build/manifest-logo.png',
+  } = props;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>You already have a Manifest account — sign in instead</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          {/* Logo */}
+          <Section style={logoSection}>
+            <Img src={logoUrl} alt="Manifest" height="32" style={logoImg} />
+          </Section>
+
+          {/* Main content */}
+          <Section style={card}>
+            <Text style={heading}>You already have an account</Text>
+            <Text style={paragraph}>
+              Hi {userName}, someone just tried to create a Manifest account with this email
+              address. You already have one, so we didn't create a second — sign in below instead.
+            </Text>
+
+            <Section style={buttonContainer}>
+              <Button style={button} href={signInUrl}>
+                Sign in
+              </Button>
+            </Section>
+
+            <Text style={hint}>
+              Forgot your password? You can{' '}
+              <Link href={resetPasswordUrl} style={hintLink}>
+                reset it here
+              </Link>
+              . If this wasn't you, no action is needed — your account and password are unchanged.
+            </Text>
+          </Section>
+
+          {/* Fallback link */}
+          <Section style={fallbackSection}>
+            <Text style={fallbackText}>
+              If the button above doesn't work, copy and paste this link into your browser:
+            </Text>
+            <Text style={fallbackUrl}>{signInUrl}</Text>
+          </Section>
+
+          {/* Footer */}
+          <Hr style={divider} />
+          <Section style={footer}>
+            <Text style={footerMuted}>
+              © 2026 MNFST Inc. All rights reserved.{' '}
+              <Link href="https://manifest.build" style={footerLink}>
+                manifest.build
+              </Link>
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+/* ── Brand tokens ──────────────────────────────────── */
+const brandBg = '#f8f6f1';
+const brandCardBg = '#ffffff';
+const brandPrimary = '#0f172a';
+const brandPrimaryFg = '#f9f8f5';
+const brandFg = '#020817';
+const brandMuted = '#64748b';
+const brandBorder = '#e5dfd6';
+const brandFont =
+  'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+/* ── Styles ────────────────────────────────────────── */
+const body: React.CSSProperties = {
+  backgroundColor: brandBg,
+  fontFamily: brandFont,
+  margin: 0,
+  padding: 0,
+};
+
+const container: React.CSSProperties = {
+  maxWidth: '520px',
+  margin: '0 auto',
+  padding: '40px 20px',
+};
+
+const logoSection: React.CSSProperties = {
+  textAlign: 'center' as const,
+  paddingBottom: '32px',
+};
+
+const logoImg: React.CSSProperties = {
+  margin: '0 auto',
+};
+
+const card: React.CSSProperties = {
+  backgroundColor: brandCardBg,
+  borderRadius: '12px',
+  padding: '40px 36px',
+  border: `1px solid ${brandBorder}`,
+};
+
+const heading: React.CSSProperties = {
+  fontSize: '22px',
+  fontWeight: 700,
+  letterSpacing: '-0.02em',
+  color: brandFg,
+  margin: '0 0 12px',
+  lineHeight: '1.3',
+};
+
+const paragraph: React.CSSProperties = {
+  fontSize: '15px',
+  lineHeight: '1.6',
+  color: '#374151',
+  margin: '0 0 28px',
+};
+
+const buttonContainer: React.CSSProperties = {
+  textAlign: 'center' as const,
+  margin: '0 0 28px',
+};
+
+const button: React.CSSProperties = {
+  backgroundColor: brandPrimary,
+  color: brandPrimaryFg,
+  fontSize: '14px',
+  fontWeight: 600,
+  padding: '14px 28px',
+  borderRadius: '8px',
+  textDecoration: 'none',
+  display: 'inline-block',
+  lineHeight: '1',
+};
+
+const hint: React.CSSProperties = {
+  fontSize: '13px',
+  lineHeight: '1.5',
+  color: brandMuted,
+  margin: 0,
+};
+
+const hintLink: React.CSSProperties = {
+  color: brandMuted,
+  textDecoration: 'underline',
+};
+
+const fallbackSection: React.CSSProperties = {
+  padding: '24px 0 0',
+};
+
+const fallbackText: React.CSSProperties = {
+  fontSize: '12px',
+  color: brandMuted,
+  margin: '0 0 6px',
+};
+
+const fallbackUrl: React.CSSProperties = {
+  fontSize: '12px',
+  color: brandMuted,
+  margin: 0,
+  wordBreak: 'break-all' as const,
+};
+
+const divider: React.CSSProperties = {
+  borderColor: brandBorder,
+  borderTop: 'none',
+  margin: '32px 0 24px',
+};
+
+const footer: React.CSSProperties = {
+  textAlign: 'center' as const,
+};
+
+const footerMuted: React.CSSProperties = {
+  fontSize: '12px',
+  color: '#94a3b8',
+  margin: 0,
+};
+
+const footerLink: React.CSSProperties = {
+  color: '#94a3b8',
+  textDecoration: 'underline',
+};

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -195,7 +195,8 @@ const Register: Component = () => {
                 </div>
               )}
               <div class="auth-form__success">
-                Click the link in your email to verify your account and get started.
+                Click the link in your email to verify your account and get started. If you already
+                had an account with this address, we've sent you a sign-in link instead.
               </div>
               <button
                 class="auth-form__link-btn"
@@ -336,7 +337,7 @@ const Register: Component = () => {
             <p class="auth-header__subtitle">
               {searchParams.context === 'login'
                 ? 'Manifest now offers Free and Pro plans. Select the one that fits your needs.'
-                : 'Monitor your AI harnesses\' costs and usage'}
+                : "Monitor your AI harnesses' costs and usage"}
             </p>
           </div>
 


### PR DESCRIPTION
Signing up with an email that already has an account showed "check your email" and sent nothing — Better Auth answers a duplicate sign-up with a synthetic 200 rather than an error whenever `requireEmailVerification` is on (which it is in cloud), so the frontend's already-exists branch never fired and no mail was triggered.

This wires `emailAndPassword.onExistingUserSignUp` so the existing account holder gets a new `ExistingAccountEmail` with a sign-in button and a reset-password link, and softens the confirmation-screen copy so it's true in both branches. The anti-enumeration response is deliberately kept intact — whoever submitted the form still learns nothing — and the unreachable-in-cloud error branch stays because it still fires in dev and on self-hosted installs with no email provider.

Verified against a real backend on a fresh Postgres in production config with outbound HTTP tapped: two signups with the same address returned identical 200s and produced exactly one mail each ("Verify your email address", then "You already have a Manifest account"), addressed to the account holder's real name, leaving a single user row. Backend (7560) and frontend (3986) suites pass, `auth.instance.ts` stays at 100% line and function coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Notify the account holder when someone signs up with an email that already has an account, sending a sign-in button and reset link. This removes the “check your email” dead end while preserving the 200 anti-enumeration response.

- **Bug Fixes**
  - Hooked `emailAndPassword.onExistingUserSignUp` to render and send `ExistingAccountEmail` with sign-in and reset links.
  - Built URLs from `BETTER_AUTH_URL` when set, falling back to `http://localhost:${PORT}`.
  - Updated register success copy to cover both verification and existing-account cases.

<sup>Written for commit 4150a2597ff0d5de4bb8ee09f6788cc509da025e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

