### PR TITLE
fix: show called tools in request details

### DIFF
--- a/.changeset/show-called-tools.md
+++ b/.changeset/show-called-tools.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show actual Provider Attempt tool calls instead of available tool definitions in recorded message details.

--- a/packages/frontend/src/components/RequestMessages.tsx
+++ b/packages/frontend/src/components/RequestMessages.tsx
@@ -2,7 +2,7 @@ import { For, Show, createMemo, createSignal, onCleanup, type Component } from '
 import {
   coerceContentToText,
   extractRecordedConversationMessages,
-  extractRequestTools,
+  extractResponseToolCalls,
   normalizeRole,
   type ChatMessage,
   type Role,
@@ -31,6 +31,15 @@ function pretty(value: unknown): string {
     return JSON.stringify(value, null, 2);
   } catch {
     return String(value);
+  }
+}
+
+function toolArguments(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
   }
 }
 
@@ -317,7 +326,7 @@ const RequestMessages: Component<{ recording: Recording | null; view?: Recording
         )
       : [],
   );
-  const tools = createMemo(() => extractRequestTools(props.recording?.request_body));
+  const toolCalls = createMemo(() => extractResponseToolCalls(props.recording?.response_body));
 
   return (
     <Show
@@ -350,25 +359,25 @@ const RequestMessages: Component<{ recording: Recording | null; view?: Recording
           <Show when={view() === 'tools'}>
             <div class="request-messages__scroll-area">
               <Show
-                when={tools().length > 0}
-                fallback={<div class="request-messages__empty">No tools were defined.</div>}
+                when={toolCalls().length > 0}
+                fallback={<div class="request-messages__empty">No tools were called.</div>}
               >
                 <div class="request-messages__tools">
-                  <For each={tools()}>
-                    {(tool) => (
+                  <For each={toolCalls()}>
+                    {(call) => (
                       <article class="request-tool">
                         <div class="request-tool__head">
                           <span class="request-messages__tool-icon" aria-hidden="true">
                             ↳
                           </span>
-                          <strong>{tool.function?.name ?? tool.type ?? 'Unknown tool'}</strong>
-                          <span>{tool.type ?? 'function'}</span>
+                          <strong>{call.function?.name ?? 'Unknown tool'}</strong>
+                          <span class="request-tool__type">{call.type ?? 'function'}</span>
+                          <Show when={call.id}>
+                            <code>{call.id}</code>
+                          </Show>
                         </div>
-                        <Show when={tool.function?.description}>
-                          <p>{tool.function?.description}</p>
-                        </Show>
-                        <Show when={tool.function?.parameters != null}>
-                          <pre>{pretty(tool.function?.parameters)}</pre>
+                        <Show when={call.function?.arguments != null}>
+                          <pre>{pretty(toolArguments(call.function?.arguments))}</pre>
                         </Show>
                       </article>
                     )}

--- a/packages/frontend/src/styles/request-drawer.css
+++ b/packages/frontend/src/styles/request-drawer.css
@@ -730,7 +730,7 @@
   font-family: var(--font-mono);
   font-weight: 700;
 }
-.request-tool__head > span:last-child {
+.request-tool__type {
   margin-left: auto;
   color: hsl(var(--muted-foreground));
   font-family: var(--font-mono);

--- a/packages/frontend/tests/components/RequestDrawer.test.tsx
+++ b/packages/frontend/tests/components/RequestDrawer.test.tsx
@@ -256,6 +256,7 @@ describe('RequestDrawer', () => {
     ));
 
     await waitFor(() => expect(screen.getByText('Messages')).toBeDefined());
+    expect(screen.getByText('Tools')).toBeDefined();
     fireEvent.click(screen.getByText('Messages'));
 
     expect(
@@ -272,6 +273,7 @@ describe('RequestDrawer', () => {
     // Switch to attempt 1 — no recording, so Messages/Tools/Raw tabs do not appear.
     fireEvent.click(container.querySelectorAll('.attempt-item')[1]!);
     expect(screen.queryByText('Messages')).toBeNull();
+    expect(screen.queryByText('Tools')).toBeNull();
     expect(
       screen.queryByText('Recorded user turn', {
         selector: '.request-message__content',

--- a/packages/frontend/tests/components/RequestMessages.test.tsx
+++ b/packages/frontend/tests/components/RequestMessages.test.tsx
@@ -32,10 +32,37 @@ describe('RequestMessages', () => {
     expect(getAllByText('Sunny.')).toHaveLength(2);
   });
 
-  it('shows tool definitions when view is tools', () => {
-    const { getByText } = render(() => <RequestMessages recording={recording} view="tools" />);
+  it('shows only tool calls emitted by the selected attempt', () => {
+    const calledRecording = {
+      ...recording,
+      response_body: {
+        type: 'json' as const,
+        body: {
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call-1',
+                    type: 'function',
+                    function: { name: 'weather', arguments: '{"city":"Paris"}' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+    const { getByText, queryByText } = render(() => (
+      <RequestMessages recording={calledRecording} view="tools" />
+    ));
     expect(getByText('weather')).toBeTruthy();
-    expect(getByText('Read the forecast')).toBeTruthy();
+    expect(getByText('call-1')).toBeTruthy();
+    expect(getByText(/"city": "Paris"/)).toBeTruthy();
+    expect(queryByText('Read the forecast')).toBeNull();
   });
 
   it('shows raw payloads when view is raw', () => {
@@ -93,7 +120,7 @@ describe('RequestMessages', () => {
     const { getByText: getText2 } = render(() => (
       <RequestMessages recording={emptyRecording} view="tools" />
     ));
-    expect(getText2('No tools were defined.')).toBeTruthy();
+    expect(getText2('No tools were called.')).toBeTruthy();
   });
 
   it('explains when recording was disabled', () => {

--- a/packages/shared/__tests__/chat-message.spec.ts
+++ b/packages/shared/__tests__/chat-message.spec.ts
@@ -4,6 +4,7 @@ import {
   extractRequestMessages,
   extractRequestTools,
   extractResponseMessages,
+  extractResponseToolCalls,
   normalizeRole,
 } from '../src/chat-message';
 
@@ -103,10 +104,7 @@ describe('recorded chat message helpers', () => {
       extractRequestMessages({
         messages: [
           {
-            content: [
-              { type: 'tool_use' },
-              { type: 'tool_result', content: 'No id' },
-            ],
+            content: [{ type: 'tool_use' }, { type: 'tool_result', content: 'No id' }],
           },
         ],
       }),
@@ -365,6 +363,185 @@ describe('recorded chat message helpers', () => {
       extractResponseMessages({
         type: 'stream',
         raw_sse: 'event: ping\ndata: {"type":"ping"}\n',
+      }),
+    ).toEqual([]);
+  });
+
+  it('extracts only tool calls emitted by JSON responses', () => {
+    expect(
+      extractResponseToolCalls({
+        type: 'json',
+        body: {
+          type: 'message',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tool-1',
+              name: 'weather',
+              input: { city: 'Paris' },
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        id: 'tool-1',
+        type: 'function',
+        function: { name: 'weather', arguments: { city: 'Paris' } },
+      },
+    ]);
+    expect(
+      extractResponseToolCalls({
+        type: 'json',
+        body: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: 'gemini-tool-1',
+                      name: 'weather',
+                      args: { city: 'Paris' },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        id: 'gemini-tool-1',
+        type: 'function',
+        function: { name: 'weather', arguments: { city: 'Paris' } },
+      },
+    ]);
+    expect(extractResponseToolCalls(null)).toEqual([]);
+  });
+
+  it('reconstructs streamed Chat Completions tool calls', () => {
+    expect(
+      extractResponseToolCalls({
+        type: 'stream',
+        raw_sse: [
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"weather","arguments":"{\\"city\\":"}}]}}]}',
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"Paris\\"}"}}]}}]}',
+          'data: [DONE]',
+        ].join('\n'),
+      }),
+    ).toEqual([
+      {
+        id: 'call-1',
+        type: 'function',
+        function: { name: 'weather', arguments: '{"city":"Paris"}' },
+      },
+    ]);
+  });
+
+  it('reconstructs streamed Responses and Anthropic tool calls', () => {
+    expect(
+      extractResponseToolCalls({
+        type: 'stream',
+        raw_sse: [
+          'data: {"type":"response.output_item.added","output_index":0,"item":{"id":"item-1","type":"function_call","call_id":"call-1","name":"lookup","arguments":""}}',
+          'data: {"type":"response.function_call_arguments.delta","item_id":"item-1","output_index":0,"delta":"{\\"id\\":"}',
+          'data: {"type":"response.function_call_arguments.delta","item_id":"item-1","output_index":0,"delta":"42}"}',
+        ].join('\n'),
+      }),
+    ).toEqual([
+      {
+        id: 'call-1',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{"id":42}' },
+      },
+    ]);
+
+    expect(
+      extractResponseToolCalls({
+        type: 'stream',
+        raw_sse: [
+          'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool-1","name":"lookup","input":{}}}',
+          'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"id\\":"}}',
+          'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"42}"}}',
+        ].join('\n'),
+      }),
+    ).toEqual([
+      {
+        id: 'tool-1',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{"id":42}' },
+      },
+    ]);
+  });
+
+  it('keeps malformed optional tool-call metadata safe', () => {
+    expect(
+      extractResponseToolCalls({
+        type: 'json',
+        body: {
+          candidates: [{ content: {} }],
+        },
+      }),
+    ).toEqual([]);
+    expect(
+      extractResponseToolCalls({
+        type: 'json',
+        body: {
+          candidates: [{ content: { parts: [{ functionCall: {} }] } }],
+        },
+      }),
+    ).toEqual([
+      {
+        id: undefined,
+        type: 'function',
+        function: { name: undefined, arguments: undefined },
+      },
+    ]);
+
+    expect(
+      extractResponseToolCalls({
+        type: 'stream',
+        raw_sse: [
+          'data: {"choices":[{"delta":{"tool_calls":[null,{"function":{"name":"look"}},{"index":0,"function":{"name":"up"}}]}}]}',
+          'data: {"type":"response.output_item.done","item":{"id":"item-only","type":"function_call"}}',
+          'data: {"type":"response.output_item.done","item":{"call_id":"call-only","type":"function_call"}}',
+          'data: {"type":"response.output_item.done","item":{"type":"function_call"}}',
+          'data: {"type":"response.function_call_arguments.delta","delta":"{}"}',
+          'data: {"type":"content_block_start","content_block":{"type":"tool_use"}}',
+          'data: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{}"}}',
+        ].join('\n'),
+      }),
+    ).toEqual([
+      {
+        type: 'function',
+        function: { name: 'lookup' },
+      },
+      {
+        id: 'item-only',
+        type: 'function',
+        function: {},
+      },
+      {
+        id: 'call-only',
+        type: 'function',
+        function: {},
+      },
+      {
+        type: 'function',
+        function: { arguments: '{}' },
+      },
+      {
+        type: 'function',
+        function: { arguments: '{}' },
+      },
+    ]);
+
+    expect(
+      extractResponseToolCalls({
+        type: 'json',
+        body: { choices: [{ message: { role: 'assistant', content: 'No call' } }] },
       }),
     ).toEqual([]);
   });

--- a/packages/shared/src/chat-message.ts
+++ b/packages/shared/src/chat-message.ts
@@ -163,15 +163,38 @@ function responsesItem(item: JsonRecord, defaultRole: string): ChatMessage[] {
 }
 
 function geminiContents(contents: unknown[]): ChatMessage[] {
-  return contents.filter(isRecord).map((content) => ({
-    role:
-      content.role === 'model'
-        ? 'assistant'
-        : typeof content.role === 'string'
-          ? content.role
-          : 'user',
-    content: content.parts,
-  }));
+  return contents.filter(isRecord).map((content) => {
+    const parts = Array.isArray(content.parts) ? content.parts : [];
+    const toolCalls: ToolCall[] = [];
+    const normalContent: unknown[] = [];
+
+    for (const part of parts) {
+      if (!isRecord(part) || !isRecord(part.functionCall)) {
+        normalContent.push(part);
+        continue;
+      }
+      const call = part.functionCall;
+      toolCalls.push({
+        id: typeof call.id === 'string' ? call.id : undefined,
+        type: 'function',
+        function: {
+          name: typeof call.name === 'string' ? call.name : undefined,
+          arguments: call.args,
+        },
+      });
+    }
+
+    return {
+      role:
+        content.role === 'model'
+          ? 'assistant'
+          : typeof content.role === 'string'
+            ? content.role
+            : 'user',
+      content: normalContent.length > 0 ? normalContent : null,
+      ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+    };
+  });
 }
 
 export function extractRequestMessages(
@@ -257,6 +280,26 @@ function extractJsonResponse(body: JsonRecord): ChatMessage[] {
 
 function extractStreamResponse(rawSse: string): ChatMessage[] {
   let text = '';
+  const toolCalls: ToolCall[] = [];
+  type MutableToolCall = ToolCall & {
+    function: { name?: string; arguments?: unknown };
+  };
+  const callsByKey = new Map<string, MutableToolCall>();
+
+  const callFor = (key: string): MutableToolCall => {
+    const existing = callsByKey.get(key);
+    if (existing) return existing;
+    const call: MutableToolCall = { type: 'function', function: {} };
+    callsByKey.set(key, call);
+    toolCalls.push(call);
+    return call;
+  };
+
+  const appendArguments = (call: MutableToolCall, fragment: string) => {
+    const current = call.function.arguments;
+    call.function.arguments = `${typeof current === 'string' ? current : ''}${fragment}`;
+  };
+
   for (const line of rawSse.split(/\r?\n/)) {
     if (!line.startsWith('data:')) continue;
     const data = line.slice(5).trim();
@@ -267,17 +310,93 @@ function extractStreamResponse(rawSse: string): ChatMessage[] {
       const choice = choices.find(isRecord);
       const delta = choice && isRecord(choice.delta) ? choice.delta : undefined;
       if (typeof delta?.content === 'string') text += delta.content;
+      if (Array.isArray(delta?.tool_calls)) {
+        for (const rawCall of delta.tool_calls) {
+          if (!isRecord(rawCall)) continue;
+          const index = typeof rawCall.index === 'number' ? rawCall.index : 0;
+          const call = callFor(`chat:${index}`);
+          if (typeof rawCall.id === 'string') call.id = rawCall.id;
+          if (typeof rawCall.type === 'string') call.type = rawCall.type;
+          if (isRecord(rawCall.function)) {
+            if (typeof rawCall.function.name === 'string') {
+              call.function.name = `${call.function.name ?? ''}${rawCall.function.name}`;
+            }
+            if (typeof rawCall.function.arguments === 'string') {
+              appendArguments(call, rawCall.function.arguments);
+            }
+          }
+        }
+      }
       if (payload.type === 'response.output_text.delta' && typeof payload.delta === 'string') {
         text += payload.delta;
       }
+      if (
+        (payload.type === 'response.output_item.added' ||
+          payload.type === 'response.output_item.done') &&
+        isRecord(payload.item) &&
+        payload.item.type === 'function_call'
+      ) {
+        const item = payload.item;
+        const itemKey =
+          typeof item.id === 'string'
+            ? item.id
+            : typeof item.call_id === 'string'
+              ? item.call_id
+              : String(payload.output_index ?? 0);
+        const call = callFor(`response:${itemKey}`);
+        call.id =
+          typeof item.call_id === 'string'
+            ? item.call_id
+            : typeof item.id === 'string'
+              ? item.id
+              : call.id;
+        if (typeof item.name === 'string') call.function.name = item.name;
+        if (typeof item.arguments === 'string') call.function.arguments = item.arguments;
+      }
+      if (
+        payload.type === 'response.function_call_arguments.delta' &&
+        typeof payload.delta === 'string'
+      ) {
+        const itemKey =
+          typeof payload.item_id === 'string' ? payload.item_id : String(payload.output_index ?? 0);
+        appendArguments(callFor(`response:${itemKey}`), payload.delta);
+      }
+      if (
+        payload.type === 'content_block_start' &&
+        isRecord(payload.content_block) &&
+        payload.content_block.type === 'tool_use'
+      ) {
+        const block = payload.content_block;
+        const call = callFor(`anthropic:${String(payload.index ?? 0)}`);
+        if (typeof block.id === 'string') call.id = block.id;
+        if (typeof block.name === 'string') call.function.name = block.name;
+        if (block.input != null) call.function.arguments = block.input;
+      }
       if (payload.type === 'content_block_delta' && isRecord(payload.delta)) {
         if (typeof payload.delta.text === 'string') text += payload.delta.text;
+        if (
+          payload.delta.type === 'input_json_delta' &&
+          typeof payload.delta.partial_json === 'string'
+        ) {
+          appendArguments(
+            callFor(`anthropic:${String(payload.index ?? 0)}`),
+            payload.delta.partial_json,
+          );
+        }
       }
     } catch {
       // Keep parsing later events when one provider emits a non-JSON line.
     }
   }
-  return text ? [{ role: 'assistant', content: text }] : [];
+  return text || toolCalls.length > 0
+    ? [
+        {
+          role: 'assistant',
+          content: text || null,
+          ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+        },
+      ]
+    : [];
 }
 
 export function extractResponseMessages(
@@ -289,6 +408,12 @@ export function extractResponseMessages(
   return responseBody?.type === 'json' && isRecord(responseBody.body)
     ? extractJsonResponse(responseBody.body)
     : [];
+}
+
+export function extractResponseToolCalls(
+  responseBody: RecordedResponseBody | null | undefined,
+): ToolCall[] {
+  return extractResponseMessages(responseBody).flatMap((message) => message.tool_calls ?? []);
 }
 
 export function extractRecordedConversationMessages(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -178,6 +178,7 @@ export {
   extractRequestMessages,
   extractRequestTools,
   extractResponseMessages,
+  extractResponseToolCalls,
   normalizeRole,
 } from './chat-message';
 export type { ChatMessage, ChatTool, RecordedResponseBody, Role, ToolCall } from './chat-message';


### PR DESCRIPTION
### ✨ What changed
- Show calls emitted by the selected Provider Attempt in the Tools tab.
- Reconstruct streamed calls for Chat Completions, Responses, and Anthropic.
- Parse Gemini JSON function calls.

### 💭 Why
Available tool definitions were shown as if they had been called.

### 👤 For users
The Tools tab keeps its name and shows only actual response calls and arguments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show only actual tool calls in the Tools tab for the selected Provider Attempt. Streamed tool calls are reconstructed and Gemini function calls are parsed so request details are accurate.

- **Bug Fixes**
  - Frontend uses `extractResponseToolCalls` to list emitted calls only; shows call ID and parsed function arguments; empty state now says “No tools were called.”
  - Shared parsing reconstructs tool calls from streams (OpenAI Chat Completions deltas, OpenAI Responses events, Anthropic tool_use) and parses Gemini `functionCall` parts.
  - Added `extractResponseToolCalls` to `packages/shared` exports; minor CSS class rename and updated tests.

<sup>Written for commit 08e67ab8d9e69f242c0eb530d65f06395a8b44d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

