### PR TITLE
fix: isolate subscription model catalogs

### DIFF
--- a/.changeset/curated-subscription-model-catalogs.md
+++ b/.changeset/curated-subscription-model-catalogs.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep subscription model availability scoped to provider discovery and curated model lists.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -4,7 +4,7 @@ import { ProviderModelRegistryService } from './provider-model-registry.service'
 import { TenantProvider } from '../entities/tenant-provider.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { DiscoveredModel } from './model-fetcher';
-import { buildSubscriptionFallbackModels, supplementWithKnownModels } from './model-fallback';
+import { supplementWithKnownModels } from './model-fallback';
 
 jest.mock('../common/utils/crypto.util', () => ({
   decrypt: jest.fn(),
@@ -1616,6 +1616,18 @@ describe('ModelDiscoveryService', () => {
           e: Date.now() + 60000,
         }),
       );
+      mockPricingSync.getAll.mockReturnValue(
+        new Map([
+          [
+            'anthropic/claude-sonnet-5:batch',
+            {
+              input: 0.000001,
+              output: 0.000005,
+              displayName: 'Anthropic: Claude Sonnet 5 (batch)',
+            },
+          ],
+        ]),
+      );
 
       const result = await service.discoverModels(
         makeProvider({
@@ -1636,6 +1648,55 @@ describe('ModelDiscoveryService', () => {
         'claude-sonnet-4',
         'claude-sonnet-5',
       ]);
+      expect(result.map((m) => m.id)).not.toContain('claude-sonnet-5:batch');
+      expect(mockPricingSync.getAll).not.toHaveBeenCalled();
+      expect(mockPricingSync.lookupPricing).not.toHaveBeenCalled();
+    });
+
+    it('should not use external catalogs when dynamic subscription discovery is empty', async () => {
+      fetcher.fetch.mockResolvedValue([]);
+      mockModelsDevSync.getModelsForProvider.mockReturnValue([
+        {
+          id: 'external-only-model',
+          name: 'External-only model',
+          contextWindow: 128000,
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          reasoning: false,
+          toolCall: true,
+        },
+      ]);
+      mockPricingSync.getAll.mockReturnValue(
+        new Map([
+          [
+            'opencode-zen/external-only-model',
+            {
+              input: 0,
+              output: 0,
+              displayName: 'External-only model',
+            },
+          ],
+        ]),
+      );
+
+      const result = await service.discoverModels(
+        makeProvider({
+          provider: 'opencode-zen',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted',
+        }),
+      );
+
+      expect(result).toEqual([]);
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'opencode-zen',
+        'decrypted-key',
+        'subscription',
+        undefined,
+      );
+      expect(mockModelsDevSync.getModelsForProvider).not.toHaveBeenCalled();
+      expect(mockPricingSync.getAll).not.toHaveBeenCalled();
+      expect(mockPricingSync.lookupPricing).not.toHaveBeenCalled();
     });
 
     it('should unwrap MiniMax OAuth blob and forward resource URL for subscription discovery', async () => {
@@ -1946,17 +2007,14 @@ describe('ModelDiscoveryService', () => {
         }),
       );
 
-      // Should only include models matching knownModels prefixes (claude-opus-4, claude-sonnet-4, claude-haiku-4)
-      // and NOT claude-2.1 or openai models. Claude Fable 5, Opus 5, and
-      // Sonnet 5 have no OpenRouter pricing entry, so they are appended
-      // directly as zero-cost known models.
+      // Subscription membership comes only from the curated knownModels list.
       expect(result).toHaveLength(6);
       expect(result.map((m) => m.id).sort()).toEqual([
         'claude-fable-5',
-        'claude-haiku-4-20260301',
-        'claude-opus-4-20260301',
+        'claude-haiku-4',
+        'claude-opus-4',
         'claude-opus-5',
-        'claude-sonnet-4-20260301',
+        'claude-sonnet-4',
         'claude-sonnet-5',
       ]);
       // All should be stamped as subscription
@@ -1967,7 +2025,7 @@ describe('ModelDiscoveryService', () => {
       expect(fetcher.fetch).not.toHaveBeenCalled();
     });
 
-    it('should cap context window via subscription capabilities', async () => {
+    it('should apply subscription context windows to curated models', async () => {
       const orMap = new Map([
         [
           'anthropic/claude-opus-4-20260301',
@@ -1989,13 +2047,13 @@ describe('ModelDiscoveryService', () => {
         }),
       );
 
-      const orModel = result.find((m) => m.id === 'claude-opus-4-20260301');
-      expect(orModel).toBeDefined();
-      // Anthropic subscription caps at 200000
-      expect(orModel!.contextWindow).toBe(200000);
+      const model = result.find((m) => m.id === 'claude-opus-4');
+      expect(model).toBeDefined();
+      expect(model!.contextWindow).toBe(200000);
+      expect(result.map((m) => m.id)).not.toContain('claude-opus-4-20260301');
     });
 
-    it('should use subscription fallback for openai when no token and pricing matches known models', async () => {
+    it('should use only curated OpenAI models when no subscription token is available', async () => {
       const orMap = new Map([
         [
           'openai/gpt-5.5',
@@ -2022,19 +2080,18 @@ describe('ModelDiscoveryService', () => {
       );
 
       const ids = result.map((m) => m.id);
-      // gpt-5.5 from OpenRouter + remaining supported knownModels added directly
       expect(ids).toContain('gpt-5.5');
       expect(ids).toContain('gpt-5.4');
       expect(ids).toContain('gpt-5.3-codex-spark');
       expect(ids).not.toContain('gpt-5.2-codex');
       expect(ids).not.toContain('gpt-5.1-codex-max');
-      // gpt-4o does NOT match any knownModel prefix
       expect(ids).not.toContain('gpt-4o');
       // All should be stamped as subscription
       for (const m of result) {
         expect(m.authType).toBe('subscription');
       }
       expect(fetcher.fetch).not.toHaveBeenCalled();
+      expect(mockPricingSync.getAll).not.toHaveBeenCalled();
     });
 
     it('should not hardcode Qwen Token Plan fallback models when subscription fetch returns no models', async () => {
@@ -2406,415 +2463,6 @@ describe('ModelDiscoveryService', () => {
       // Both entries kept — one with inferred api_key, one with inferred subscription
       expect(result).toHaveLength(2);
       expect(result.map((m) => m.authType).sort()).toEqual(['api_key', 'subscription']);
-    });
-  });
-
-  /* ── buildSubscriptionFallbackModels ── */
-
-  describe('buildSubscriptionFallbackModels', () => {
-    it('should return empty for unsupported providers', () => {
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'unknown-provider');
-      expect(result).toEqual([]);
-    });
-
-    it('should include OpenRouter matches plus uncovered knownModels for openai', () => {
-      const orMap = new Map([
-        [
-          'openai/gpt-5.5',
-          {
-            input: 0.000001,
-            output: 0.000004,
-            contextWindow: 200000,
-            displayName: 'GPT-5.5',
-          },
-        ],
-        [
-          'openai/gpt-4o',
-          { input: 0.0000025, output: 0.00001, contextWindow: 128000, displayName: 'GPT-4o' },
-        ],
-        [
-          'openai/gpt-5.4-mini',
-          {
-            input: 0.000002,
-            output: 0.000008,
-            contextWindow: 128000,
-            displayName: 'GPT-5.4 Mini',
-          },
-        ],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'openai');
-      const ids = result.map((m) => m.id);
-
-      // gpt-5.5 and gpt-5.4-mini from OpenRouter, plus remaining supported knownModels added directly
-      expect(ids).toContain('gpt-5.5');
-      expect(ids).toContain('gpt-5.4-mini');
-      expect(ids).toContain('gpt-5.4');
-      expect(ids).toContain('gpt-5.3-codex-spark');
-      expect(ids).not.toContain('gpt-5.3-codex');
-      expect(ids).not.toContain('gpt-5.2-codex');
-      expect(ids).not.toContain('gpt-5.2');
-      expect(ids).not.toContain('gpt-5.1-codex-max');
-      expect(ids).not.toContain('gpt-5.1-codex');
-      // gpt-4o is NOT included (not a known model prefix)
-      expect(ids).not.toContain('gpt-4o');
-    });
-
-    it('should filter OpenRouter cache by known model prefixes', () => {
-      const orMap = new Map([
-        [
-          'anthropic/claude-opus-4-latest',
-          {
-            input: 0.000015,
-            output: 0.000075,
-            contextWindow: 200000,
-            displayName: 'Claude Opus 4',
-          },
-        ],
-        [
-          'anthropic/claude-2.1',
-          { input: 0.000008, output: 0.000024, contextWindow: 200000, displayName: 'Claude 2.1' },
-        ],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
-      const ids = result.map((m) => m.id);
-
-      // claude-opus-4-latest from OpenRouter (covers prefix claude-opus-4)
-      expect(ids).toContain('claude-opus-4-latest');
-      // claude-sonnet-4 and claude-haiku-4 not in OpenRouter, added as zero-cost
-      expect(ids).toContain('claude-sonnet-4');
-      expect(ids).toContain('claude-haiku-4');
-      // claude-2.1 NOT included (not a known prefix)
-      expect(ids).not.toContain('claude-2.1');
-      // claude-opus-4 NOT added (covered by claude-opus-4-latest)
-      expect(ids).not.toContain('claude-opus-4');
-      expect(result[0].provider).toBe('anthropic');
-    });
-
-    it('should normalize Anthropic short-form dot ids from OpenRouter to dash ids', () => {
-      const orMap = new Map([
-        [
-          'anthropic/claude-sonnet-4.6',
-          {
-            input: 0.000003,
-            output: 0.000015,
-            contextWindow: 200000,
-            displayName: 'Claude Sonnet 4.6',
-          },
-        ],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
-
-      expect(result.map((m) => m.id)).toContain('claude-sonnet-4-6');
-      expect(result.map((m) => m.id)).not.toContain('claude-sonnet-4.6');
-    });
-
-    it('should apply maxContextWindow cap from subscription capabilities', () => {
-      const orMap = new Map([
-        [
-          'anthropic/claude-sonnet-4-20260301',
-          { input: 0.000003, output: 0.000015, contextWindow: 1000000, displayName: 'Sonnet' },
-        ],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
-      const orModel = result.find((m) => m.id === 'claude-sonnet-4-20260301');
-
-      expect(orModel).toBeDefined();
-      expect(orModel!.contextWindow).toBe(200000);
-    });
-
-    it('should return knownModels directly when pricingSync is null', () => {
-      const result = buildSubscriptionFallbackModels(null as never, 'anthropic');
-
-      // No OpenRouter data, but knownModels are added directly
-      expect(result).toHaveLength(6);
-      expect(result.map((m) => m.id).sort()).toEqual([
-        'claude-fable-5',
-        'claude-haiku-4',
-        'claude-opus-4',
-        'claude-opus-5',
-        'claude-sonnet-4',
-        'claude-sonnet-5',
-      ]);
-      expect(result[0].inputPricePerToken).toBe(0);
-    });
-
-    it('should return BytePlus knownModels directly when pricingSync is null', () => {
-      const result = buildSubscriptionFallbackModels(null as never, 'byteplus');
-
-      expect(result.map((m) => m.id)).toEqual([
-        'ark-code-latest',
-        'bytedance-seed-code',
-        'glm-5.1',
-        'glm-4.7',
-        'deepseek-v3.2',
-        'deepseek-v4-flash',
-        'deepseek-v4-pro',
-        'kimi-k2.5',
-        'gpt-oss-120b',
-      ]);
-      expect(result[0]).toMatchObject({
-        provider: 'byteplus',
-        contextWindow: 256000,
-        inputPricePerToken: 0,
-        outputPricePerToken: 0,
-      });
-    });
-
-    it('should not duplicate knownModel when already in OpenRouter', () => {
-      const orMap = new Map([
-        [
-          'anthropic/claude-opus-4',
-          { input: 0.000015, output: 0.000075, contextWindow: 200000, displayName: 'Opus 4' },
-        ],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
-      const opusModels = result.filter((m) => m.id.startsWith('claude-opus-4'));
-
-      // Only one claude-opus-4 entry (from OpenRouter), not duplicated
-      expect(opusModels).toHaveLength(1);
-      expect(opusModels[0].displayName).toBe('Opus 4');
-    });
-
-    it('should use default context window when entry has none', () => {
-      const orMap = new Map([
-        ['anthropic/claude-haiku-4-latest', { input: 0.0000008, output: 0.000004 }],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
-      const orModel = result.find((m) => m.id === 'claude-haiku-4-latest');
-
-      expect(orModel).toBeDefined();
-      // Default 128000 is below maxContextWindow 200000, so no cap applied
-      expect(orModel!.contextWindow).toBe(128000);
-    });
-
-    it('should use model id as displayName when entry has no displayName', () => {
-      const orMap = new Map([
-        [
-          'anthropic/claude-opus-4-latest',
-          { input: 0.000015, output: 0.000075, contextWindow: 200000, displayName: '' },
-        ],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
-      const orModel = result.find((m) => m.id === 'claude-opus-4-latest');
-
-      expect(orModel).toBeDefined();
-      expect(orModel!.displayName).toBe('claude-opus-4-latest');
-    });
-
-    it('should add openai knownModels even without OpenRouter data', () => {
-      mockPricingSync.getAll.mockReturnValue(new Map());
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'openai');
-
-      expect(result.length).toBe(7);
-      expect(result.map((m) => m.id)).toContain('gpt-5.6-sol');
-      expect(result.map((m) => m.id)).toContain('gpt-5.6-terra');
-      expect(result.map((m) => m.id)).toContain('gpt-5.6-luna');
-      expect(result.map((m) => m.id)).toContain('gpt-5.5');
-      expect(result.map((m) => m.id)).toContain('gpt-5.4');
-      expect(result.map((m) => m.id)).toContain('gpt-5.4-mini');
-      expect(result.map((m) => m.id)).toContain('gpt-5.3-codex-spark');
-      expect(result.map((m) => m.id)).not.toContain('gpt-5.3-codex');
-      expect(result.map((m) => m.id)).not.toContain('gpt-5.2-codex');
-      expect(result.map((m) => m.id)).not.toContain('gpt-5.1-codex-max');
-      // All zero-cost subscription models
-      for (const m of result) {
-        expect(m.inputPricePerToken).toBe(0);
-        expect(m.outputPricePerToken).toBe(0);
-      }
-    });
-
-    it('should preserve MiniMax model casing in subscription fallback models', () => {
-      const result = buildSubscriptionFallbackModels(null as never, 'minimax');
-
-      expect(result.map((m) => m.id)).toEqual([
-        'MiniMax-M3',
-        'MiniMax-M2.7',
-        'MiniMax-M2.7-highspeed',
-        'MiniMax-M2.5',
-        'MiniMax-M2.5-highspeed',
-        'MiniMax-M2.1',
-        'MiniMax-M2.1-highspeed',
-        'MiniMax-M2',
-      ]);
-    });
-
-    it('should not build hardcoded Qwen Token Plan fallback models', () => {
-      const orMap = new Map([
-        [
-          'qwen/qwen3.6-plus',
-          {
-            input: 0.0000005,
-            output: 0.000003,
-            contextWindow: 1000000,
-            displayName: 'Qwen 3.6 Plus',
-          },
-        ],
-        [
-          'qwen/qwen3.6-plus-20260402',
-          {
-            input: 0.0000005,
-            output: 0.000003,
-            contextWindow: 1000000,
-            displayName: 'Qwen 3.6 Plus snapshot',
-          },
-        ],
-        [
-          'qwen/qwen-image-2.0',
-          {
-            input: 0,
-            output: 0,
-            contextWindow: 0,
-            displayName: 'Qwen Image 2.0',
-          },
-        ],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'qwen');
-
-      expect(result).toEqual([]);
-    });
-
-    it('should use exact match mode for gemini — excludes suffixed cache entries', () => {
-      const orMap = new Map([
-        // Exact knownModel matches — included
-        [
-          'google/gemini-2.5-pro',
-          {
-            input: 0.00000125,
-            output: 0.00001,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Pro',
-          },
-        ],
-        [
-          'google/gemini-2.5-flash',
-          {
-            input: 0.0000003,
-            output: 0.0000025,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Flash',
-          },
-        ],
-        [
-          'google/gemini-3.1-pro-preview',
-          {
-            input: 0.000002,
-            output: 0.000012,
-            contextWindow: 1000000,
-            displayName: 'Gemini 3.1 Pro Preview',
-          },
-        ],
-        // Suffixed variants — excluded because gemini uses 'exact' mode
-        [
-          'google/gemini-2.5-pro-preview-06-05',
-          {
-            input: 0.00000125,
-            output: 0.00001,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Pro Preview',
-          },
-        ],
-        [
-          'google/gemini-2.5-flash-lite-preview-06-17',
-          {
-            input: 0.0000001,
-            output: 0.0000008,
-            contextWindow: 1000000,
-            displayName: 'Flash Lite Preview',
-          },
-        ],
-        // Unrelated provider — excluded
-        [
-          'openai/gpt-4o',
-          { input: 0.0000025, output: 0.00001, contextWindow: 128000, displayName: 'GPT-4o' },
-        ],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'gemini');
-      const ids = result.map((m) => m.id);
-
-      // Exact matches included
-      expect(ids).toContain('gemini-2.5-pro');
-      expect(ids).toContain('gemini-2.5-flash');
-      expect(ids).toContain('gemini-3.1-pro-preview');
-      // Suffixed entries excluded (exact mode vs prefix mode)
-      expect(ids).not.toContain('gemini-2.5-pro-preview-06-05');
-      expect(ids).not.toContain('gemini-2.5-flash-lite-preview-06-17');
-      // gpt-4o is not a gemini model
-      expect(ids).not.toContain('gpt-4o');
-      // gemini-2.5-flash-lite not in cache → added as zero-cost known model
-      expect(ids).toContain('gemini-2.5-flash-lite');
-      expect(result.find((m) => m.id === 'gemini-2.5-flash-lite')!.inputPricePerToken).toBe(0);
-    });
-
-    it('gemini exact mode vs anthropic prefix mode — illustrates the difference', () => {
-      // For a prefix-mode provider (anthropic), a suffixed model IS included.
-      // For gemini (exact mode), only verbatim knownModels entries are included.
-      const orMap = new Map([
-        // This would match the 'claude-opus-4' prefix → included for anthropic
-        [
-          'anthropic/claude-opus-4-20260301',
-          {
-            input: 0.000015,
-            output: 0.000075,
-            contextWindow: 200000,
-            displayName: 'Claude Opus 4',
-          },
-        ],
-        // This has a preview suffix → excluded for gemini (exact), would be included for prefix
-        [
-          'google/gemini-2.5-pro-preview-06-05',
-          {
-            input: 0.00000125,
-            output: 0.00001,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Pro Preview',
-          },
-        ],
-        // Exact match → included for gemini
-        [
-          'google/gemini-2.5-pro',
-          {
-            input: 0.00000125,
-            output: 0.00001,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Pro',
-          },
-        ],
-      ]);
-      mockPricingSync.getAll.mockReturnValue(orMap);
-
-      const geminiResult = buildSubscriptionFallbackModels(mockPricingSync as never, 'gemini');
-      const anthropicResult = buildSubscriptionFallbackModels(
-        mockPricingSync as never,
-        'anthropic',
-      );
-
-      // Anthropic includes the dated suffix via prefix match
-      expect(anthropicResult.map((m) => m.id)).toContain('claude-opus-4-20260301');
-      // Gemini excludes the preview suffix (exact mode)
-      expect(geminiResult.map((m) => m.id)).not.toContain('gemini-2.5-pro-preview-06-05');
-      // Gemini only has the verbatim match
-      expect(geminiResult.map((m) => m.id)).toContain('gemini-2.5-pro');
-      expect(geminiResult.map((m) => m.id)).toContain('gemini-3.1-pro-preview');
-      expect(geminiResult.map((m) => m.id)).toContain('gemini-3.1-flash-lite-preview');
     });
   });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -239,13 +239,16 @@ export class ModelDiscoveryService {
     // subscription discovery is also static so connecting Claude Code does
     // not spend live /models or /messages calls before the first real request.
     if (useCuratedSubscriptionModels) {
-      raw = buildSubscriptionFallbackModels(this.pricingSync, provider.provider);
+      raw = buildSubscriptionFallbackModels(provider.provider);
       if (raw.length > 0) {
         this.logger.log(
           `Subscription provider ${provider.provider} — using ${raw.length} curated models`,
         );
       }
-    } else if (prefersModelsDevCatalog(provider.provider)) {
+    } else if (
+      provider.auth_type !== 'subscription' &&
+      prefersModelsDevCatalog(provider.provider)
+    ) {
       raw = buildModelsDevModels();
       if (raw.length > 0) {
         this.logger.log(`Using ${raw.length} models from models.dev for ${provider.provider}`);
@@ -265,7 +268,7 @@ export class ModelDiscoveryService {
       // actually grants must use the curated `knownModels` list — otherwise
       // the routing UI offers models that 404 at chat time.
       if (raw.length === 0 && provider.auth_type === 'subscription') {
-        raw = buildSubscriptionFallbackModels(this.pricingSync, provider.provider);
+        raw = buildSubscriptionFallbackModels(provider.provider);
         if (raw.length > 0) {
           this.logger.log(
             `Subscription provider ${provider.provider} — using ${raw.length} curated models`,
@@ -273,8 +276,9 @@ export class ModelDiscoveryService {
         }
       }
 
-      // If native API returned no models, try models.dev first, then OpenRouter.
-      if (raw.length === 0) {
+      // External catalogs may enrich provider-discovered models, but they must
+      // never determine which models a subscription can access.
+      if (raw.length === 0 && provider.auth_type !== 'subscription') {
         raw = buildModelsDevModels();
         if (raw.length > 0) {
           this.logger.log(
@@ -284,7 +288,11 @@ export class ModelDiscoveryService {
       }
       // If models.dev also had nothing, fall back to OpenRouter filtered by confirmed models.
       // Qwen is excluded because OpenRouter/pricing ids can diverge from DashScope ids.
-      if (raw.length === 0 && !isQwenProvider(provider.provider)) {
+      if (
+        raw.length === 0 &&
+        provider.auth_type !== 'subscription' &&
+        !isQwenProvider(provider.provider)
+      ) {
         const confirmed = this.modelRegistry?.getConfirmedModels(provider.provider) ?? null;
         raw = buildFallbackModels(this.pricingSync, provider.provider, confirmed);
         if (raw.length > 0) {
@@ -295,8 +303,8 @@ export class ModelDiscoveryService {
       }
     }
 
-    // For subscription providers, supplement with knownModels so users can
-    // always select them, even if the live API or OpenRouter didn't return them.
+    // For subscription providers, supplement live discovery with the explicit
+    // curated list so users can always select known supported models.
     if (provider.auth_type === 'subscription') {
       raw = supplementWithKnownModels(raw, provider.provider);
     }

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -264,343 +264,47 @@ describe('lookupWithVariants', () => {
 });
 
 describe('buildSubscriptionFallbackModels', () => {
-  it('should return empty for providers with no known models', () => {
-    const cache = new Map([['openai/gpt-4o', { input: 0.01, output: 0.02 }]]);
-
-    const result = buildSubscriptionFallbackModels(makePricingSync(cache), 'unknown-provider');
-
-    expect(result).toEqual([]);
+  it('returns empty for providers without curated models', () => {
+    expect(buildSubscriptionFallbackModels('unknown-provider')).toEqual([]);
+    expect(buildSubscriptionFallbackModels('opencode-go')).toEqual([]);
   });
 
-  it('should return models for known subscription providers', () => {
-    const cache = new Map([
-      ['anthropic/claude-opus-4-6', { input: 0.015, output: 0.075, displayName: 'Claude Opus' }],
+  it('returns exactly the curated Anthropic subscription models', () => {
+    const result = buildSubscriptionFallbackModels('anthropic');
+
+    expect(result.map((model) => model.id)).toEqual([
+      'claude-fable-5',
+      'claude-opus-4',
+      'claude-sonnet-4',
+      'claude-haiku-4',
+      'claude-opus-5',
+      'claude-sonnet-5',
     ]);
-
-    const result = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic');
-
-    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result.every((model) => model.provider === 'anthropic')).toBe(true);
+    expect(result.every((model) => model.displayName === model.id)).toBe(true);
+    expect(result.every((model) => model.inputPricePerToken === 0)).toBe(true);
+    expect(result.every((model) => model.outputPricePerToken === 0)).toBe(true);
   });
 
-  it('should handle null pricingSync', () => {
-    const result = buildSubscriptionFallbackModels(null, 'anthropic');
+  it('applies subscription context windows to curated models', () => {
+    const result = buildSubscriptionFallbackModels('anthropic');
 
-    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result.find((model) => model.id === 'claude-opus-4')?.contextWindow).toBe(200000);
+    expect(result.find((model) => model.id === 'claude-opus-5')?.contextWindow).toBe(1000000);
+    expect(result.find((model) => model.id === 'claude-sonnet-5')?.contextWindow).toBe(1000000);
   });
 
-  it('excludes Anthropic claude-*-fast pseudo-models that 404 at the API', () => {
-    const cache = new Map([
-      [
-        'anthropic/claude-opus-4-8',
-        { input: 0.015, output: 0.075, displayName: 'Claude Opus 4.8' },
-      ],
-      [
-        'anthropic/claude-opus-4.8-fast',
-        { input: 0.015, output: 0.075, displayName: 'Claude Opus 4.8 (fast)' },
-      ],
+  it('preserves curated model casing', () => {
+    expect(buildSubscriptionFallbackModels('minimax').map((model) => model.id)).toEqual([
+      'MiniMax-M3',
+      'MiniMax-M2.7',
+      'MiniMax-M2.7-highspeed',
+      'MiniMax-M2.5',
+      'MiniMax-M2.5-highspeed',
+      'MiniMax-M2.1',
+      'MiniMax-M2.1-highspeed',
+      'MiniMax-M2',
     ]);
-
-    const ids = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic').map(
-      (m) => m.id,
-    );
-
-    expect(ids).toContain('claude-opus-4-8');
-    expect(ids.some((id) => id.includes('-fast'))).toBe(false);
-  });
-
-  it('uses the Anthropic Opus 4.8 subscription context override', () => {
-    const cache = new Map([
-      [
-        'anthropic/claude-opus-4-8',
-        {
-          input: 0.015,
-          output: 0.075,
-          contextWindow: 200000,
-          displayName: 'Claude Opus 4.8',
-        },
-      ],
-    ]);
-
-    const model = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic').find(
-      (m) => m.id === 'claude-opus-4-8',
-    );
-
-    expect(model).toBeDefined();
-    expect(model!.contextWindow).toBe(1000000);
-  });
-
-  it('applies Anthropic Opus 4.8 context override to dated variants', () => {
-    const cache = new Map([
-      [
-        'anthropic/claude-opus-4-8-20260929',
-        {
-          input: 0.015,
-          output: 0.075,
-          contextWindow: 200000,
-          displayName: 'Claude Opus 4.8',
-        },
-      ],
-    ]);
-
-    const model = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic').find(
-      (m) => m.id === 'claude-opus-4-8-20260929',
-    );
-
-    expect(model).toBeDefined();
-    expect(model!.contextWindow).toBe(1000000);
-  });
-
-  it('uses the Anthropic Opus 5 subscription context override', () => {
-    const cache = new Map([
-      [
-        'anthropic/claude-opus-5',
-        {
-          input: 0.005,
-          output: 0.025,
-          contextWindow: 200000,
-          displayName: 'Claude Opus 5',
-        },
-      ],
-    ]);
-
-    const model = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic').find(
-      (m) => m.id === 'claude-opus-5',
-    );
-
-    expect(model).toBeDefined();
-    expect(model!.contextWindow).toBe(1000000);
-  });
-
-  it('surfaces claude-opus-5 even when the pricing cache lacks it', () => {
-    // The 5 generation dropped the claude-opus-4 prefix, so Opus 5 reaches the
-    // curated catalog only via its own knownModels entry.
-    const ids = buildSubscriptionFallbackModels(makePricingSync(new Map()), 'anthropic').map(
-      (m) => m.id,
-    );
-
-    expect(ids).toContain('claude-opus-5');
-  });
-
-  it('surfaces claude-fable-5 even when the pricing cache lacks it', () => {
-    // claude-fable-5 is a valid Anthropic subscription model with no pricing
-    // cache entry; the knownModels fallback must still offer it.
-    const ids = buildSubscriptionFallbackModels(makePricingSync(new Map()), 'anthropic').map(
-      (m) => m.id,
-    );
-
-    expect(ids).toContain('claude-fable-5');
-  });
-
-  it('returns [] for opencode-go because its catalog is fetched dynamically', () => {
-    // OpenCode Go has no hardcoded knownModels. The fallback path must stay empty
-    // so we do not fabricate stale entries when the live catalog is unreachable.
-    const result = buildSubscriptionFallbackModels(makePricingSync(new Map()), 'opencode-go');
-    expect(result).toEqual([]);
-  });
-
-  it('surfaces the fixed Mistral Vibe model even when the pricing cache lacks it', () => {
-    const ids = buildSubscriptionFallbackModels(makePricingSync(new Map()), 'mistral').map(
-      (m) => m.id,
-    );
-
-    expect(ids).toEqual(['mistral-vibe-cli-latest']);
-  });
-
-  it('keeps Mistral Vibe fallback matching exact', () => {
-    const cache = new Map([
-      [
-        'mistralai/mistral-vibe-cli-latest',
-        { input: 0.000001, output: 0.000003, displayName: 'Mistral Vibe CLI' },
-      ],
-      [
-        'mistralai/mistral-vibe-cli-fast',
-        { input: 0.000001, output: 0.000003, displayName: 'Mistral Vibe CLI Fast' },
-      ],
-    ]);
-
-    const result = buildSubscriptionFallbackModels(makePricingSync(cache), 'mistral');
-    expect(result.map((m) => m.id)).toEqual(['mistral-vibe-cli-latest']);
-    expect(result[0].displayName).toBe('Mistral Vibe CLI');
-  });
-
-  describe('knownModelsMatch exact mode (gemini)', () => {
-    it('includes only verbatim knownModel entries from the OpenRouter cache', () => {
-      const cache = new Map([
-        // Exact match for 'gemini-2.5-pro' → included
-        [
-          'google/gemini-2.5-pro',
-          {
-            input: 0.00000125,
-            output: 0.00001,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Pro',
-          },
-        ],
-        // Exact match for 'gemini-2.5-flash' → included
-        [
-          'google/gemini-2.5-flash',
-          {
-            input: 0.0000003,
-            output: 0.0000025,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Flash',
-          },
-        ],
-        // Exact current preview model → included because it is explicitly known
-        [
-          'google/gemini-3.1-pro-preview',
-          {
-            input: 0.000002,
-            output: 0.000012,
-            contextWindow: 1000000,
-            displayName: 'Gemini 3.1 Pro Preview',
-          },
-        ],
-        // Suffixed preview → excluded in exact mode
-        [
-          'google/gemini-2.5-pro-preview-06-05',
-          {
-            input: 0.00000125,
-            output: 0.00001,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Pro Preview',
-          },
-        ],
-        // Suffixed lite preview → excluded in exact mode
-        [
-          'google/gemini-2.5-flash-lite-preview-06-17',
-          {
-            input: 0.0000001,
-            output: 0.0000008,
-            contextWindow: 1000000,
-            displayName: 'Flash Lite Preview',
-          },
-        ],
-        // Different provider — excluded
-        [
-          'openai/gpt-4o',
-          { input: 0.0000025, output: 0.00001, contextWindow: 128000, displayName: 'GPT-4o' },
-        ],
-      ]);
-
-      const result = buildSubscriptionFallbackModels(makePricingSync(cache), 'gemini');
-      const ids = result.map((m) => m.id);
-
-      expect(ids).toContain('gemini-2.5-pro');
-      expect(ids).toContain('gemini-2.5-flash');
-      expect(ids).toContain('gemini-3.1-pro-preview');
-      // Suffixed variants excluded
-      expect(ids).not.toContain('gemini-2.5-pro-preview-06-05');
-      expect(ids).not.toContain('gemini-2.5-flash-lite-preview-06-17');
-      // gemini-2.5-flash-lite knownModel not in cache → added as zero-cost directly
-      expect(ids).toContain('gemini-2.5-flash-lite');
-      expect(result.find((m) => m.id === 'gemini-2.5-flash-lite')!.inputPricePerToken).toBe(0);
-    });
-
-    it('compares exact match case-insensitively', () => {
-      // OpenRouter may return 'gemini-2.5-pro' in lowercase, config has lowercase too
-      const cache = new Map([
-        [
-          'google/gemini-2.5-pro',
-          {
-            input: 0.00000125,
-            output: 0.00001,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Pro',
-          },
-        ],
-      ]);
-
-      const result = buildSubscriptionFallbackModels(makePricingSync(cache), 'gemini');
-      expect(result.map((m) => m.id)).toContain('gemini-2.5-pro');
-    });
-
-    it('contrast: prefix mode keeps suffix entries that exact mode would drop', () => {
-      // Anthropic uses prefix mode: 'claude-opus-4-20260301' starts with 'claude-opus-4' → included
-      // Gemini uses exact mode: 'gemini-2.5-pro-preview' does NOT equal 'gemini-2.5-pro' → excluded
-      const anthropicCache = new Map([
-        [
-          'anthropic/claude-opus-4-20260301',
-          {
-            input: 0.000015,
-            output: 0.000075,
-            contextWindow: 200000,
-            displayName: 'Claude Opus 4',
-          },
-        ],
-      ]);
-      const geminiCache = new Map([
-        [
-          'google/gemini-2.5-pro-preview',
-          {
-            input: 0.00000125,
-            output: 0.00001,
-            contextWindow: 1000000,
-            displayName: 'Gemini 2.5 Pro Preview',
-          },
-        ],
-      ]);
-
-      const anthropicResult = buildSubscriptionFallbackModels(
-        makePricingSync(anthropicCache),
-        'anthropic',
-      );
-      const geminiResult = buildSubscriptionFallbackModels(makePricingSync(geminiCache), 'gemini');
-
-      // Prefix: dated suffix accepted
-      expect(anthropicResult.map((m) => m.id)).toContain('claude-opus-4-20260301');
-      // Exact: preview suffix rejected
-      expect(geminiResult.map((m) => m.id)).not.toContain('gemini-2.5-pro-preview');
-      // Exact mode keeps explicit known preview IDs separate from their base model IDs.
-      expect(geminiResult.map((m) => m.id)).toContain('gemini-2.5-pro');
-      expect(geminiResult.map((m) => m.id)).toContain('gemini-2.5-flash');
-      expect(geminiResult.map((m) => m.id)).toContain('gemini-2.5-flash-lite');
-      expect(geminiResult.map((m) => m.id)).toContain('gemini-3.1-pro-preview');
-      expect(geminiResult.map((m) => m.id)).toContain('gemini-3.1-flash-lite');
-      expect(geminiResult.map((m) => m.id)).toContain('gemini-3.1-flash-lite-preview');
-    });
-
-    it('applies maxContextWindow cap from gemini subscription capabilities', () => {
-      const cache = new Map([
-        // OpenRouter reports 2M but Gemini subscription caps at 1M
-        [
-          'google/gemini-2.5-pro',
-          {
-            input: 0.00000125,
-            output: 0.00001,
-            contextWindow: 2000000,
-            displayName: 'Gemini 2.5 Pro',
-          },
-        ],
-      ]);
-
-      const result = buildSubscriptionFallbackModels(makePricingSync(cache), 'gemini');
-      const proModel = result.find((m) => m.id === 'gemini-2.5-pro');
-
-      expect(proModel).toBeDefined();
-      // Capped at Gemini subscription capability maxContextWindow (1000000)
-      expect(proModel!.contextWindow).toBe(1000000);
-    });
-
-    it('returns all gemini knownModels as zero-cost when pricingSync returns nothing', () => {
-      const result = buildSubscriptionFallbackModels(makePricingSync(new Map()), 'gemini');
-
-      expect(result).toHaveLength(7);
-      expect(result.map((m) => m.id).sort()).toEqual([
-        'gemini-2.5-flash',
-        'gemini-2.5-flash-lite',
-        'gemini-2.5-pro',
-        'gemini-3-flash-preview',
-        'gemini-3.1-flash-lite',
-        'gemini-3.1-flash-lite-preview',
-        'gemini-3.1-pro-preview',
-      ]);
-      for (const m of result) {
-        expect(m.inputPricePerToken).toBe(0);
-        expect(m.outputPricePerToken).toBe(0);
-        expect(m.provider).toBe('gemini');
-      }
-    });
   });
 });
 

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -6,7 +6,6 @@ import {
 import {
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
-  getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
   type SubscriptionCapabilities,
 } from 'manifest-shared';
@@ -270,97 +269,31 @@ export function buildFallbackModels(
 }
 
 /**
- * Build a curated fallback model list for subscription providers without a token.
- * Uses knownModels prefixes from subscription-capabilities to filter the OpenRouter cache,
- * and applies capability restrictions (e.g., context window caps).
- * Any knownModels not found in OpenRouter are added directly as zero-cost entries.
+ * Build a curated fallback model list for subscription providers.
+ * Model availability comes exclusively from the provider's knownModels list.
  */
-export function buildSubscriptionFallbackModels(
-  pricingSync: PricingLookup | null,
-  providerId: string,
-): DiscoveredModel[] {
-  const knownPrefixes = getSubscriptionKnownModels(providerId);
-  if (!knownPrefixes) return [];
-  const normalizedKnownPrefixes = knownPrefixes.map((modelId) => modelId.toLowerCase());
-  const matchMode = getSubscriptionKnownModelsMatch(providerId);
-  const excludedSubstrings = getSubscriptionExcludedModels(providerId).map((s) => s.toLowerCase());
-  const isExcluded = (lowerId: string): boolean =>
-    excludedSubstrings.some((sub) => lowerId.includes(sub));
-
+export function buildSubscriptionFallbackModels(providerId: string): DiscoveredModel[] {
+  const knownModels = getSubscriptionKnownModels(providerId);
+  if (!knownModels) return [];
   const capabilities = getSubscriptionCapabilities(providerId);
-  const models: DiscoveredModel[] = [];
-  const seen = new Set<string>();
-
-  const orPrefix = pricingSync ? findOpenRouterPrefix(providerId) : null;
-
-  if (pricingSync && orPrefix) {
-    for (const [fullId, entry] of pricingSync.getAll()) {
-      if (!fullId.startsWith(`${orPrefix}/`)) continue;
-      const modelId = normalizeProviderModelId(providerId, fullId.substring(orPrefix.length + 1));
-      const lowerId = modelId.toLowerCase();
-      const matches =
-        matchMode === 'exact'
-          ? normalizedKnownPrefixes.includes(lowerId)
-          : normalizedKnownPrefixes.some((p: string) => lowerId.startsWith(p));
-      if (!matches) continue;
-      // Drop pricing-cache pseudo-models (e.g. Anthropic `claude-*-fast`) that
-      // match a known prefix but 404 at the subscription endpoint.
-      if (isExcluded(lowerId)) continue;
-      if (seen.has(modelId)) continue;
-      seen.add(modelId);
-
-      const contextWindow = resolveSubscriptionContextWindow(
-        modelId,
-        entry.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
-        capabilities,
-      );
-
-      models.push({
-        id: modelId,
-        displayName: entry.displayName || modelId,
-        provider: providerId,
-        contextWindow,
-        inputPricePerToken: entry.input,
-        outputPricePerToken: entry.output,
-        capabilityReasoning: false,
-        capabilityCode: false,
-        qualityScore: 3,
-      });
-    }
-  }
-
-  // Add any knownModels not already covered by discovered models. Prefix-mode
-  // providers treat versioned IDs as covered by the family ID; exact-mode
-  // providers only treat an identical ID as covered.
   const defaultCtx = capabilities?.maxContextWindow ?? 200000;
-  for (const modelId of knownPrefixes) {
-    const lowerModelId = modelId.toLowerCase();
-    const covered = models.some((m) => {
-      const lowerDiscovered = m.id.toLowerCase();
-      if (lowerDiscovered === lowerModelId) return true;
-      return matchMode !== 'exact' && lowerDiscovered.startsWith(`${lowerModelId}-`);
-    });
-    if (covered) continue;
-    models.push({
-      id: modelId,
-      displayName: modelId,
-      provider: providerId,
-      contextWindow: resolveSubscriptionContextWindow(modelId, defaultCtx, capabilities),
-      inputPricePerToken: 0,
-      outputPricePerToken: 0,
-      capabilityReasoning: false,
-      capabilityCode: false,
-      qualityScore: 3,
-    });
-  }
-
-  return models;
+  return knownModels.map((modelId) => ({
+    id: modelId,
+    displayName: modelId,
+    provider: providerId,
+    contextWindow: resolveSubscriptionContextWindow(modelId, defaultCtx, capabilities),
+    inputPricePerToken: 0,
+    outputPricePerToken: 0,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 3,
+  }));
 }
 
 /**
  * Supplement discovered models with knownModels from subscription-capabilities.
  * Ensures subscription users always have the known models available as selectable options,
- * even if the live API or OpenRouter cache didn't return them.
+ * even if the live provider API did not return them.
  */
 export function supplementWithKnownModels(
   raw: DiscoveredModel[],

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -5,7 +5,6 @@ import {
   supportsSubscriptionProvider,
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
-  getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
 } from '../src/subscription';
 
@@ -492,22 +491,6 @@ describe('getSubscriptionKnownModelsMatch', () => {
   it('is case-insensitive', () => {
     expect(getSubscriptionKnownModelsMatch('GEMINI')).toBe('exact');
     expect(getSubscriptionKnownModelsMatch('Anthropic')).toBe('prefix');
-  });
-});
-
-describe('getSubscriptionExcludedModels', () => {
-  it('returns the -fast and retired-snapshot exclusions for anthropic', () => {
-    // `-20250514` blocks the claude-{sonnet,opus}-4-20250514 snapshots
-    // retired on 2026-06-15 if the pricing cache still surfaces them.
-    expect(getSubscriptionExcludedModels('anthropic')).toEqual(['-fast', '-20250514']);
-  });
-
-  it('returns an empty array for providers with no exclusion configured', () => {
-    expect(getSubscriptionExcludedModels('gemini')).toEqual([]);
-  });
-
-  it('returns an empty array for unknown providers', () => {
-    expect(getSubscriptionExcludedModels('unknown')).toEqual([]);
   });
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -145,7 +145,6 @@ export {
   supportsSubscriptionProvider,
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
-  getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
 } from './subscription';
 export type { SubscriptionCapabilities, SubscriptionProviderConfig } from './subscription';

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -21,11 +21,6 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       'claude-opus-5',
       'claude-sonnet-5',
     ]),
-    // `claude-*-fast` ids exist in the OpenRouter pricing cache but 404 at
-    // api.anthropic.com — fast mode is an `anthropic-beta` header on the base
-    // Opus model, not a distinct model id. Keep them out of the catalog.
-    // `*-20250514` snapshots were retired on 2026-06-15.
-    knownModelsExclude: Object.freeze(['-fast', '-20250514']),
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
       modelContextWindows: Object.freeze({

--- a/packages/shared/src/subscription/helpers.ts
+++ b/packages/shared/src/subscription/helpers.ts
@@ -36,11 +36,6 @@ export function getSubscriptionKnownModelsMatch(providerId: string): 'prefix' | 
   return config?.knownModelsMatch ?? 'prefix';
 }
 
-export function getSubscriptionExcludedModels(providerId: string): readonly string[] {
-  const config = getSubscriptionProviderConfig(providerId);
-  return config?.knownModelsExclude ?? [];
-}
-
 export function getSubscriptionCapabilities(
   providerId: string,
 ): Readonly<SubscriptionCapabilities> | null {

--- a/packages/shared/src/subscription/index.ts
+++ b/packages/shared/src/subscription/index.ts
@@ -5,6 +5,5 @@ export {
   supportsSubscriptionProvider,
   getSubscriptionKnownModels,
   getSubscriptionKnownModelsMatch,
-  getSubscriptionExcludedModels,
   getSubscriptionCapabilities,
 } from './helpers';

--- a/packages/shared/src/subscription/types.ts
+++ b/packages/shared/src/subscription/types.ts
@@ -14,22 +14,10 @@ export interface SubscriptionProviderConfig {
   subscriptionTokenPrefix?: string;
   knownModels?: readonly string[];
   /**
-   * How `knownModels` is matched against the OpenRouter pricing cache:
-   *   `prefix` (default) — keep any cache entry whose id starts with one
-   *     of `knownModels`. Useful for vendors whose OAuth tokens accept
-   *     dated suffixes (Anthropic: `claude-opus-4-*`).
-   *   `exact` — only keep cache entries whose id matches a `knownModels`
-   *     entry verbatim. Use when the subscription endpoint exposes a
-   *     strict whitelist (Gemini CodeAssist 404s on suffixed variants).
+   * How a known model is considered covered by live subscription discovery:
+   * `prefix` (default) accepts a more specific discovered variant, while
+   * `exact` requires the curated model ID itself to be present.
    */
   knownModelsMatch?: 'prefix' | 'exact';
-  /**
-   * Case-insensitive substrings that disqualify a model id from the curated
-   * subscription catalog, even when it matches `knownModels`. Used to drop
-   * pricing-cache entries that look like real models but 404 at the
-   * subscription endpoint — e.g. Anthropic's `claude-*-fast` ids, where "fast
-   * mode" is an `anthropic-beta` header on the base model, not a model id.
-   */
-  knownModelsExclude?: readonly string[];
   subscriptionCapabilities?: Readonly<SubscriptionCapabilities>;
 }


### PR DESCRIPTION
### ✨ What changed
- Build subscription fallbacks only from curated provider models.
- Stop empty subscription discovery from falling through to external catalogs.
- Remove obsolete exclusion settings and add regression coverage.

### 💭 Why
OpenRouter-specific variants were leaking into subscription model pickers.

### 👤 For users
Subscription pickers no longer show unavailable variants such as Anthropic batch models.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit subscription model catalogs to curated provider lists and stop using external catalogs for subscriptions. Fixes leaked variants in subscription pickers (e.g., `claude-sonnet-5:batch`).

- **Bug Fixes**
  - Subscription discovery now uses only curated `knownModels`; external catalogs are ignored when `auth_type === 'subscription'`.
  - Rewrote `buildSubscriptionFallbackModels(providerId)` to return curated, zero-cost models with subscription context windows; removed pricing/OpenRouter filtering and `knownModelsExclude`.
  - Updated `ModelDiscoveryService` so external catalogs only enrich non-subscription providers; no fallbacks to `models.dev` or OpenRouter for subscriptions.
  - Added tests to confirm curated-only catalogs and block leaked variants.

<sup>Written for commit cbb07523c0c698c77d8179ca78cdab9d8e7215ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

