### PR TITLE
fix: update user discovery offer to $25 credit and 15-min call

### DIFF
--- a/packages/frontend/src/components/UserDiscoveryBanner.tsx
+++ b/packages/frontend/src/components/UserDiscoveryBanner.tsx
@@ -4,7 +4,7 @@ export const USER_DISCOVERY_BANNER_DISMISSED_KEY =
   'manifest:user-discovery-banner-dismissed:v1';
 
 export const USER_DISCOVERY_BOOKING_URL =
-  'https://calendly.com/sebastien-manifest/30min';
+  'https://calendly.com/sebastien-manifest/15min';
 
 function readDismissed(): boolean {
   try {
@@ -35,7 +35,7 @@ const UserDiscoveryBanner: Component = () => {
       <aside class="overview-discovery-banner" aria-label="Manifest user research">
         <div class="overview-discovery-banner__inner">
           <span class="overview-discovery-banner__text">
-            🎁 Talk to us and get $10 of Gemini credit{' '}
+            🎁 Talk to us and get $25 of Gemini credit{' '}
             <a
               href={USER_DISCOVERY_BOOKING_URL}
               target="_blank"

--- a/packages/frontend/src/components/UserDiscoveryModal.tsx
+++ b/packages/frontend/src/components/UserDiscoveryModal.tsx
@@ -29,8 +29,8 @@ interface UserDiscoveryModalProps {
 }
 
 const benefits = [
-  '30 minutes through a video call.',
-  'Quick access to $10 of Gemini tokens through Manifest.',
+  '15 minutes through a video call.',
+  'Quick access to $25 of Gemini tokens through Manifest.',
   'You talk and we listen. Just questions and nothing to sell.',
 ];
 
@@ -92,7 +92,7 @@ const UserDiscoveryModal: Component<UserDiscoveryModalProps> = (props) => {
                 class="user-discovery-modal__title"
               >
                 Talk to us and get{' '}
-                <mark class="user-discovery-modal__highlight">$10</mark> credit
+                <mark class="user-discovery-modal__highlight">$25</mark> credit
                 for{' '}
                 <img
                   class="user-discovery-modal__title-logo"
@@ -126,7 +126,7 @@ const UserDiscoveryModal: Component<UserDiscoveryModalProps> = (props) => {
                 class="btn btn--primary user-discovery-modal__cta"
                 onClick={book}
               >
-                Book my slot to get $10
+                Book my slot to get $25
               </button>
               <button
                 type="button"

--- a/packages/frontend/src/pages/Help.tsx
+++ b/packages/frontend/src/pages/Help.tsx
@@ -23,12 +23,12 @@ const Help: Component = () => {
           <div class="settings-card__label">
             <span class="settings-card__label-title">Schedule a Call</span>
             <span class="settings-card__label-desc">
-              Book a 30-min call with us to get help setting things up.
+              Book a 15-min call with us to get help setting things up.
             </span>
           </div>
           <div class="settings-card__control">
             <a
-              href="https://calendly.com/sebastien-manifest/30min?month=2026-02"
+              href="https://calendly.com/sebastien-manifest/15min"
               target="_blank"
               rel="noopener noreferrer"
               class="btn btn--outline btn--sm"

--- a/packages/frontend/tests/components/Help.test.tsx
+++ b/packages/frontend/tests/components/Help.test.tsx
@@ -50,7 +50,7 @@ describe("Help", () => {
     const links = screen.getAllByRole("link");
     const bookLink = links.find((l) => l.textContent?.includes("Book"));
     expect(bookLink?.getAttribute("href")).toBe(
-      "https://calendly.com/sebastien-manifest/30min?month=2026-02",
+      "https://calendly.com/sebastien-manifest/15min",
     );
   });
 
@@ -89,7 +89,7 @@ describe("Help", () => {
   it("describes the call duration in the Schedule a Call section", () => {
     render(() => <Help />);
     expect(
-      screen.getByText(/Book a 30-min call with us to get help setting things up\./),
+      screen.getByText(/Book a 15-min call with us to get help setting things up\./),
     ).toBeDefined();
   });
 

--- a/packages/frontend/tests/components/UserDiscoveryBanner.test.tsx
+++ b/packages/frontend/tests/components/UserDiscoveryBanner.test.tsx
@@ -16,7 +16,7 @@ describe('UserDiscoveryBanner', () => {
 
     expect(container.querySelector('.overview-discovery-banner')).not.toBeNull();
     expect(
-      screen.getByText(/Talk to us and get \$10 of Gemini credit/),
+      screen.getByText(/Talk to us and get \$25 of Gemini credit/),
     ).toBeDefined();
 
     const cta = screen.getByText('Book a slot →') as HTMLAnchorElement;

--- a/packages/frontend/tests/components/UserDiscoveryModal.test.tsx
+++ b/packages/frontend/tests/components/UserDiscoveryModal.test.tsx
@@ -27,14 +27,14 @@ describe('UserDiscoveryModal', () => {
 
     const heading = screen.getByRole('heading', { level: 2 });
     expect(heading.textContent?.replace(/\s+/g, ' ').trim()).toContain(
-      'Talk to us and get $10 credit for',
+      'Talk to us and get $25 credit for',
     );
-    expect(screen.getByText('$10')).toBeDefined();
+    expect(screen.getByText('$25')).toBeDefined();
     expect(screen.getByAltText('Gemini')).toBeDefined();
     expect(screen.getByText(/around agent reliability/)).toBeDefined();
-    expect(screen.getByText('30 minutes through a video call.')).toBeDefined();
+    expect(screen.getByText('15 minutes through a video call.')).toBeDefined();
     expect(
-      screen.getByText('Quick access to $10 of Gemini tokens through Manifest.'),
+      screen.getByText('Quick access to $25 of Gemini tokens through Manifest.'),
     ).toBeDefined();
     expect(
       screen.getByText(
@@ -75,7 +75,7 @@ describe('UserDiscoveryModal', () => {
 
     render(() => <UserDiscoveryModal open onClose={onClose} />);
 
-    fireEvent.click(screen.getByText('Book my slot to get $10'));
+    fireEvent.click(screen.getByText('Book my slot to get $25'));
 
     expect(openSpy).toHaveBeenCalledWith(
       USER_DISCOVERY_BOOKING_URL,

--- a/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverviewFilter.test.tsx
@@ -436,7 +436,7 @@ describe('GlobalOverview filter onUnselectAll', () => {
     render(() => <GlobalOverview />);
 
     await waitFor(() =>
-      expect(document.body.textContent).toContain('Book my slot to get $10'),
+      expect(document.body.textContent).toContain('Book my slot to get $25'),
     );
 
     const later = [...document.querySelectorAll('button')].find(
@@ -446,7 +446,7 @@ describe('GlobalOverview filter onUnselectAll', () => {
 
     expect(localStorage.getItem('manifest:user-discovery-modal-dismissed:v1')).toBe('true');
     await waitFor(() =>
-      expect(document.body.textContent).not.toContain('Book my slot to get $10'),
+      expect(document.body.textContent).not.toContain('Book my slot to get $25'),
     );
   });
 });


### PR DESCRIPTION
## Summary

- Banner: "$10 of Gemini credit" → "$25 of Gemini credit"
- Modal: "$10" → "$25" in heading, benefits list, and CTA button
- Modal: "30 minutes through a video call" → "15 minutes through a video call"
- Help page: "Book a 30-min call" → "Book a 15-min call", Calendly URL updated to `/15min`
- Calendly booking URL updated from `30min` to `15min` in `UserDiscoveryBanner`

## Test plan

- [ ] Banner shows "$25 of Gemini credit"
- [ ] Modal shows "$25" and "15 minutes" throughout
- [ ] "Book my slot to get $25" CTA opens the 15-min Calendly link
- [ ] Help page shows "15-min call" and links to the 15-min slot
- [ ] All frontend tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the user discovery offer to $25 Gemini credit and a 15-minute call across the banner, modal, and Help page. Switches Calendly links to /15min (removes the month param on Help) and aligns all copy and tests.

<sup>Written for commit c78018a16c651081e99e4570b86bc509a48488a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

