### PR TITLE
fix: record provider cache writes

### DIFF
--- a/.changeset/normalize-cache-write-usage.md
+++ b/.changeset/normalize-cache-write-usage.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Record provider cache-write usage consistently across response formats.

--- a/packages/backend/src/analytics/controllers/agent-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agent-analytics.controller.spec.ts
@@ -24,6 +24,9 @@ describe('AgentAnalyticsController', () => {
       input_tokens: 3000,
       output_tokens: 2000,
       cache_read_tokens: 1000,
+      cache_creation_tokens: 250,
+      cache_read_rate: 1 / 3,
+      cache_write_rate: 1 / 12,
       message_count: 10,
       trend_pct: -15,
     });

--- a/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
@@ -45,7 +45,13 @@ describe('AgentAnalyticsService', () => {
   describe('getUsage', () => {
     it('returns token usage with trend', async () => {
       mockGetRawOne
-        .mockResolvedValueOnce({ input: 3000, output: 2000, cache_read: 500, messages: 10 })
+        .mockResolvedValueOnce({
+          input: 3000,
+          output: 2000,
+          cache_read: 500,
+          cache_creation: 300,
+          messages: 10,
+        })
         .mockResolvedValueOnce({ total: 4000 });
 
       const result = await service.getUsage('24h', scope);
@@ -55,13 +61,22 @@ describe('AgentAnalyticsService', () => {
       expect(result.input_tokens).toBe(3000);
       expect(result.output_tokens).toBe(2000);
       expect(result.cache_read_tokens).toBe(500);
+      expect(result.cache_creation_tokens).toBe(300);
+      expect(result.cache_read_rate).toBeCloseTo(1 / 6);
+      expect(result.cache_write_rate).toBe(0.1);
       expect(result.message_count).toBe(10);
       expect(result.trend_pct).toBe(25);
     });
 
     it('handles zero previous period', async () => {
       mockGetRawOne
-        .mockResolvedValueOnce({ input: 100, output: 50, cache_read: 0, messages: 1 })
+        .mockResolvedValueOnce({
+          input: 100,
+          output: 50,
+          cache_read: 0,
+          cache_creation: 0,
+          messages: 1,
+        })
         .mockResolvedValueOnce({ total: 0 });
 
       const result = await service.getUsage('24h', scope);
@@ -71,13 +86,36 @@ describe('AgentAnalyticsService', () => {
 
     it('passes tenant and agent params to queries', async () => {
       mockGetRawOne
-        .mockResolvedValueOnce({ input: 0, output: 0, cache_read: 0, messages: 0 })
+        .mockResolvedValueOnce({
+          input: 0,
+          output: 0,
+          cache_read: 0,
+          cache_creation: 0,
+          messages: 0,
+        })
         .mockResolvedValueOnce({ total: 0 });
 
       await service.getUsage('7d', scope);
 
       // Both calls should have been made (current and previous)
       expect(mockGetRawOne).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns zero cache rates when there are no input tokens', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({
+          input: 0,
+          output: 0,
+          cache_read: 0,
+          cache_creation: 0,
+          messages: 0,
+        })
+        .mockResolvedValueOnce({ total: 0 });
+
+      const result = await service.getUsage('24h', scope);
+
+      expect(result.cache_read_rate).toBe(0);
+      expect(result.cache_write_rate).toBe(0);
     });
   });
 

--- a/packages/backend/src/analytics/services/agent-analytics.service.ts
+++ b/packages/backend/src/analytics/services/agent-analytics.service.ts
@@ -17,6 +17,9 @@ export interface AgentUsageResult {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_rate: number;
+  cache_write_rate: number;
   message_count: number;
   trend_pct: number;
 }
@@ -47,6 +50,7 @@ export class AgentAnalyticsService {
         .select('COALESCE(SUM(at.input_tokens), 0)', 'input')
         .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'output')
         .addSelect('COALESCE(SUM(at.cache_read_tokens), 0)', 'cache_read')
+        .addSelect('COALESCE(SUM(at.cache_creation_tokens), 0)', 'cache_creation')
         .addSelect(sqlCountMessages(), 'messages')
         .where('at.timestamp >= :cutoff', { cutoff })
         .andWhere('at.tenant_id = :tenantId', { tenantId: scope.tenantId })
@@ -65,6 +69,7 @@ export class AgentAnalyticsService {
     const input = Number(currentRows?.input ?? 0);
     const output = Number(currentRows?.output ?? 0);
     const cacheRead = Number(currentRows?.cache_read ?? 0);
+    const cacheCreation = Number(currentRows?.cache_creation ?? 0);
     const messages = Number(currentRows?.messages ?? 0);
     const currentTotal = input + output;
     const previousTotal = Number(prevRows?.total ?? 0);
@@ -75,6 +80,9 @@ export class AgentAnalyticsService {
       input_tokens: input,
       output_tokens: output,
       cache_read_tokens: cacheRead,
+      cache_creation_tokens: cacheCreation,
+      cache_read_rate: input > 0 ? cacheRead / input : 0,
+      cache_write_rate: input > 0 ? cacheCreation / input : 0,
       message_count: messages,
       trend_pct: computeTrend(currentTotal, previousTotal),
     };

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
@@ -196,6 +196,34 @@ describe('issue #1871: cache_control round-trip through /v1/messages', () => {
       });
     });
 
+    it('carries nested cache writes through the messages conversion', () => {
+      const openAiChatResponse = {
+        id: 'cc_write',
+        model: 'gpt-4o-mini',
+        choices: [{ message: { content: 'pong' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 5,
+          prompt_tokens_details: { cached_tokens: 20, cache_write_tokens: 30 },
+        },
+      };
+
+      const messagesResponse = chatCompletionsResponseToMessages(openAiChatResponse, 'gpt-4o-mini');
+
+      expect(messagesResponse.usage).toEqual({
+        input_tokens: 50,
+        output_tokens: 5,
+        cache_creation_input_tokens: 30,
+        cache_read_input_tokens: 20,
+      });
+      expect(parseUsageObject(messagesResponse.usage)).toEqual({
+        prompt_tokens: 100,
+        completion_tokens: 5,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 30,
+      });
+    });
+
     it('carries Moonshot top-level cached_tokens through the messages conversion', () => {
       const moonshotChatResponse = {
         id: 'cc_kimi',

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-cache-control-roundtrip.spec.ts
@@ -224,6 +224,32 @@ describe('issue #1871: cache_control round-trip through /v1/messages', () => {
       });
     });
 
+    it.each([
+      ['top-level cache creation', { cache_creation_input_tokens: 30 }],
+      ['nested cache creation', { prompt_tokens_details: { cache_creation_input_tokens: 30 } }],
+    ])('carries %s through the messages conversion', (_label, cacheUsage) => {
+      const messagesResponse = chatCompletionsResponseToMessages(
+        {
+          id: 'cc_cache_creation',
+          model: 'gpt-4o-mini',
+          choices: [{ message: { content: 'pong' }, finish_reason: 'stop' }],
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 5,
+            ...cacheUsage,
+          },
+        },
+        'gpt-4o-mini',
+      );
+
+      expect(messagesResponse.usage).toEqual({
+        input_tokens: 70,
+        output_tokens: 5,
+        cache_creation_input_tokens: 30,
+        cache_read_input_tokens: 0,
+      });
+    });
+
     it('carries Moonshot top-level cached_tokens through the messages conversion', () => {
       const moonshotChatResponse = {
         id: 'cc_kimi',

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
@@ -150,6 +150,27 @@ describe('ChatGPT Adapter – transformResponsesStreamChunk', () => {
     expect(json.usage.cache_creation_tokens).toBe(30);
   });
 
+  it('extracts cache_creation_input_tokens from completed event usage details', () => {
+    const event =
+      'event: response.completed\ndata: ' +
+      JSON.stringify({
+        response: {
+          output: [],
+          usage: {
+            input_tokens: 100,
+            output_tokens: 5,
+            total_tokens: 105,
+            input_tokens_details: { cache_creation_input_tokens: 30 },
+          },
+        },
+      });
+
+    const result = transformResponsesStreamChunk(event, 'gpt-5');
+    const json = JSON.parse(result!.match(/data: (.+)/)![1]);
+
+    expect(json.usage.cache_creation_tokens).toBe(30);
+  });
+
   it('returns null for irrelevant events', () => {
     const chunk = 'event: response.created\ndata: {"id":"resp_123"}';
     const result = transformResponsesStreamChunk(chunk, 'gpt-5');

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
@@ -129,6 +129,27 @@ describe('ChatGPT Adapter – transformResponsesStreamChunk', () => {
     expect(json.usage.cache_read_tokens).toBe(42);
   });
 
+  it('extracts cache_write_tokens from completed event usage details', () => {
+    const event =
+      'event: response.completed\ndata: ' +
+      JSON.stringify({
+        response: {
+          output: [],
+          usage: {
+            input_tokens: 100,
+            output_tokens: 5,
+            total_tokens: 105,
+            input_tokens_details: { cached_tokens: 10, cache_write_tokens: 30 },
+          },
+        },
+      });
+
+    const result = transformResponsesStreamChunk(event, 'gpt-5');
+    const json = JSON.parse(result!.match(/data: (.+)/)![1]);
+
+    expect(json.usage.cache_creation_tokens).toBe(30);
+  });
+
   it('returns null for irrelevant events', () => {
     const chunk = 'event: response.created\ndata: {"id":"resp_123"}';
     const result = transformResponsesStreamChunk(chunk, 'gpt-5');

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -423,6 +423,7 @@ describe('Responses adapter', () => {
             completion_tokens: 3,
             total_tokens: 13,
             cache_read_tokens: 4,
+            cache_creation_tokens: 2,
           },
         },
         'fallback-model',
@@ -446,7 +447,7 @@ describe('Responses adapter', () => {
       ]);
       expect(result.usage).toEqual({
         input_tokens: 10,
-        input_tokens_details: { cached_tokens: 4 },
+        input_tokens_details: { cached_tokens: 4, cache_write_tokens: 2 },
         output_tokens: 3,
         output_tokens_details: { reasoning_tokens: 0 },
         total_tokens: 13,

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -1213,6 +1213,39 @@ describe('parseUsageObject', () => {
     });
   });
 
+  it.each([
+    ['OpenAI cache_write_tokens', { cache_write_tokens: 7 }],
+    ['Qwen cache_creation_input_tokens', { cache_creation_input_tokens: 9 }],
+  ])('maps nested %s to cache creation usage', (_label, promptTokensDetails) => {
+    expect(
+      parseUsageObject({
+        prompt_tokens: 20,
+        completion_tokens: 5,
+        prompt_tokens_details: promptTokensDetails,
+      }),
+    ).toEqual({
+      prompt_tokens: 20,
+      completion_tokens: 5,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: Object.values(promptTokensDetails)[0],
+    });
+  });
+
+  it('maps Responses cache_write_tokens to cache creation usage', () => {
+    expect(
+      parseUsageObject({
+        input_tokens: 20,
+        output_tokens: 5,
+        input_tokens_details: { cached_tokens: 4, cache_write_tokens: 6 },
+      }),
+    ).toEqual({
+      prompt_tokens: 20,
+      completion_tokens: 5,
+      cache_read_tokens: 4,
+      cache_creation_tokens: 6,
+    });
+  });
+
   it('defaults output_tokens to 0 in the Anthropic shape when missing', () => {
     expect(parseUsageObject({ input_tokens: 4 })).toEqual({
       prompt_tokens: 4,

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -1213,6 +1213,21 @@ describe('parseUsageObject', () => {
     });
   });
 
+  it('passes through top-level cache_creation_input_tokens for the OpenAI-compat shape', () => {
+    expect(
+      parseUsageObject({
+        prompt_tokens: 20,
+        completion_tokens: 5,
+        cache_creation_input_tokens: 9,
+      }),
+    ).toEqual({
+      prompt_tokens: 20,
+      completion_tokens: 5,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: 9,
+    });
+  });
+
   it.each([
     ['OpenAI cache_write_tokens', { cache_write_tokens: 7 }],
     ['Qwen cache_creation_input_tokens', { cache_creation_input_tokens: 9 }],
@@ -1237,6 +1252,21 @@ describe('parseUsageObject', () => {
         input_tokens: 20,
         output_tokens: 5,
         input_tokens_details: { cached_tokens: 4, cache_write_tokens: 6 },
+      }),
+    ).toEqual({
+      prompt_tokens: 20,
+      completion_tokens: 5,
+      cache_read_tokens: 4,
+      cache_creation_tokens: 6,
+    });
+  });
+
+  it('maps Responses cache_creation_input_tokens to cache creation usage', () => {
+    expect(
+      parseUsageObject({
+        input_tokens: 20,
+        output_tokens: 5,
+        input_tokens_details: { cached_tokens: 4, cache_creation_input_tokens: 6 },
       }),
     ).toEqual({
       prompt_tokens: 20,

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -283,7 +283,16 @@ function toAnthropicUsage(usage: unknown): JsonRecord {
           : typeof promptDetails?.cached_tokens === 'number'
             ? promptDetails.cached_tokens
             : 0;
-  const cacheCreation = typeof u.cache_creation_tokens === 'number' ? u.cache_creation_tokens : 0;
+  const cacheCreation =
+    typeof u.cache_creation_tokens === 'number'
+      ? u.cache_creation_tokens
+      : typeof u.cache_creation_input_tokens === 'number'
+        ? u.cache_creation_input_tokens
+        : typeof promptDetails?.cache_write_tokens === 'number'
+          ? promptDetails.cache_write_tokens
+          : typeof promptDetails?.cache_creation_input_tokens === 'number'
+            ? promptDetails.cache_creation_input_tokens
+            : 0;
   // Chat-shape prompt_tokens is the full input total (uncached + cache reads +
   // cache creation). Anthropic Messages' input_tokens is the uncached portion
   // only, with cache_read_input_tokens / cache_creation_input_tokens reported

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
@@ -237,7 +237,7 @@ describe('chatgpt-adapter', () => {
             input_tokens: 10,
             output_tokens: 2,
             total_tokens: 12,
-            input_tokens_details: { cached_tokens: 3 },
+            input_tokens_details: { cached_tokens: 3, cache_write_tokens: 2 },
           },
         },
         'gpt-5',
@@ -252,7 +252,7 @@ describe('chatgpt-adapter', () => {
         completion_tokens: 2,
         total_tokens: 12,
         cache_read_tokens: 3,
-        cache_creation_tokens: 0,
+        cache_creation_tokens: 2,
       });
     });
 

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
@@ -256,6 +256,23 @@ describe('chatgpt-adapter', () => {
       });
     });
 
+    it('accepts cache_creation_input_tokens in Responses usage details', () => {
+      const out = fromResponsesResponse(
+        {
+          output: [{ type: 'message', content: [{ type: 'output_text', text: 'Hello' }] }],
+          usage: {
+            input_tokens: 10,
+            output_tokens: 2,
+            total_tokens: 12,
+            input_tokens_details: { cache_creation_input_tokens: 4 },
+          },
+        },
+        'gpt-5',
+      );
+
+      expect(out.usage).toMatchObject({ cache_creation_tokens: 4 });
+    });
+
     it('assembles a tool_calls envelope and sets finish_reason accordingly', () => {
       const out = fromResponsesResponse(
         {

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -247,7 +247,8 @@ export function fromResponsesResponse(
       completion_tokens: (usage.output_tokens as number) ?? 0,
       total_tokens: (usage.total_tokens as number) ?? 0,
       cache_read_tokens: inputDetails?.cached_tokens ?? 0,
-      cache_creation_tokens: 0,
+      cache_creation_tokens:
+        inputDetails?.cache_write_tokens ?? inputDetails?.cache_creation_input_tokens ?? 0,
     },
   };
 }
@@ -398,7 +399,8 @@ function extractResponseUsage(
     completion_tokens: (responseUsage.output_tokens as number) ?? 0,
     total_tokens: (responseUsage.total_tokens as number) ?? 0,
     cache_read_tokens: inputDetails?.cached_tokens ?? 0,
-    cache_creation_tokens: 0,
+    cache_creation_tokens:
+      inputDetails?.cache_write_tokens ?? inputDetails?.cache_creation_input_tokens ?? 0,
   };
 }
 

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -400,10 +400,15 @@ function toResponsesUsage(usage: unknown): JsonRecord | null {
     typeof usage.total_tokens === 'number' ? usage.total_tokens : promptTokens + completionTokens;
   const cachedTokens =
     typeof usage.cache_read_tokens === 'number' ? usage.cache_read_tokens : undefined;
+  const cacheWriteTokens =
+    typeof usage.cache_creation_tokens === 'number' ? usage.cache_creation_tokens : undefined;
 
   return {
     input_tokens: promptTokens,
-    input_tokens_details: { cached_tokens: cachedTokens ?? 0 },
+    input_tokens_details: {
+      cached_tokens: cachedTokens ?? 0,
+      cache_write_tokens: cacheWriteTokens ?? 0,
+    },
     output_tokens: completionTokens,
     output_tokens_details: { reasoning_tokens: 0 },
     total_tokens: totalTokens,

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -108,12 +108,21 @@ export function parseUsageObject(usage: unknown): StreamUsage | null {
             : typeof promptDetails?.cached_tokens === 'number'
               ? promptDetails.cached_tokens
               : undefined;
+    const cacheCreation =
+      typeof u.cache_creation_tokens === 'number'
+        ? u.cache_creation_tokens
+        : typeof u.cache_creation_input_tokens === 'number'
+          ? u.cache_creation_input_tokens
+          : typeof promptDetails?.cache_write_tokens === 'number'
+            ? promptDetails.cache_write_tokens
+            : typeof promptDetails?.cache_creation_input_tokens === 'number'
+              ? promptDetails.cache_creation_input_tokens
+              : undefined;
     return {
       prompt_tokens: u.prompt_tokens,
       completion_tokens: typeof u.completion_tokens === 'number' ? u.completion_tokens : 0,
       cache_read_tokens: cacheRead,
-      cache_creation_tokens:
-        typeof u.cache_creation_tokens === 'number' ? u.cache_creation_tokens : undefined,
+      cache_creation_tokens: cacheCreation,
       ...(reportedCostUsd !== undefined ? { reported_cost_usd: reportedCostUsd } : {}),
     };
   }
@@ -140,6 +149,12 @@ export function parseUsageObject(usage: unknown): StreamUsage | null {
     const isAnthropicNative = nativeCacheRead > 0 || nativeCacheCreation > 0;
     const nestedCacheRead =
       typeof inputDetails?.cached_tokens === 'number' ? inputDetails.cached_tokens : 0;
+    const nestedCacheCreation =
+      typeof inputDetails?.cache_write_tokens === 'number'
+        ? inputDetails.cache_write_tokens
+        : typeof inputDetails?.cache_creation_input_tokens === 'number'
+          ? inputDetails.cache_creation_input_tokens
+          : 0;
     const promptTokens = isAnthropicNative
       ? u.input_tokens + nativeCacheRead + nativeCacheCreation
       : u.input_tokens;
@@ -148,7 +163,7 @@ export function parseUsageObject(usage: unknown): StreamUsage | null {
       prompt_tokens: promptTokens,
       completion_tokens: typeof u.output_tokens === 'number' ? u.output_tokens : 0,
       cache_read_tokens: isAnthropicNative ? nativeCacheRead : cacheRead || undefined,
-      cache_creation_tokens: nativeCacheCreation,
+      cache_creation_tokens: isAnthropicNative ? nativeCacheCreation : nestedCacheCreation,
       ...(reportedCostUsd !== undefined ? { reported_cost_usd: reportedCostUsd } : {}),
     };
   }

--- a/packages/backend/test/messages-cache-tokens.e2e-spec.ts
+++ b/packages/backend/test/messages-cache-tokens.e2e-spec.ts
@@ -159,10 +159,18 @@ async function postMessages(body: Record<string, unknown>): Promise<request.Resp
     .expect(200);
 }
 
-async function flushRecorder(): Promise<void> {
-  // recordSuccess fires off the response handler asynchronously — give it a
-  // tick or two before reading agent_messages.
-  await new Promise((r) => setTimeout(r, 200));
+async function waitForRecordedMessage(ds: DataSource): Promise<Record<string, unknown>[]> {
+  let rows: Record<string, unknown>[] = [];
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    rows = await ds.query(
+      `SELECT input_tokens, cache_read_tokens, cache_creation_tokens, status
+         FROM agent_messages WHERE agent_id = $1 ORDER BY timestamp DESC LIMIT 1`,
+      [TEST_AGENT_ID],
+    );
+    if (rows[0] && rows[0].status !== 'pending') return rows;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return rows;
 }
 
 describe('/v1/messages cache token round-trip (#1871)', () => {
@@ -198,12 +206,7 @@ describe('/v1/messages cache token round-trip (#1871)', () => {
       cache_read_input_tokens: 0,
     });
 
-    await flushRecorder();
-    const rows = await ds.query(
-      `SELECT input_tokens, cache_read_tokens, cache_creation_tokens, status
-         FROM agent_messages WHERE agent_id = $1 ORDER BY timestamp DESC LIMIT 1`,
-      [TEST_AGENT_ID],
-    );
+    const rows = await waitForRecordedMessage(ds);
     expect(rows).toHaveLength(1);
     expect(rows[0].status).toBe('success');
     // input_tokens stores the chat-shape total (uncached + cache reads + creation).
@@ -244,12 +247,7 @@ describe('/v1/messages cache token round-trip (#1871)', () => {
       cache_read_input_tokens: 3006,
     });
 
-    await flushRecorder();
-    const rows = await ds.query(
-      `SELECT input_tokens, cache_read_tokens, cache_creation_tokens
-         FROM agent_messages WHERE agent_id = $1 ORDER BY timestamp DESC LIMIT 1`,
-      [TEST_AGENT_ID],
-    );
+    const rows = await waitForRecordedMessage(ds);
     expect(rows).toHaveLength(1);
     expect(Number(rows[0].input_tokens)).toBe(3013);
     expect(Number(rows[0].cache_read_tokens)).toBe(3006);


### PR DESCRIPTION
### ✨ What changed

- Normalize nested cache-write counters from OpenAI, Qwen, Responses, and Anthropic-compatible usage shapes.
- Preserve writes through streaming and protocol conversions so storage and cost calculation receive them.
- Add aggregate cache creation totals plus read/write rates to agent usage analytics.

### 💭 Why

Several providers reported cache creation successfully, but adapters replaced or dropped those counters before recording, understating cache costs and effectiveness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record cache-write usage from all providers consistently across adapters and streams so analytics, storage, and cost calculations reflect cache creation. Adds cache creation totals and read/write rates to agent usage, with fallbacks for varied provider usage shapes.

- **Bug Fixes**
  - Normalize cache-write fields from OpenAI/Qwen/Responses/Anthropic (top-level and nested), including `cache_write_tokens` and `cache_creation_input_tokens`, and carry them through `messages`, `chat`, and streaming events.
  - Preserve cache writes in Responses/ChatGPT adapters and Anthropic Messages conversion; `parseUsageObject` maps all fallbacks correctly; add tests to cover these paths and reduce e2e flakiness by waiting for recorded rows.

- **New Features**
  - Agent usage includes `cache_creation_tokens`, `cache_read_rate`, and `cache_write_rate`; rates are computed against input tokens and return 0 when inputs are 0.

<sup>Written for commit f80272491c1cedbc419428bc3deb155c984aa7a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

