### PR TITLE
feat: defer plan selection until after onboarding

### DIFF
--- a/packages/frontend/src/components/AuthGuard.tsx
+++ b/packages/frontend/src/components/AuthGuard.tsx
@@ -3,6 +3,7 @@ import { Show, createEffect, createSignal, type ParentComponent } from 'solid-js
 import { authClient } from '../services/auth-client.js';
 import { buildLoginRedirect } from '../services/auth-redirects.js';
 import { hasPlanBeenChosen, markPlanChosen } from '../services/plan-selection.js';
+import { hasOnboardingBeenDone } from '../services/onboarding.js';
 import { getBillingStatus } from '../services/api/billing.js';
 
 const AuthGuard: ParentComponent = (props) => {
@@ -20,14 +21,24 @@ const AuthGuard: ParentComponent = (props) => {
     }
     const userId = s.data.user?.id;
     if (planChecked()) return;
+    // /upgrade is the plan selection destination — never intercept it.
+    if (location.pathname === '/upgrade') {
+      setPlanChecked(true);
+      return;
+    }
     if (userId && hasPlanBeenChosen(userId)) {
+      setPlanChecked(true);
+      return;
+    }
+    // Don't gate on plan selection before the user has completed onboarding.
+    if (userId && !hasOnboardingBeenDone(userId)) {
       setPlanChecked(true);
       return;
     }
     getBillingStatus()
       .then((status) => {
         if (status?.enabled && status.plan !== 'pro') {
-          navigate('/register?step=plan&context=login', { replace: true });
+          navigate('/upgrade', { replace: true });
         } else {
           if (userId) markPlanChosen(userId);
           setPlanChecked(true);
@@ -45,7 +56,11 @@ const AuthGuard: ParentComponent = (props) => {
         <div class="auth-layout">
           <div class="auth-card" style="text-align: center;">
             <div class="auth-logo">
-              <img src="/logotype-white.svg" alt="Manifest" class="auth-logo__img auth-logo__img--light" />
+              <img
+                src="/logotype-white.svg"
+                alt="Manifest"
+                class="auth-logo__img auth-logo__img--light"
+              />
               <img src="/logotype-dark.svg" alt="" class="auth-logo__img auth-logo__img--dark" />
             </div>
             <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm);">

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -110,16 +110,6 @@ const Register: Component = () => {
     setLastAuthMethod('email');
 
     if (data?.token) {
-      try {
-        const status = await getBillingStatus();
-        if (status?.enabled) {
-          setProPrice(formatBillingPrice(status.priceMonthly));
-          window.location.href = '/register?step=plan';
-          return;
-        }
-      } catch {
-        /* billing unavailable — skip plan step */
-      }
       window.location.href = '/welcome';
       return;
     }

--- a/packages/frontend/src/pages/Upgrade.tsx
+++ b/packages/frontend/src/pages/Upgrade.tsx
@@ -42,12 +42,6 @@ const Upgrade: Component = () => {
   });
 
   const handlePlanSelect = async (plan: PlanId) => {
-    if (plan === 'free') {
-      const uid = userId();
-      if (uid) markPlanChosen(uid);
-      navigate('/');
-      return;
-    }
     if (plan === 'enterprise') {
       return;
     }

--- a/packages/frontend/src/pages/Upgrade.tsx
+++ b/packages/frontend/src/pages/Upgrade.tsx
@@ -11,10 +11,13 @@ import { authClient } from '../services/auth-client.js';
 import { getBillingStatus } from '../services/api/billing.js';
 import { toast } from '../services/toast-store.js';
 import { FREE_REQUEST_LIMIT_LABEL, formatBillingPrice } from '../services/billing-display.js';
+import { markPlanChosen } from '../services/plan-selection.js';
 
 const Upgrade: Component = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const session = authClient.useSession();
+  const userId = () => session()?.data?.user?.id ?? '';
   const [billingError, setBillingError] = createSignal(false);
   const [billing] = createResource(async () => {
     setBillingError(false);
@@ -40,6 +43,8 @@ const Upgrade: Component = () => {
 
   const handlePlanSelect = async (plan: PlanId) => {
     if (plan === 'free') {
+      const uid = userId();
+      if (uid) markPlanChosen(uid);
       navigate('/');
       return;
     }
@@ -57,6 +62,8 @@ const Upgrade: Component = () => {
       });
       const error = (res as { error?: unknown } | undefined)?.error;
       if (error) throw error;
+      const uid = userId();
+      if (uid) markPlanChosen(uid);
     } catch {
       toast.error('Could not start the upgrade. Please try again.');
     } finally {
@@ -147,7 +154,14 @@ const Upgrade: Component = () => {
                     </div>
                     <p class="upgrade-plan-card__desc">For prototypes and small projects.</p>
                     <div class="upgrade-plan-card__cta">
-                      <button class="btn btn--outline" onClick={() => navigate('/')}>
+                      <button
+                        class="btn btn--outline"
+                        onClick={() => {
+                          const uid = userId();
+                          if (uid) markPlanChosen(uid);
+                          navigate('/');
+                        }}
+                      >
                         Use Manifest for free
                       </button>
                     </div>

--- a/packages/frontend/src/pages/Welcome.tsx
+++ b/packages/frontend/src/pages/Welcome.tsx
@@ -712,7 +712,7 @@ const Welcome: Component = () => {
   const skipOnboarding = () => {
     const uid = userId();
     if (uid) markOnboardingDone(uid);
-    navigate('/');
+    navigate('/upgrade');
   };
 
   const openOnboardingPaywall = () => {

--- a/packages/frontend/tests/components/AuthGuard.test.tsx
+++ b/packages/frontend/tests/components/AuthGuard.test.tsx
@@ -85,6 +85,20 @@ describe('AuthGuard', () => {
     expect(mockGetBillingStatus).not.toHaveBeenCalled();
   });
 
+  it('skips billing check and renders children when on /upgrade', async () => {
+    localStorage.setItem('manifest_onboarding_done_u1', '1');
+    mockLocation = { pathname: '/upgrade', search: '' };
+    mockGetBillingStatus.mockResolvedValue({ enabled: true, plan: 'free' });
+    render(() => (
+      <AuthGuard>
+        <span>Protected content</span>
+      </AuthGuard>
+    ));
+
+    expect(await screen.findByText('Protected content')).toBeDefined();
+    expect(mockGetBillingStatus).not.toHaveBeenCalled();
+  });
+
   it('fails open when billing status cannot be loaded', async () => {
     mockGetBillingStatus.mockRejectedValue(new Error('network'));
     render(() => (

--- a/packages/frontend/tests/components/AuthGuard.test.tsx
+++ b/packages/frontend/tests/components/AuthGuard.test.tsx
@@ -59,7 +59,8 @@ describe('AuthGuard', () => {
     expect(mockGetBillingStatus).not.toHaveBeenCalled();
   });
 
-  it('redirects authenticated free users to the plan step', async () => {
+  it('redirects authenticated free users to /upgrade after onboarding', async () => {
+    localStorage.setItem('manifest_onboarding_done_u1', '1');
     mockGetBillingStatus.mockResolvedValue({ enabled: true, plan: 'free' });
     render(() => (
       <AuthGuard>
@@ -68,8 +69,20 @@ describe('AuthGuard', () => {
     ));
 
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/register?step=plan&context=login', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/upgrade', { replace: true });
     });
+  });
+
+  it('skips billing check and renders children when onboarding is not done', async () => {
+    mockGetBillingStatus.mockResolvedValue({ enabled: true, plan: 'free' });
+    render(() => (
+      <AuthGuard>
+        <span>Protected content</span>
+      </AuthGuard>
+    ));
+
+    expect(await screen.findByText('Protected content')).toBeDefined();
+    expect(mockGetBillingStatus).not.toHaveBeenCalled();
   });
 
   it('fails open when billing status cannot be loaded', async () => {

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -193,7 +193,7 @@ describe('Register', () => {
     expect(container.querySelector('a[href="/reset-password"]')).not.toBeNull();
   });
 
-  it('opens the plan step when signup returns a token and billing is enabled', async () => {
+  it('redirects directly to /welcome when signup returns a token', async () => {
     const locationSpy = vi.spyOn(window, 'location', 'get').mockReturnValue({
       ...window.location,
       href: '',
@@ -201,11 +201,6 @@ describe('Register', () => {
     const hrefSetter = vi.fn();
     Object.defineProperty(window.location, 'href', { set: hrefSetter, configurable: true });
 
-    mockGetBillingStatus.mockResolvedValue({
-      enabled: true,
-      plan: 'free',
-      priceMonthly: { amount: 20, currency: 'USD', interval: 'month' },
-    });
     mockSignUpEmail.mockResolvedValue({
       data: { token: 'tok', user: { id: 'u1' } },
       error: null,
@@ -220,7 +215,7 @@ describe('Register', () => {
     });
     fireEvent.submit(container.querySelector('form')!);
     await vi.waitFor(() => {
-      expect(hrefSetter).toHaveBeenCalledWith('/register?step=plan');
+      expect(hrefSetter).toHaveBeenCalledWith('/welcome');
     });
 
     locationSpy.mockRestore();

--- a/packages/frontend/tests/pages/Upgrade.test.tsx
+++ b/packages/frontend/tests/pages/Upgrade.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@solidjs/meta', () => ({
 const mockUpgrade = vi.fn();
 vi.mock('../../src/services/auth-client.js', () => ({
   authClient: {
+    useSession: () => () => ({ data: { user: { id: 'u1' } }, isPending: false }),
     subscription: {
       upgrade: (...args: unknown[]) => mockUpgrade(...args),
     },


### PR DESCRIPTION
## Summary

- New users are redirected directly to `/welcome` after signup, bypassing the plan picker
- `AuthGuard` skips the billing/plan check for users who haven't completed onboarding yet
- Skip and completion both navigate to `/upgrade` so the plan picker appears after onboarding
- `AuthGuard` never intercepts `/upgrade` itself (avoids redirect loop)
- `markPlanChosen` is now called correctly from `Upgrade.tsx` on both free and pro paths

## Test plan

- [ ] New cloud user signs up → lands on `/welcome` directly (no plan step in between)
- [ ] Clicking "Skip setup for now" → navigates to `/upgrade` plan picker
- [ ] Completing onboarding → navigates to `/upgrade` plan picker
- [ ] Choosing Free on `/upgrade` → lands on dashboard, plan check cleared
- [ ] Returning user with localStorage cleared + onboarding done → `/upgrade` on next login
- [ ] Returning user with localStorage flag → goes straight to dashboard
- [ ] Self-hosted (billing disabled) → not affected, passes through AuthGuard unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move plan selection to after onboarding to reduce signup friction and avoid redirect loops. New users land on /welcome; plan picking happens on /upgrade, and choosing Free or Pro marks the plan as chosen.

- **New Features**
  - New signups land on /welcome; skipping or completing onboarding goes to /upgrade.
  - AuthGuard defers plan checks until onboarding is done, never intercepts /upgrade, and redirects free users to /upgrade.
  - Register no longer checks billing; always redirects to /welcome.
  - Tests updated for the new flow and to cover the /upgrade guard path.

- **Bug Fixes**
  - Removed a dead Free-plan branch in Upgrade.

<sup>Written for commit 2bdf2d83c0628c2027b365c95d70c17fd2968006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

