### PR TITLE
fix: use reachable Gemini Free gateway

### DIFF
--- a/.changeset/gemini-free-provider.md
+++ b/.changeset/gemini-free-provider.md
@@ -3,4 +3,4 @@
 ---
 
 Add a Gemini Free provider with Gemini-scoped keys and a reusable managed free-provider
-configuration.
+configuration. Use the existing managed gateway by default.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -78,13 +78,13 @@ BETTER_AUTH_SECRET=
 # Timeout (ms) to wait for deliverable text or tool output from ChatGPT Codex.
 # CODEX_SEMANTIC_OUTPUT_TIMEOUT_MS=60000
 
-# Managed free providers (optional). A LiteLLM master key enables automatic
+# Managed free providers (optional). A master key enables automatic
 # virtual-key provisioning; users can otherwise paste a key obtained through
 # the provider's "Get API key" link.
-# LITELLM_BASE_URL=https://litellm.manifest.build
-# LITELLM_MASTER_KEY=
-# LITELLM_AUTO_PROVISION_ALLOWLIST=  # Optional comma-separated user emails
-# LITELLM_GEMINI_FREE_MAX_BUDGET=10  # Budget in USD for each generated key
+# CREDITS_BASE_URL=https://credits.manifest.build
+# CREDITS_MASTER_KEY=
+# CREDITS_AUTO_PROVISION_ALLOWLIST=  # Optional comma-separated user emails
+# CREDITS_GEMINI_FREE_MAX_BUDGET=10  # Budget in USD for each generated key
 
 # ─── Email provider (optional) ─────────────────────────────────────────────
 #

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -59,13 +59,13 @@ BETTER_AUTH_URL=http://localhost:3001
 # CODEX_SEMANTIC_OUTPUT_TIMEOUT_MS=60000
 
 # ── Managed free providers (optional) ───────────────
-# LiteLLM gateway used by providers such as Gemini Free. A master key enables
+# Managed gateway used by providers such as Gemini Free. A master key enables
 # automatic virtual-key provisioning; without it, users can still paste a
 # virtual key obtained through the provider's "Get API key" link.
-# LITELLM_BASE_URL=https://litellm.manifest.build
-# LITELLM_MASTER_KEY=
-# LITELLM_AUTO_PROVISION_ALLOWLIST=  # Optional comma-separated user emails
-# LITELLM_GEMINI_FREE_MAX_BUDGET=10  # Budget in USD for each generated key
+# CREDITS_BASE_URL=https://credits.manifest.build
+# CREDITS_MASTER_KEY=
+# CREDITS_AUTO_PROVISION_ALLOWLIST=  # Optional comma-separated user emails
+# CREDITS_GEMINI_FREE_MAX_BUDGET=10  # Budget in USD for each generated key
 
 # ── Email provider (optional, unified) ──────────────
 # Used for BOTH Better Auth transactional emails (login verification,

--- a/packages/backend/src/common/constants/managed-free-providers.spec.ts
+++ b/packages/backend/src/common/constants/managed-free-providers.spec.ts
@@ -13,23 +13,23 @@ describe('managed free provider config', () => {
 
   beforeEach(() => {
     process.env = { ...env };
-    delete process.env['LITELLM_BASE_URL'];
-    delete process.env['LITELLM_MASTER_KEY'];
-    delete process.env['LITELLM_GEMINI_FREE_MAX_BUDGET'];
-    delete process.env['LITELLM_AUTO_PROVISION_ALLOWLIST'];
+    delete process.env['CREDITS_BASE_URL'];
+    delete process.env['CREDITS_MASTER_KEY'];
+    delete process.env['CREDITS_GEMINI_FREE_MAX_BUDGET'];
+    delete process.env['CREDITS_AUTO_PROVISION_ALLOWLIST'];
   });
 
   afterAll(() => {
     process.env = env;
   });
 
-  it('defaults to the internal LiteLLM gateway', () => {
-    expect(getManagedFreeLiteLlmBaseUrl()).toBe('https://litellm.manifest.build');
+  it('defaults to the managed gateway', () => {
+    expect(getManagedFreeLiteLlmBaseUrl()).toBe('https://credits.manifest.build');
   });
 
   it('strips trailing slashes from the base URL', () => {
-    process.env['LITELLM_BASE_URL'] = 'https://example.com/litellm/';
-    expect(getManagedFreeLiteLlmBaseUrl()).toBe('https://example.com/litellm');
+    process.env['CREDITS_BASE_URL'] = 'https://example.com/credits/';
+    expect(getManagedFreeLiteLlmBaseUrl()).toBe('https://example.com/credits');
   });
 
   it('defaults the maximum budget to 10', () => {
@@ -39,34 +39,34 @@ describe('managed free provider config', () => {
 
   it('parses valid budgets and rejects invalid values', () => {
     const config = getManagedFreeProviderConfig('gemini-free')!;
-    process.env['LITELLM_GEMINI_FREE_MAX_BUDGET'] = '12.5';
+    process.env['CREDITS_GEMINI_FREE_MAX_BUDGET'] = '12.5';
     expect(getManagedFreeLiteLlmMaxBudgetUsd(config)).toBe(12.5);
-    process.env['LITELLM_GEMINI_FREE_MAX_BUDGET'] = '-1';
+    process.env['CREDITS_GEMINI_FREE_MAX_BUDGET'] = '-1';
     expect(getManagedFreeLiteLlmMaxBudgetUsd(config)).toBe(10);
-    process.env['LITELLM_GEMINI_FREE_MAX_BUDGET'] = 'invalid';
+    process.env['CREDITS_GEMINI_FREE_MAX_BUDGET'] = 'invalid';
     expect(getManagedFreeLiteLlmMaxBudgetUsd(config)).toBe(10);
   });
 
   it('builds the model catalog URL from the configured gateway', () => {
-    process.env['LITELLM_BASE_URL'] = 'https://litellm.test/';
-    expect(getManagedFreeLiteLlmModelsUrl()).toBe('https://litellm.test/v1/models');
+    process.env['CREDITS_BASE_URL'] = 'https://credits.test/';
+    expect(getManagedFreeLiteLlmModelsUrl()).toBe('https://credits.test/v1/models');
   });
 
   it('parses allowlisted emails', () => {
-    process.env['LITELLM_AUTO_PROVISION_ALLOWLIST'] = 'A@x.com, b@y.com ';
+    process.env['CREDITS_AUTO_PROVISION_ALLOWLIST'] = 'A@x.com, b@y.com ';
     expect(getManagedFreeLiteLlmAutoAllowlist()).toEqual(['a@x.com', 'b@y.com']);
   });
 
   it('requires the master key for automatic provisioning', () => {
     expect(isManagedFreeLiteLlmAutoEligible('a@x.com')).toBe(false);
-    process.env['LITELLM_MASTER_KEY'] = 'sk-test';
+    process.env['CREDITS_MASTER_KEY'] = 'sk-test';
     expect(isManagedFreeLiteLlmAutoEligible('a@x.com')).toBe(true);
     expect(getManagedFreeLiteLlmMasterKey()).toBe('sk-test');
   });
 
   it('honors the allowlist when configured', () => {
-    process.env['LITELLM_MASTER_KEY'] = 'sk-test';
-    process.env['LITELLM_AUTO_PROVISION_ALLOWLIST'] = 'allowed@example.com';
+    process.env['CREDITS_MASTER_KEY'] = 'sk-test';
+    process.env['CREDITS_AUTO_PROVISION_ALLOWLIST'] = 'allowed@example.com';
     expect(isManagedFreeLiteLlmAutoEligible('allowed@example.com')).toBe(true);
     expect(isManagedFreeLiteLlmAutoEligible('other@example.com')).toBe(false);
   });
@@ -78,7 +78,7 @@ describe('managed free provider config', () => {
       litellmModels: ['gemini/*'],
       catalogModelIdPrefix: 'gemini-',
       preferredModelIdPrefix: 'gemini/',
-      maxBudgetEnvVar: 'LITELLM_GEMINI_FREE_MAX_BUDGET',
+      maxBudgetEnvVar: 'CREDITS_GEMINI_FREE_MAX_BUDGET',
     });
   });
 });

--- a/packages/backend/src/common/constants/managed-free-providers.ts
+++ b/packages/backend/src/common/constants/managed-free-providers.ts
@@ -24,7 +24,7 @@ export const MANAGED_FREE_PROVIDER_CONFIGS: readonly ManagedFreeProviderConfig[]
     preferredModelIdPrefix: 'gemini/',
     nonChatModelPattern:
       /(?:\*|(?:^|\/)aqs-|nano-banana|deep-research|computer-use|lyria|veo-|native-audio|audio-preview|image-generation|(?:^|\/)imagen|-image(?:$|-|\/)|live-preview|(?:^|\/|-)live-|embedding|robotics|tts|gemini-1\.5|gemini-2\.0-flash-001|gemini-2\.0-flash-lite|flash-lite-preview-\d|\/gemini-exp-|-exp-\d|learnlm|gemma-|omni-flash|customtools)/i,
-    maxBudgetEnvVar: 'LITELLM_GEMINI_FREE_MAX_BUDGET',
+    maxBudgetEnvVar: 'CREDITS_GEMINI_FREE_MAX_BUDGET',
   },
 ];
 
@@ -38,16 +38,16 @@ export function getManagedFreeProviderConfig(
   return MANAGED_FREE_PROVIDER_BY_ID.get(providerId.toLowerCase());
 }
 
-const DEFAULT_LITELLM_BASE_URL = 'https://litellm.manifest.build';
+const DEFAULT_CREDITS_BASE_URL = 'https://credits.manifest.build';
 const DEFAULT_MAX_BUDGET_USD = 10;
 
 export function getManagedFreeLiteLlmBaseUrl(): string {
-  const raw = process.env['LITELLM_BASE_URL']?.trim() || DEFAULT_LITELLM_BASE_URL;
+  const raw = process.env['CREDITS_BASE_URL']?.trim() || DEFAULT_CREDITS_BASE_URL;
   return raw.replace(/\/+$/, '');
 }
 
 export function getManagedFreeLiteLlmMasterKey(): string | null {
-  const key = process.env['LITELLM_MASTER_KEY']?.trim();
+  const key = process.env['CREDITS_MASTER_KEY']?.trim();
   return key && key.length > 0 ? key : null;
 }
 
@@ -60,7 +60,7 @@ export function getManagedFreeLiteLlmMaxBudgetUsd(config: ManagedFreeProviderCon
 
 /** Comma-separated emails. Empty means any user is eligible when a master key is configured. */
 export function getManagedFreeLiteLlmAutoAllowlist(): string[] {
-  const raw = process.env['LITELLM_AUTO_PROVISION_ALLOWLIST']?.trim() ?? '';
+  const raw = process.env['CREDITS_AUTO_PROVISION_ALLOWLIST']?.trim() ?? '';
   if (!raw) return [];
   return raw
     .split(',')

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -57,7 +57,7 @@ describe('ProviderModelFetcherService', () => {
   });
 
   it('discovers only Gemini models from the Gemini Free LiteLLM catalog', async () => {
-    process.env['LITELLM_BASE_URL'] = 'https://litellm.test';
+    process.env['CREDITS_BASE_URL'] = 'https://credits.test';
     fetchSpy.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -74,7 +74,7 @@ describe('ProviderModelFetcherService', () => {
     const result = await service.fetch('gemini-free', 'sk-virtual');
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      'https://litellm.test/v1/models',
+      'https://credits.test/v1/models',
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: 'Bearer sk-virtual',

--- a/packages/backend/src/routing/managed-free-provider/managed-free-provider.service.spec.ts
+++ b/packages/backend/src/routing/managed-free-provider/managed-free-provider.service.spec.ts
@@ -23,9 +23,9 @@ describe('ManagedFreeProviderService', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     process.env = { ...env };
-    process.env['LITELLM_MASTER_KEY'] = 'sk-master';
-    process.env['LITELLM_BASE_URL'] = 'https://litellm.test';
-    delete process.env['LITELLM_AUTO_PROVISION_ALLOWLIST'];
+    process.env['CREDITS_MASTER_KEY'] = 'sk-master';
+    process.env['CREDITS_BASE_URL'] = 'https://credits.test';
+    delete process.env['CREDITS_AUTO_PROVISION_ALLOWLIST'];
     service = new ManagedFreeProviderService(
       providerRepo as never,
       providerService as never,
@@ -147,7 +147,7 @@ describe('ManagedFreeProviderService', () => {
     });
 
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://litellm.test/key/generate',
+      'https://credits.test/key/generate',
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({ Authorization: 'Bearer sk-master' }),
@@ -168,7 +168,7 @@ describe('ManagedFreeProviderService', () => {
   });
 
   it('returns none when automatic provisioning is unavailable', async () => {
-    delete process.env['LITELLM_MASTER_KEY'];
+    delete process.env['CREDITS_MASTER_KEY'];
     providerRepo.find.mockResolvedValue([]);
 
     await expect(
@@ -186,7 +186,7 @@ describe('ManagedFreeProviderService', () => {
   });
 
   it('rejects direct key generation when the master key is missing', async () => {
-    delete process.env['LITELLM_MASTER_KEY'];
+    delete process.env['CREDITS_MASTER_KEY'];
     const privateService = service as unknown as {
       mintVirtualKey(
         config: ManagedFreeProviderConfig,

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -560,7 +560,7 @@ describe('ProviderClient', () => {
     });
 
     it('preserves the Gemini vendor prefix for Gemini Free LiteLLM requests', async () => {
-      process.env['LITELLM_BASE_URL'] = 'https://litellm.test';
+      process.env['CREDITS_BASE_URL'] = 'https://credits.test';
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       await client.forward({
@@ -572,7 +572,7 @@ describe('ProviderClient', () => {
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://litellm.test/v1/chat/completions',
+        'https://credits.test/v1/chat/completions',
         expect.objectContaining({
           headers: expect.objectContaining({ Authorization: 'Bearer sk-virtual' }),
         }),

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -230,10 +230,10 @@ describe('resolveEndpointKey', () => {
 
 describe('PROVIDER_ENDPOINTS', () => {
   it('routes Gemini Free through the configured LiteLLM gateway', () => {
-    process.env['LITELLM_BASE_URL'] = 'https://litellm.test/';
+    process.env['CREDITS_BASE_URL'] = 'https://credits.test/';
     const endpoint = PROVIDER_ENDPOINTS['gemini-free'];
 
-    expect(endpoint.baseUrl).toBe('https://litellm.test');
+    expect(endpoint.baseUrl).toBe('https://credits.test');
     expect(endpoint.buildPath('gemini/gemini-2.5-flash')).toBe('/v1/chat/completions');
     expect(endpoint.buildHeaders('sk-virtual')).toEqual({
       Authorization: 'Bearer sk-virtual',


### PR DESCRIPTION
### ✨ What changed
- Point Gemini Free defaults and examples to the existing managed gateway.
- Rename managed gateway settings to `CREDITS_*`.
- Cover the default URL and settings in focused tests.

### 💭 Why
The previous hostname did not resolve, so model discovery returned an empty list.

### 👤 For users
Gemini Free keys now load eligible models without an operator override.

### 🔧 For operators
Use the documented `CREDITS_*` variables for managed gateway overrides.