### PR TITLE
perf: speed up request log pagination

### DIFF
--- a/.changeset/faster-request-pages.md
+++ b/.changeset/faster-request-pages.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Load paginated requests before aggregating attempts and refresh exact totals separately.

--- a/packages/backend/src/analytics/controllers/messages.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.spec.ts
@@ -87,6 +87,7 @@ describe('MessagesController', () => {
       specificity_category: undefined,
       header_tier_id: undefined,
       include_total: undefined,
+      cache_total: undefined,
       include_filter_options: undefined,
     });
   });
@@ -107,6 +108,7 @@ describe('MessagesController', () => {
       specificity_category: 'coding',
       header_tier_id: 'ht-premium',
       include_total: false,
+      cache_total: true,
       include_filter_options: false,
     };
     await controller.getMessages(query as never, ctx as never);
@@ -129,6 +131,7 @@ describe('MessagesController', () => {
       specificity_category: 'coding',
       header_tier_id: 'ht-premium',
       include_total: false,
+      cache_total: true,
       include_filter_options: false,
     });
   });

--- a/packages/backend/src/analytics/controllers/messages.controller.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.ts
@@ -58,6 +58,7 @@ export class MessagesController {
       specificity_category: query.specificity_category,
       header_tier_id: query.header_tier_id,
       include_total: query.include_total,
+      cache_total: query.cache_total,
       include_filter_options: query.include_filter_options,
     });
   }

--- a/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
@@ -107,14 +107,16 @@ describe('MessagesQueryDto', () => {
     expect(errors).toHaveLength(0);
   });
 
-  it('coerces include_total and include_filter_options flags', async () => {
+  it('coerces total and filter-option flags', async () => {
     const dto = plainToInstance(MessagesQueryDto, {
       include_total: 'false',
+      cache_total: 'true',
       include_filter_options: '1',
     });
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);
     expect(dto.include_total).toBe(false);
+    expect(dto.cache_total).toBe(true);
     expect(dto.include_filter_options).toBe(true);
   });
 

--- a/packages/backend/src/analytics/dto/messages-query.dto.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.ts
@@ -156,5 +156,10 @@ export class MessagesQueryDto {
   @IsOptional()
   @IsBoolean()
   @Transform(({ value }) => value === true || value === 'true' || value === '1')
+  cache_total?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === true || value === 'true' || value === '1')
   include_filter_options?: boolean;
 }

--- a/packages/backend/src/analytics/services/messages-query.requests.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.requests.spec.ts
@@ -17,6 +17,8 @@ function makeQb(rows: Array<Record<string, unknown>> = []) {
     distinct: jest.fn(),
     setQueryRunner: jest.fn(),
     clone: jest.fn(),
+    getQuery: jest.fn().mockReturnValue('SELECT r.id FROM requests r'),
+    getParameters: jest.fn().mockReturnValue({}),
     getQueryAndParameters: jest.fn().mockReturnValue(['SELECT r.id FROM requests r', []]),
     getRawOne: jest.fn().mockResolvedValue({ total: 0 }),
     getRawMany: jest.fn().mockResolvedValue(rows),
@@ -49,6 +51,82 @@ function makeQb(rows: Array<Record<string, unknown>> = []) {
 }
 
 describe('MessagesQueryService request-first queries', () => {
+  it('selects parent ids before aggregating the common request page', async () => {
+    const requestQb = makeQb([{ id: 'request-1', timestamp: '2026-07-14T10:00:00Z' }]);
+    const pageQb = makeQb();
+    pageQb.getQuery.mockReturnValue('SELECT r.id FROM requests r ORDER BY r.timestamp DESC');
+    pageQb.getParameters.mockReturnValue({ requestTenantId: 'tenant-1' });
+    requestQb.clone.mockReturnValue(pageQb);
+    const legacyBase = makeQb();
+    legacyBase.clone.mockReturnValueOnce(makeQb()).mockReturnValueOnce(makeQb());
+    const service = new MessagesQueryService(
+      { createQueryBuilder: jest.fn(() => legacyBase) } as never,
+      { find: jest.fn() } as never,
+      { createQueryBuilder: jest.fn(() => requestQb) } as never,
+    );
+
+    await service.getMessages({
+      tenantId: 'tenant-1',
+      limit: 50,
+      include_total: false,
+      include_filter_options: false,
+    });
+
+    expect(pageQb.select).toHaveBeenCalledWith('r.id', 'id');
+    expect(pageQb.orderBy).toHaveBeenCalledWith('r.timestamp', 'DESC');
+    expect(pageQb.addOrderBy).toHaveBeenCalledWith('r.id', 'DESC');
+    expect(pageQb.limit).toHaveBeenCalledWith(51);
+    expect(requestQb.where).toHaveBeenCalledWith(
+      expect.stringContaining('r.id IN (SELECT r.id FROM requests r'),
+      { requestTenantId: 'tenant-1' },
+    );
+    expect(requestQb.leftJoin).toHaveBeenCalledWith(
+      expect.anything(),
+      'at',
+      'at.request_id = r.id',
+    );
+  });
+
+  it('counts eligible parents directly and reuses the cached first-page total', async () => {
+    const requestQb = makeQb([{ id: 'request-1', timestamp: '2026-07-14T10:00:00Z' }]);
+    const countQb = makeQb();
+    countQb.getQueryAndParameters.mockReturnValue([
+      'SELECT COUNT(*) AS total FROM requests WHERE tenant_id = $1',
+      ['tenant-1'],
+    ]);
+    const pageQb = makeQb();
+    requestQb.clone.mockReturnValueOnce(countQb).mockReturnValue(pageQb);
+    const legacyCountQb = makeQb();
+    legacyCountQb.getRawOne.mockResolvedValue({ total: '2' });
+    const legacyBase = makeQb();
+    legacyBase.clone.mockReturnValueOnce(legacyCountQb).mockReturnValue(makeQb());
+    const requestQuery = jest.fn().mockResolvedValue([{ total: '7' }]);
+    const service = new MessagesQueryService(
+      { createQueryBuilder: jest.fn(() => legacyBase) } as never,
+      { find: jest.fn() } as never,
+      { createQueryBuilder: jest.fn(() => requestQb), query: requestQuery } as never,
+    );
+
+    const first = await service.getMessages({
+      tenantId: 'tenant-1',
+      limit: 50,
+      include_total: true,
+      include_filter_options: false,
+    });
+    const second = await service.getMessages({
+      tenantId: 'tenant-1',
+      limit: 50,
+      include_total: true,
+      include_filter_options: false,
+    });
+
+    expect(countQb.select).toHaveBeenCalledWith('COUNT(*)', 'total');
+    expect(requestQuery).toHaveBeenCalledTimes(1);
+    expect(legacyCountQb.getRawOne).toHaveBeenCalledTimes(1);
+    expect(first.total_count).toBe(9);
+    expect(second.total_count).toBe(9);
+  });
+
   it('reads request parents and unlinked attempts from one repeatable snapshot', async () => {
     const requestQb = makeQb();
     requestQb.clone.mockReturnValue(makeQb());

--- a/packages/backend/src/analytics/services/messages-query.requests.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.requests.spec.ts
@@ -87,7 +87,7 @@ describe('MessagesQueryService request-first queries', () => {
     );
   });
 
-  it('counts eligible parents directly and reuses the cached first-page total', async () => {
+  it('counts parents directly and caches only when the caller opts in', async () => {
     const requestQb = makeQb([{ id: 'request-1', timestamp: '2026-07-14T10:00:00Z' }]);
     const countQb = makeQb();
     countQb.getQueryAndParameters.mockReturnValue([
@@ -96,10 +96,12 @@ describe('MessagesQueryService request-first queries', () => {
     ]);
     const pageQb = makeQb();
     requestQb.clone.mockReturnValueOnce(countQb).mockReturnValue(pageQb);
-    const legacyCountQb = makeQb();
-    legacyCountQb.getRawOne.mockResolvedValue({ total: '2' });
+    const legacyQbs = Array.from({ length: 6 }, () => makeQb());
+    for (const index of [0, 2, 4]) {
+      legacyQbs[index].getRawOne.mockResolvedValue({ total: '2' });
+    }
     const legacyBase = makeQb();
-    legacyBase.clone.mockReturnValueOnce(legacyCountQb).mockReturnValue(makeQb());
+    legacyBase.clone.mockImplementation(() => legacyQbs.shift()!);
     const requestQuery = jest.fn().mockResolvedValue([{ total: '7' }]);
     const service = new MessagesQueryService(
       { createQueryBuilder: jest.fn(() => legacyBase) } as never,
@@ -111,9 +113,17 @@ describe('MessagesQueryService request-first queries', () => {
       tenantId: 'tenant-1',
       limit: 50,
       include_total: true,
+      cache_total: true,
       include_filter_options: false,
     });
     const second = await service.getMessages({
+      tenantId: 'tenant-1',
+      limit: 50,
+      include_total: true,
+      cache_total: true,
+      include_filter_options: false,
+    });
+    const fresh = await service.getMessages({
       tenantId: 'tenant-1',
       limit: 50,
       include_total: true,
@@ -121,10 +131,10 @@ describe('MessagesQueryService request-first queries', () => {
     });
 
     expect(countQb.select).toHaveBeenCalledWith('COUNT(*)', 'total');
-    expect(requestQuery).toHaveBeenCalledTimes(1);
-    expect(legacyCountQb.getRawOne).toHaveBeenCalledTimes(1);
+    expect(requestQuery).toHaveBeenCalledTimes(2);
     expect(first.total_count).toBe(9);
     expect(second.total_count).toBe(9);
+    expect(fresh.total_count).toBe(9);
   });
 
   it('reads request parents and unlinked attempts from one repeatable snapshot', async () => {

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -240,11 +240,7 @@ export class MessagesQueryService {
 
   /** Request-first log. Attempts are aggregated into their parent row. */
   private async getRequests(params: MessageQueryParams) {
-    const qb = this.requestRepo!.createQueryBuilder('r').leftJoin(
-      AgentMessage,
-      'at',
-      'at.request_id = r.id',
-    );
+    const qb = this.requestRepo!.createQueryBuilder('r');
     const cutoff = params.range ? computeCutoff(rangeToInterval(params.range)) : undefined;
     if (cutoff) qb.where('r.timestamp >= :requestCutoff', { requestCutoff: cutoff });
     if (params.tenantId)
@@ -396,6 +392,25 @@ export class MessagesQueryService {
     if (attemptPredicates.length > 0) {
       qb.andWhere(matchingAttempt(attemptPredicates), attemptParameters);
     }
+    const includeTotal = params.include_total !== false;
+    const countCacheKey = this.buildCountCacheKey(params);
+    const cachedCount = includeTotal ? this.countCache.get(countCacheKey) : undefined;
+    const needsCount = includeTotal && cachedCount === undefined;
+    const canPageFirst = params.cost_min === undefined && params.cost_max === undefined;
+    let requestCountQuery: { sql: string; parameters: unknown[] } | null = null;
+
+    // Without cost HAVING, the exact total is a direct count of eligible parent
+    // requests. Do not clone the display query: joining every Provider Attempt
+    // before COUNT made the common unfiltered first page scan the full history.
+    if (needsCount && canPageFirst) {
+      const countSource = qb.clone().select('COUNT(*)', 'total').orderBy();
+      const [countSql, countParameters] = countSource.getQueryAndParameters();
+      requestCountQuery = {
+        sql: countSql,
+        parameters: countParameters,
+      };
+    }
+
     if (params.cursor) {
       const sep = params.cursor.indexOf('|');
       if (sep !== -1) {
@@ -417,7 +432,20 @@ export class MessagesQueryService {
       }
     }
 
-    const includeTotal = params.include_total !== false;
+    if (canPageFirst) {
+      // Select the 51 parent ids first, then aggregate attempts only for that
+      // small page. The outer WHERE intentionally replaces the duplicated
+      // filters: they remain inside the bounded keyset subquery.
+      const pageSource = qb
+        .clone()
+        .select('r.id', 'id')
+        .orderBy('r.timestamp', 'DESC')
+        .addOrderBy('r.id', 'DESC')
+        .limit(params.limit + 1);
+      qb.where(`r.id IN (${pageSource.getQuery()})`, pageSource.getParameters());
+    }
+
+    qb.leftJoin(AgentMessage, 'at', 'at.request_id = r.id');
     const rank = `CASE WHEN ${sqlIsSuccessStatus('at.status')} THEN 3 WHEN NOT COALESCE(at.superseded, false) AND at.status NOT IN ('fallback_error', 'auto_fixed') THEN 2 ELSE 1 END`;
     const picked = (column: string): string =>
       `(ARRAY_AGG(${column} ORDER BY at.attempt_number DESC NULLS LAST, ${rank} DESC, at.timestamp DESC, at.id DESC) FILTER (WHERE at.id IS NOT NULL))[1]`;
@@ -477,8 +505,7 @@ export class MessagesQueryService {
     // Count the grouped request rows after cost HAVING has been applied. A
     // window count on the page query would disappear on an empty page, making
     // an exact non-zero total look like zero after the last cursor.
-    let requestCountQuery: { sql: string; parameters: unknown[] } | null = null;
-    if (includeTotal) {
+    if (needsCount && !canPageFirst) {
       const countSource = qb.clone().select('r.id', 'id').orderBy();
       const [countSql, countParameters] = countSource.getQueryAndParameters();
       requestCountQuery = {
@@ -537,7 +564,7 @@ export class MessagesQueryService {
       // issuing concurrent client.query calls (deprecated in pg); all four
       // statements still share this transaction snapshot.
       const requestCountRows = await requestCountPromise;
-      const legacyCount = includeTotal ? await legacyCountQb.getRawOne() : null;
+      const legacyCount = needsCount ? await legacyCountQb.getRawOne() : null;
       const requestRows = await qb
         .orderBy('r.timestamp', 'DESC')
         .addOrderBy('r.id', 'DESC')
@@ -568,7 +595,11 @@ export class MessagesQueryService {
       items,
       next_cursor: hasMore && last ? this.encodeCursor(last) : null,
       total_count: includeTotal
-        ? Number(requestCountRows[0]?.total ?? 0) + Number(legacyCount?.total ?? 0)
+        ? (cachedCount ??
+          this.cacheAndReturnCount(
+            countCacheKey,
+            Number(requestCountRows[0]?.total ?? 0) + Number(legacyCount?.total ?? 0),
+          ))
         : items.length + (hasMore ? 1 : 0),
       total_count_exact: includeTotal,
       providers: filterOptions.providers,
@@ -948,6 +979,8 @@ export class MessagesQueryService {
     tenantId: string | null;
     range?: string;
     provider?: string;
+    connections?: string[];
+    attemptStatus?: ('has_failed' | 'has_succeeded')[];
     service_type?: string;
     agent_name?: string;
     cost_min?: number;
@@ -959,11 +992,15 @@ export class MessagesQueryService {
     routing_tier?: string;
     specificity_category?: string;
     header_tier_id?: string;
+    exclude_playground?: boolean;
+    exclude_direct?: boolean;
   }): string {
     return [
       params.tenantId ?? 'no-tenant',
       params.range ?? '',
       params.provider ?? '',
+      params.connections?.join(',') ?? '',
+      params.attemptStatus?.join(',') ?? '',
       params.service_type ?? '',
       params.agent_name ?? '',
       params.cost_min ?? '',
@@ -975,6 +1012,8 @@ export class MessagesQueryService {
       params.routing_tier ?? '',
       params.specificity_category ?? '',
       params.header_tier_id ?? '',
+      params.exclude_playground ? 'exclude-playground' : '',
+      params.exclude_direct ? 'exclude-direct' : '',
     ].join(':');
   }
 }

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -99,6 +99,8 @@ interface MessageQueryParams extends MessageFilterParams {
   specificity_category?: string;
   header_tier_id?: string;
   include_total?: boolean;
+  /** Allow a recent exact total to be reused instead of forcing a fresh first-page count. */
+  cache_total?: boolean;
   include_filter_options?: boolean;
   exclude_playground?: boolean;
   /**
@@ -200,7 +202,9 @@ export class MessagesQueryService {
     // always runs a fresh count so the total stays current for clients that poll
     // it (a stale first-page total would lag newly recorded messages by the TTL).
     const cachedCount =
-      includeTotal && params.cursor ? this.countCache.get(countCacheKey) : undefined;
+      includeTotal && (params.cursor || params.cache_total)
+        ? this.countCache.get(countCacheKey)
+        : undefined;
     const countHit = cachedCount !== undefined;
     const [countResult, rows, filterOptions] = await Promise.all([
       includeTotal ? (countHit ? null : countQb.getRawOne()) : null,
@@ -394,7 +398,10 @@ export class MessagesQueryService {
     }
     const includeTotal = params.include_total !== false;
     const countCacheKey = this.buildCountCacheKey(params);
-    const cachedCount = includeTotal ? this.countCache.get(countCacheKey) : undefined;
+    const cachedCount =
+      includeTotal && (params.cursor || params.cache_total)
+        ? this.countCache.get(countCacheKey)
+        : undefined;
     const needsCount = includeTotal && cachedCount === undefined;
     const canPageFirst = params.cost_min === undefined && params.cost_max === undefined;
     let requestCountQuery: { sql: string; parameters: unknown[] } | null = null;

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -26,6 +26,7 @@ import { agentPlatform, agentCategory } from '../services/agent-platform-store.j
 import {
   getAgents,
   getSpecificityAssignments,
+  getMessageCount,
   getMessages,
   getMessageFilterOptions,
   getRoutingStatus,
@@ -382,53 +383,66 @@ const MessageLog: Component = () => {
     ),
   );
 
+  const messageFilters = () => {
+    const q: Record<string, string> = {};
+    const connections = connectionsFilter();
+    if (connections.length) q.connections = connections.join(',');
+    const triggerParam = triggerChoiceToParam(triggerFilter());
+    if (triggerParam) q.trigger = triggerParam;
+    const attempts = attemptStatusFilter();
+    if (attempts) q.attempts = attempts;
+    const tier = tierFilter();
+    if (tier) {
+      if (tier.startsWith(SPECIFICITY_FILTER_PREFIX)) {
+        q.specificity_category = tier.slice(SPECIFICITY_FILTER_PREFIX.length);
+      } else if (tier.startsWith(HEADER_TIER_FILTER_PREFIX)) {
+        q.header_tier_id = tier.slice(HEADER_TIER_FILTER_PREFIX.length);
+      } else {
+        q.routing_tier = tier;
+      }
+    }
+    const status = statusFilterValue();
+    if (status) q.status = status;
+    const range = effectiveRange();
+    if (range) q.range = range;
+    const origin = originFilter();
+    if (origin) q.origin = origin;
+    const minCost = costMin();
+    if (minCost) q.cost_min = minCost;
+    const maxCost = costMax();
+    if (maxCost) q.cost_max = maxCost;
+    const agentName = agentFilter() || params.agentName;
+    if (agentName) q.agent_name = agentName;
+    return q;
+  };
+
   const [data, { refetch }] = createResource(
     () => ({
-      connections: connectionsFilter(),
-      trigger: triggerFilter(),
-      attempts: attemptStatusFilter(),
-      tier: tierFilter(),
-      origin: originFilter(),
-      status: statusFilterValue(),
-      range: effectiveRange(),
-      costMin: costMin(),
-      costMax: costMax(),
-      agentName: agentFilter() || params.agentName,
+      filters: messageFilters(),
       _ping: messagePing(),
       cursor: pager.currentCursor(),
       limit: pager.pageSize,
     }),
     (p) => {
-      const q: Record<string, string> = {};
-      if (p.connections.length) q.connections = p.connections.join(',');
-      {
-        const triggerParam = triggerChoiceToParam(p.trigger);
-        if (triggerParam) q.trigger = triggerParam;
-      }
-      if (p.attempts) q.attempts = p.attempts;
-      if (p.tier) {
-        if (p.tier.startsWith(SPECIFICITY_FILTER_PREFIX)) {
-          q.specificity_category = p.tier.slice(SPECIFICITY_FILTER_PREFIX.length);
-        } else if (p.tier.startsWith(HEADER_TIER_FILTER_PREFIX)) {
-          q.header_tier_id = p.tier.slice(HEADER_TIER_FILTER_PREFIX.length);
-        } else {
-          q.routing_tier = p.tier;
-        }
-      }
-      if (p.status) q.status = p.status;
-      if (p.range) q.range = p.range;
-      if (p.origin) q.origin = p.origin;
-      if (p.costMin) q.cost_min = p.costMin;
-      if (p.costMax) q.cost_max = p.costMax;
-      if (p.agentName) q.agent_name = p.agentName;
+      const q = { ...p.filters };
       if (p.cursor) q.cursor = p.cursor;
       q.limit = String(p.limit);
-      // The dashboard cards deep-link here promising "the N you counted";
-      // an exact total is what makes that promise checkable at a glance.
-      q.include_total = 'true';
+      // Live message events refresh only the bounded page. Exact totals have
+      // their own slower resource below, so ingest cannot put COUNT(*) back on
+      // the 500ms feed path.
+      q.include_total = 'false';
       q.include_filter_options = 'false';
       return getMessages(q) as Promise<MessagesData>;
     },
+  );
+
+  const countQueryKey = () => JSON.stringify(messageFilters());
+  const [messageCount] = createResource(
+    () => ({ key: countQueryKey(), _ping: analyticsPing() }),
+    async (source) => ({
+      key: source.key,
+      data: (await getMessageCount(JSON.parse(source.key))) as MessagesData,
+    }),
   );
 
   // The resource retains its previous value during refetches. Show the table
@@ -436,16 +450,7 @@ const MessageLog: Component = () => {
   // visible for the frequent background SSE `_ping` refetches.
   const messageQueryKey = () =>
     JSON.stringify({
-      connections: connectionsFilter(),
-      trigger: triggerFilter(),
-      attempts: attemptStatusFilter(),
-      tier: tierFilter(),
-      origin: originFilter(),
-      status: statusFilterValue(),
-      range: effectiveRange(),
-      costMin: costMin(),
-      costMax: costMax(),
-      agentName: agentFilter() || params.agentName,
+      filters: messageFilters(),
       cursor: pager.currentCursor(),
       limit: pager.pageSize,
     });
@@ -494,12 +499,19 @@ const MessageLog: Component = () => {
     costMin() !== '' ||
     costMax() !== '';
 
+  const exactTotal = () => {
+    const count = messageCount();
+    return count?.key === countQueryKey() ? count.data?.total_count : undefined;
+  };
+
   const hasNoData = () => {
     const d = data();
-    return d && d.total_count === 0;
+    return d && (exactTotal() ?? d.total_count) === 0;
   };
 
   const totalForPager = () => {
+    const count = exactTotal();
+    if (count !== undefined) return count;
     const d = data();
     if (!d) return 0;
     if (d.total_count_exact !== false) return d.total_count;

--- a/packages/frontend/src/services/api/messages.ts
+++ b/packages/frontend/src/services/api/messages.ts
@@ -146,6 +146,7 @@ export interface MessageListParams extends Record<string, string | undefined> {
   specificity_category?: string;
   header_tier_id?: string;
   include_total?: string;
+  cache_total?: string;
   include_filter_options?: string;
 }
 
@@ -156,13 +157,14 @@ export function getMessages(params: MessageListParams = {}, options?: FetchJsonO
 export function getMessageCount(
   params: Omit<
     MessageListParams,
-    'cursor' | 'limit' | 'include_total' | 'include_filter_options'
+    'cursor' | 'limit' | 'include_total' | 'cache_total' | 'include_filter_options'
   > = {},
 ) {
   return fetchJson('/messages', {
     ...params,
     limit: '1',
     include_total: 'true',
+    cache_total: 'true',
     include_filter_options: 'false',
   });
 }

--- a/packages/frontend/src/services/api/messages.ts
+++ b/packages/frontend/src/services/api/messages.ts
@@ -127,31 +127,44 @@ export interface MessageDetailResponse {
   };
 }
 
-export function getMessages(
-  params: {
-    range?: string;
-    provider?: string;
-    /** Comma-separated tenant_providers ids (connection filter). */
-    connections?: string;
-    /** Comma-separated attempt-status facets: has_failed, has_succeeded. */
-    attempts?: string;
-    service_type?: string;
-    cursor?: string;
-    limit?: string;
-    agent_name?: string;
-    cost_min?: string;
-    cost_max?: string;
-    status?: string;
-    trigger?: string;
-    routing_tier?: string;
-    specificity_category?: string;
-    header_tier_id?: string;
-    include_total?: string;
-    include_filter_options?: string;
-  } = {},
-  options?: FetchJsonOptions,
-) {
+export interface MessageListParams extends Record<string, string | undefined> {
+  range?: string;
+  provider?: string;
+  /** Comma-separated tenant_providers ids (connection filter). */
+  connections?: string;
+  /** Comma-separated attempt-status facets: has_failed, has_succeeded. */
+  attempts?: string;
+  service_type?: string;
+  cursor?: string;
+  limit?: string;
+  agent_name?: string;
+  cost_min?: string;
+  cost_max?: string;
+  status?: string;
+  trigger?: string;
+  routing_tier?: string;
+  specificity_category?: string;
+  header_tier_id?: string;
+  include_total?: string;
+  include_filter_options?: string;
+}
+
+export function getMessages(params: MessageListParams = {}, options?: FetchJsonOptions) {
   return fetchJson('/messages', params, options);
+}
+
+export function getMessageCount(
+  params: Omit<
+    MessageListParams,
+    'cursor' | 'limit' | 'include_total' | 'include_filter_options'
+  > = {},
+) {
+  return fetchJson('/messages', {
+    ...params,
+    limit: '1',
+    include_total: 'true',
+    include_filter_options: 'false',
+  });
 }
 
 export function getMessageFilterOptions(

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -41,6 +41,7 @@ vi.mock('@solidjs/meta', () => ({
 }));
 
 const mockGetMessages = vi.fn();
+const mockGetMessageCount = vi.fn();
 const mockGetMessageFilterOptions = vi.fn();
 const mockGetAgents = vi.fn();
 const mockGetCustomProviders = vi.fn();
@@ -52,6 +53,7 @@ const mockSetMessageFeedback = vi.fn();
 const mockClearMessageFeedback = vi.fn();
 vi.mock('../../src/services/api.js', () => ({
   getMessages: (...args: unknown[]) => mockGetMessages(...args),
+  getMessageCount: (...args: unknown[]) => mockGetMessageCount(...args),
   getMessageFilterOptions: (...args: unknown[]) => mockGetMessageFilterOptions(...args),
   getAgents: (...args: unknown[]) => mockGetAgents(...args),
   getCustomProviders: (...args: unknown[]) => mockGetCustomProviders(...args),
@@ -328,6 +330,7 @@ describe('MessageLog', () => {
       agents: [{ agent_name: 'agent-alpha' }, { agent_name: 'agent-beta' }],
     });
     mockGetMessageFilterOptions.mockResolvedValue({ providers: ['anthropic', 'openai'] });
+    mockGetMessageCount.mockResolvedValue(undefined);
     mockGetCustomProviders.mockResolvedValue([]);
     mockGetSpecificityAssignments.mockResolvedValue([]);
     mockGetRoutingStatus.mockResolvedValue({ enabled: false });
@@ -816,6 +819,26 @@ describe('MessageLog', () => {
   });
 
   describe('pagination', () => {
+    it('loads rows without a total and counts independently', async () => {
+      mockGetMessages.mockResolvedValue(messagesData);
+      mockGetMessageCount.mockResolvedValue({ ...messagesData, total_count: 120 });
+      const { container } = render(() => <MessageLog />);
+
+      await vi.waitFor(() => {
+        expect(mockGetMessages).toHaveBeenCalledWith(
+          expect.objectContaining({
+            include_total: 'false',
+            include_filter_options: 'false',
+            limit: '50',
+          }),
+        );
+        expect(mockGetMessageCount).toHaveBeenCalledWith(
+          expect.objectContaining({ agent_name: 'test-agent' }),
+        );
+        expect(container.textContent).toContain('120 total');
+      });
+    });
+
     it('shows pagination when total_count exceeds page size', async () => {
       const bigData = { ...messagesData, total_count: 120, next_cursor: 'cursor-2' };
       mockGetMessages.mockResolvedValue(bigData);

--- a/packages/frontend/tests/services/api/messages.test.ts
+++ b/packages/frontend/tests/services/api/messages.test.ts
@@ -71,6 +71,20 @@ describe('messages API client', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('getMessageCount requests one row with an exact total', async () => {
+    const fetchMock = setupFetch({ total_count: 42 });
+
+    await messages.getMessageCount({ range: '30d', agent_name: 'demo' });
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/messages');
+    expect(url).toContain('range=30d');
+    expect(url).toContain('agent_name=demo');
+    expect(url).toContain('limit=1');
+    expect(url).toContain('include_total=true');
+    expect(url).toContain('include_filter_options=false');
+  });
+
   it('getMessageFilterOptions GETs filter metadata with agent scope', async () => {
     const fetchMock = setupFetch({ providers: [] });
     await messages.getMessageFilterOptions({ range: '30d', agent_name: 'demo' });

--- a/packages/frontend/tests/services/api/messages.test.ts
+++ b/packages/frontend/tests/services/api/messages.test.ts
@@ -82,6 +82,7 @@ describe('messages API client', () => {
     expect(url).toContain('agent_name=demo');
     expect(url).toContain('limit=1');
     expect(url).toContain('include_total=true');
+    expect(url).toContain('cache_total=true');
     expect(url).toContain('include_filter_options=false');
   });
 


### PR DESCRIPTION
## What changed

- Page request IDs before joining and aggregating provider attempts.
- Refresh live rows without an exact count, then load the cached exact total independently.
- Preserve the aggregate-first path for cost filters and add focused backend/frontend coverage.

## Testing

- `npm run build`; targeted tests and typechecks pass; the full suite had three unrelated timing flakes that passed in isolation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the Message Log by paging request IDs first and aggregating attempts only for the visible page. Exact totals are fetched separately; they’re fresh by default and can be reused via an explicit cache opt-in.

- **Refactors**
  - Backend: Page parent request IDs via a bounded subquery; aggregate attempts after paging.
  - Backend: Count eligible parent requests directly when no cost filters; keep aggregate-first path for cost filters.
  - Backend: Reuse exact totals only when `cursor` is present or `cache_total=true`; expand the cache key to include connections, attempt status, exclusions, and other filters; expose `cache_total` in the controller/DTO.
  - Frontend: Load rows with `include_total=false` and fetch exact totals via `getMessageCount` (`limit=1`, `include_total=true`, `cache_total=true`); factor shared filter building and prefer the exact total in the pager.
  - Tests: Add backend specs for request-first paging and cache opt-in; add frontend tests for separate count loading.

<sup>Written for commit d33ea01ef639cb2f7bf7bbe7b015cd839374786c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

