### PR TITLE
fix: show Gemini streaming responses

### DIFF
--- a/.changeset/show-gemini-stream-output.md
+++ b/.changeset/show-gemini-stream-output.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show recorded Gemini streaming responses in Provider Attempt message details.

--- a/packages/shared/__tests__/chat-message.spec.ts
+++ b/packages/shared/__tests__/chat-message.spec.ts
@@ -345,6 +345,18 @@ describe('recorded chat message helpers', () => {
     ]);
   });
 
+  it('reconstructs Gemini streaming text from candidate parts', () => {
+    expect(
+      extractResponseMessages({
+        type: 'stream',
+        raw_sse: [
+          'data: {"candidates":[{"content":{"parts":[{"text":"Hello! ","thoughtSignature":"signature"}],"role":"model"},"index":0}]}',
+          'data: {"candidates":[{"content":{"parts":[{"text":"How can I help?"}],"role":"model"},"finishReason":"STOP","index":0}]}',
+        ].join('\r\n\r\n'),
+      }),
+    ).toEqual([{ role: 'assistant', content: 'Hello! How can I help?' }]);
+  });
+
   it('reconstructs Responses and Anthropic streaming text and skips bad events', () => {
     expect(
       extractResponseMessages({

--- a/packages/shared/src/chat-message.ts
+++ b/packages/shared/src/chat-message.ts
@@ -310,6 +310,14 @@ function extractStreamResponse(rawSse: string): ChatMessage[] {
       const choice = choices.find(isRecord);
       const delta = choice && isRecord(choice.delta) ? choice.delta : undefined;
       if (typeof delta?.content === 'string') text += delta.content;
+      if (Array.isArray(payload.candidates)) {
+        const content = extractJsonResponse(payload)[0]?.content;
+        if (Array.isArray(content)) {
+          for (const part of content) {
+            if (isRecord(part) && typeof part.text === 'string') text += part.text;
+          }
+        }
+      }
       if (Array.isArray(delta?.tool_calls)) {
         for (const rawCall of delta.tool_calls) {
           if (!isRecord(rawCall)) continue;


### PR DESCRIPTION
### ✨ What changed
- Parse Gemini SSE candidate text in recorded Provider Attempt responses.
- Preserve whitespace across streamed parts and cover `thoughtSignature` payloads.

### 💭 Why
Gemini responses were present in Raw but missing from Messages.

### 👤 For users
Recorded Gemini assistant replies now appear in Messages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Gemini streaming replies by parsing SSE candidate parts and preserving whitespace, so recorded assistant messages appear in Messages (not only Raw).

- **Bug Fixes**
  - Update `packages/shared` `extractStreamResponse` to read Gemini `candidates[].content.parts[].text` (including `thoughtSignature`) and append to the stream.
  - Add test to verify Gemini text reconstruction across streamed parts.

<sup>Written for commit 8ccb8f64176671320422f9cf6aa8160e8de502d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

