### PR TITLE
fix: bound routing momentum cache

### DIFF
--- a/.changeset/bound-session-momentum-cache.md
+++ b/.changeset/bound-session-momentum-cache.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Bound routing momentum memory by session count and session-key length.

--- a/packages/backend/src/routing/proxy/__tests__/session-momentum.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/session-momentum.service.spec.ts
@@ -1,4 +1,8 @@
-import { SessionMomentumService } from '../session-momentum.service';
+import {
+  SESSION_MOMENTUM_MAX_KEY_LENGTH,
+  SESSION_MOMENTUM_MAX_SESSIONS,
+  SessionMomentumService,
+} from '../session-momentum.service';
 
 describe('SessionMomentumService', () => {
   let service: SessionMomentumService;
@@ -119,6 +123,35 @@ describe('SessionMomentumService', () => {
     service.recordTier('b', 'complex');
     expect(service.getRecentTiers('a')).toEqual(['simple']);
     expect(service.getRecentTiers('b')).toEqual(['complex']);
+  });
+
+  it('caps the total session count and evicts the least recently used entry', () => {
+    service.recordTier('oldest', 'simple');
+    service.recordTier('recent', 'complex');
+    service.getRecentTiers('oldest');
+
+    for (let i = 2; i < SESSION_MOMENTUM_MAX_SESSIONS; i++) {
+      service.recordTier(`session-${i}`, 'standard');
+    }
+    service.recordTier('overflow', 'reasoning');
+
+    const sessions = (service as unknown as { sessions: Map<string, unknown> }).sessions;
+    expect(sessions.size).toBe(SESSION_MOMENTUM_MAX_SESSIONS);
+    expect(service.getRecentTiers('recent')).toBeUndefined();
+    expect(service.getRecentTiers('oldest')).toEqual(['simple']);
+    expect(service.getRecentTiers('overflow')).toEqual(['reasoning']);
+  });
+
+  it('does not retain oversized session keys', () => {
+    const oversizedKey = 'x'.repeat(SESSION_MOMENTUM_MAX_KEY_LENGTH + 1);
+
+    service.recordTier(oversizedKey, 'simple');
+    service.recordCategory(oversizedKey, 'coding');
+
+    expect(service.getRecentTiers(oversizedKey)).toBeUndefined();
+    expect(service.getRecentCategories(oversizedKey)).toBeUndefined();
+    const sessions = (service as unknown as { sessions: Map<string, unknown> }).sessions;
+    expect(sessions.size).toBe(0);
   });
 
   describe('specificity categories', () => {

--- a/packages/backend/src/routing/proxy/session-momentum.service.ts
+++ b/packages/backend/src/routing/proxy/session-momentum.service.ts
@@ -9,6 +9,8 @@ interface MomentumEntry {
 }
 
 const MAX_ENTRIES = 5;
+export const SESSION_MOMENTUM_MAX_SESSIONS = 10_000;
+export const SESSION_MOMENTUM_MAX_KEY_LENGTH = 512;
 const TTL_MS = 30 * 60 * 1000; // 30 minutes
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -29,42 +31,32 @@ export class SessionMomentumService implements OnModuleDestroy {
   }
 
   getRecentTiers(sessionKey: string): Tier[] | undefined {
+    if (!this.isCacheableKey(sessionKey)) return undefined;
     const entry = this.readFresh(sessionKey);
     return entry?.tiers;
   }
 
   getRecentCategories(sessionKey: string): SpecificityCategory[] | undefined {
+    if (!this.isCacheableKey(sessionKey)) return undefined;
     const entry = this.readFresh(sessionKey);
     if (!entry || entry.categories.length === 0) return undefined;
     return entry.categories;
   }
 
   recordTier(sessionKey: string, tier: Tier): void {
-    const existing = this.sessions.get(sessionKey);
-    if (existing) {
-      existing.tiers = [tier, ...existing.tiers].slice(0, MAX_ENTRIES);
-      existing.lastUpdated = Date.now();
-    } else {
-      this.sessions.set(sessionKey, {
-        tiers: [tier],
-        categories: [],
-        lastUpdated: Date.now(),
-      });
-    }
+    if (!this.isCacheableKey(sessionKey)) return;
+    const entry = this.getOrCreate(sessionKey);
+    entry.tiers = [tier, ...entry.tiers].slice(0, MAX_ENTRIES);
+    entry.lastUpdated = Date.now();
+    this.touch(sessionKey, entry);
   }
 
   recordCategory(sessionKey: string, category: SpecificityCategory): void {
-    const existing = this.sessions.get(sessionKey);
-    if (existing) {
-      existing.categories = [category, ...existing.categories].slice(0, MAX_ENTRIES);
-      existing.lastUpdated = Date.now();
-    } else {
-      this.sessions.set(sessionKey, {
-        tiers: [],
-        categories: [category],
-        lastUpdated: Date.now(),
-      });
-    }
+    if (!this.isCacheableKey(sessionKey)) return;
+    const entry = this.getOrCreate(sessionKey);
+    entry.categories = [category, ...entry.categories].slice(0, MAX_ENTRIES);
+    entry.lastUpdated = Date.now();
+    this.touch(sessionKey, entry);
   }
 
   private readFresh(sessionKey: string): MomentumEntry | undefined {
@@ -74,7 +66,35 @@ export class SessionMomentumService implements OnModuleDestroy {
       this.sessions.delete(sessionKey);
       return undefined;
     }
+    this.touch(sessionKey, entry);
     return entry;
+  }
+
+  private getOrCreate(sessionKey: string): MomentumEntry {
+    const existing = this.sessions.get(sessionKey);
+    if (existing) return existing;
+
+    if (this.sessions.size >= SESSION_MOMENTUM_MAX_SESSIONS) {
+      const oldestKey = this.sessions.keys().next().value as string | undefined;
+      if (oldestKey !== undefined) this.sessions.delete(oldestKey);
+    }
+
+    const entry: MomentumEntry = {
+      tiers: [],
+      categories: [],
+      lastUpdated: Date.now(),
+    };
+    this.sessions.set(sessionKey, entry);
+    return entry;
+  }
+
+  private touch(sessionKey: string, entry: MomentumEntry): void {
+    this.sessions.delete(sessionKey);
+    this.sessions.set(sessionKey, entry);
+  }
+
+  private isCacheableKey(sessionKey: string): boolean {
+    return sessionKey.length <= SESSION_MOMENTUM_MAX_KEY_LENGTH;
   }
 
   private evictStale(): void {


### PR DESCRIPTION
## Summary
- cap routing momentum at 10,000 active sessions
- evict the least recently used session at capacity
- ignore session keys longer than 512 characters

## Testing
- session momentum unit tests
- backend build
- ESLint and changeset validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the routing momentum in-memory cache to keep memory usage predictable. Adds LRU eviction and ignores oversized session keys.

- **Bug Fixes**
  - Cap to 10,000 sessions and evict the least recently used entry at capacity.
  - Ignore session keys longer than 512 characters.
  - Refresh recency on read/write to maintain LRU ordering; added unit tests for caps and key length.

<sup>Written for commit ca1ce30f91044ada02da15eda80a3a87121bf864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

