### PR TITLE
perf: enable Anthropic automatic caching

### DIFF
--- a/.changeset/anthropic-automatic-caching.md
+++ b/.changeset/anthropic-automatic-caching.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Enable automatic prompt caching for Anthropic API keys and OpenRouter Claude models.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -2431,6 +2431,24 @@ describe('Anthropic Adapter', () => {
       expect(countCacheControls(body)).toBe(1);
     });
 
+    it('does not mix a default automatic breakpoint with a one-hour explicit breakpoint', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'hi' }],
+        system: [
+          {
+            type: 'text',
+            text: 'instructions',
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+          },
+        ],
+      };
+
+      applyAnthropicAutomaticCacheControl(body);
+
+      expect((body as Record<string, unknown>).cache_control).toBeUndefined();
+      expect(countCacheControls(body)).toBe(1);
+    });
+
     it('does not add top-level automatic cache_control when the body is already at the Anthropic cap', () => {
       const cache = { type: 'ephemeral' };
       const body = {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1145,7 +1145,7 @@ describe('ProviderClient', () => {
       expect(headers['anthropic-beta']).toBeUndefined();
     });
 
-    it('does not include top-level cache_control in Anthropic request body', async () => {
+    it('includes automatic cache_control in Anthropic API-key requests', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       await client.forward({
@@ -1157,7 +1157,7 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.cache_control).toBeUndefined();
+      expect(sentBody.cache_control).toEqual({ type: 'ephemeral' });
     });
 
     it('converts request body to Anthropic format with model', async () => {
@@ -1317,7 +1317,7 @@ describe('ProviderClient', () => {
       expect(tools[0].cache_control).toEqual({ type: 'ephemeral' });
     });
 
-    it('includes block-level cache_control for regular Anthropic API key auth', async () => {
+    it('includes automatic and block-level cache_control for regular Anthropic API key auth', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       const bodyWithSystem = {
@@ -1337,7 +1337,7 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.cache_control).toBeUndefined();
+      expect(sentBody.cache_control).toEqual({ type: 'ephemeral' });
       const system = sentBody.system as Array<{ cache_control?: unknown }>;
       expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
       const tools = sentBody.tools as Array<{ cache_control?: unknown }>;
@@ -2789,6 +2789,7 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.cache_control).toEqual({ type: 'ephemeral' });
       const sysMsg = sentBody.messages[0];
       expect(Array.isArray(sysMsg.content)).toBe(true);
       expect(sysMsg.content[0].cache_control).toEqual({ type: 'ephemeral' });
@@ -2812,7 +2813,55 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.cache_control).toEqual({ type: 'ephemeral' });
       expect(sentBody.messages[0].content[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+
+    it('keeps caller-supplied OpenRouter automatic cache control', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const cacheControl = { type: 'ephemeral', ttl: '1h' };
+
+      await client.forward({
+        provider: 'openrouter',
+        apiKey: 'sk-or',
+        model: 'anthropic/claude-sonnet-4-20250514',
+        body: {
+          cache_control: cacheControl,
+          messages: [{ role: 'user', content: 'Hi' }],
+        },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.cache_control).toEqual(cacheControl);
+    });
+
+    it('does not exceed the Anthropic cache control cap on OpenRouter', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const cacheControl = { type: 'ephemeral' };
+
+      await client.forward({
+        provider: 'openrouter',
+        apiKey: 'sk-or',
+        model: 'anthropic/claude-sonnet-4-20250514',
+        body: {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'one', cache_control: cacheControl },
+                { type: 'text', text: 'two', cache_control: cacheControl },
+                { type: 'text', text: 'three', cache_control: cacheControl },
+                { type: 'text', text: 'four', cache_control: cacheControl },
+              ],
+            },
+          ],
+        },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.cache_control).toBeUndefined();
     });
 
     it('injects message cache_control for google models on openrouter', async () => {

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -100,6 +100,17 @@ function countCacheControlBlocks(value: unknown): number {
   return count;
 }
 
+function hasOneHourCacheControl(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+
+  if (!Array.isArray(value)) {
+    const cacheControl = (value as Record<string, unknown>).cache_control;
+    if (isObjectRecord(cacheControl) && cacheControl.ttl === '1h') return true;
+  }
+  const children = Array.isArray(value) ? value : Object.values(value);
+  return children.some(hasOneHourCacheControl);
+}
+
 function tryAddCacheControl(
   block: { cache_control?: unknown } | undefined,
   budget: { remaining: number },
@@ -112,6 +123,10 @@ function tryAddCacheControl(
 export function applyAnthropicAutomaticCacheControl(body: Record<string, unknown>): void {
   if (body.cache_control !== undefined) return;
   if (countCacheControlBlocks(body) >= MAX_CACHE_CONTROL_BLOCKS) return;
+  // Anthropic rejects a default five-minute automatic breakpoint when the
+  // final explicit breakpoint uses a one-hour TTL. Preserve the caller's
+  // explicit cache plan instead of risking a provider-side 400.
+  if (hasOneHourCacheControl(body)) return;
   body.cache_control = CACHE;
 }
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -118,11 +118,8 @@ const QWEN_TOKEN_PLAN_RESPONSES_RE = /^qwen3\.7-max$/i;
 const COPILOT_CHAT_COMPLETIONS_ENDPOINT = '/chat/completions';
 const COPILOT_RESPONSES_ENDPOINTS = new Set(['/responses', 'ws:/responses']);
 
-function shouldApplyAnthropicAutomaticCacheControl(
-  endpointKey: string,
-  authType: string | undefined,
-): boolean {
-  return endpointKey === 'anthropic' && authType === 'subscription';
+function shouldApplyAnthropicAutomaticCacheControl(endpointKey: string): boolean {
+  return endpointKey === 'anthropic';
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -611,7 +608,7 @@ export class ProviderClient {
           : undefined;
       requestBody.model = bareModel;
       if (stream) requestBody.stream = true;
-      if (shouldApplyAnthropicAutomaticCacheControl(endpointKey, authType)) {
+      if (shouldApplyAnthropicAutomaticCacheControl(endpointKey)) {
         applyAnthropicAutomaticCacheControl(requestBody);
       }
       return {
@@ -706,7 +703,12 @@ export class ProviderClient {
     }
     if (endpointKey === 'openrouter') {
       const cacheMode = openRouterCacheMode(ctx.model);
-      if (cacheMode) injectOpenRouterCacheControl(requestBody, cacheMode);
+      if (cacheMode) {
+        injectOpenRouterCacheControl(requestBody, cacheMode);
+        if (cacheMode === 'anthropic') {
+          applyAnthropicAutomaticCacheControl(requestBody);
+        }
+      }
     }
     return {
       url: `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`,


### PR DESCRIPTION
### ✨ What changed

- Add top-level automatic cache control for native Anthropic API-key requests.
- Enable the same automatic mode for Anthropic models routed through OpenRouter.
- Preserve caller controls and enforce Anthropic’s four-breakpoint cap.

### 💭 Why

Existing system/tool breakpoints cache stable definitions, but automatic caching also covers the growing conversation prefix and improves hit rates in agentic loops.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables automatic Anthropic prompt caching to improve reuse of stable prefixes and speed up agent loops. Preserves caller settings, enforces Anthropic’s four-breakpoint limit, and avoids mixing with explicit 1h TTLs to prevent provider errors.

- **New Features**
  - Adds default top-level `cache_control: { type: 'ephemeral' }` for native `anthropic` requests; system/tool blocks still use ephemeral caching.
  - Applies the same behavior for Anthropic models via `openrouter`, while honoring any caller-provided `cache_control` (including TTL).
  - Skips adding top-level caching when at Anthropic’s four-breakpoint cap or when an explicit 1h TTL breakpoint exists.

<sup>Written for commit 5021d2b9513c559ca061c6aebbeb4ee4302c96d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

