### PR TITLE
fix: scope proxy session caches

### DIFF
--- a/.changeset/scope-proxy-session-caches.md
+++ b/.changeset/scope-proxy-session-caches.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Scope proxy replay caches and routing momentum to their owning tenant and agent.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-session-scope.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-session-scope.spec.ts
@@ -1,0 +1,35 @@
+import { buildProxySessionScope } from '../proxy-session-scope';
+
+describe('buildProxySessionScope', () => {
+  it('builds a deterministic fixed-length key for the same scope', () => {
+    const first = buildProxySessionScope('tenant-1', 'agent-1', 'session-1');
+    const second = buildProxySessionScope('tenant-1', 'agent-1', 'session-1');
+
+    expect(first).toEqual(second);
+    expect(first.cacheKey).toMatch(/^v1:[a-f0-9]{64}$/);
+    expect(first.momentumKey).toBe(first.cacheKey);
+    expect(first.cacheKey).not.toContain('session-1');
+  });
+
+  it.each([
+    ['tenant-2', 'agent-1', 'session-1'],
+    ['tenant-1', 'agent-2', 'session-1'],
+    ['tenant-1', 'agent-1', 'session-2'],
+  ])('isolates a different tenant, agent, or session', (tenantId, agentId, sessionKey) => {
+    const baseline = buildProxySessionScope('tenant-1', 'agent-1', 'session-1');
+    const scoped = buildProxySessionScope(tenantId, agentId, sessionKey);
+
+    expect(scoped.cacheKey).not.toBe(baseline.cacheKey);
+  });
+
+  it.each([undefined, '', ['session-1']])(
+    'uses a cache-only default scope when no explicit string header is present',
+    (header) => {
+      const scope = buildProxySessionScope('tenant-1', 'agent-1', header);
+
+      expect(scope.sessionKey).toBe('default');
+      expect(scope.cacheKey).toMatch(/^v1:[a-f0-9]{64}$/);
+      expect(scope.momentumKey).toBeUndefined();
+    },
+  );
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -10,6 +10,7 @@ import { ReasoningContentCache } from '../reasoning-content-cache';
 import { ResponsesSseError } from '../chatgpt-adapter';
 import type { DiscoveredModel } from '../../../model-discovery/model-fetcher';
 import type { StartProviderAttempt } from '../proxy-types';
+import { buildProxySessionScope } from '../proxy-session-scope';
 
 /**
  * Flush enough microtasks for the recorder's fire-and-forget chain to
@@ -1851,12 +1852,15 @@ describe('ProxyController', () => {
 
     await controller.chatCompletions(req as never, res as never);
 
+    const scope = buildProxySessionScope('tenant-1', 'agent-1', 'my-session');
     expect(proxyService.proxyRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: 'agent-1',
         userId: 'user-1',
         body: req.body,
         sessionKey: 'my-session',
+        sessionCacheKey: scope.cacheKey,
+        sessionMomentumKey: scope.momentumKey,
         tenantId: 'tenant-1',
         agentName: 'test-agent',
         signal: expect.any(AbortSignal),
@@ -1887,12 +1891,15 @@ describe('ProxyController', () => {
 
     await controller.chatCompletions(req as never, res as never);
 
+    const scope = buildProxySessionScope('tenant-1', 'agent-1', undefined);
     expect(proxyService.proxyRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: 'agent-1',
         userId: 'user-1',
         body: req.body,
         sessionKey: 'default',
+        sessionCacheKey: scope.cacheKey,
+        sessionMomentumKey: undefined,
         tenantId: 'tenant-1',
         agentName: 'test-agent',
         signal: expect.any(AbortSignal),

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -226,6 +226,8 @@ describe('ProxyService — orchestration', () => {
     userId: 'user-1',
     body: { messages: [{ role: 'user', content: 'hi' }] },
     sessionKey: 'sess-1',
+    sessionCacheKey: 'cache-sess-1',
+    sessionMomentumKey: 'momentum-sess-1',
     tenantId: 'tenant-1',
     agentName: 'demo-agent',
     ...overrides,
@@ -1641,7 +1643,31 @@ describe('ProxyService — orchestration', () => {
       expect(result.meta.tier).toBe('standard');
       expect(result.meta.model).toBe('gpt-4o');
       expect(result.meta.provider).toBe('openai');
-      expect(momentum.recordTier).toHaveBeenCalledWith('sess-1', 'standard');
+      expect(momentum.recordTier).toHaveBeenCalledWith('momentum-sess-1', 'standard');
+    });
+
+    it('skips routing momentum when the caller did not supply a session key', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(200),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await svc.proxyRequest(baseOpts({ sessionMomentumKey: undefined }));
+
+      expect(momentum.getRecentTiers).not.toHaveBeenCalled();
+      expect(momentum.getRecentCategories).not.toHaveBeenCalled();
+      expect(momentum.recordTier).not.toHaveBeenCalled();
+      expect(momentum.recordCategory).not.toHaveBeenCalled();
     });
 
     it('passes the raw stored OpenAI OAuth blob alongside the unwrapped access token', async () => {
@@ -1761,7 +1787,7 @@ describe('ProxyService — orchestration', () => {
         isChatGpt: false,
       });
       await svc.proxyRequest(baseOpts());
-      expect(momentum.recordCategory).toHaveBeenCalledWith('sess-1', 'coding');
+      expect(momentum.recordCategory).toHaveBeenCalledWith('momentum-sess-1', 'coding');
     });
 
     it('skips category recording for unknown values', async () => {
@@ -2823,9 +2849,9 @@ describe('ProxyService — orchestration', () => {
       });
 
       await svc.proxyRequest(baseOpts());
-      expect(signatureCache.retrieve).toHaveBeenCalledWith('sess-1', 'tool-call-1');
-      expect(thinkingCache.retrieve).toHaveBeenCalledWith('sess-1', 'first-use-1');
-      expect(reasoningCache.retrieve).toHaveBeenCalledWith('sess-1', 'reasoning-call-1');
+      expect(signatureCache.retrieve).toHaveBeenCalledWith('cache-sess-1', 'tool-call-1');
+      expect(thinkingCache.retrieve).toHaveBeenCalledWith('cache-sess-1', 'first-use-1');
+      expect(reasoningCache.retrieve).toHaveBeenCalledWith('cache-sess-1', 'reasoning-call-1');
     });
 
     it('strips system / developer roles when scoring', async () => {

--- a/packages/backend/src/routing/proxy/proxy-session-scope.ts
+++ b/packages/backend/src/routing/proxy/proxy-session-scope.ts
@@ -1,0 +1,37 @@
+import { createHash } from 'crypto';
+
+const DEFAULT_SESSION_KEY = 'default';
+const SESSION_SCOPE_VERSION = 'v1';
+
+export interface ProxySessionScope {
+  /** Caller-facing session key retained for provider forwarding and message attribution. */
+  sessionKey: string;
+  /** Fixed-length tenant/agent/session key used only for internal replay caches. */
+  cacheKey: string;
+  /** Routing momentum is enabled only when the caller supplied a session key. */
+  momentumKey?: string;
+}
+
+export function buildProxySessionScope(
+  tenantId: string,
+  agentId: string,
+  sessionHeader: unknown,
+): ProxySessionScope {
+  const explicitSessionKey =
+    typeof sessionHeader === 'string' && sessionHeader.length > 0 ? sessionHeader : undefined;
+  const sessionKey = explicitSessionKey ?? DEFAULT_SESSION_KEY;
+  const digest = createHash('sha256')
+    .update(tenantId)
+    .update('\0')
+    .update(agentId)
+    .update('\0')
+    .update(sessionKey)
+    .digest('hex');
+  const cacheKey = `${SESSION_SCOPE_VERSION}:${digest}`;
+
+  return {
+    sessionKey,
+    cacheKey,
+    ...(explicitSessionKey ? { momentumKey: cacheKey } : {}),
+  };
+}

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -137,6 +137,10 @@ export interface ProxyRequestOptions {
   routingBody?: Record<string, unknown>;
   apiMode?: ProxyApiMode;
   sessionKey: string;
+  /** Fixed-length tenant/agent/session key for internal replay caches. */
+  sessionCacheKey: string;
+  /** Scoped routing-momentum key; absent when the caller omitted x-session-key. */
+  sessionMomentumKey?: string;
   agentName?: string;
   signal?: AbortSignal;
   specificityOverride?: string;

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -33,6 +33,7 @@ import { classifyCaller } from './caller-classifier';
 import { ObservationReporter } from '../autofix/observation-reporter';
 import type { AutofixRecord } from '../autofix/autofix.types';
 import { sanitizeRequestHeaders } from './request-headers';
+import { buildProxySessionScope } from './proxy-session-scope';
 import {
   buildMetaHeaders,
   buildOpenAiCompatibleError,
@@ -230,9 +231,10 @@ export class ProxyController {
     res: ExpressResponse,
     apiMode: ProxyApiMode,
   ): Promise<void> {
-    const { tenantId } = req.ingestionContext;
+    const { agentId, tenantId } = req.ingestionContext;
     const body = req.body as Record<string, unknown>;
-    const sessionKey = this.extractSessionKey(req);
+    const sessionScope = buildProxySessionScope(tenantId, agentId, req.headers['x-session-key']);
+    const { sessionKey } = sessionScope;
     const traceId = this.extractTraceId(req);
     const requestId = uuid();
     const callerAttribution = classifyCaller(req.headers);
@@ -380,6 +382,8 @@ export class ProxyController {
         body,
         routingBody,
         sessionKey,
+        sessionCacheKey: sessionScope.cacheKey,
+        sessionMomentumKey: sessionScope.momentumKey,
         agentName: req.ingestionContext.agentName,
         signal: clientAbort.signal,
         specificityOverride,
@@ -481,7 +485,7 @@ export class ProxyController {
           metaHeaders,
           this.providerClient,
           this.signatureCache,
-          sessionKey,
+          sessionScope.cacheKey,
           this.thinkingCache,
           apiMode,
           this.reasoningCache,
@@ -495,7 +499,7 @@ export class ProxyController {
           metaHeaders,
           this.providerClient,
           this.signatureCache,
-          sessionKey,
+          sessionScope.cacheKey,
           this.thinkingCache,
           apiMode,
           this.reasoningCache,
@@ -824,8 +828,12 @@ export class ProxyController {
     return parts.length >= 2 ? parts[1] : undefined;
   }
 
-  private extractSessionKey(req: Request): string {
-    return (req.headers['x-session-key'] as string) || 'default';
+  private extractSessionKey(req: Request & { ingestionContext: IngestionContext }): string {
+    return buildProxySessionScope(
+      req.ingestionContext.tenantId,
+      req.ingestionContext.agentId,
+      req.headers['x-session-key'],
+    ).sessionKey;
   }
 
   private extractRequestedModel(body: Record<string, unknown> | undefined): string | undefined {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -182,6 +182,7 @@ interface ResolvedHealContext {
   tenantId: string;
   apiMode: ProxyApiMode;
   sessionKey: string;
+  sessionMomentumKey?: string;
   signal?: AbortSignal;
   stream: boolean;
   specificityOverride?: ProxyRequestOptions['specificityOverride'];
@@ -215,6 +216,8 @@ interface UnavailableModelHealContext {
   agentName?: string;
   apiMode: ProxyApiMode;
   sessionKey: string;
+  sessionCacheKey: string;
+  sessionMomentumKey?: string;
   signal?: AbortSignal;
   stream: boolean;
   specificityOverride?: ProxyRequestOptions['specificityOverride'];
@@ -256,6 +259,8 @@ export class ProxyService {
       tenantId,
       body,
       sessionKey,
+      sessionCacheKey,
+      sessionMomentumKey,
       agentName,
       signal,
       specificityOverride,
@@ -282,7 +287,7 @@ export class ProxyService {
       tenantId,
       routingSource,
       resolveRoutingChatBody,
-      sessionKey,
+      sessionMomentumKey,
       specificityOverride,
       headers,
       apiMode,
@@ -301,6 +306,8 @@ export class ProxyService {
           agentName,
           apiMode,
           sessionKey,
+          sessionCacheKey,
+          sessionMomentumKey,
           signal,
           stream,
           specificityOverride,
@@ -326,7 +333,7 @@ export class ProxyService {
     );
 
     const { signatureLookup, thinkingLookup, reasoningContentLookup } =
-      this.buildCacheLookups(sessionKey);
+      this.buildCacheLookups(sessionCacheKey);
 
     // Per-attempt param-defaults merge happens inside the fallback service
     // so each forward (primary + every fallback iteration) looks up its
@@ -419,6 +426,7 @@ export class ProxyService {
           resolveChatBody,
           stream,
           sessionKey,
+          sessionMomentumKey,
           signal,
           signatureLookup,
           thinkingLookup,
@@ -493,6 +501,7 @@ export class ProxyService {
                 tenantId,
                 apiMode: autofixApiMode,
                 sessionKey,
+                sessionMomentumKey,
                 signal,
                 stream,
                 specificityOverride,
@@ -538,6 +547,7 @@ export class ProxyService {
         resolveChatBody,
         stream,
         sessionKey,
+        sessionMomentumKey,
         signal,
         signatureLookup,
         thinkingLookup,
@@ -588,8 +598,8 @@ export class ProxyService {
           retryWireBody: forward.retryWireBody,
           providerCallStarted: forward.providerCallStarted,
         };
-        this.recordTierIfScoring(sessionKey, resolved.tier);
-        this.recordCategoryIfValid(sessionKey, resolved.specificity_category);
+        this.recordTierIfScoring(sessionMomentumKey, resolved.tier);
+        this.recordCategoryIfValid(sessionMomentumKey, resolved.specificity_category);
         return {
           forward: peeked,
           meta: this.buildBaseMeta(resolved, primaryModel, {
@@ -639,6 +649,7 @@ export class ProxyService {
           resolveChatBody,
           stream,
           sessionKey,
+          sessionMomentumKey,
           signal,
           signatureLookup,
           thinkingLookup,
@@ -664,8 +675,8 @@ export class ProxyService {
 
       // Warmup failed and no fallbacks available: return the synthetic 502
       // instead of the original forward (whose body was consumed by peekStream).
-      this.recordTierIfScoring(sessionKey, resolved.tier);
-      this.recordCategoryIfValid(sessionKey, resolved.specificity_category);
+      this.recordTierIfScoring(sessionMomentumKey, resolved.tier);
+      this.recordCategoryIfValid(sessionMomentumKey, resolved.specificity_category);
       return {
         forward: syntheticForward,
         meta: this.buildBaseMeta(resolved, primaryModel, {
@@ -680,8 +691,8 @@ export class ProxyService {
       };
     }
 
-    this.recordTierIfScoring(sessionKey, resolved.tier);
-    this.recordCategoryIfValid(sessionKey, resolved.specificity_category);
+    this.recordTierIfScoring(sessionMomentumKey, resolved.tier);
+    this.recordCategoryIfValid(sessionMomentumKey, resolved.specificity_category);
     return {
       forward,
       meta: this.buildBaseMeta(resolved, primaryModel, {
@@ -696,7 +707,8 @@ export class ProxyService {
     };
   }
 
-  private recordTierIfScoring(sessionKey: string, tier: TierSlot): void {
+  private recordTierIfScoring(sessionKey: string | undefined, tier: TierSlot): void {
+    if (!sessionKey) return;
     if ((TIERS as readonly string[]).includes(tier)) {
       this.momentum.recordTier(sessionKey, tier as Tier);
     }
@@ -751,7 +763,7 @@ export class ProxyService {
       ctx.tenantId,
       healedBody,
       resolveChatBody,
-      ctx.sessionKey,
+      ctx.sessionMomentumKey,
       ctx.specificityOverride,
       ctx.headers,
       ctx.apiMode,
@@ -860,7 +872,7 @@ export class ProxyService {
     tenantId: string,
     body: ProxyRequestOptions['body'],
     resolveChatBody: ResolveChatBody | undefined,
-    sessionKey: string,
+    sessionMomentumKey: string | undefined,
     specificityOverride: ProxyRequestOptions['specificityOverride'],
     headers: ProxyRequestOptions['headers'],
     apiMode: ProxyApiMode,
@@ -885,8 +897,12 @@ export class ProxyService {
     }
 
     const isHeartbeat = this.detectHeartbeatBody(body, apiMode);
-    const recentTiers = this.momentum.getRecentTiers(sessionKey);
-    const recentCategories = this.momentum.getRecentCategories(sessionKey);
+    const recentTiers = sessionMomentumKey
+      ? this.momentum.getRecentTiers(sessionMomentumKey)
+      : undefined;
+    const recentCategories = sessionMomentumKey
+      ? this.momentum.getRecentCategories(sessionMomentumKey)
+      : undefined;
 
     const baseResolved = await (isHeartbeat
       ? this.resolveService.resolveForTier(agentId, tenantId, 'simple')
@@ -1021,6 +1037,7 @@ export class ProxyService {
     resolveChatBody?: ResolveChatBody;
     stream: boolean;
     sessionKey: string;
+    sessionMomentumKey?: string;
     signal?: AbortSignal;
     signatureLookup: SignatureLookup;
     thinkingLookup: ThinkingBlockLookup;
@@ -1044,6 +1061,7 @@ export class ProxyService {
       resolveChatBody,
       stream,
       sessionKey,
+      sessionMomentumKey,
       signal,
       apiMode,
     } = args;
@@ -1083,8 +1101,8 @@ export class ProxyService {
       args.credentialDashboardUrl,
     );
 
-    this.recordTierIfScoring(sessionKey, resolved.tier);
-    this.recordCategoryIfValid(sessionKey, resolved.specificity_category);
+    this.recordTierIfScoring(sessionMomentumKey, resolved.tier);
+    this.recordCategoryIfValid(sessionMomentumKey, resolved.specificity_category);
 
     if (success) {
       // Re-snapshot for the fallback's actual provider — its model-scoped
@@ -1220,7 +1238,11 @@ export class ProxyService {
     };
   }
 
-  private recordCategoryIfValid(sessionKey: string, category: string | undefined): void {
+  private recordCategoryIfValid(
+    sessionKey: string | undefined,
+    category: string | undefined,
+  ): void {
+    if (!sessionKey) return;
     if (!category) return;
     if (!(SPECIFICITY_CATEGORIES as readonly string[]).includes(category)) return;
     this.momentum.recordCategory(sessionKey, category as SpecificityCategory);
@@ -1337,11 +1359,12 @@ export class ProxyService {
       requestBody: ctx.body,
       reforward: (healedBody) =>
         this.forwardResolvedHealed(healedBody, {
-          ...this.buildCacheLookups(ctx.sessionKey),
+          ...this.buildCacheLookups(ctx.sessionCacheKey),
           agentId: ctx.agentId,
           tenantId: ctx.tenantId,
           apiMode: ctx.apiMode,
           sessionKey: ctx.sessionKey,
+          sessionMomentumKey: ctx.sessionMomentumKey,
           signal: ctx.signal,
           stream,
           specificityOverride: ctx.specificityOverride,


### PR DESCRIPTION
## Summary
- isolate replay caches by tenant, agent, and caller session
- keep raw session keys for providers and request attribution
- skip routing momentum when no session header is supplied

## Testing
- targeted proxy controller and service tests
- backend build
- ESLint and changeset validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes proxy replay caches and routing momentum by tenant, agent, and session to prevent cross-session leakage. Adds a hashed, fixed-length session cache key and disables momentum when no `x-session-key` is provided.

- **Bug Fixes**
  - Generate session scope via `buildProxySessionScope`, producing a deterministic `sessionCacheKey` (`v1:<sha256>`) while retaining the raw `sessionKey` for provider forwarding and attribution.
  - Default to `sessionKey` = `default` when the header is missing; use the cache key for replay caches only and skip momentum.
  - Controller/service now pass `sessionCacheKey` and `sessionMomentumKey`; cache lookups and momentum recording updated; targeted tests added.

<sup>Written for commit 4fae2b804a79a5e41a8f6f140a2e151807219fb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

