### PR TITLE
feat: record messages for new harnesses

### DIFF
--- a/.changeset/default-new-agent-recording.md
+++ b/.changeset/default-new-agent-recording.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Enable message recording by default for newly created harnesses without changing existing harness settings.

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -36,6 +36,7 @@ import { ExtendDashboardCoveringIndex1801200000000 } from './migrations/18012000
 import { AddTenantRequestUsage1801300000000 } from './migrations/1801300000000-AddTenantRequestUsage';
 import { AddRequestRecordings1801300000000 } from './migrations/1801300000000-AddRequestRecordings';
 import { MoveRecordingsToProviderAttempts1801400000000 } from './migrations/1801400000000-MoveRecordingsToProviderAttempts';
+import { EnableRecordingForNewAgents1801500000000 } from './migrations/1801500000000-EnableRecordingForNewAgents';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -310,4 +311,5 @@ export const migrations = [
   AddTenantRequestUsage1801300000000,
   AddRequestRecordings1801300000000,
   MoveRecordingsToProviderAttempts1801400000000,
+  EnableRecordingForNewAgents1801500000000,
 ];

--- a/packages/backend/src/database/migrations/1801500000000-EnableRecordingForNewAgents.spec.ts
+++ b/packages/backend/src/database/migrations/1801500000000-EnableRecordingForNewAgents.spec.ts
@@ -1,0 +1,29 @@
+import { EnableRecordingForNewAgents1801500000000 } from './1801500000000-EnableRecordingForNewAgents';
+
+describe('EnableRecordingForNewAgents1801500000000', () => {
+  const migration = new EnableRecordingForNewAgents1801500000000();
+  const query = jest.fn().mockResolvedValue([]);
+  const queryRunner = { query } as never;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('enables recording only through the default for newly inserted agents', async () => {
+    await migration.up(queryRunner);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith(
+      `ALTER TABLE "agents" ALTER COLUMN "record_messages" SET DEFAULT true`,
+    );
+    expect(query.mock.calls.flat().join(' ')).not.toMatch(/\bUPDATE\b/i);
+  });
+
+  it('restores the disabled default without changing existing agents', async () => {
+    await migration.down(queryRunner);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith(
+      `ALTER TABLE "agents" ALTER COLUMN "record_messages" SET DEFAULT false`,
+    );
+    expect(query.mock.calls.flat().join(' ')).not.toMatch(/\bUPDATE\b/i);
+  });
+});

--- a/packages/backend/src/database/migrations/1801500000000-EnableRecordingForNewAgents.ts
+++ b/packages/backend/src/database/migrations/1801500000000-EnableRecordingForNewAgents.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EnableRecordingForNewAgents1801500000000 implements MigrationInterface {
+  name = 'EnableRecordingForNewAgents1801500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agents" ALTER COLUMN "record_messages" SET DEFAULT true`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agents" ALTER COLUMN "record_messages" SET DEFAULT false`,
+    );
+  }
+}

--- a/packages/backend/src/entities/agent.entity.ts
+++ b/packages/backend/src/entities/agent.entity.ts
@@ -37,9 +37,9 @@ export class Agent {
   @Column('boolean', { nullable: true })
   autofix_enabled!: boolean | null;
 
-  // Opt-in because recorded request/response bodies can contain sensitive
-  // application data and grow storage in proportion to request volume.
-  @Column('boolean', { default: false })
+  // Enabled for newly created agents. Existing agents keep their persisted
+  // choice because the migration changes only the column default.
+  @Column('boolean', { default: true })
   record_messages!: boolean;
 
   // Reserved Playground agent (the per-tenant "Playground" agent). Hidden

--- a/packages/backend/test/message-log-completeness.e2e-spec.ts
+++ b/packages/backend/test/message-log-completeness.e2e-spec.ts
@@ -171,6 +171,13 @@ async function settle(expected: number, timeoutMs = 15000): Promise<void> {
 }
 
 async function truncate(): Promise<void> {
+  // Recording-enabled responses can finish before the terminal Request upsert.
+  // Wait for that writer before deleting rows so it cannot recreate a prior
+  // test's Request after cleanup.
+  await settle(0);
+  if ((await pendingRequestCount()) !== 0) {
+    throw new Error('Timed out waiting for pending Requests before cleanup');
+  }
   await ds.query(`DELETE FROM agent_messages WHERE tenant_id = $1`, [TEST_TENANT_ID]);
   await ds.query(`DELETE FROM requests WHERE tenant_id = $1`, [TEST_TENANT_ID]);
 }

--- a/packages/frontend/tests/pages/SettingsRecordingSection.test.tsx
+++ b/packages/frontend/tests/pages/SettingsRecordingSection.test.tsx
@@ -18,7 +18,7 @@ describe('SettingsRecordingSection', () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(cleanup);
 
-  it('renders opt-in recording off by default', async () => {
+  it('renders the disabled state returned for an existing agent', async () => {
     getRecording.mockResolvedValue({ enabled: false });
     const { getByRole, getByText } = render(() => (
       <SettingsRecordingSection agentName={() => 'demo'} />


### PR DESCRIPTION
### ✨ What changed
- Enable message recording for newly created harnesses.
- Preserve every existing harness recording setting.
- Wait for terminal Request writes before E2E cleanup.

### 💭 Why
New harnesses should capture Provider Attempt payloads without requiring manual setup.

### 🔧 For operators
Migration `1801500000000` changes only the `record_messages` column default. No existing rows are updated.