### PR TITLE
fix: keep routing mounted during model refresh

### DIFF
--- a/.changeset/calm-routes-stay.md
+++ b/.changeset/calm-routes-stay.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep the routing page mounted while refreshed model data loads.

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -507,7 +507,7 @@ const Routing: Component = () => {
       />
 
       <Show
-        when={!connectedProviders.loading && !enabledProviders.loading}
+        when={connectedProviders() !== undefined && enabledProviders() !== undefined}
         fallback={<RoutingLoadingSkeleton />}
       >
         <Show when={hasProviders()} fallback={<NoConnectionsPrompt />}>

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -1408,6 +1408,42 @@ describe('Routing page', () => {
     });
   });
 
+  it('keeps the routing page mounted when model refresh completes after a selection', async () => {
+    let resolveProviderRefresh!: (providers: typeof baseProvider[]) => void;
+    mockGetProviders
+      .mockResolvedValueOnce([baseProvider])
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveProviderRefresh = resolve;
+          }),
+      );
+
+    render(() => <Routing />);
+    await waitFor(() => {
+      expect(screen.getByTestId('default-section')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByTestId('open-dropdown'));
+    await waitFor(() => {
+      expect((lastModalsProps?.dropdownTier as () => string | null)()).toBe('simple');
+    });
+    fireEvent.click(screen.getByTestId('modal-trigger-override'));
+    await waitFor(() => {
+      expect((lastModalsProps?.dropdownTier as () => string | null)()).toBeNull();
+    });
+
+    fireEvent.click(screen.getByTestId('modal-trigger-provider-update'));
+    await waitFor(() => {
+      expect(mockGetProviders).toHaveBeenCalledTimes(2);
+    });
+
+    expect(screen.queryByTestId('loading-skeleton')).toBeNull();
+    expect(screen.getByTestId('default-section')).toBeDefined();
+
+    resolveProviderRefresh([baseProvider]);
+  });
+
   it('closes the instruction modal via onInstructionClose', async () => {
     render(() => <Routing />);
     await waitFor(() => {


### PR DESCRIPTION
### ✨ What changed
- Keep resolved Routing content mounted during background model refreshes.
- Cover model selection followed by a pending provider refresh.

### 💭 Why
Daily picker refreshes were replacing Routing with a full-page loading skeleton after model selection.

### 👤 For users
Setting a routing model no longer flashes the full Routing page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the `Routing` page mounted during provider/model refresh so users don’t see the full-page loading skeleton after selecting a model. This removes the flash and keeps content visible.

- **Bug Fixes**
  - Gate rendering by checking `connectedProviders()` and `enabledProviders()` for `undefined` instead of `*.loading`, keeping content mounted during background refresh.
  - Added a test to verify the page stays mounted after a model selection while provider refresh completes.

<sup>Written for commit 55cf1407907f8bc7be00163c1175362686523f12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

