### PR TITLE
fix: refresh provider models live

### DIFF
--- a/packages/frontend/src/components/ProviderDetailView.tsx
+++ b/packages/frontend/src/components/ProviderDetailView.tsx
@@ -39,7 +39,7 @@ export interface ProviderDetailViewProps {
   validationError: Accessor<string | null>;
   setValidationError: Setter<string | null>;
   onBack: () => void;
-  onUpdate: () => void;
+  onUpdate: () => void | Promise<void>;
   onPollProviders?: () => void | Promise<void>;
   onClose: () => void;
   initialAddKey?: boolean;
@@ -140,12 +140,17 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
   };
 
   const [refreshing, setRefreshing] = createSignal(false);
+  const [refreshedModelCount, setRefreshedModelCount] = createSignal<number | null>(null);
+  const [refreshedAt, setRefreshedAt] = createSignal<string | null>(null);
 
   const activeProviderRow = () => getProviderByAuth(props.selectedAuthType());
-  const lastFetchedAgo = () => formatTimeAgo(activeProviderRow()?.models_fetched_at ?? null);
+  const modelCount = () => refreshedModelCount() ?? activeProviderRow()?.cached_model_count ?? 0;
+  const lastFetchedAgo = () =>
+    formatTimeAgo(refreshedAt() ?? activeProviderRow()?.models_fetched_at ?? null);
 
   const handleRefreshModels = async () => {
     setRefreshing(true);
+    let refreshed = false;
     try {
       const result = await refreshProviderModels(
         props.agentName,
@@ -153,13 +158,20 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
         props.selectedAuthType(),
       );
       if (result.ok) {
+        refreshed = true;
+        setRefreshedModelCount(result.model_count);
+        setRefreshedAt(result.last_fetched_at);
         toast.success(
           `${provDef.name}: refreshed ${result.model_count} model${result.model_count === 1 ? '' : 's'}`,
         );
       } else {
         toast.error(result.error ?? `Couldn't refresh ${provDef.name}`);
       }
-      props.onUpdate();
+      await props.onUpdate();
+      if (refreshed) {
+        setRefreshedModelCount(null);
+        setRefreshedAt(null);
+      }
     } catch {
       // network/server error toast already raised by fetchMutate
     } finally {
@@ -270,8 +282,8 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
       <Show when={connected()}>
         <div class="provider-detail__models-bar">
           <span>
-            {activeProviderRow()?.cached_model_count ?? 0} model
-            {(activeProviderRow()?.cached_model_count ?? 0) === 1 ? '' : 's'}
+            {modelCount()} model
+            {modelCount() === 1 ? '' : 's'}
             <Show when={lastFetchedAgo()}> - last refreshed: {lastFetchedAgo()}</Show>
           </span>
           <button

--- a/packages/frontend/tests/components/ProviderDetailView.test.tsx
+++ b/packages/frontend/tests/components/ProviderDetailView.test.tsx
@@ -468,6 +468,58 @@ describe('ProviderDetailView', () => {
       });
     });
 
+    it('updates the model count immediately after a successful refresh', async () => {
+      const props = createTestProps({
+        provId: 'anthropic',
+        providers: connectedAnthropicSub,
+        selectedAuthType: 'subscription',
+      });
+      const [providers, setProviders] = createSignal(connectedAnthropicSub);
+      props.onUpdate.mockImplementation(() => {
+        setProviders([
+          {
+            ...connectedAnthropicSub[0]!,
+            cached_model_count: 3,
+            models_fetched_at: '2026-04-12T10:00:00Z',
+          },
+        ]);
+      });
+      render(() => <ProviderDetailView {...props} providers={providers()} />);
+
+      fireEvent.click(screen.getByLabelText('Refresh models from Anthropic'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/3 models - last refreshed: 5m ago/)).toBeDefined();
+      });
+    });
+
+    it('keeps refreshing until the parent model catalog has reloaded', async () => {
+      const props = createTestProps({
+        provId: 'anthropic',
+        providers: connectedAnthropicSub,
+        selectedAuthType: 'subscription',
+      });
+      let finishUpdate!: () => void;
+      props.onUpdate.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            finishUpdate = resolve;
+          }),
+      );
+      render(() => <ProviderDetailView {...props} />);
+
+      fireEvent.click(screen.getByLabelText('Refresh models from Anthropic'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Refreshing…')).toBeDefined();
+      });
+      finishUpdate();
+
+      await waitFor(() => {
+        expect(screen.getByText('Refresh models')).toBeDefined();
+      });
+    });
+
     it('shows a singular model count in the success toast', async () => {
       mockRefreshProviderModels.mockResolvedValueOnce({
         ok: true,


### PR DESCRIPTION
### ✨ What changed
- Refresh connection model metadata before ending the loading state.
- Show the returned count and timestamp during the parent refresh.
- Add refresh-state regression coverage.

### 💭 Why
A successful provider refresh left the connection view showing stale model metadata until a later render.

### 👤 For users
Provider connections now show the refreshed model count and time as soon as refresh completes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider model refresh to show the updated model count and last refreshed time immediately, and keeps the "Refreshing…" state until the parent finishes reloading.

- **Bug Fixes**
  - Display refreshed model count and timestamp right after a successful refresh.
  - Await `onUpdate` (now async) and keep "Refreshing…" until it resolves; then clear temporary values.
  - Add tests for immediate UI update and correct loading behavior.

<sup>Written for commit 07cb4c363742c402cf02cdaac783156a3b270487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

