### PR TITLE
fix: honor model routes on messages endpoint

### DIFF
--- a/.changeset/route-anthropic-message-models.md
+++ b/.changeset/route-anthropic-message-models.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Honor requested model routes on the Anthropic Messages endpoint.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -977,7 +977,7 @@ describe('ProxyService — orchestration', () => {
     });
   });
 
-  describe('explicit OpenAI-compatible model routing', () => {
+  describe('explicit model routing', () => {
     beforeEach(() => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
@@ -1401,12 +1401,68 @@ describe('ProxyService — orchestration', () => {
       );
     });
 
-    it('does not treat the Anthropic Messages model field as an SDK routing override', async () => {
+    it.each([
+      ['provider-qualified', 'openai/gpt-5.5', 'openai', 'gpt-5.5'],
+      ['provider-native', 'claude-haiku-4-5', 'anthropic', 'claude-haiku-4-5'],
+    ])(
+      'routes a %s model from an Anthropic Messages request',
+      async (_kind, requestedModel, provider, model) => {
+        modelDiscovery.getModelsForAgent.mockResolvedValue([
+          discoveredModel({ id: model, provider, authType: 'api_key' }),
+        ]);
+
+        await svc.proxyRequest(
+          baseOpts({
+            apiMode: 'messages',
+            body: {
+              model: requestedModel,
+              max_tokens: 32,
+              messages: [{ role: 'user', content: 'hi' }],
+            },
+          }),
+        );
+
+        expect(modelDiscovery.getModelsForAgent).toHaveBeenCalledWith('tenant-1', 'agent-1');
+        expect(resolveService.resolveLazy).not.toHaveBeenCalled();
+        expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+          expect.objectContaining({
+            provider,
+            authType: 'api_key',
+            model,
+          }),
+        );
+      },
+    );
+
+    it('returns model-not-available for an unknown Anthropic Messages model', async () => {
+      const result = await svc.proxyRequest(
+        baseOpts({
+          apiMode: 'messages',
+          body: {
+            model: 'bogus/does-not-exist',
+            max_tokens: 32,
+            messages: [{ role: 'user', content: 'hi' }],
+          },
+        }),
+      );
+      const body = await result.forward.response.text();
+
+      expect(resolveService.resolveLazy).not.toHaveBeenCalled();
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      expect(body).toContain('M302');
+      expect(body).toContain('bogus/does-not-exist');
+      expect(result.meta).toMatchObject({
+        reason: 'model_not_available',
+        manifest_error_code: 'M302',
+      });
+    });
+
+    it('leaves auto on the existing Anthropic Messages resolver path', async () => {
       await svc.proxyRequest(
         baseOpts({
           apiMode: 'messages',
           body: {
-            model: 'claude-haiku-4-5',
+            model: 'auto',
             max_tokens: 32,
             messages: [{ role: 'user', content: 'hi' }],
           },
@@ -1414,6 +1470,7 @@ describe('ProxyService — orchestration', () => {
       );
 
       expect(modelDiscovery.getModelsForAgent).not.toHaveBeenCalled();
+      expect(resolveService.resolveLazy).toHaveBeenCalled();
       expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
         expect.objectContaining({
           provider: 'anthropic',
@@ -2537,7 +2594,7 @@ describe('ProxyService — orchestration', () => {
         baseOpts({
           apiMode: 'messages',
           body: {
-            model: 'claude-sonnet-4-5',
+            model: 'auto',
             messages: [{ role: 'user', content: 'Hello' }],
           },
         } as never),
@@ -2545,7 +2602,7 @@ describe('ProxyService — orchestration', () => {
 
       expect(convertSpy).not.toHaveBeenCalled();
       expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body).toEqual({
-        model: 'claude-sonnet-4-5',
+        model: 'auto',
         messages: [{ role: 'user', content: 'Hello' }],
       });
     });

--- a/packages/backend/src/routing/proxy/openai-model-id.ts
+++ b/packages/backend/src/routing/proxy/openai-model-id.ts
@@ -18,7 +18,7 @@ export function openAiModelId(model: DiscoveredModel): string {
 }
 
 /**
- * Resolve the `model` field of an OpenAI-compatible request to a route.
+ * Resolve the `model` field of a proxy request to a route.
  *
  * Matches the provider-qualified id published by `/v1/models`
  * (`openai/gpt-5.4-nano`) first, then the bare provider-native name

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -866,9 +866,10 @@ export class ProxyService {
     apiMode: ProxyApiMode,
   ): Promise<ResolvedRouting> {
     const requestedModel = typeof body.model === 'string' ? body.model : undefined;
-    // Anthropic Messages requests require a provider-native model field; only
-    // OpenAI-compatible surfaces use /v1/models IDs as route overrides.
-    if (apiMode !== 'messages' && requestedModel && requestedModel !== OPENAI_MODEL_ID_AUTO) {
+    // Every public proxy surface treats a concrete model as an explicit route.
+    // The resolver accepts both provider-qualified /v1/models IDs and the
+    // unambiguous provider-native IDs required by Anthropic clients.
+    if (requestedModel && requestedModel !== OPENAI_MODEL_ID_AUTO) {
       const explicit = await this.resolveExplicitModel(agentId, tenantId, requestedModel, headers);
       if (explicit) return explicit;
       return {
@@ -916,7 +917,7 @@ export class ProxyService {
   }
 
   /**
-   * Route the `model` an OpenAI-compatible client named in the body.
+   * Route the `model` a proxy client named in the body.
    *
    * A matching header tier wins: that rule is an override the operator
    * configured on purpose, and the SDK's `model` field is mandatory, so most


### PR DESCRIPTION
### ✨ What changed
- Route concrete Messages models through the authenticated model list.
- Return M302 when the requested Messages model is unavailable.

### 💭 Why
`/v1/messages` ignored concrete model requests and silently used the agent default.

### 👤 For users
`/v1/messages` now honors provider-qualified and provider-native model IDs.

### 📝 Notes
Closes #2620


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/v1/messages` honor explicit model routes. Concrete `model` values now route to the authenticated provider/model and unknown models return `M302` instead of falling back to the agent default. Closes #2620.

- **Bug Fixes**
  - Route provider-qualified (`openai/gpt-5.5`) and provider-native (`claude-haiku-4-5`) IDs on Anthropic Messages; keep `auto` on the existing resolver path.
  - Return `M302` (`model_not_available`) with the requested id when the model isn’t available.
  - Tests added in `packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts`; minor updates in `proxy.service.ts` and `openai-model-id.ts`.

<sup>Written for commit 6183252764150786fe396b1f4625053e061d8bf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

