### PR TITLE
fix: keep routing model picker open

### DIFF
--- a/.changeset/steady-model-picker.md
+++ b/.changeset/steady-model-picker.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep the routing model picker open while refreshed model data loads.

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, onMount, Show, type Component } from 'solid-js';
+import { createSignal, For, onMount, Show, startTransition, type Component } from 'solid-js';
 import {
   refreshModels,
   refreshProviderModels,
@@ -120,6 +120,9 @@ const ModelPickerModal: Component<Props> = (props) => {
   );
   const [refreshingProvId, setRefreshingProvId] = createSignal<string | null>(null);
   const [refreshingAll, setRefreshingAll] = createSignal(false);
+  // Parent callbacks refetch resources read inside this modal's Suspense
+  // boundary. Keep the current picker visible until those resources settle.
+  const notifyProviderRefreshed = () => startTransition(() => props.onProviderRefreshed?.());
 
   onMount(() => {
     const agentName = props.agentName;
@@ -137,7 +140,7 @@ const ModelPickerModal: Component<Props> = (props) => {
     void (async () => {
       try {
         await refreshModels(agentName);
-        await props.onProviderRefreshed?.();
+        await notifyProviderRefreshed();
       } catch {
         // network/server error toast already raised by fetchMutate
       } finally {
@@ -177,7 +180,7 @@ const ModelPickerModal: Component<Props> = (props) => {
       } else {
         toast.error(result.error ?? `Couldn't refresh ${displayName}`);
       }
-      await props.onProviderRefreshed?.();
+      await notifyProviderRefreshed();
     } catch {
       // network/server error toast already raised by fetchMutate
     } finally {

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, screen, waitFor } from '@solidjs/testing-library';
+import { createResource, Suspense } from 'solid-js';
 
 vi.mock('../../src/components/ProviderIcon.js', () => ({
   providerIcon: () => null,
@@ -218,6 +219,67 @@ describe('ModelPickerModal', () => {
 
       await Promise.resolve();
       expect(mockRefreshModels).not.toHaveBeenCalled();
+    });
+
+    it('stays open while refreshed model data is loading after the user scrolls', async () => {
+      let resolveAutomaticRefresh!: (value: { ok: boolean }) => void;
+      let resolveModelsRefetch!: (value: AvailableModel[]) => void;
+      let modelRequestCount = 0;
+      mockRefreshModels.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveAutomaticRefresh = resolve;
+          }),
+      );
+      const staleProviders = apiKeyOnly.map((provider) => ({
+        ...provider,
+        models_fetched_at: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+      }));
+
+      const Parent = () => {
+        const [models, { refetch }] = createResource(async () => {
+          modelRequestCount += 1;
+          if (modelRequestCount === 1) return baseModels;
+          return new Promise<AvailableModel[]>((resolve) => {
+            resolveModelsRefetch = resolve;
+          });
+        });
+
+        return (
+          <Suspense fallback={<div data-testid="picker-loading" />}>
+            <ModelPickerModal
+              tierId="default"
+              agentName="demo-agent"
+              models={models() ?? []}
+              tiers={[]}
+              connectedProviders={staleProviders}
+              onSelect={vi.fn()}
+              onClose={vi.fn()}
+              onProviderRefreshed={async () => {
+                await refetch();
+              }}
+            />
+          </Suspense>
+        );
+      };
+
+      const { container } = render(() => <Parent />);
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeDefined();
+      });
+
+      fireEvent.scroll(container.querySelector('.routing-modal__list') as HTMLElement, {
+        target: { scrollTop: 200 },
+      });
+      resolveAutomaticRefresh({ ok: true });
+
+      await waitFor(() => {
+        expect(modelRequestCount).toBe(2);
+      });
+      expect(screen.queryByTestId('picker-loading')).toBeNull();
+      expect(screen.getByRole('dialog')).toBeDefined();
+
+      resolveModelsRefetch(baseModels);
     });
 
     it('ignores stale inactive and custom providers', async () => {


### PR DESCRIPTION
### ✨ What changed
- Keep the model picker visible while refreshed provider data reloads.
- Cover the delayed refresh after scrolling inside the picker.

### 💭 Why
The automatic daily refresh crossed a null Suspense boundary and temporarily removed the open picker.

### 👤 For users
The routing model popup stays open while its models refresh.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the routing model picker open while provider/model data refreshes to stop it from closing or flickering. Covers auto refresh and delayed refetches after scrolling.

- **Bug Fixes**
  - Runs provider refresh callbacks inside a transition so the modal stays visible through the Suspense boundary.
  - Adds a test to ensure the picker remains open while refetched model data loads after user scroll.

<sup>Written for commit d5c6bc6f8889c45cde029d05cfed871d0b83f39d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

