### PR TITLE
fix: preserve OpenRouter model modalities

### DIFF
--- a/.changeset/openrouter-model-modalities.md
+++ b/.changeset/openrouter-model-modalities.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Preserve OpenRouter input and output modalities during model discovery.

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2031,6 +2031,43 @@ describe('ProviderModelFetcherService', () => {
       );
     });
 
+    it('should normalize OpenRouter input and output modalities', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 'deepseek/deepseek-v4-flash',
+              architecture: {
+                input_modalities: ['text'],
+                output_modalities: ['text'],
+              },
+            },
+            {
+              id: 'google/gemini-2.5-flash',
+              architecture: {
+                input_modalities: ['file', 'image', 'text', 'audio', 'video'],
+                output_modalities: ['text'],
+              },
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openrouter', '');
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          inputModalities: ['text'],
+          outputModalities: ['text'],
+        }),
+        expect.objectContaining({
+          inputModalities: ['text', 'image', 'audio', 'video'],
+          outputModalities: ['text'],
+        }),
+      ]);
+    });
+
     it('should filter out non-text output modality models', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -2050,6 +2050,13 @@ describe('ProviderModelFetcherService', () => {
                 output_modalities: ['text'],
               },
             },
+            {
+              id: 'file-only',
+              architecture: {
+                input_modalities: ['file'],
+                output_modalities: ['text'],
+              },
+            },
           ],
         }),
       });
@@ -2065,7 +2072,11 @@ describe('ProviderModelFetcherService', () => {
           inputModalities: ['text', 'image', 'audio', 'video'],
           outputModalities: ['text'],
         }),
+        expect.objectContaining({
+          outputModalities: ['text'],
+        }),
       ]);
+      expect(result[2]).not.toHaveProperty('inputModalities');
     });
 
     it('should filter out non-text output modality models', async () => {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -32,6 +32,7 @@ import {
 import {
   getSubscriptionCapabilities,
   getSubscriptionKnownModels,
+  MODEL_MODALITIES,
   type ModelCapability,
   type ModelModality,
 } from 'manifest-shared';
@@ -565,8 +566,17 @@ interface OpenRouterModelEntry {
   id: string;
   name?: string;
   context_length?: number;
-  architecture?: { output_modalities?: string[] };
+  architecture?: { input_modalities?: string[]; output_modalities?: string[] };
   pricing?: { prompt?: string; completion?: string };
+}
+
+function normalizeOpenRouterModalities(
+  values: readonly string[] | undefined,
+): readonly ModelModality[] | undefined {
+  if (!values?.length) return undefined;
+  const upstreamModalities = new Set(values.map((value) => value.toLowerCase()));
+  const modalities = MODEL_MODALITIES.filter((modality) => upstreamModalities.has(modality));
+  return modalities.length > 0 ? modalities : undefined;
 }
 
 interface FireworksModelEntry {
@@ -604,6 +614,8 @@ function parseOpenRouter(body: unknown, provider: string): DiscoveredModel[] {
       const entry = m as OpenRouterModelEntry;
       const prompt = entry.pricing?.prompt ? Number(entry.pricing.prompt) : null;
       const completion = entry.pricing?.completion ? Number(entry.pricing.completion) : null;
+      const inputModalities = normalizeOpenRouterModalities(entry.architecture?.input_modalities);
+      const outputModalities = normalizeOpenRouterModalities(entry.architecture?.output_modalities);
       return {
         id: entry.id,
         displayName: entry.name || entry.id,
@@ -615,6 +627,8 @@ function parseOpenRouter(body: unknown, provider: string): DiscoveredModel[] {
           completion !== null && Number.isFinite(completion) && completion >= 0 ? completion : null,
         capabilityReasoning: false,
         capabilityCode: false,
+        ...(inputModalities ? { inputModalities } : {}),
+        ...(outputModalities ? { outputModalities } : {}),
         qualityScore: 3,
       };
     });


### PR DESCRIPTION
### ✨ What changed
- Preserve supported OpenRouter input and output modalities during discovery.
- Cover DeepSeek V4 Flash and Gemini 2.5 Flash catalog shapes.

### 💭 Why
Manifest discarded OpenRouter input modality evidence, so capability consumers treated multimodal models as unknown.

### 👤 For users
OpenRouter image-capable models now publish their supported input modalities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves OpenRouter input and output modalities during model discovery so multimodal models are correctly detected and exposed to capability consumers.

- **Bug Fixes**
  - Parse and normalize OpenRouter `architecture.input_modalities` and `architecture.output_modalities` against `MODEL_MODALITIES` from `manifest-shared` (drops unsupported values like `file`) and store them in discovery results.
  - Add tests for DeepSeek V4 Flash, Gemini 2.5 Flash, and a `file`-only input case to ensure unsupported modalities are omitted.

<sup>Written for commit b0aaf6f3d6a6e1c9796fc588182cf5bf77a30ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

