### PR TITLE
fix: isolate headerless Codex affinity

### DIFF
--- a/.changeset/isolate-codex-affinity.md
+++ b/.changeset/isolate-codex-affinity.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Prevent headerless Codex subscription requests from sharing token-wide cache affinity.

--- a/packages/backend/src/routing/proxy/__tests__/codex-session-affinity.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/codex-session-affinity.spec.ts
@@ -48,19 +48,20 @@ describe('CodexSessionAffinity', () => {
     });
 
     it.each([[undefined], [''], [42]])(
-      'injects a stable per-token default when prompt_cache_key is %p',
+      'injects request-local affinity when prompt_cache_key is %p',
       (callerKey) => {
         const body: Record<string, unknown> = { prompt_cache_key: callerKey };
         const bodyAgain: Record<string, unknown> = { prompt_cache_key: callerKey };
-        const otherToken: Record<string, unknown> = { prompt_cache_key: callerKey };
 
-        affinity.prepare('token', body);
-        affinity.prepare('token', bodyAgain);
-        affinity.prepare('token-2', otherToken);
+        const first = affinity.prepare('token', body);
+        const second = affinity.prepare('token', bodyAgain);
 
         expect(body.prompt_cache_key).toMatch(UUID_RE);
-        expect(bodyAgain.prompt_cache_key).toBe(body.prompt_cache_key);
-        expect(otherToken.prompt_cache_key).not.toBe(body.prompt_cache_key);
+        expect(bodyAgain.prompt_cache_key).toMatch(UUID_RE);
+        expect(bodyAgain.prompt_cache_key).not.toBe(body.prompt_cache_key);
+        expect(second.headers['session-id']).not.toBe(first.headers['session-id']);
+        expect(first.storeKey).toBeUndefined();
+        expect(second.storeKey).toBeUndefined();
       },
     );
 
@@ -81,10 +82,10 @@ describe('CodexSessionAffinity', () => {
       // The giant key is never echoed back to the upstream…
       expect(body.prompt_cache_key).toMatch(UUID_RE);
       expect(body.prompt_cache_key).not.toBe(longKey);
-      // …and distinct over-long keys collapse onto the single per-token session
-      // (storeKey is just the token), so they cannot amplify the cache.
-      expect(first.storeKey).toBe(second.storeKey);
-      expect(first.headers['session-id']).toBe(second.headers['session-id']);
+      // …and invalid keys do not create persistent token-wide sessions.
+      expect(first.storeKey).toBeUndefined();
+      expect(second.storeKey).toBeUndefined();
+      expect(first.headers['session-id']).not.toBe(second.headers['session-id']);
     });
 
     it('accepts a prompt_cache_key at the length boundary', () => {
@@ -136,6 +137,16 @@ describe('CodexSessionAffinity', () => {
   });
 
   describe('capture + replay', () => {
+    it('does not replay turn-state for requests without a cache key', () => {
+      const first = affinity.prepare('token', {});
+      affinity.capture(first.storeKey, okResponseWithTurnState('turn-abc'));
+
+      const second = affinity.prepare('token', {});
+
+      expect(second.headers).not.toHaveProperty('x-codex-turn-state');
+      expect(second.headers['session-id']).not.toBe(first.headers['session-id']);
+    });
+
     it('replays the captured turn-state token on the next request for the same session', () => {
       const first = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
       affinity.capture(first.storeKey, okResponseWithTurnState('turn-abc'));
@@ -210,21 +221,27 @@ describe('CodexSessionAffinity', () => {
 
   describe('capacity', () => {
     it('evicts the oldest session at capacity, preserving recently used ones', () => {
-      const first = affinity.prepare('token-0', {});
-      const second = affinity.prepare('token-1', {});
+      const first = affinity.prepare('token', { prompt_cache_key: 'conv-0' });
+      const second = affinity.prepare('token', { prompt_cache_key: 'conv-1' });
       for (let i = 2; i < 10_000; i++) {
-        affinity.prepare(`token-${i}`, {});
+        affinity.prepare('token', { prompt_cache_key: `conv-${i}` });
       }
 
-      // Touching token-0 at capacity must not evict anything, and moves it to
+      // Touching conv-0 at capacity must not evict anything, and moves it to
       // the back of the recency order…
-      expect(affinity.prepare('token-0', {}).headers).toEqual(first.headers);
+      expect(affinity.prepare('token', { prompt_cache_key: 'conv-0' }).headers).toEqual(
+        first.headers,
+      );
 
-      // …so a brand-new session evicts token-1 (now the oldest), not token-0.
-      affinity.prepare('token-overflow', {});
+      // …so a brand-new session evicts conv-1 (now the oldest), not conv-0.
+      affinity.prepare('token', { prompt_cache_key: 'conv-overflow' });
 
-      expect(affinity.prepare('token-1', {}).headers).not.toEqual(second.headers);
-      expect(affinity.prepare('token-0', {}).headers).toEqual(first.headers);
+      expect(affinity.prepare('token', { prompt_cache_key: 'conv-1' }).headers).not.toEqual(
+        second.headers,
+      );
+      expect(affinity.prepare('token', { prompt_cache_key: 'conv-0' }).headers).toEqual(
+        first.headers,
+      );
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
@@ -242,8 +242,9 @@ describe('ProviderClient — Codex prompt-cache affinity (openai-subscription)',
   it('sends deterministic session-id/thread-id headers across requests', async () => {
     mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
-    await client.forward({ ...subscriptionOpts });
-    await client.forward({ ...subscriptionOpts });
+    const scoped = { ...subscriptionOpts, body: { ...body, prompt_cache_key: 'conversation-1' } };
+    await client.forward(scoped);
+    await client.forward(scoped);
 
     const first = mockFetch.mock.calls[0][1].headers as Record<string, string>;
     const second = mockFetch.mock.calls[1][1].headers as Record<string, string>;
@@ -252,13 +253,19 @@ describe('ProviderClient — Codex prompt-cache affinity (openai-subscription)',
     expect(first['thread-id']).toBe(second['thread-id']);
   });
 
-  it('injects a stable default prompt_cache_key into the outgoing body', async () => {
+  it('injects request-local prompt cache affinity without a caller key', async () => {
     mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
     await client.forward({ ...subscriptionOpts });
+    await client.forward({ ...subscriptionOpts });
 
-    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
-    expect(sentBody.prompt_cache_key).toMatch(UUID_RE);
+    const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body as string);
+    const firstHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    const secondHeaders = mockFetch.mock.calls[1][1].headers as Record<string, string>;
+    expect(firstBody.prompt_cache_key).toMatch(UUID_RE);
+    expect(secondBody.prompt_cache_key).not.toBe(firstBody.prompt_cache_key);
+    expect(secondHeaders['session-id']).not.toBe(firstHeaders['session-id']);
   });
 
   it('keeps the caller-supplied prompt_cache_key on the Chat Completions path', async () => {
@@ -302,8 +309,9 @@ describe('ProviderClient — Codex prompt-cache affinity (openai-subscription)',
     );
     mockFetch.mockResolvedValueOnce(new Response(completed, { status: 200 }));
 
-    await client.forward({ ...subscriptionOpts });
-    await client.forward({ ...subscriptionOpts });
+    const scoped = { ...subscriptionOpts, body: { ...body, prompt_cache_key: 'conversation-1' } };
+    await client.forward(scoped);
+    await client.forward(scoped);
 
     const first = mockFetch.mock.calls[0][1].headers as Record<string, string>;
     const second = mockFetch.mock.calls[1][1].headers as Record<string, string>;

--- a/packages/backend/src/routing/proxy/codex-session-affinity.ts
+++ b/packages/backend/src/routing/proxy/codex-session-affinity.ts
@@ -22,7 +22,7 @@ export interface CodexAffinityRequest {
   /** Headers to merge into the upstream request. */
   headers: Record<string, string>;
   /** Key under which `capture()` stores the response's turn-state token. */
-  storeKey: string;
+  storeKey?: string;
 }
 
 /**
@@ -40,9 +40,9 @@ export interface CodexAffinityRequest {
  *
  * This service closes that gap:
  * - `prepare()` resolves a session for the subscription token + the caller's
- *   `prompt_cache_key` (injecting a stable default when the caller sent none,
- *   exactly like the CLI) and attaches its ids plus the last seen turn-state
- *   token.
+ *   `prompt_cache_key` and attaches its ids plus the last seen turn-state
+ *   token. Requests without a caller cache key receive request-local affinity
+ *   because the subscription token is a credential, not a conversation scope.
  * - `capture()` stores the response's turn-state token for the next request,
  *   and drops it on upstream errors so a poisoned token can't wedge a session.
  *
@@ -64,7 +64,7 @@ export class CodexSessionAffinity {
 
   /**
    * Resolve affinity headers for an outgoing Codex-backend request and inject
-   * a stable `prompt_cache_key` into `requestBody` when the caller sent none.
+   * a request-local `prompt_cache_key` into `requestBody` when the caller sent none.
    */
   prepare(apiKey: string, requestBody: Record<string, unknown>): CodexAffinityRequest {
     const callerKey = requestBody.prompt_cache_key;
@@ -72,9 +72,10 @@ export class CodexSessionAffinity {
       typeof callerKey === 'string' && callerKey && callerKey.length <= MAX_CACHE_KEY_LEN
         ? callerKey
         : null;
-    const storeKey = cacheKey ? `${apiKey}\u0000${cacheKey}` : apiKey;
-
-    const session = this.getOrCreateSession(storeKey, cacheKey);
+    const storeKey = cacheKey ? `${apiKey}\u0000${cacheKey}` : undefined;
+    const session = storeKey
+      ? this.getOrCreateSession(storeKey, cacheKey)
+      : this.createSession(null);
     requestBody.prompt_cache_key = session.promptCacheKey;
 
     const headers: Record<string, string> = {
@@ -90,7 +91,8 @@ export class CodexSessionAffinity {
    * Store the response's sticky-routing token for the next request in this
    * session, or evict the stale one when the upstream rejected the request.
    */
-  capture(storeKey: string, response: Response): void {
+  capture(storeKey: string | undefined, response: Response): void {
+    if (!storeKey) return;
     const session = this.sessions.get(storeKey);
     // The session can be gone when a request outlives the TTL; the next
     // prepare() starts a fresh one, so there is nothing to record here.
@@ -121,14 +123,18 @@ export class CodexSessionAffinity {
       const oldest = this.sessions.keys().next().value as string;
       this.sessions.delete(oldest);
     }
-    const session: CodexSession = {
+    const session = this.createSession(callerCacheKey);
+    this.sessions.set(storeKey, session);
+    return session;
+  }
+
+  private createSession(callerCacheKey: string | null): CodexSession {
+    return {
       sessionId: randomUUID(),
       threadId: randomUUID(),
       promptCacheKey: callerCacheKey ?? randomUUID(),
       expiresAt: Date.now() + SESSION_TTL_MS,
     };
-    this.sessions.set(storeKey, session);
-    return session;
   }
 
   /** Lazily evict expired entries to avoid unbounded growth. */


### PR DESCRIPTION
### ✨ What changed

- Make Codex subscription affinity request-local when no valid prompt cache key is present.
- Keep stable shard headers and turn-state replay for explicit cache keys.
- Avoid persisting invalid or over-long keys.

### 💭 Why

A subscription token is a shared credential, not a conversation identity. Reusing it as the fallback affinity key could mix unrelated agents on one sticky session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates Codex session affinity so requests without a `prompt_cache_key` no longer share token-wide sticky sessions. Explicit cache keys still get stable headers and turn-state replay.

- **Bug Fixes**
  - Use request-local affinity when `prompt_cache_key` is missing or invalid; no `storeKey` is persisted and `capture()` is a no-op in that case.
  - Keep deterministic `session-id`/`thread-id` and replay only when a valid caller `prompt_cache_key` is present.
  - Reject over-long keys and replace with a UUID in the body without creating token-wide sessions.

<sup>Written for commit ed926b2f98f97a89541652de9320fdcb2823bcf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

