### PR TITLE
perf: reduce dashboard refresh load

### DIFF
--- a/.changeset/calm-dashboards-rest.md
+++ b/.changeset/calm-dashboards-rest.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Cache provider usage aggregates and coalesce live dashboard refreshes.

--- a/packages/backend/src/analytics/controllers/provider-usage.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/provider-usage.controller.spec.ts
@@ -1,5 +1,9 @@
+import { CACHE_TTL_METADATA } from '@nestjs/cache-manager';
+import { INTERCEPTORS_METADATA } from '@nestjs/common/constants';
 import { ProviderUsageController } from './provider-usage.controller';
 import type { TenantContext } from '../../common/decorators/tenant-context.decorator';
+import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
+import { DASHBOARD_CACHE_TTL_MS } from '../../common/constants/cache.constants';
 import type { ProviderUsageSummary } from '../services/provider-usage.service';
 
 describe('ProviderUsageController', () => {
@@ -12,6 +16,15 @@ describe('ProviderUsageController', () => {
   afterAll(() => {
     if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
     else process.env['MANIFEST_MODE'] = previousMode;
+  });
+
+  it('caches the expensive 30-day aggregation per tenant', () => {
+    expect(Reflect.getMetadata(CACHE_TTL_METADATA, ProviderUsageController)).toBe(
+      DASHBOARD_CACHE_TTL_MS,
+    );
+    expect(Reflect.getMetadata(INTERCEPTORS_METADATA, ProviderUsageController)).toContain(
+      UserCacheInterceptor,
+    );
   });
 
   it('delegates to ProviderUsageService and wraps the result in { providers }', async () => {

--- a/packages/backend/src/analytics/controllers/provider-usage.controller.ts
+++ b/packages/backend/src/analytics/controllers/provider-usage.controller.ts
@@ -1,5 +1,8 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseInterceptors } from '@nestjs/common';
+import { CacheTTL } from '@nestjs/cache-manager';
 import { TenantCtx, TenantContext } from '../../common/decorators/tenant-context.decorator';
+import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
+import { DASHBOARD_CACHE_TTL_MS } from '../../common/constants/cache.constants';
 import { ProviderUsageService, ProviderUsageSummary } from '../services/provider-usage.service';
 import { filterProvidersForDeployment } from '../../common/utils/provider-availability';
 
@@ -14,6 +17,8 @@ import { filterProvidersForDeployment } from '../../common/utils/provider-availa
  * once this resolves.
  */
 @Controller('api/v1/providers/usage')
+@UseInterceptors(UserCacheInterceptor)
+@CacheTTL(DASHBOARD_CACHE_TTL_MS)
 export class ProviderUsageController {
   constructor(private readonly providerUsage: ProviderUsageService) {}
 

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -56,7 +56,7 @@ import {
   type MessageColumnKey,
   type MessageRow,
 } from '../components/message-table-types.js';
-import { agentPing, messagePing, routingPing } from '../services/sse.js';
+import { agentPing, analyticsPing, routingPing } from '../services/sse.js';
 import '../styles/overview.css';
 import '../styles/charts.css';
 import '../styles/analytics-overview.css';
@@ -251,7 +251,7 @@ const GlobalOverview: Component = () => {
 
   // ── Data resources (5 parallel) ──────────────────────────────────────
   const [overview] = createResource(
-    () => ({ range: effectiveChartRange(), _ping: messagePing() }),
+    () => ({ range: effectiveChartRange(), _ping: analyticsPing() }),
     (p) => getOverview(p.range) as Promise<OverviewResponse>,
   );
 
@@ -265,7 +265,7 @@ const GlobalOverview: Component = () => {
   const rangeChanging = () => overview.loading && loadedRange() !== effectiveChartRange();
 
   const [agents] = createResource(
-    () => ({ _agentPing: agentPing(), _messagePing: messagePing() }),
+    () => ({ _agentPing: agentPing(), _analyticsPing: analyticsPing() }),
     async () => {
       try {
         const data = (await getAgents()) as { agents?: AgentRow[] } | AgentRow[] | null;
@@ -293,10 +293,10 @@ const GlobalOverview: Component = () => {
   );
 
   // USAGE resource — the expensive 30d aggregation, fetched independently. Its
-  // source carries the SSE ping signals (a new ingested message → messagePing,
+  // source carries the SSE ping signals (new message activity → analyticsPing,
   // a provider connect/disconnect/rename → routingPing) so stats refresh live.
   const [providerUsage] = createResource(
-    () => ({ m: messagePing(), r: routingPing() }),
+    () => ({ m: analyticsPing(), r: routingPing() }),
     async () => {
       try {
         return (await getGlobalProviderUsage()).providers;
@@ -308,19 +308,19 @@ const GlobalOverview: Component = () => {
 
   // ── Auto-fix resources (conditional on tenant access) ────────────────
   const [autofixCohort] = createResource(
-    () => ({ _ping: messagePing() }),
+    () => ({ _ping: analyticsPing() }),
     () => getAutofixCohort(),
   );
   const autofixEligible = () => autofixCohort()?.eligible ?? false;
   const [autofixStats] = createResource(
-    () => (autofixEligible() ? { range: effectiveChartRange(), _ping: messagePing() } : false),
+    () => (autofixEligible() ? { range: effectiveChartRange(), _ping: analyticsPing() } : false),
     (p) => getAutofixStats(p.range),
   );
 
   // Disposition timeseries: feeds the "By request status" chart view AND the
   // Self-healed requests tab (recovered subset: healed + fallback series).
   const [requestStatusTs] = createResource(
-    () => ({ range: effectiveChartRange(), _ping: messagePing() }),
+    () => ({ range: effectiveChartRange(), _ping: analyticsPing() }),
     (p) => getAutofixTimeseries(p.range, 'disposition'),
   );
   const selfHealedTs = () => {
@@ -342,7 +342,7 @@ const GlobalOverview: Component = () => {
   // Harness table usage, driven by the page range selector (the workspace
   // agents endpoint is a fixed window; this table must follow the filter).
   const [harnessUsage] = createResource(
-    () => ({ range: effectiveChartRange(), _ping: messagePing() }),
+    () => ({ range: effectiveChartRange(), _ping: analyticsPing() }),
     (p) => getOverviewAgentUsage(p.range) as Promise<UsageTSResult>,
   );
   const harnessUsageFor = (agentName: string) => {
@@ -359,17 +359,17 @@ const GlobalOverview: Component = () => {
   };
 
   const [agentReliability] = createResource(
-    () => ({ range: effectiveChartRange(), _ping: messagePing() }),
+    () => ({ range: effectiveChartRange(), _ping: analyticsPing() }),
     (p) => getPerAgentReliability(p.range),
   );
 
   const [providerReliability] = createResource(
-    () => ({ range: effectiveChartRange(), _ping: messagePing() }),
+    () => ({ range: effectiveChartRange(), _ping: analyticsPing() }),
     (p) => getPerProviderReliability(p.range),
   );
 
   const [modelReliability] = createResource(
-    () => ({ range: effectiveChartRange(), _ping: messagePing() }),
+    () => ({ range: effectiveChartRange(), _ping: analyticsPing() }),
     (p) => getPerModelReliability(p.range),
   );
 
@@ -393,7 +393,7 @@ const GlobalOverview: Component = () => {
   };
 
   const [usageTimeseries] = createResource(
-    () => ({ range: effectiveChartRange(), group: groupBy(), _ping: messagePing() }),
+    () => ({ range: effectiveChartRange(), group: groupBy(), _ping: analyticsPing() }),
     (p) => usageFetcher(p.range, p.group),
   );
 

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -38,7 +38,7 @@ import { PROVIDERS, SPECIFICITY_STAGES } from '../services/providers.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
 import { platformIcon } from 'manifest-shared';
 import { ALL_TIERS, TIER_LABELS_ALL } from 'manifest-shared';
-import { messagePing } from '../services/sse.js';
+import { analyticsPing, messagePing } from '../services/sse.js';
 import '../styles/overview.css';
 import '../styles/routing.css';
 // The filtered-empty state here reuses .model-filter__empty classes, so this
@@ -459,7 +459,7 @@ const MessageLog: Component = () => {
     () => ({
       agentName: agentFilter() || params.agentName,
       range: effectiveRange(),
-      _ping: messagePing(),
+      _ping: analyticsPing(),
     }),
     (p) => {
       const q: Record<string, string> = {};

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -34,7 +34,7 @@ import {
 } from '../services/api/analytics.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { isRecentlyCreated, isSetupPending, clearSetupPending } from '../services/recent-agents.js';
-import { messagePing } from '../services/sse.js';
+import { analyticsPing } from '../services/sse.js';
 import {
   RANGE_STORAGE_KEY,
   VALID_RANGES,
@@ -173,7 +173,7 @@ const Overview: Component = () => {
     () =>
       billing.loading
         ? false
-        : { range: effectiveRange(), agentName: params.agentName, _ping: messagePing() },
+        : { range: effectiveRange(), agentName: params.agentName, _ping: analyticsPing() },
     (p) => getOverview(p.range, p.agentName) as Promise<OverviewData>,
   );
 
@@ -252,7 +252,7 @@ const Overview: Component = () => {
   const tsKey = (): TimeseriesKey => ({
     range: effectiveRange(),
     agent: params.agentName,
-    _ping: messagePing(),
+    _ping: analyticsPing(),
   });
   const [providerTokenTs] = createResource(
     () => (tokenChartRequested() && !billing.loading ? tsKey() : false),
@@ -269,7 +269,7 @@ const Overview: Component = () => {
 
   // ── Auto-fix resources (conditional on tenant cohort) ───────────────
   const [autofixCohort] = createResource(
-    () => ({ _ping: messagePing() }),
+    () => ({ _ping: analyticsPing() }),
     () => getAutofixCohort(),
   );
   const autofixEligible = () => autofixCohort()?.eligible ?? false;
@@ -279,7 +279,7 @@ const Overview: Component = () => {
         ? {
             range: effectiveRange(),
             agent: decodeURIComponent(params.agentName),
-            _ping: messagePing(),
+            _ping: analyticsPing(),
           }
         : false,
     (p) => getAutofixStats(p.range, p.agent),
@@ -291,7 +291,7 @@ const Overview: Component = () => {
     () => ({
       range: effectiveRange(),
       agent: decodeURIComponent(params.agentName),
-      _ping: messagePing(),
+      _ping: analyticsPing(),
     }),
     (p) => getAutofixTimeseries(p.range, 'disposition', p.agent),
   );
@@ -299,7 +299,7 @@ const Overview: Component = () => {
     () => ({
       range: effectiveRange(),
       agent: decodeURIComponent(params.agentName),
-      _ping: messagePing(),
+      _ping: analyticsPing(),
     }),
     (p) => getPerModelReliability(p.range, p.agent),
   );

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -9,7 +9,7 @@ import { getAgents, deleteAgent } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 import { formatNumber } from '../services/formatters.js';
 import Sparkline from '../components/Sparkline.jsx';
-import { agentPing, messagePing } from '../services/sse.js';
+import { agentPing, analyticsPing } from '../services/sse.js';
 import { platformIcon } from 'manifest-shared';
 
 interface Agent {
@@ -65,7 +65,7 @@ const DeleteIcon: Component = () => (
 
 const Workspace: Component = () => {
   const [data, { refetch }] = createResource(
-    () => ({ _agentPing: agentPing(), _messagePing: messagePing() }),
+    () => ({ _agentPing: agentPing(), _analyticsPing: analyticsPing() }),
     () => getAgents() as Promise<AgentsData>,
   );
   const [modalOpen, setModalOpen] = createSignal(false);

--- a/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
+++ b/packages/frontend/src/pages/providers/ProviderConnectionsPage.tsx
@@ -21,7 +21,7 @@ import {
   connectionUsage,
   type TenantProviderSummary,
 } from '../../services/api/providers.js';
-import { messagePing, routingPing } from '../../services/sse.js';
+import { analyticsPing, routingPing } from '../../services/sse.js';
 import { renameProviderKey } from '../../services/api/routing.js';
 import type { AuthType, CustomProviderData, RoutingProvider } from '../../services/api.js';
 import type { CustomProviderPrefill, ProviderDeepLink } from '../../services/routing-params.js';
@@ -294,11 +294,11 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
   });
 
   // USAGE resource — the expensive 30d aggregation, fetched independently. Its
-  // source includes the SSE ping signals so a newly ingested message
-  // (messagePing) or a provider connect/disconnect/rename (routingPing)
-  // re-runs the usage fetch within ~500ms, exactly like Overview/MessageLog.
+  // source includes the SSE ping signals so coalesced message activity
+  // (analyticsPing) or a provider connect/disconnect/rename (routingPing)
+  // re-runs the usage fetch.
   const [usage, { refetch: refetchUsage }] = createResource(
-    () => ({ m: messagePing(), r: routingPing() }),
+    () => ({ m: analyticsPing(), r: routingPing() }),
     async () => {
       try {
         return (await getProviderUsage()).providers;
@@ -403,7 +403,7 @@ const ProviderConnectionsPage: Component<ProviderConnectionsPageProps> = (props)
   );
 
   const [autofixCohort] = createResource(
-    () => ({ _ping: messagePing() }),
+    () => ({ _ping: analyticsPing() }),
     () => getAutofixCohort(),
   );
   const autofixEligible = () => autofixCohort()?.eligible ?? false;

--- a/packages/frontend/src/services/api/cache.ts
+++ b/packages/frontend/src/services/api/cache.ts
@@ -196,9 +196,11 @@ export function invalidateAll(): void {
  * so the matching rules live with the cache they govern.
  */
 export const INVALIDATION_GROUPS = {
+  // Keep the message feed near-real-time without forcing every aggregate chart
+  // to refetch at the feed's faster cadence.
+  message: ['/messages'],
   // A new/changed message moves every usage-derived chart, summary, and table.
-  message: [
-    '/messages',
+  analytics: [
     '/overview',
     '/costs',
     '/tokens',

--- a/packages/frontend/src/services/sse.ts
+++ b/packages/frontend/src/services/sse.ts
@@ -7,10 +7,11 @@ import { invalidateGroup } from './api/cache.js';
 // signals so a routing-only change doesn't refetch the message log etc.
 const [pingCount, setPingCount] = createSignal(0);
 const [messagePing, setMessagePing] = createSignal(0);
+const [analyticsPing, setAnalyticsPing] = createSignal(0);
 const [agentPing, setAgentPing] = createSignal(0);
 const [routingPing, setRoutingPing] = createSignal(0);
 
-export { pingCount, messagePing, agentPing, routingPing };
+export { pingCount, messagePing, analyticsPing, agentPing, routingPing };
 
 /** Refresh views derived from the harness list after a local mutation. */
 export function refreshAgents(): void {
@@ -24,16 +25,26 @@ export function connectSse(): () => void {
   const bumpPing = () => setPingCount((n) => n + 1);
 
   // Coalesce message-class bumps. A chatty agent emits one SSE `message` event
-  // per ingested record, and every bump refetches the Overview/MessageLog
-  // resources. Collapsing a burst into a single bump every 500ms keeps backend
-  // QPS sane at the cost of a small refresh delay on the dashboard.
+  // per ingested record. The recent-message feed refreshes every 500ms while
+  // aggregate dashboard resources use the slower analytics bump below.
   let messageBumpTimer: ReturnType<typeof setTimeout> | null = null;
+  let analyticsBumpTimer: ReturnType<typeof setTimeout> | null = null;
   const bumpMessagePing = () => {
+    // Aggregate charts and 30-day summaries are much heavier than the recent
+    // message feed. Refresh them within a few seconds, but not twice per second
+    // during sustained agent traffic.
+    if (!analyticsBumpTimer) {
+      analyticsBumpTimer = setTimeout(() => {
+        analyticsBumpTimer = null;
+        invalidateGroup('analytics');
+        setAnalyticsPing((n) => n + 1);
+      }, 5_000);
+    }
     if (messageBumpTimer) return;
     messageBumpTimer = setTimeout(() => {
       messageBumpTimer = null;
       // Invalidate the SWR cache BEFORE bumping the ping. The ping drives the
-      // resource refetch; if the stale message/overview/usage entries were still
+      // resource refetch; if stale message entries were still
       // cached, that refetch would read them and the dashboard wouldn't update
       // live. Dropping them first guarantees the refetch hits the network.
       invalidateGroup('message');
@@ -73,7 +84,9 @@ export function connectSse(): () => void {
 
   return () => {
     if (messageBumpTimer) clearTimeout(messageBumpTimer);
+    if (analyticsBumpTimer) clearTimeout(analyticsBumpTimer);
     messageBumpTimer = null;
+    analyticsBumpTimer = null;
     es.close();
   };
 }

--- a/packages/frontend/tests/components/App.test.tsx
+++ b/packages/frontend/tests/components/App.test.tsx
@@ -40,6 +40,7 @@ vi.mock("../../src/components/AuthGuard.jsx", () => ({
 
 vi.mock("../../src/services/sse.js", () => ({
   connectSse: () => () => {},
+  analyticsPing: () => 0,
 }));
 
 import App from "../../src/App";

--- a/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
@@ -21,7 +21,7 @@ const apiMocks = vi.hoisted(() => ({
 
 const sseMocks = vi.hoisted(() => ({
   bumpAgent: undefined as undefined | (() => void),
-  bumpMessage: undefined as undefined | (() => void),
+  bumpAnalytics: undefined as undefined | (() => void),
   bumpRouting: undefined as undefined | (() => void),
   reset: undefined as undefined | (() => void),
 }));
@@ -204,17 +204,17 @@ vi.mock('../../src/components/GlobalOverviewSkeleton.jsx', () => ({
 vi.mock('../../src/services/sse.js', async () => {
   const { createSignal } = await vi.importActual<typeof import('solid-js')>('solid-js');
   const [agentPing, setAgentPing] = createSignal(0);
-  const [messagePing, setMessagePing] = createSignal(0);
+  const [analyticsPing, setAnalyticsPing] = createSignal(0);
   const [routingPing, setRoutingPing] = createSignal(0);
   sseMocks.bumpAgent = () => setAgentPing((n) => n + 1);
-  sseMocks.bumpMessage = () => setMessagePing((n) => n + 1);
+  sseMocks.bumpAnalytics = () => setAnalyticsPing((n) => n + 1);
   sseMocks.bumpRouting = () => setRoutingPing((n) => n + 1);
   sseMocks.reset = () => {
     setAgentPing(0);
-    setMessagePing(0);
+    setAnalyticsPing(0);
     setRoutingPing(0);
   };
-  return { agentPing, messagePing, routingPing };
+  return { agentPing, analyticsPing, routingPing };
 });
 
 vi.mock('../../src/services/scroll-fade.js', () => ({
@@ -345,7 +345,7 @@ afterEach(() => {
 });
 
 describe('GlobalOverview filter onUnselectAll', () => {
-  it('refetches global usage data when a message SSE ping lands', async () => {
+  it('refetches global usage data when an analytics SSE ping lands', async () => {
     render(() => <GlobalOverview />);
 
     await waitFor(() => expect(apiMocks.getOverview).toHaveBeenCalledTimes(1));
@@ -354,7 +354,7 @@ describe('GlobalOverview filter onUnselectAll', () => {
     expect(apiMocks.getGlobalProviderUsage).toHaveBeenCalledTimes(1);
     expect(apiMocks.getOverviewProviderUsage).toHaveBeenCalledTimes(1);
 
-    sseMocks.bumpMessage?.();
+    sseMocks.bumpAnalytics?.();
 
     await waitFor(() => expect(apiMocks.getOverview).toHaveBeenCalledTimes(2));
     expect(apiMocks.getAgents).toHaveBeenCalledTimes(2);
@@ -372,7 +372,7 @@ describe('GlobalOverview filter onUnselectAll', () => {
 
     // A background SSE ping refetch keeps the dashboard in place (no skeleton).
     apiMocks.getOverview.mockReturnValue(new Promise(() => {}));
-    sseMocks.bumpMessage?.();
+    sseMocks.bumpAnalytics?.();
     await Promise.resolve();
     expect(queryByTestId('global-overview-skeleton')).toBeNull();
     expect(container.querySelector('.chart-card')).not.toBeNull();

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -156,6 +156,7 @@ vi.mock('../../src/services/api/billing.js', () => ({
 vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
   messagePing: () => pingBox.read(),
+  analyticsPing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
 }));

--- a/packages/frontend/tests/pages/Overview-limits.test.tsx
+++ b/packages/frontend/tests/pages/Overview-limits.test.tsx
@@ -31,6 +31,7 @@ vi.mock('../../src/services/toast-store.js', () => ({
 vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
   messagePing: () => 0,
+  analyticsPing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
 }));

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -38,7 +38,8 @@ vi.mock('../../src/services/api.js', () => ({
 
 vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
-  messagePing: () => pingBox.read(),
+  messagePing: () => 0,
+  analyticsPing: () => pingBox.read(),
   agentPing: () => 0,
   routingPing: () => 0,
 }));

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -345,6 +345,7 @@ vi.mock('../../src/components/AuthBadge.jsx', () => ({
 vi.mock('../../src/services/sse.js', () => ({
   agentPing: () => 0,
   messagePing: () => 0,
+  analyticsPing: () => 0,
   routingPing: () => 0,
 }));
 

--- a/packages/frontend/tests/pages/ProviderPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderPages.test.tsx
@@ -126,6 +126,7 @@ vi.mock('../../src/services/api/autofix.js', () => ({
 // accessors so the page mounts without a live EventSource under jsdom.
 vi.mock('../../src/services/sse.js', () => ({
   messagePing: () => 0,
+  analyticsPing: () => 0,
   routingPing: () => 0,
 }));
 

--- a/packages/frontend/tests/pages/ProviderUsageLive.test.tsx
+++ b/packages/frontend/tests/pages/ProviderUsageLive.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Verifies the LIVE-UPDATE requirement: the provider pages' usage resource
  * must re-fetch when the SSE ping signals change, so a newly ingested message
- * (messagePing) or a provider connect/disconnect/rename (routingPing) refreshes
- * the stats within ~500ms — exactly like Overview/MessageLog. We back the ping
+ * (analyticsPing) or a provider connect/disconnect/rename (routingPing) refreshes
+ * the stats. We back the ping
  * mocks with real Solid signals and assert the usage endpoint is re-invoked
  * when either bumps; config (the cheap endpoint) must NOT re-fetch on pings.
  */
@@ -10,7 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { cleanup, render, waitFor } from '@solidjs/testing-library';
 import { createSignal } from 'solid-js';
 
-const [messagePingSig, setMessagePing] = createSignal(0);
+const [analyticsPingSig, setAnalyticsPing] = createSignal(0);
 const [routingPingSig, setRoutingPing] = createSignal(0);
 
 const mocks = vi.hoisted(() => ({
@@ -50,7 +50,7 @@ vi.mock('../../src/services/api/routing.js', () => ({
 }));
 
 vi.mock('../../src/services/sse.js', () => ({
-  messagePing: () => messagePingSig(),
+  analyticsPing: () => analyticsPingSig(),
   routingPing: () => routingPingSig(),
 }));
 
@@ -63,7 +63,7 @@ import Byok from '../../src/pages/providers/Byok';
 
 describe('provider usage live updates', () => {
   beforeEach(() => {
-    setMessagePing(0);
+    setAnalyticsPing(0);
     setRoutingPing(0);
     mocks.getGlobalProviders.mockResolvedValue({
       providers: [
@@ -99,14 +99,14 @@ describe('provider usage live updates', () => {
     vi.clearAllMocks();
   });
 
-  it('re-fetches usage on messagePing and routingPing, but not config', async () => {
+  it('re-fetches usage on analyticsPing and routingPing, but not config', async () => {
     render(() => <Byok />);
 
     await waitFor(() => expect(mocks.getProviderUsage).toHaveBeenCalledTimes(1));
     expect(mocks.getGlobalProviders).toHaveBeenCalledTimes(1);
 
-    // A newly ingested message bumps messagePing → usage refetch.
-    setMessagePing(1);
+    // Coalesced message activity bumps analyticsPing → usage refetch.
+    setAnalyticsPing(1);
     await waitFor(() => expect(mocks.getProviderUsage).toHaveBeenCalledTimes(2));
 
     // A provider change bumps routingPing → usage refetch.

--- a/packages/frontend/tests/pages/Workspace-validation.test.tsx
+++ b/packages/frontend/tests/pages/Workspace-validation.test.tsx
@@ -54,6 +54,7 @@ vi.mock('../../src/components/Sparkline.jsx', () => ({
 vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
   messagePing: () => 0,
+  analyticsPing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
   refreshAgents: vi.fn(),

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -77,6 +77,7 @@ vi.mock('../../src/components/Sparkline.jsx', () => ({
 vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
   messagePing: () => 0,
+  analyticsPing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
   refreshAgents: vi.fn(),

--- a/packages/frontend/tests/services/api/cache.test.ts
+++ b/packages/frontend/tests/services/api/cache.test.ts
@@ -303,17 +303,17 @@ describe('api SWR cache', () => {
   });
 
   describe('invalidateGroup', () => {
-    it('invalidates every fragment in a group', async () => {
-      // Seed one key per fragment of the message group, plus an unrelated key.
-      for (const fragment of INVALIDATION_GROUPS.message) {
+    it('invalidates every analytics fragment', async () => {
+      // Seed one key per aggregate group fragment, plus an unrelated key.
+      for (const fragment of INVALIDATION_GROUPS.analytics) {
         await cachedFetch(`/api/v1${fragment}`, () => Promise.resolve(1));
       }
       await cachedFetch('/api/v1/model-prices', () => Promise.resolve(99));
 
-      invalidateGroup('message');
+      invalidateGroup('analytics');
 
-      // Every message-group key refetches.
-      for (const fragment of INVALIDATION_GROUPS.message) {
+      // Every analytics-group key refetches.
+      for (const fragment of INVALIDATION_GROUPS.analytics) {
         const fetcher = vi.fn().mockResolvedValue(2);
         await cachedFetch(`/api/v1${fragment}`, fetcher);
         expect(fetcher).toHaveBeenCalledTimes(1);
@@ -322,6 +322,20 @@ describe('api SWR cache', () => {
       const modelPricesFetcher = vi.fn().mockResolvedValue(100);
       await cachedFetch('/api/v1/model-prices', modelPricesFetcher);
       expect(modelPricesFetcher).not.toHaveBeenCalled();
+    });
+
+    it('keeps analytics cached when only the message feed is invalidated', async () => {
+      await cachedFetch('/api/v1/messages', () => Promise.resolve(1));
+      await cachedFetch('/api/v1/overview', () => Promise.resolve(2));
+
+      invalidateGroup('message');
+
+      const messagesFetcher = vi.fn().mockResolvedValue(10);
+      const overviewFetcher = vi.fn().mockResolvedValue(20);
+      await cachedFetch('/api/v1/messages', messagesFetcher);
+      await cachedFetch('/api/v1/overview', overviewFetcher);
+      expect(messagesFetcher).toHaveBeenCalledTimes(1);
+      expect(overviewFetcher).not.toHaveBeenCalled();
     });
 
     it('routing group invalidates routing/provider keys', async () => {

--- a/packages/frontend/tests/services/sse.test.ts
+++ b/packages/frontend/tests/services/sse.test.ts
@@ -59,72 +59,83 @@ describe("sse", { timeout: 20000 }, () => {
     expect(messagePing()).toBe(beforeMessage + 1);
   });
 
-  it("bumps pingCount immediately but debounces messagePing on 'message'", async () => {
+  it("refreshes messages after 500ms and analytics after 5s", async () => {
     vi.useFakeTimers();
-    const { connectSse, pingCount, messagePing } = await import(
-      "../../src/services/sse"
-    );
+    const { connectSse, pingCount, messagePing, analyticsPing } =
+      await import("../../src/services/sse");
     connectSse();
     const handler = getHandler("message");
     expect(handler).toBeDefined();
     const beforePing = pingCount();
     const beforeMessage = messagePing();
+    const beforeAnalytics = analyticsPing();
     handler();
     expect(pingCount()).toBe(beforePing + 1);
     expect(messagePing()).toBe(beforeMessage);
+    expect(analyticsPing()).toBe(beforeAnalytics);
     vi.advanceTimersByTime(500);
     expect(messagePing()).toBe(beforeMessage + 1);
+    expect(analyticsPing()).toBe(beforeAnalytics);
+    vi.advanceTimersByTime(4_500);
+    expect(analyticsPing()).toBe(beforeAnalytics + 1);
   });
 
-  it("coalesces a burst of 'message' events into a single bump per window", async () => {
+  it("coalesces message and analytics bursts at their separate cadences", async () => {
     vi.useFakeTimers();
-    const { connectSse, messagePing } = await import("../../src/services/sse");
+    const { connectSse, messagePing, analyticsPing } = await import("../../src/services/sse");
     connectSse();
     const handler = getHandler("message");
-    const before = messagePing();
+    const beforeMessage = messagePing();
+    const beforeAnalytics = analyticsPing();
     // Five events inside 100ms collapse into one scheduled bump.
     for (let i = 0; i < 5; i++) handler();
     vi.advanceTimersByTime(100);
-    expect(messagePing()).toBe(before);
+    expect(messagePing()).toBe(beforeMessage);
     vi.advanceTimersByTime(400);
-    expect(messagePing()).toBe(before + 1);
+    expect(messagePing()).toBe(beforeMessage + 1);
     // A later event opens a fresh window.
     handler();
     vi.advanceTimersByTime(500);
-    expect(messagePing()).toBe(before + 2);
+    expect(messagePing()).toBe(beforeMessage + 2);
+    expect(analyticsPing()).toBe(beforeAnalytics);
+    vi.advanceTimersByTime(4_000);
+    expect(analyticsPing()).toBe(beforeAnalytics + 1);
   });
 
-  it("clears the pending message bump timer on cleanup", async () => {
+  it("clears pending message and analytics bump timers on cleanup", async () => {
     vi.useFakeTimers();
-    const { connectSse, messagePing } = await import("../../src/services/sse");
+    const { connectSse, messagePing, analyticsPing } = await import("../../src/services/sse");
     const cleanup = connectSse();
     const handler = getHandler("message");
-    const before = messagePing();
+    const beforeMessage = messagePing();
+    const beforeAnalytics = analyticsPing();
     handler();
     cleanup();
-    vi.advanceTimersByTime(1000);
-    // The scheduled bump must not fire after cleanup.
-    expect(messagePing()).toBe(before);
+    vi.advanceTimersByTime(5_000);
+    // Neither scheduled bump may fire after cleanup.
+    expect(messagePing()).toBe(beforeMessage);
+    expect(analyticsPing()).toBe(beforeAnalytics);
     expect(mockEventSource.close).toHaveBeenCalled();
   });
 
-  it("increments agentPing AND pingCount on 'agent' event without touching messagePing", async () => {
+  it("increments agentPing AND pingCount without scheduling message analytics", async () => {
     vi.useFakeTimers();
-    const { connectSse, pingCount, agentPing, messagePing } = await import(
-      "../../src/services/sse"
-    );
+    const { connectSse, pingCount, agentPing, messagePing, analyticsPing } =
+      await import("../../src/services/sse");
     connectSse();
     const handler = getHandler("agent");
     expect(handler).toBeDefined();
     const beforePing = pingCount();
     const beforeAgent = agentPing();
     const beforeMessage = messagePing();
+    const beforeAnalytics = analyticsPing();
     handler();
     expect(agentPing()).toBe(beforeAgent + 1);
     expect(pingCount()).toBe(beforePing + 1);
-    // 'agent' must NOT schedule a messagePing bump.
-    vi.advanceTimersByTime(500);
+    // 'agent' must NOT schedule either message-derived bump.
+    vi.advanceTimersByTime(5_000);
     expect(messagePing()).toBe(beforeMessage);
+    expect(analyticsPing()).toBe(beforeAnalytics);
   });
 
   it("increments routingPing AND pingCount on 'routing' event", async () => {
@@ -197,6 +208,22 @@ describe("sse cache invalidation", () => {
     expect(order[0]).toBe("invalidate:message");
   });
 
+  it("invalidates the 'analytics' group BEFORE the slower analyticsPing", async () => {
+    vi.useFakeTimers();
+    const { connectSse, analyticsPing } = await import("../../src/services/sse");
+    connectSse();
+    const handler = getHandler("message");
+    const before = analyticsPing();
+    handler();
+    vi.advanceTimersByTime(4_999);
+    expect(analyticsPing()).toBe(before);
+    expect(invalidateGroup).not.toHaveBeenCalledWith("analytics");
+    vi.advanceTimersByTime(1);
+    expect(analyticsPing()).toBe(before + 1);
+    expect(invalidateGroup).toHaveBeenCalledWith("analytics");
+    expect(order.at(-1)).toBe("invalidate:analytics");
+  });
+
   it("invalidates the 'agent' group BEFORE bumping agentPing", async () => {
     const { connectSse, agentPing } = await import("../../src/services/sse");
     connectSse();
@@ -234,17 +261,19 @@ describe("sse cache invalidation", () => {
     ]);
   });
 
-  it("clears the pending message-bump timer on cleanup without invalidating", async () => {
+  it("clears pending message and analytics timers on cleanup without invalidating", async () => {
     vi.useFakeTimers();
-    const { connectSse, messagePing } = await import("../../src/services/sse");
+    const { connectSse, messagePing, analyticsPing } = await import("../../src/services/sse");
     const cleanup = connectSse();
     const handler = getHandler("message");
     const before = messagePing();
+    const beforeAnalytics = analyticsPing();
     handler();
     cleanup();
-    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(5_000);
     // Neither the bump nor its invalidation fire after cleanup.
     expect(messagePing()).toBe(before);
+    expect(analyticsPing()).toBe(beforeAnalytics);
     expect(invalidateGroup).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### ✨ What changed
- Cache provider usage aggregates for 30 seconds per tenant.
- Refresh aggregate dashboards every five seconds while Messages stay near-real-time.

### 💭 Why
Busy agents could trigger repeated 30-day scans and chart updates twice per second.

### 👤 For users
Dashboards stay responsive during sustained request traffic.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces dashboard refresh load by caching 30‑day provider usage per tenant and coalescing analytics refreshes. Heavy charts update every 5s while the message feed stays near real-time.

- **Performance**
  - Backend: Added `UserCacheInterceptor` and `@CacheTTL(DASHBOARD_CACHE_TTL_MS)` to cache provider usage aggregates for 30 seconds per tenant.
  - Frontend: Introduced `analyticsPing` (5s cadence) alongside `messagePing` (~500ms) and switched analytics resources to `analyticsPing`.
  - Cache: Split invalidation groups into `message` and `analytics` in `packages/frontend/src/services/api/cache.ts` to avoid thrashing aggregate caches.
  - SSE: Coalesces bursts; invalidates `message` immediately and `analytics` on a 5s timer.
  - Tests: Updated to cover new pings, timers, and cache behavior.

<sup>Written for commit c5fc0f89c2fdd8ad2b30c008ad774d0fe10284de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

