### PR TITLE
Fix horizontal overflow in request drawer

### DIFF
--- a/.changeset/1d967d1d.md
+++ b/.changeset/1d967d1d.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix horizontal overflow in request drawer: error, autofix and fallback context cards now span full width, long error messages wrap instead of scrolling horizontally, and the tabs bar uses a muted background.

--- a/packages/frontend/src/components/RequestDrawer.tsx
+++ b/packages/frontend/src/components/RequestDrawer.tsx
@@ -570,7 +570,7 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
 
                                 {/* Origin: this attempt IS the healed Auto-fix retry */}
                                 <Show when={att().autofix_role === 'retry'}>
-                                  <div style="margin-top: 16px; padding: 12px 16px; background: hsl(222 47% 50% / 0.06); border: 1px solid hsl(222 47% 50% / 0.3); border-radius: var(--radius);">
+                                  <div class="drawer-context-card drawer-context-card--autofix">
                                     <div style="margin-bottom: 8px;">
                                       <span class="trigger-badge trigger-badge--autofix">
                                         <AutofixIcon />
@@ -617,7 +617,7 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
 
                                 {/* Origin: this attempt IS the fallback recovery */}
                                 <Show when={att().fallback_from_model}>
-                                  <div style="margin-top: 16px; padding: 12px 16px; background: hsl(36 80% 60% / 0.08); border: 1px solid hsl(36 80% 50% / 0.3); border-radius: var(--radius);">
+                                  <div class="drawer-context-card drawer-context-card--fallback">
                                     <div style="margin-bottom: 8px;">
                                       <span class="trigger-badge trigger-badge--fallback">
                                         <FallbackIcon />
@@ -636,11 +636,11 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
                                 {/* Error block if this attempt failed — never hidden
                                   by the context cards around it */}
                                 <Show when={att().error_message}>
-                                  <div style="margin-top: 16px; padding: 12px 16px; background: hsl(var(--destructive) / 0.06); border: 1px solid hsl(var(--destructive) / 0.25); border-radius: var(--radius);">
+                                  <div class="drawer-context-card drawer-context-card--error">
                                     <div style="font-size: var(--font-size-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; color: hsl(var(--foreground));">
                                       Error
                                     </div>
-                                    <div style="font-size: var(--font-size-sm); color: hsl(var(--destructive)); font-family: var(--font-mono, monospace); word-break: break-word; margin-bottom: 8px;">
+                                    <div style="font-size: var(--font-size-sm); color: hsl(var(--destructive)); font-family: var(--font-mono, monospace); overflow-wrap: anywhere; white-space: pre-wrap; margin-bottom: 8px;">
                                       {att().error_message}
                                     </div>
                                     <Show
@@ -686,7 +686,7 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
                                 <Show
                                   when={att().autofix_applied && att().autofix_role !== 'retry'}
                                 >
-                                  <div style="margin-top: 16px; padding: 12px 16px; background: hsl(222 47% 50% / 0.06); border: 1px solid hsl(222 47% 50% / 0.3); border-radius: var(--radius);">
+                                  <div class="drawer-context-card drawer-context-card--autofix">
                                     <div style="margin-bottom: 8px;">
                                       <span class="trigger-badge trigger-badge--autofix">
                                         <AutofixIcon />
@@ -743,7 +743,7 @@ const RequestDrawer: Component<RequestDrawerProps> = (props) => {
                                     attempts()[att().index]?.fallback_from_model
                                   }
                                 >
-                                  <div style="margin-top: 16px; padding: 12px 16px; background: hsl(36 80% 60% / 0.08); border: 1px solid hsl(36 80% 50% / 0.3); border-radius: var(--radius);">
+                                  <div class="drawer-context-card drawer-context-card--fallback">
                                     <div style="margin-bottom: 8px;">
                                       <span class="trigger-badge trigger-badge--fallback">
                                         <FallbackIcon />

--- a/packages/frontend/src/styles/data.css
+++ b/packages/frontend/src/styles/data.css
@@ -1401,6 +1401,7 @@ table.msg-detail__table td {
 .error-autofix-row__meta-value strong {
   overflow-wrap: anywhere;
   word-break: break-word;
+  white-space: pre-wrap;
 }
 
 .error-autofix-row__meta-value strong {

--- a/packages/frontend/src/styles/request-drawer.css
+++ b/packages/frontend/src/styles/request-drawer.css
@@ -238,7 +238,7 @@
   border-radius: 0;
   padding: 3px 16px;
   flex-shrink: 0;
-  background: hsl(var(--card));
+  background: hsl(var(--muted));
   border-bottom: 1px solid hsl(var(--border));
 }
 
@@ -246,7 +246,11 @@
 .drawer__body {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 16px;
+  /* overflow-wrap is inherited — all text descendants wrap at the body boundary */
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Messages tab — fills remaining height, no padding (layout managed internally) */
@@ -282,6 +286,27 @@
   color: hsl(var(--muted-foreground));
   white-space: nowrap;
   padding-right: 12px;
+}
+
+/* ── Context cards (error, autofix, fallback) inside the Details tab ── */
+/* grid-column: 1 / -1 spans both KV columns so the card is full width */
+.drawer-context-card {
+  grid-column: 1 / -1;
+  margin-top: 16px;
+  padding: 12px 16px;
+  border-radius: var(--radius);
+}
+.drawer-context-card--error {
+  background: hsl(var(--destructive) / 0.06);
+  border: 1px solid hsl(var(--destructive) / 0.25);
+}
+.drawer-context-card--autofix {
+  background: hsl(222 47% 50% / 0.06);
+  border: 1px solid hsl(222 47% 50% / 0.3);
+}
+.drawer-context-card--fallback {
+  background: hsl(36 80% 60% / 0.08);
+  border: 1px solid hsl(36 80% 50% / 0.3);
 }
 
 /* ── Recorded conversation ── */


### PR DESCRIPTION
✨ What changed
- Error, auto-fix, and fallback context cards now span the full width of the drawer instead of sitting inside a narrow column
- Long error messages wrap at the drawer boundary instead of causing a horizontal scrollbar
- Error text preserves provider line breaks
- Tabs bar has a muted background to visually separate it from the content
- Key/value layout in Details, Headers, and Params tabs is unchanged

💭 Why
Long provider error messages and model IDs caused the drawer body to scroll horizontally. The root cause was context cards being placed inside a two-column grid without spanning both columns, which forced the max-content column to expand to the card's intrinsic width.

👤 For users
No more horizontal scrollbar when viewing failed requests with long error messages. Cards fit within the drawer and text wraps naturally.

🔧 For operators
No operator impact.

🧪 How to test
1. Open the Messages log and click any failed request
2. In the drawer, go to the Details tab
3. Confirm the error card takes the full width and long error text wraps
4. Confirm the Status/Provider/Model fields still show key and value on the same line
5. Open a request with a very long model ID or error URL and confirm no horizontal scrollbar appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes horizontal overflow in the request drawer by making context cards full width and wrapping long text. Removes the horizontal scrollbar while keeping the key/value layout intact.

- **Bug Fixes**
  - Error, autofix, and fallback cards now span the full width via a shared `.drawer-context-card` class (`grid-column: 1 / -1`).
  - Drawer body hides horizontal overflow and enables global text wrapping; error text preserves provider line breaks with `white-space: pre-wrap`.
  - Tabs bar uses a muted background to separate navigation from content.

<sup>Written for commit 1b633b612338681f600b33dc18a14d1bc8b7fd38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

