### PR TITLE
fix: bound reasoning cache writes

### DIFF
--- a/.changeset/bound-reasoning-cache-writes.md
+++ b/.changeset/bound-reasoning-cache-writes.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Bound and coalesce shared reasoning-cache writes during database stalls.

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -1,6 +1,17 @@
 import type { Repository } from 'typeorm';
 import { ReasoningContentCacheEntry } from '../../../entities/reasoning-content-cache-entry.entity';
-import { ReasoningContentCache, MAX_CACHE_ENTRIES } from '../reasoning-content-cache';
+import {
+  MAX_CACHE_ENTRIES,
+  MAX_PENDING_PERSIST_WRITES,
+  MAX_PERSIST_CONCURRENCY,
+  MAX_REASONING_CACHE_BYTES,
+  MAX_REASONING_CONTENT_BYTES,
+  ReasoningContentCache,
+} from '../reasoning-content-cache';
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+}
 
 const makeRepo = () =>
   ({
@@ -104,6 +115,71 @@ describe('ReasoningContentCache', () => {
       }),
       ['session_key', 'first_tool_call_id'],
     );
+  });
+
+  it('skips oversized reasoning_content in memory and shared persistence', () => {
+    const repo = makeRepo();
+    const sharedCache = new ReasoningContentCache(repo);
+    const oversized = '💭'.repeat(Math.floor(MAX_REASONING_CONTENT_BYTES / 4) + 1);
+
+    sharedCache.store('session-1', 'call_1', oversized);
+
+    expect(sharedCache.retrieve('session-1', 'call_1')).toBeNull();
+    expect(repo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('coalesces queued writes for the same cache key and persists the latest value', async () => {
+    const repo = makeRepo();
+    const resolvers: Array<() => void> = [];
+    repo.upsert.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(() => resolve({} as never));
+        }),
+    );
+    const sharedCache = new ReasoningContentCache(repo);
+
+    for (let i = 0; i < MAX_PERSIST_CONCURRENCY; i++) {
+      sharedCache.store('session-1', `active-${i}`, `content-${i}`);
+    }
+    sharedCache.store('session-1', 'queued', 'old');
+    sharedCache.store('session-1', 'queued', 'latest');
+
+    expect(repo.upsert).toHaveBeenCalledTimes(MAX_PERSIST_CONCURRENCY);
+    const pending = (
+      sharedCache as unknown as {
+        pendingPersists: Map<string, { content: string }>;
+      }
+    ).pendingPersists;
+    expect(pending.size).toBe(1);
+    expect([...pending.values()][0].content).toBe('latest');
+
+    resolvers.splice(0).forEach((resolve) => resolve());
+    await flushMicrotasks();
+
+    expect(repo.upsert).toHaveBeenCalledTimes(MAX_PERSIST_CONCURRENCY + 1);
+    expect(repo.upsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({ content: 'latest' }),
+      ['session_key', 'first_tool_call_id'],
+    );
+  });
+
+  it('bounds active and queued shared-cache writes during repository stalls', () => {
+    const repo = makeRepo();
+    repo.upsert.mockImplementation(() => new Promise(() => undefined));
+    const sharedCache = new ReasoningContentCache(repo);
+
+    for (let i = 0; i < MAX_PERSIST_CONCURRENCY + MAX_PENDING_PERSIST_WRITES + 5; i++) {
+      sharedCache.store('session-1', `call-${i}`, `content-${i}`);
+    }
+
+    const state = sharedCache as unknown as {
+      activePersistWrites: number;
+      pendingPersists: Map<string, unknown>;
+    };
+    expect(repo.upsert).toHaveBeenCalledTimes(MAX_PERSIST_CONCURRENCY);
+    expect(state.activePersistWrites).toBe(MAX_PERSIST_CONCURRENCY);
+    expect(state.pendingPersists.size).toBe(MAX_PENDING_PERSIST_WRITES);
   });
 
   it('retrieves shared reasoning_content and warms the local cache', async () => {
@@ -264,6 +340,18 @@ describe('ReasoningContentCache', () => {
     expect(cache.retrieve('session', 'call_4')).toBeNull();
     expect(cache.retrieve('session', 'call_5')).not.toBeNull();
     expect(cache.retrieve('session', `call_${MAX_CACHE_ENTRIES + 4}`)).not.toBeNull();
+  });
+
+  it('evicts the oldest in-memory entries once the byte budget is exceeded', () => {
+    const content = 'x'.repeat(MAX_REASONING_CONTENT_BYTES);
+    const entriesAtBudget = MAX_REASONING_CACHE_BYTES / MAX_REASONING_CONTENT_BYTES;
+    for (let i = 0; i <= entriesAtBudget; i++) {
+      cache.store('session', `call_${i}`, content);
+    }
+
+    expect(cache.retrieve('session', 'call_0')).toBeNull();
+    expect(cache.retrieve('session', 'call_1')).toBe(content);
+    expect(cache.retrieve('session', `call_${entriesAtBudget}`)).toBe(content);
   });
 
   it('evicts expired entries lazily when cleanup interval has elapsed', () => {

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -7,6 +7,14 @@ import { supportsReasoningContent } from './reasoning-format';
 interface CachedReasoningContent {
   content: string;
   expiresAt: number;
+  bytes: number;
+}
+
+interface PendingPersistence {
+  sessionKey: string;
+  cacheKey: string;
+  content: string;
+  expiresAt: number;
 }
 
 const TTL_MS = 30 * 60 * 1000; // 30 minutes
@@ -19,6 +27,13 @@ const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
  * `expires_at`.
  */
 export const MAX_CACHE_ENTRIES = 10_000;
+/** Skip pathological single values rather than retaining or persisting them. */
+export const MAX_REASONING_CONTENT_BYTES = 256 * 1024;
+/** Bound aggregate reasoning strings retained by this process. */
+export const MAX_REASONING_CACHE_BYTES = 64 * 1024 * 1024;
+/** Shared persistence is best-effort; cap stalled writes and retain local hits. */
+export const MAX_PENDING_PERSIST_WRITES = 256;
+export const MAX_PERSIST_CONCURRENCY = 4;
 
 /**
  * In-memory cache for OpenAI-compatible `reasoning_content` strings.
@@ -35,7 +50,11 @@ export const MAX_CACHE_ENTRIES = 10_000;
 export class ReasoningContentCache {
   private readonly logger = new Logger(ReasoningContentCache.name);
   private cache = new Map<string, CachedReasoningContent>();
+  private cacheBytes = 0;
   private lastCleanup = Date.now();
+  private readonly pendingPersists = new Map<string, PendingPersistence>();
+  private activePersistWrites = 0;
+  private warnedPersistenceQueueFull = false;
 
   constructor(
     @Optional()
@@ -52,9 +71,8 @@ export class ReasoningContentCache {
     if (!content) return;
     this.maybeCleanup();
     const expiresAt = Date.now() + TTL_MS;
-    this.cache.set(`${sessionKey}:${cacheKey}`, { content, expiresAt });
-    this.evictOverflow();
-    void this.persist(sessionKey, cacheKey, content, expiresAt);
+    if (!this.storeLocal(sessionKey, cacheKey, content, expiresAt)) return;
+    this.enqueuePersist({ sessionKey, cacheKey, content, expiresAt });
   }
 
   /** Retrieve cached reasoning_content, or null if not found/expired. */
@@ -62,7 +80,7 @@ export class ReasoningContentCache {
     const entry = this.cache.get(`${sessionKey}:${firstToolCallId}`);
     if (!entry) return null;
     if (Date.now() > entry.expiresAt) {
-      this.cache.delete(`${sessionKey}:${firstToolCallId}`);
+      this.deleteLocal(`${sessionKey}:${firstToolCallId}`);
       return null;
     }
     return entry.content;
@@ -98,13 +116,10 @@ export class ReasoningContentCache {
           expired.push(row.first_tool_call_id);
           continue;
         }
+        const expiresAt = new Date(row.expires_at).getTime();
+        if (!this.storeLocal(sessionKey, row.first_tool_call_id, row.content, expiresAt)) continue;
         result.set(row.first_tool_call_id, row.content);
-        this.cache.set(`${sessionKey}:${row.first_tool_call_id}`, {
-          content: row.content,
-          expiresAt: new Date(row.expires_at).getTime(),
-        });
       }
-      this.evictOverflow();
       if (expired.length > 0) void this.deleteExpired(sessionKey, expired);
     } catch (err) {
       this.logger.warn(`Failed to read shared reasoning_content cache: ${String(err)}`);
@@ -149,7 +164,10 @@ export class ReasoningContentCache {
   clearSession(sessionKey: string): void {
     const prefix = `${sessionKey}:`;
     for (const key of this.cache.keys()) {
-      if (key.startsWith(prefix)) this.cache.delete(key);
+      if (key.startsWith(prefix)) this.deleteLocal(key);
+    }
+    for (const [key, pending] of this.pendingPersists) {
+      if (pending.sessionKey === sessionKey) this.pendingPersists.delete(key);
     }
     if (this.repo) {
       void this.repo.delete({ session_key: sessionKey }).catch((err) => {
@@ -158,12 +176,35 @@ export class ReasoningContentCache {
     }
   }
 
-  /** Bound the in-memory cache to MAX_CACHE_ENTRIES, evicting oldest (FIFO) first. */
+  private storeLocal(
+    sessionKey: string,
+    cacheKey: string,
+    content: string,
+    expiresAt: number,
+  ): boolean {
+    const bytes = Buffer.byteLength(content, 'utf8');
+    if (bytes > MAX_REASONING_CONTENT_BYTES) return false;
+
+    const key = `${sessionKey}:${cacheKey}`;
+    this.deleteLocal(key);
+    this.cache.set(key, { content, expiresAt, bytes });
+    this.cacheBytes += bytes;
+    this.evictOverflow();
+    return true;
+  }
+
+  private deleteLocal(key: string): void {
+    const existing = this.cache.get(key);
+    if (!existing) return;
+    this.cache.delete(key);
+    this.cacheBytes -= existing.bytes;
+  }
+
+  /** Bound local entry count and bytes, evicting oldest (FIFO) first. */
   private evictOverflow(): void {
-    while (this.cache.size > MAX_CACHE_ENTRIES) {
-      // size > cap (> 0) guarantees a first key exists.
+    while (this.cache.size > MAX_CACHE_ENTRIES || this.cacheBytes > MAX_REASONING_CACHE_BYTES) {
       const oldest = this.cache.keys().next().value as string;
-      this.cache.delete(oldest);
+      this.deleteLocal(oldest);
     }
   }
 
@@ -173,26 +214,62 @@ export class ReasoningContentCache {
     if (now - this.lastCleanup < CLEANUP_INTERVAL_MS) return;
     this.lastCleanup = now;
     for (const [key, entry] of this.cache) {
-      if (now > entry.expiresAt) this.cache.delete(key);
+      if (now > entry.expiresAt) this.deleteLocal(key);
     }
     if (this.repo) void this.cleanupSharedExpired(now);
   }
 
-  private async persist(
-    sessionKey: string,
-    firstToolCallId: string,
-    content: string,
-    expiresAt: number,
-  ): Promise<void> {
+  private enqueuePersist(entry: PendingPersistence): void {
+    if (!this.repo) return;
+    const queueKey = JSON.stringify([entry.sessionKey, entry.cacheKey]);
+    if (
+      !this.pendingPersists.has(queueKey) &&
+      this.pendingPersists.size >= MAX_PENDING_PERSIST_WRITES
+    ) {
+      if (!this.warnedPersistenceQueueFull) {
+        this.warnedPersistenceQueueFull = true;
+        this.logger.warn('Reasoning_content persistence queue is full; dropping shared-cache write');
+      }
+      return;
+    }
+
+    this.pendingPersists.set(queueKey, entry);
+    this.drainPersistQueue();
+  }
+
+  private drainPersistQueue(): void {
+    if (!this.repo) return;
+    while (
+      this.activePersistWrites < MAX_PERSIST_CONCURRENCY &&
+      this.pendingPersists.size > 0
+    ) {
+      const next = this.pendingPersists.entries().next().value as
+        | [string, PendingPersistence]
+        | undefined;
+      if (!next) return;
+      const [queueKey, entry] = next;
+      this.pendingPersists.delete(queueKey);
+      this.activePersistWrites++;
+      void this.persist(entry).finally(() => {
+        this.activePersistWrites--;
+        if (this.pendingPersists.size < MAX_PENDING_PERSIST_WRITES) {
+          this.warnedPersistenceQueueFull = false;
+        }
+        this.drainPersistQueue();
+      });
+    }
+  }
+
+  private async persist(entry: PendingPersistence): Promise<void> {
     if (!this.repo) return;
     const now = new Date().toISOString();
     try {
       await this.repo.upsert(
         {
-          session_key: sessionKey,
-          first_tool_call_id: firstToolCallId,
-          content,
-          expires_at: new Date(expiresAt).toISOString(),
+          session_key: entry.sessionKey,
+          first_tool_call_id: entry.cacheKey,
+          content: entry.content,
+          expires_at: new Date(entry.expiresAt).toISOString(),
           created_at: now,
           updated_at: now,
         },


### PR DESCRIPTION
## Summary
- cap reasoning cache values at 256 KiB and local content at 64 MiB
- limit shared-cache persistence to four concurrent and 256 queued writes
- coalesce queued updates by session and tool call

## Testing
- reasoning content cache unit tests
- backend build
- ESLint and changeset validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound reasoning cache memory and DB write throughput to prevent stalls and memory bloat during database backpressure. Adds size caps, write coalescing, and concurrency limits for shared-cache persistence.

- **Bug Fixes**
  - Cap single `reasoning_content` to 256 KiB; drop oversized values (local and shared).
  - Cap local cache to 64 MiB and 10k entries; evict oldest by FIFO with byte tracking.
  - Limit shared-cache persistence to 4 concurrent writes and 256 queued; coalesce by session + tool call and keep only the latest.
  - Clear pending persists on session purge and skip expired entries; keep warming local cache on reads.

<sup>Written for commit ea4e86512551c759c862aabcf75165e8f259833c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

