### PR TITLE
fix: simplify Gemini Free key placeholder

### DIFF
--- a/.changeset/gemini-free-provider.md
+++ b/.changeset/gemini-free-provider.md
@@ -2,5 +2,5 @@
 'manifest': patch
 ---
 
-Add a Gemini Free provider backed by Gemini-scoped LiteLLM virtual keys and a reusable managed
-free-provider configuration.
+Add a Gemini Free provider with Gemini-scoped keys and a reusable managed free-provider
+configuration.

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -468,11 +468,11 @@ describe('PROVIDERS', () => {
     expect(ollama.minKeyLength).toBe(0);
   });
 
-  it('exposes Gemini Free as a LiteLLM virtual-key provider', () => {
+  it('exposes Gemini Free as a managed free provider', () => {
     const provider = PROVIDERS.find((entry) => entry.id === 'gemini-free')!;
     expect(provider.name).toBe('Gemini Free');
     expect(provider.subtitle).toBe('Free Gemini models via Manifest');
-    expect(provider.keyPlaceholder).toBe('sk-... (LiteLLM virtual key)');
+    expect(provider.keyPlaceholder).toBe('sk-...');
     expect(getRoutingProviderApiKeyUrl('gemini-free')).toBe(
       'https://calendly.com/sebastien-manifest/30min',
     );

--- a/packages/shared/__tests__/providers.spec.ts
+++ b/packages/shared/__tests__/providers.spec.ts
@@ -161,7 +161,7 @@ describe('SHARED_PROVIDER_BY_ID', () => {
     expect(provider!.displayName).toBe('Gemini Free');
     expect(provider!.aliases).toEqual(['gemini free']);
     expect(provider!.openRouterPrefixes).toEqual([]);
-    expect(provider!.keyPlaceholder).toBe('sk-... (LiteLLM virtual key)');
+    expect(provider!.keyPlaceholder).toBe('sk-...');
     expect(provider!.managedFree).toBe(true);
   });
 

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -231,7 +231,7 @@ export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
     color: '#4285f4',
     keyPrefix: 'sk-',
     minKeyLength: 10,
-    keyPlaceholder: 'sk-... (LiteLLM virtual key)',
+    keyPlaceholder: 'sk-...',
     managedFree: true,
   },
   {


### PR DESCRIPTION
### ✨ What changed
- Shorten the Gemini Free key placeholder to `sk-...`.
- Generalize the pending Gemini Free release note.

### 💭 Why
The key field should not expose internal implementation details.

### 👤 For users
Gemini Free now shows a neutral key placeholder.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the Gemini Free key placeholder to `sk-...` to avoid exposing internal implementation details. Updated provider config, tests, and the changeset with neutral wording.

<sup>Written for commit 795a18c6bca29ae85e3dc359f24bbef24f49efe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

