### PR TITLE
perf: do not block billing status on usage baseline scan

### DIFF
--- a/.changeset/billing-status-baseline-nonblocking.md
+++ b/.changeset/billing-status-baseline-nonblocking.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop blocking `/billing/status` and free-tier admission on the historical request-usage baseline scan; return the live counter immediately and finish the baseline in the background so Overview can load while the one-shot COUNT runs.

--- a/.changeset/billing-status-baseline-nonblocking.md
+++ b/.changeset/billing-status-baseline-nonblocking.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Stop blocking `/billing/status` and free-tier admission on the historical request-usage baseline scan; return the live counter immediately and finish the baseline in the background so Overview can load while the one-shot COUNT runs.
+Stop blocking `/billing/status` and free-tier admission on the historical request-usage baseline scan; return the live counter immediately and finish the baseline in the background. Dashboards no longer wait on billing at all: the plan is resolved once at login via the new light `GET /api/v1/billing/plan` and read synchronously, so Overview, Global Overview, and the Requests log fetch each chart exactly once at the right range.

--- a/packages/backend/src/billing/billing.controller.spec.ts
+++ b/packages/backend/src/billing/billing.controller.spec.ts
@@ -5,6 +5,7 @@ import { PlanService } from './plan.service';
 describe('BillingController', () => {
   let controller: BillingController;
   const getBillingStatus = jest.fn();
+  const getPlanStatus = jest.fn();
   const updateBillingEmailPreferences = jest.fn();
 
   beforeEach(async () => {
@@ -13,7 +14,7 @@ describe('BillingController', () => {
       providers: [
         {
           provide: PlanService,
-          useValue: { getBillingStatus, updateBillingEmailPreferences },
+          useValue: { getBillingStatus, getPlanStatus, updateBillingEmailPreferences },
         },
       ],
     }).compile();
@@ -28,6 +29,15 @@ describe('BillingController', () => {
     const result = await controller.status(ctx as never);
     expect(getBillingStatus).toHaveBeenCalledWith(ctx);
     expect(result).toBe(status);
+  });
+
+  it('returns the light plan status for the request tenant context', async () => {
+    const planStatus = { enabled: true, plan: 'pro' };
+    getPlanStatus.mockResolvedValue(planStatus);
+    const ctx = { tenantId: 't1', userId: 'u1' };
+    const result = await controller.plan(ctx as never);
+    expect(getPlanStatus).toHaveBeenCalledWith(ctx);
+    expect(result).toBe(planStatus);
   });
 
   it('updates billing email preferences for the request tenant context', async () => {

--- a/packages/backend/src/billing/billing.controller.ts
+++ b/packages/backend/src/billing/billing.controller.ts
@@ -12,6 +12,11 @@ export class BillingController {
     return this.planService.getBillingStatus(ctx);
   }
 
+  @Get('billing/plan')
+  async plan(@TenantCtx() ctx: TenantContext) {
+    return this.planService.getPlanStatus(ctx);
+  }
+
   @Patch('billing/email-preferences')
   async updateEmailPreferences(
     @TenantCtx() ctx: TenantContext,

--- a/packages/backend/src/billing/plan.service.spec.ts
+++ b/packages/backend/src/billing/plan.service.spec.ts
@@ -175,6 +175,35 @@ describe('PlanService', () => {
       // periodEnd is the 1st of next month at midnight UTC.
       expect(status.requests.periodEnd).toMatch(/^\d{4}-\d{2}-01T00:00:00\.000Z$/);
     });
+
+    it('returns live usage without waiting for the historical baseline scan', async () => {
+      enableBilling();
+      let resolveBaseline!: (v: Array<{ n: string }>) => void;
+      const baselineHang = new Promise<Array<{ n: string }>>((r) => {
+        resolveBaseline = r;
+      });
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('FROM "tenant_request_usage"') && sql.includes('SELECT "request_count"')) {
+          return Promise.resolve([{ n: '8', baseline_counted: false }]);
+        }
+        if (sql.includes('EXTRACT(EPOCH')) {
+          return Promise.resolve([{ cutover_ms: String(Date.parse('2026-07-28T09:00:00Z')) }]);
+        }
+        if (sql.includes('SELECT COUNT(*)')) return baselineHang;
+        if (sql.includes('FROM (SELECT 1) seed') || sql.includes('subscriptionPlan')) {
+          return Promise.resolve([{ subscriptionPlan: 'free' }]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const status = await service.getBillingStatus(CTX);
+      expect(status.requests.used).toBe(8);
+
+      // Unblock the background init so the suite does not leak a hanging promise.
+      resolveBaseline([{ n: '1' }]);
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+    });
   });
 
   describe('billing email preferences', () => {
@@ -344,7 +373,7 @@ describe('PlanService', () => {
       expect(mockQuery.mock.calls[1][1][1]).toBe(toSqlTimestamp(new Date(Date.UTC(2026, 7, 1))));
     });
 
-    it('adds the historical baseline once to live trigger increments', async () => {
+    it('returns the live counter immediately and baselines history in the background', async () => {
       const cutover = Date.parse('2026-07-28T09:00:00Z');
       mockQuery
         .mockResolvedValueOnce([{ n: '3', baseline_counted: false }])
@@ -352,7 +381,12 @@ describe('PlanService', () => {
         .mockResolvedValueOnce([{ n: '2' }])
         .mockResolvedValueOnce([{ n: '5' }]);
 
-      expect(await service.countRequestsSince('t1', START)).toBe(5);
+      // Hot path must not wait on the historical COUNT — only live increments.
+      expect(await service.countRequestsSince('t1', START)).toBe(3);
+
+      // Flush the scheduled baseline init.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
 
       const [baselineSql, baselineParams] = mockQuery.mock.calls[2];
       expect(baselineSql).toContain('FROM "requests" r');
@@ -370,7 +404,7 @@ describe('PlanService', () => {
       );
     });
 
-    it('initializes a post-cutover window at zero without scanning history', async () => {
+    it('schedules a post-cutover zero-row without blocking or scanning history', async () => {
       const augustStart = Date.UTC(2026, 7, 1);
       const cutover = Date.parse('2026-07-28T09:00:00Z');
       mockQuery
@@ -379,6 +413,10 @@ describe('PlanService', () => {
         .mockResolvedValueOnce([{ n: '0' }]);
 
       expect(await service.countRequestsSince('t1', augustStart)).toBe(0);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
       expect(mockQuery).toHaveBeenCalledTimes(3);
       expect(
         mockQuery.mock.calls.every(([sql]) => !String(sql).includes('FROM "requests" r')),
@@ -389,7 +427,7 @@ describe('PlanService', () => {
     it('coalesces concurrent baseline initialization within one process', async () => {
       const cutover = Date.parse('2026-07-28T09:00:00Z');
       mockQuery.mockImplementation((sql: string) => {
-        if (sql.includes('SELECT "request_count"')) return Promise.resolve([]);
+        if (sql.includes('SELECT "request_count"')) return Promise.resolve([{ n: 0, baseline_counted: false }]);
         if (sql.includes('EXTRACT(EPOCH')) return Promise.resolve([{ cutover_ms: cutover }]);
         if (sql.includes('SELECT COUNT(*)')) return Promise.resolve([{ n: '4' }]);
         if (sql.includes('INSERT INTO "tenant_request_usage"'))
@@ -397,12 +435,16 @@ describe('PlanService', () => {
         return Promise.resolve([]);
       });
 
+      // Both callers return the live counter immediately (0), without awaiting baseline.
       await expect(
         Promise.all([
           service.countRequestsSince('t1', START),
           service.countRequestsSince('t1', START),
         ]),
-      ).resolves.toEqual([4, 4]);
+      ).resolves.toEqual([0, 0]);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
 
       expect(
         mockQuery.mock.calls.filter(([sql]) => String(sql).includes('EXTRACT(EPOCH')),
@@ -417,12 +459,14 @@ describe('PlanService', () => {
       ).toHaveLength(1);
     });
 
-    it('fails initialization when the migration cutover marker is missing', async () => {
+    it('does not fail the hot path when the migration cutover marker is missing', async () => {
       mockQuery.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
-      await expect(service.countRequestsSince('t1', START)).rejects.toThrow(
-        'Missing request usage cutover state',
-      );
+      // Live counter is 0; baseline init fails in the background.
+      await expect(service.countRequestsSince('t1', START)).resolves.toBe(0);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
     });
 
     it('rethrows a DB error so the next call can retry', async () => {

--- a/packages/backend/src/billing/plan.service.spec.ts
+++ b/packages/backend/src/billing/plan.service.spec.ts
@@ -82,6 +82,20 @@ describe('PlanService', () => {
     });
   });
 
+  describe('getPlanStatus', () => {
+    it('reports billing disabled without querying', async () => {
+      expect(await service.getPlanStatus(CTX)).toEqual({ enabled: false, plan: 'free' });
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('returns the resolved plan with a single snapshot query when enabled', async () => {
+      enableBilling();
+      mockQuery.mockResolvedValueOnce([{ subscriptionPlan: 'pro' }]);
+      expect(await service.getPlanStatus(CTX)).toEqual({ enabled: true, plan: 'pro' });
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getLimits', () => {
     it('returns unlimited when billing is disabled', async () => {
       expect(await service.getLimits(CTX)).toEqual({ requestsPerMonth: null });
@@ -427,7 +441,8 @@ describe('PlanService', () => {
     it('coalesces concurrent baseline initialization within one process', async () => {
       const cutover = Date.parse('2026-07-28T09:00:00Z');
       mockQuery.mockImplementation((sql: string) => {
-        if (sql.includes('SELECT "request_count"')) return Promise.resolve([{ n: 0, baseline_counted: false }]);
+        if (sql.includes('SELECT "request_count"'))
+          return Promise.resolve([{ n: 0, baseline_counted: false }]);
         if (sql.includes('EXTRACT(EPOCH')) return Promise.resolve([{ cutover_ms: cutover }]);
         if (sql.includes('SELECT COUNT(*)')) return Promise.resolve([{ n: '4' }]);
         if (sql.includes('INSERT INTO "tenant_request_usage"'))

--- a/packages/backend/src/billing/plan.service.ts
+++ b/packages/backend/src/billing/plan.service.ts
@@ -71,7 +71,9 @@ export class PlanService {
   private suppressedCountFailureWarns = 0;
   private lastLimitFailureWarnAtMs = 0;
   private suppressedLimitFailureWarns = 0;
-  private readonly requestUsageInitializations = new Map<string, Promise<number>>();
+  /** In-flight baseline initializations keyed by tenant+window. Never awaited on
+   * the admission/billing hot path — only used for single-flight coalescing. */
+  private readonly requestUsageInitializations = new Map<string, Promise<void>>();
 
   constructor(
     @InjectRepository(Tenant) private readonly tenantRepo: Repository<Tenant>,
@@ -169,9 +171,14 @@ export class PlanService {
 
   /**
    * Routed requests recorded for the tenant in the effective monthly quota
-   * window. The steady-state admission path is one PK read. The first request
-   * for a tenant/window lazily adds its pre-cutover baseline exactly once; the
-   * trigger can keep adding live requests while that initialization runs.
+   * window. Hot path is one PK read of `tenant_request_usage`.
+   *
+   * When the pre-cutover baseline has not been applied yet (`baseline_counted =
+   * false`, or the row is missing), this returns the live post-cutover counter
+   * immediately and schedules the historical baseline scan in the background.
+   * Waiting on that scan used to block `/billing/status` and free-tier
+   * admission for tens of seconds on high-volume tenants. Undercounting until
+   * the baseline lands is fail-open — the same posture as a COUNT failure.
    */
   async countRequestsSince(tenantId: string | null, monthStartMs: number): Promise<number> {
     if (!tenantId) return 0;
@@ -187,19 +194,35 @@ export class PlanService {
       );
     if (rows[0]?.baseline_counted) return Number(rows[0].n);
 
-    const initializationKey = `${tenantId}:${windowStart}`;
-    const existing = this.requestUsageInitializations.get(initializationKey);
-    if (existing) return existing;
+    // Live trigger increments only (or 0 if the row does not exist yet). Kick
+    // the one-shot historical baseline off the hot path so dashboard/admission
+    // stay O(1) even for large pre-cutover histories.
+    this.scheduleRequestUsageInitialization(tenantId, windowStartMs, windowStart);
+    return Number(rows[0]?.n ?? 0);
+  }
 
-    const pending = this.initializeRequestUsage(tenantId, windowStartMs, windowStart).finally(
-      () => {
+  /** Single-flight background baseline init. Errors are logged, not thrown. */
+  private scheduleRequestUsageInitialization(
+    tenantId: string,
+    windowStartMs: number,
+    windowStart: string,
+  ): void {
+    const initializationKey = `${tenantId}:${windowStart}`;
+    if (this.requestUsageInitializations.has(initializationKey)) return;
+
+    const pending = this.initializeRequestUsage(tenantId, windowStartMs, windowStart)
+      .then(() => undefined)
+      .catch((err: Error) => {
+        this.logger.warn(
+          `Request usage baseline init failed for tenant ${tenantId}: ${err.message}`,
+        );
+      })
+      .finally(() => {
         if (this.requestUsageInitializations.get(initializationKey) === pending) {
           this.requestUsageInitializations.delete(initializationKey);
         }
-      },
-    );
+      });
     this.requestUsageInitializations.set(initializationKey, pending);
-    return pending;
   }
 
   private async initializeRequestUsage(
@@ -400,11 +423,14 @@ export class PlanService {
     const limits = this.limitsForSnapshot(snapshot);
     const emailPreferences = normalizeBillingEmailPreferences(snapshot.billingEmailPreferences);
     const now = new Date();
-    const requestsUsed = await this.countRequestsSince(ctx.tenantId, this.monthStartMsUtc(now));
+    const [requestsUsed, priceMonthly] = await Promise.all([
+      this.countRequestsSince(ctx.tenantId, this.monthStartMsUtc(now)),
+      this.getProPrice(),
+    ]);
     return {
       enabled: true,
       plan: snapshot.plan,
-      priceMonthly: await this.getProPrice(),
+      priceMonthly,
       emailPreferences,
       requests: {
         used: requestsUsed,

--- a/packages/backend/src/billing/plan.service.ts
+++ b/packages/backend/src/billing/plan.service.ts
@@ -4,6 +4,7 @@ import { DataSource, Repository } from 'typeorm';
 import { MANIFEST_ERROR_ORIGINS, PLAN_LIMITS, UNLIMITED_PLAN_LIMITS } from 'manifest-shared';
 import type {
   BillingEmailPreferences,
+  BillingPlanStatus,
   BillingPrice,
   BillingStatus,
   Plan,
@@ -135,6 +136,15 @@ export class PlanService {
   /** Resolve the tenant's plan from better-auth's webhook-synced subscription table. */
   async getPlan(ctx: TenantContext): Promise<Plan> {
     return (await this.getBillingSnapshot(ctx)).plan;
+  }
+
+  /**
+   * Light plan lookup for UI gating (range locks, AuthGuard bootstrap). One
+   * snapshot query — never touches the usage counter or Stripe.
+   */
+  async getPlanStatus(ctx: TenantContext): Promise<BillingPlanStatus> {
+    if (!isBillingEnabled()) return { enabled: false, plan: 'free' };
+    return { enabled: true, plan: await this.getPlan(ctx) };
   }
 
   private limitsForSnapshot(snapshot: BillingSnapshot): PlanLimits {

--- a/packages/backend/test/tenant-request-usage-migration.e2e-spec.ts
+++ b/packages/backend/test/tenant-request-usage-migration.e2e-spec.ts
@@ -193,11 +193,23 @@ describe('AddTenantRequestUsage migration (e2e)', () => {
     expect(legacyColumn).toEqual([]);
   });
 
-  it('lazily initializes the exact historical baseline once', async () => {
+  it('initializes the exact historical baseline once in the background', async () => {
     const planService = new PlanService({} as never, ds);
 
-    expect(await planService.countRequestsSince(TENANT, Date.UTC(2026, 6, 1))).toBe(2);
-    expect(await usageRow(ds)).toEqual({ count: 2, initialized: true });
+    // The hot path returns the live counter immediately (no row yet → 0) and
+    // schedules the one-shot historical baseline off the request path.
+    expect(await planService.countRequestsSince(TENANT, Date.UTC(2026, 6, 1))).toBe(0);
+
+    // The background init lands the exact baseline and flips the flag.
+    const deadline = Date.now() + 10_000;
+    let row = await usageRow(ds);
+    while (!row?.initialized && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      row = await usageRow(ds);
+    }
+    expect(row).toEqual({ count: 2, initialized: true });
+
+    // Steady state: subsequent reads serve the initialized counter directly.
     expect(await planService.countRequestsSince(TENANT, Date.UTC(2026, 6, 1))).toBe(2);
     expect(await usageRow(ds)).toEqual({ count: 2, initialized: true });
   });

--- a/packages/frontend/src/components/AuthGuard.tsx
+++ b/packages/frontend/src/components/AuthGuard.tsx
@@ -4,7 +4,7 @@ import { authClient } from '../services/auth-client.js';
 import { buildLoginRedirect } from '../services/auth-redirects.js';
 import { hasPlanBeenChosen, markPlanChosen } from '../services/plan-selection.js';
 import { hasOnboardingBeenDone } from '../services/onboarding.js';
-import { getBillingStatus } from '../services/api/billing.js';
+import { loadPlan } from '../services/plan-store.js';
 
 const AuthGuard: ParentComponent = (props) => {
   const session = authClient.useSession();
@@ -21,32 +21,31 @@ const AuthGuard: ParentComponent = (props) => {
     }
     const userId = s.data.user?.id;
     if (planChecked()) return;
-    // /upgrade is the plan selection destination — never intercept it.
-    if (location.pathname === '/upgrade') {
-      setPlanChecked(true);
-      return;
-    }
-    if (userId && hasPlanBeenChosen(userId)) {
-      setPlanChecked(true);
-      return;
-    }
-    // Don't gate on plan selection before the user has completed onboarding.
-    if (userId && !hasOnboardingBeenDone(userId)) {
-      setPlanChecked(true);
-      return;
-    }
-    getBillingStatus()
-      .then((status) => {
-        if (status?.enabled && status.plan !== 'pro') {
-          navigate('/upgrade', { replace: true });
-        } else {
-          if (userId) markPlanChosen(userId);
-          setPlanChecked(true);
-        }
-      })
-      .catch(() => {
+    // Resolve the plan store before rendering any page — downstream consumers
+    // (range locks) read it synchronously. loadPlan never rejects (fail-open)
+    // and costs one indexed query.
+    loadPlan().then((status) => {
+      // /upgrade is the plan selection destination — never intercept it.
+      if (location.pathname === '/upgrade') {
         setPlanChecked(true);
-      });
+        return;
+      }
+      if (userId && hasPlanBeenChosen(userId)) {
+        setPlanChecked(true);
+        return;
+      }
+      // Don't gate on plan selection before the user has completed onboarding.
+      if (userId && !hasOnboardingBeenDone(userId)) {
+        setPlanChecked(true);
+        return;
+      }
+      if (status.enabled && status.plan !== 'pro') {
+        navigate('/upgrade', { replace: true });
+        return;
+      }
+      if (userId) markPlanChosen(userId);
+      setPlanChecked(true);
+    });
   });
 
   return (

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -29,7 +29,7 @@ import {
   getOverviewAgentUsage,
   getOverviewProviderUsage,
 } from '../services/api/analytics.js';
-import { getBillingStatus } from '../services/api/billing.js';
+import { usePlanRangeLock } from '../services/plan-range-lock.js';
 import { formatNumber, formatCost } from '../services/formatters.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
 import { preloadModelDisplayNames } from '../services/model-display.js';
@@ -180,20 +180,13 @@ const GlobalOverview: Component = () => {
 
   preloadModelDisplayNames();
 
-  const [billing] = createResource(async () => {
-    try {
-      return await getBillingStatus();
-    } catch {
-      return null;
-    }
-  });
-  const isFreePlan = () => billing()?.enabled && billing()?.plan === 'free';
-  const shouldLockProRanges = () => billing.loading || isFreePlan();
-  const isProRangeLocked = (range: string) =>
-    shouldLockProRanges() && PRO_DASHBOARD_RANGES.has(range);
-
   // ── Range state (persisted in localStorage) ──────────────────────────
   const [chartRange, setChartRangeRaw] = createSignal(loadRange());
+  const {
+    isFreePlan,
+    isProRangeLocked,
+    effectiveRange: effectiveChartRange,
+  } = usePlanRangeLock(chartRange, PRO_DASHBOARD_RANGES, '7d');
   const setChartRange = (v: string) => {
     if (isFreePlan() && PRO_DASHBOARD_RANGES.has(v)) return;
     setChartRangeRaw(v);
@@ -229,11 +222,6 @@ const GlobalOverview: Component = () => {
     'requests',
   );
 
-  // Local providers only exist on self-hosted installs; cloud hides the
-  // Local stat card and drops the stats grid to three columns.
-  const effectiveChartRange = createMemo(() =>
-    isProRangeLocked(chartRange()) ? '7d' : chartRange(),
-  );
   const proBadge = () => (
     <span class="pro-range-badge" aria-label="Pro plan required">
       PRO

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -33,7 +33,7 @@ import {
   listHeaderTiers,
 } from '../services/api.js';
 import { createCursorPagination } from '../services/cursor-pagination.js';
-import { getBillingStatus } from '../services/api/billing.js';
+import { usePlanRangeLock } from '../services/plan-range-lock.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { PROVIDERS, SPECIFICITY_STAGES } from '../services/providers.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
@@ -157,7 +157,8 @@ const MessageLog: Component = () => {
       // includePlayground=true so the reserved Playground agent appears in the
       // filter and the log can be narrowed to Playground runs.
       const data = (await getAgents(true)) as
-        { agents?: AgentFilterOption[] } | AgentFilterOption[];
+        | { agents?: AgentFilterOption[] }
+        | AgentFilterOption[];
       return (Array.isArray(data) ? data : (data?.agents ?? [])) as AgentFilterOption[];
     },
   );
@@ -263,19 +264,8 @@ const MessageLog: Component = () => {
   const [rangeFilter, setRangeFilterValue] = createSignal<MessageRangeFilterValue>(
     normalizeRangeFilter(searchParams.range),
   );
-  const [billing] = createResource(async () => {
-    try {
-      return await getBillingStatus();
-    } catch {
-      return null;
-    }
-  });
-  const isFreePlan = () => billing()?.enabled && billing()?.plan === 'free';
-  const shouldLockProRanges = () => billing.loading || isFreePlan();
-  const isProRangeLocked = (value: string) => shouldLockProRanges() && PRO_RANGES.has(value);
-  const effectiveRange = createMemo<MessageRangeFilterValue>(() =>
-    isProRangeLocked(rangeFilter()) ? '7d' : rangeFilter(),
-  );
+  const { isFreePlan, isProRangeLocked, effectiveRange } =
+    usePlanRangeLock<MessageRangeFilterValue>(rangeFilter, PRO_RANGES, '7d');
   const [tierFilter, setTierFilter] = createSignal('');
   const [originFilter, setOriginFilter] = createSignal('');
   const [statusFilterValue, setStatusFilterValue] = createSignal<MessageStatusFilterValue>(

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -169,11 +169,10 @@ const Overview: Component = () => {
     !!localStorage.getItem(`setup_completed_${params.agentName}`),
   );
 
+  // Do not wait on billing/status: plan only gates range options, and a slow
+  // usage counter must not stall the whole dashboard shell.
   const [data, { refetch }] = createResource(
-    () =>
-      billing.loading
-        ? false
-        : { range: effectiveRange(), agentName: params.agentName, _ping: analyticsPing() },
+    () => ({ range: effectiveRange(), agentName: params.agentName, _ping: analyticsPing() }),
     (p) => getOverview(p.range, p.agentName) as Promise<OverviewData>,
   );
 
@@ -255,15 +254,15 @@ const Overview: Component = () => {
     _ping: analyticsPing(),
   });
   const [providerTokenTs] = createResource(
-    () => (tokenChartRequested() && !billing.loading ? tsKey() : false),
+    () => (tokenChartRequested() ? tsKey() : false),
     (p) => getPerProviderTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
   const [providerMessageTs] = createResource(
-    () => (billing.loading ? false : tsKey()),
+    () => tsKey(),
     (p) => getPerProviderMessageTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
   const [providerCostTs] = createResource(
-    () => (costChartRequested() && !billing.loading ? tsKey() : false),
+    () => (costChartRequested() ? tsKey() : false),
     (p) => getPerProviderCostTimeseries(p.agent, p.range) as Promise<PivotedTimeseries>,
   );
 
@@ -412,7 +411,7 @@ const Overview: Component = () => {
       </div>
 
       <Show
-        when={!billing.loading && (data() !== undefined || !data.loading) && !rangeChanging()}
+        when={(data() !== undefined || !data.loading) && !rangeChanging()}
         fallback={<OverviewSkeleton />}
       >
         <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -41,7 +41,7 @@ import {
   useOverviewColumns,
   useOverviewRange,
 } from '../services/use-overview-range.js';
-import { getBillingStatus } from '../services/api/billing.js';
+import { usePlanRangeLock } from '../services/plan-range-lock.js';
 import '../styles/overview.css';
 import '../styles/charts.css';
 import '../styles/routing.css';
@@ -118,25 +118,6 @@ const Overview: Component = () => {
   const location = useLocation<{ newApiKey?: string }>();
   const navigate = useNavigate();
   preloadModelDisplayNames();
-  const [billing] = createResource(async () => {
-    try {
-      return await getBillingStatus();
-    } catch {
-      return null;
-    }
-  });
-  const isFreePlan = () => billing()?.enabled && billing()?.plan === 'free';
-  const shouldLockProRanges = () => billing.loading || isFreePlan();
-  const isProRangeLocked = (value: string) => shouldLockProRanges() && PRO_RANGES.has(value);
-  const proBadge = () => (
-    <span class="pro-range-badge" aria-label="Pro plan required">
-      PRO
-    </span>
-  );
-  const agentRangeOptions = () =>
-    AGENT_RANGE_OPTIONS.map((opt) =>
-      isProRangeLocked(opt.value) ? { ...opt, disabled: true, badge: proBadge() } : opt,
-    );
   const { columns } = useOverviewColumns();
   // Only treat the stored value as a user selection when it is actually valid.
   // An invalid stored range falls through to the smart-range cascade.
@@ -146,7 +127,20 @@ const Overview: Component = () => {
   const { range, setRange, handleRangeChange } = useOverviewRange({
     markUserSelected: () => setUserSelectedRange(true),
   });
-  const effectiveRange = createMemo(() => (isProRangeLocked(range()) ? '7d' : range()));
+  const { isFreePlan, isProRangeLocked, effectiveRange } = usePlanRangeLock(
+    range,
+    PRO_RANGES,
+    '7d',
+  );
+  const proBadge = () => (
+    <span class="pro-range-badge" aria-label="Pro plan required">
+      PRO
+    </span>
+  );
+  const agentRangeOptions = () =>
+    AGENT_RANGE_OPTIONS.map((opt) =>
+      isProRangeLocked(opt.value) ? { ...opt, disabled: true, badge: proBadge() } : opt,
+    );
   const [activeView, setActiveViewRaw] = createSignal<ProviderView>('requests');
   const [tokenChartRequested, setTokenChartRequested] = createSignal(false);
   const [costChartRequested, setCostChartRequested] = createSignal(false);
@@ -169,8 +163,8 @@ const Overview: Component = () => {
     !!localStorage.getItem(`setup_completed_${params.agentName}`),
   );
 
-  // Do not wait on billing/status: plan only gates range options, and a slow
-  // usage counter must not stall the whole dashboard shell.
+  // Never waits on billing/status: the plan-hint lock resolves the range
+  // synchronously, so this fetches exactly once at the right range.
   const [data, { refetch }] = createResource(
     () => ({ range: effectiveRange(), agentName: params.agentName, _ping: analyticsPing() }),
     (p) => getOverview(p.range, p.agentName) as Promise<OverviewData>,

--- a/packages/frontend/src/services/api/billing.ts
+++ b/packages/frontend/src/services/api/billing.ts
@@ -1,15 +1,20 @@
 import { fetchJson, fetchMutate, type FetchJsonOptions } from './core';
-import type { BillingEmailPreferences, BillingStatus } from 'manifest-shared';
+import type { BillingEmailPreferences, BillingPlanStatus, BillingStatus } from 'manifest-shared';
 
 // Re-export so UI components can import the type from the API module they
 // already use, instead of reaching across package boundaries for it.
-export type { BillingEmailPreferences, BillingStatus };
+export type { BillingEmailPreferences, BillingPlanStatus, BillingStatus };
 
 export function getBillingStatus(options?: FetchJsonOptions): Promise<BillingStatus> {
   if (options) {
     return fetchJson<BillingStatus>('/billing/status', undefined, options);
   }
   return fetchJson<BillingStatus>('/billing/status');
+}
+
+/** Light plan lookup — no usage counter, no Stripe price. See plan-store.ts. */
+export function getBillingPlan(): Promise<BillingPlanStatus> {
+  return fetchJson<BillingPlanStatus>('/billing/plan');
 }
 
 export function updateBillingEmailPreferences(

--- a/packages/frontend/src/services/plan-range-lock.ts
+++ b/packages/frontend/src/services/plan-range-lock.ts
@@ -1,0 +1,30 @@
+import { createMemo, type Accessor } from 'solid-js';
+import { isFreePlan } from './plan-store.js';
+
+export interface PlanRangeLock<T extends string> {
+  /** True for a Free cloud tenant (synchronous read of the plan store). */
+  isFreePlan: Accessor<boolean>;
+  /** Whether a picker option must be disabled. */
+  isProRangeLocked: (value: string) => boolean;
+  /** The range to fetch with: the selection, clamped while PRO ranges are locked. */
+  effectiveRange: Accessor<T>;
+}
+
+/**
+ * Shared plan-based range lock for the Overview / Global Overview / Requests
+ * dashboards: PRO ranges are Free-tenant-locked and clamp to the fallback.
+ *
+ * The plan comes from the plan store, which AuthGuard resolves before any
+ * page renders — so the lock is synchronous, `effectiveRange` is stable from
+ * first paint, and every range-keyed resource fetches exactly once at the
+ * right range. No billing fetch, no loading state, nothing to flicker.
+ */
+export function usePlanRangeLock<T extends string>(
+  range: Accessor<T>,
+  proRanges: ReadonlySet<string>,
+  fallback: T,
+): PlanRangeLock<T> {
+  const isProRangeLocked = (value: string) => isFreePlan() && proRanges.has(value);
+  const effectiveRange = createMemo(() => (isProRangeLocked(range()) ? fallback : range()));
+  return { isFreePlan, isProRangeLocked, effectiveRange };
+}

--- a/packages/frontend/src/services/plan-store.ts
+++ b/packages/frontend/src/services/plan-store.ts
@@ -1,0 +1,53 @@
+import { createSignal } from 'solid-js';
+import { getBillingPlan, type BillingPlanStatus } from './api/billing.js';
+
+/**
+ * The tenant's billing plan, resolved once per app boot behind AuthGuard and
+ * read synchronously everywhere after. Plan is session-scoped data (it only
+ * changes on upgrade/downgrade, which round-trips through Stripe checkout and
+ * reboots the app), so it rides the bootstrap instead of the live
+ * /billing/status endpoint — pages never wait on billing to decide range
+ * locks, and nothing can flicker or double-fetch.
+ */
+
+/** Fail-open default: on a fetch error the UI behaves as if billing is off. */
+const FAIL_OPEN: BillingPlanStatus = { enabled: false, plan: 'free' };
+
+const [planStatus, setPlanStatus] = createSignal<BillingPlanStatus | null>(null);
+
+let inflight: Promise<BillingPlanStatus> | null = null;
+
+/**
+ * Resolve the plan once per boot (deduped). Never rejects — a failed lookup
+ * falls open so a billing hiccup can't block the dashboard.
+ */
+export function loadPlan(): Promise<BillingPlanStatus> {
+  const current = planStatus();
+  if (current) return Promise.resolve(current);
+  inflight ??= getBillingPlan()
+    .catch(() => FAIL_OPEN)
+    .then((status) => {
+      setPlanStatus(status);
+      inflight = null;
+      return status;
+    });
+  return inflight;
+}
+
+/**
+ * True for a Free cloud tenant. Synchronous: AuthGuard awaits {@link loadPlan}
+ * before rendering any page, so by the time a consumer runs this is settled.
+ * (Reactive anyway, so a late resolution still propagates.)
+ */
+export const isFreePlan = (): boolean => {
+  const status = planStatus();
+  return !!status && status.enabled && status.plan === 'free';
+};
+
+export { planStatus };
+
+/** Reset the store (tests, or forcing a re-resolve after a plan change). */
+export function resetPlanStore(next: BillingPlanStatus | null = null): void {
+  setPlanStatus(next);
+  inflight = null;
+}

--- a/packages/frontend/tests/components/AuthGuard.test.tsx
+++ b/packages/frontend/tests/components/AuthGuard.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@solidjs/testing-library';
 
 const mockNavigate = vi.fn();
-const mockGetBillingStatus = vi.fn().mockResolvedValue({ enabled: false, plan: 'free' });
+const mockGetBillingPlan = vi.fn().mockResolvedValue({ enabled: false, plan: 'free' });
 let mockLocation = { pathname: '/', search: '' };
 let mockSessionData: any = {
   data: { user: { id: 'u1', name: 'Test' } },
@@ -21,16 +21,18 @@ vi.mock('../../src/services/auth-client.js', () => ({
 }));
 
 vi.mock('../../src/services/api/billing.js', () => ({
-  getBillingStatus: (...args: unknown[]) => mockGetBillingStatus(...args),
+  getBillingPlan: (...args: unknown[]) => mockGetBillingPlan(...args),
 }));
 
 import AuthGuard from '../../src/components/AuthGuard';
+import { resetPlanStore } from '../../src/services/plan-store';
 
 describe('AuthGuard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
-    mockGetBillingStatus.mockResolvedValue({ enabled: false, plan: 'free' });
+    resetPlanStore();
+    mockGetBillingPlan.mockResolvedValue({ enabled: false, plan: 'free' });
     mockSessionData = {
       data: { user: { id: 'u1', name: 'Test' } },
       isPending: false,
@@ -47,8 +49,10 @@ describe('AuthGuard', () => {
     expect(await screen.findByText('Protected content')).toBeDefined();
   });
 
-  it('renders children without a billing call when the user already chose a plan', async () => {
+  it('skips the upgrade redirect when the user already chose a plan', async () => {
     localStorage.setItem('manifest_plan_chosen_u1', '1');
+    localStorage.setItem('manifest_onboarding_done_u1', '1');
+    mockGetBillingPlan.mockResolvedValue({ enabled: true, plan: 'free' });
     render(() => (
       <AuthGuard>
         <span>Protected content</span>
@@ -56,12 +60,15 @@ describe('AuthGuard', () => {
     ));
 
     expect(await screen.findByText('Protected content')).toBeDefined();
-    expect(mockGetBillingStatus).not.toHaveBeenCalled();
+    // The plan store still resolves at bootstrap (range locks read it), but a
+    // chosen plan never redirects to /upgrade again.
+    expect(mockGetBillingPlan).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('redirects authenticated free users to /upgrade after onboarding', async () => {
     localStorage.setItem('manifest_onboarding_done_u1', '1');
-    mockGetBillingStatus.mockResolvedValue({ enabled: true, plan: 'free' });
+    mockGetBillingPlan.mockResolvedValue({ enabled: true, plan: 'free' });
     render(() => (
       <AuthGuard>
         <span>Protected content</span>
@@ -73,8 +80,8 @@ describe('AuthGuard', () => {
     });
   });
 
-  it('skips billing check and renders children when onboarding is not done', async () => {
-    mockGetBillingStatus.mockResolvedValue({ enabled: true, plan: 'free' });
+  it('skips the upgrade redirect and renders children when onboarding is not done', async () => {
+    mockGetBillingPlan.mockResolvedValue({ enabled: true, plan: 'free' });
     render(() => (
       <AuthGuard>
         <span>Protected content</span>
@@ -82,13 +89,15 @@ describe('AuthGuard', () => {
     ));
 
     expect(await screen.findByText('Protected content')).toBeDefined();
-    expect(mockGetBillingStatus).not.toHaveBeenCalled();
+    // The plan store still resolves (bootstrap), but no redirect fires before
+    // onboarding completes.
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('skips billing check and renders children when on /upgrade', async () => {
+  it('skips the upgrade redirect and renders children when on /upgrade', async () => {
     localStorage.setItem('manifest_onboarding_done_u1', '1');
     mockLocation = { pathname: '/upgrade', search: '' };
-    mockGetBillingStatus.mockResolvedValue({ enabled: true, plan: 'free' });
+    mockGetBillingPlan.mockResolvedValue({ enabled: true, plan: 'free' });
     render(() => (
       <AuthGuard>
         <span>Protected content</span>
@@ -96,11 +105,11 @@ describe('AuthGuard', () => {
     ));
 
     expect(await screen.findByText('Protected content')).toBeDefined();
-    expect(mockGetBillingStatus).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('fails open when billing status cannot be loaded', async () => {
-    mockGetBillingStatus.mockRejectedValue(new Error('network'));
+  it('fails open when the plan cannot be loaded', async () => {
+    mockGetBillingPlan.mockRejectedValue(new Error('network'));
     render(() => (
       <AuthGuard>
         <span>Protected content</span>

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -150,10 +150,7 @@ vi.mock('../../src/components/MultiSelect.jsx', () => ({
   ),
 }));
 
-const mockGetBillingStatus = vi.fn().mockResolvedValue({ enabled: false, plan: 'free' });
-vi.mock('../../src/services/api/billing.js', () => ({
-  getBillingStatus: (...args: unknown[]) => mockGetBillingStatus(...args),
-}));
+import { resetPlanStore } from '../../src/services/plan-store';
 
 vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
@@ -338,7 +335,7 @@ describe('MessageLog', () => {
     const [ping, setPing] = createSignal(0);
     pingBox.read = ping;
     pingBox.set = setPing;
-    mockGetBillingStatus.mockResolvedValue({ enabled: false, plan: 'free' });
+    resetPlanStore({ enabled: false, plan: 'free' });
   });
 
   it('renders Requests heading', () => {
@@ -706,7 +703,9 @@ describe('MessageLog', () => {
 
   it('clamps a Pro-range deep link before loading data for a free plan', async () => {
     mockSearchParams = { range: '365d' };
-    mockGetBillingStatus.mockResolvedValue({ enabled: true, plan: 'free' });
+    // The plan store is resolved by AuthGuard before any page mounts, so the
+    // clamp is synchronous — no fetch ever goes out at the PRO range.
+    resetPlanStore({ enabled: true, plan: 'free' });
     mockGetMessages.mockResolvedValue(messagesData);
 
     render(() => <MessageLog />);

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -124,10 +124,7 @@ vi.mock('../../src/services/api/routing.js', () => ({
   getAutofix: () => Promise.resolve({ available: false, enabled: false }),
 }));
 
-const mockGetBillingStatus = vi.fn();
-vi.mock('../../src/services/api/billing.js', () => ({
-  getBillingStatus: (...args: unknown[]) => mockGetBillingStatus(...args),
-}));
+import { resetPlanStore } from '../../src/services/plan-store';
 
 vi.mock('../../src/components/MultiAgentTokenChart.jsx', () => ({
   AGENT_COLORS: ['#111111', '#222222', '#333333'],
@@ -285,11 +282,7 @@ describe('Overview', () => {
     });
     mockGetCustomProviders.mockResolvedValue([]);
     mockPerProvider.mockResolvedValue({ agents: [], timeseries: [] });
-    mockGetBillingStatus.mockResolvedValue({
-      enabled: false,
-      plan: 'free',
-      emailPreferences: { usageAlerts: true },
-    });
+    resetPlanStore({ enabled: false, plan: 'free' });
   });
 
   it('renders Overview heading with agent name', () => {
@@ -538,13 +531,16 @@ describe('Overview', () => {
 
   it('hides the self-healed tab and KPI cards for non-cohort tenants', async () => {
     mockGetOverview.mockResolvedValue(overviewData);
-    render(() => <Overview />);
+    const { container } = render(() => <Overview />);
 
     await vi.waitFor(() => {
       expect(screen.getAllByText('Requests').length).toBeGreaterThan(0);
     });
     expect(screen.queryByText('Recovered requests')).toBeNull();
-    expect(screen.queryByText('Success rate')).toBeNull();
+    // The Auto-fix KPI row is the only overview-stat-card surface on this page;
+    // 'Success rate' alone is ambiguous (CostByModelTable has a per-model
+    // reliability column of the same name for every tenant).
+    expect(container.querySelector('.overview-stat-card')).toBeNull();
     expect(mockGetAutofixStats).not.toHaveBeenCalled();
   });
 
@@ -953,11 +949,7 @@ describe('Overview', () => {
 
     it('limits Free users to 7-day dashboard ranges and labels longer ranges as Pro-only', async () => {
       localStorage.setItem('manifest_chart_range', '365d');
-      mockGetBillingStatus.mockResolvedValue({
-        enabled: true,
-        plan: 'free',
-        emailPreferences: { usageAlerts: true },
-      });
+      resetPlanStore({ enabled: true, plan: 'free' });
       mockGetOverview.mockResolvedValue(overviewData);
 
       const { container } = render(() => <Overview />);

--- a/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
+++ b/packages/frontend/tests/pages/ProviderOverviewPages.test.tsx
@@ -389,6 +389,7 @@ vi.mock('../../src/services/setup-status.js', () => ({
 
 import GlobalOverview from '../../src/pages/GlobalOverview';
 import ConnectionDetail from '../../src/pages/providers/ConnectionDetail';
+import { resetPlanStore } from '../../src/services/plan-store';
 
 const overviewResponse = {
   summary: {
@@ -726,6 +727,7 @@ function ensureStorageLike(kind: 'localStorage' | 'sessionStorage') {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetPlanStore();
   ensureStorageLike('localStorage').clear();
   ensureStorageLike('sessionStorage').clear();
   localStorage.setItem('manifest_global_group', 'provider');
@@ -857,19 +859,7 @@ describe('GlobalOverview (analytics)', () => {
 
   it('limits Free users to 7-day dashboard ranges and labels longer ranges as Pro-only', async () => {
     localStorage.setItem('manifest_global_range', '365d');
-    apiMocks.getBillingStatus.mockResolvedValue({
-      enabled: true,
-      plan: 'free',
-      priceMonthly: { amount: 20, currency: 'USD', interval: 'month' },
-      emailPreferences: { usageAlerts: true },
-      requests: {
-        used: 120,
-        limit: FREE_PLAN_REQUESTS_PER_MONTH,
-        periodEnd: '2026-08-01T00:00:00.000Z',
-      },
-      cancelAtPeriodEnd: false,
-      subscriptionPeriodEnd: null,
-    });
+    resetPlanStore({ enabled: true, plan: 'free' });
 
     render(() => <GlobalOverview />);
 

--- a/packages/frontend/tests/services/plan-range-lock.test.ts
+++ b/packages/frontend/tests/services/plan-range-lock.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRoot, createSignal } from 'solid-js';
+import { usePlanRangeLock } from '../../src/services/plan-range-lock.js';
+import { resetPlanStore } from '../../src/services/plan-store.js';
+
+const PRO_RANGES = new Set(['30d', '90d', '365d']);
+
+const withLock = (
+  initialRange: string,
+  body: (
+    lock: ReturnType<typeof usePlanRangeLock<string>>,
+    setRange: (v: string) => void,
+  ) => void,
+) => {
+  createRoot((dispose) => {
+    const [range, setRange] = createSignal(initialRange);
+    const lock = usePlanRangeLock(range, PRO_RANGES, '7d');
+    try {
+      body(lock, setRange);
+    } finally {
+      dispose();
+    }
+  });
+};
+
+describe('usePlanRangeLock', () => {
+  beforeEach(() => {
+    resetPlanStore();
+  });
+
+  it('locks PRO ranges and clamps to the fallback for a free plan', () => {
+    resetPlanStore({ enabled: true, plan: 'free' });
+    withLock('90d', (lock) => {
+      expect(lock.isFreePlan()).toBe(true);
+      expect(lock.isProRangeLocked('90d')).toBe(true);
+      expect(lock.isProRangeLocked('7d')).toBe(false);
+      expect(lock.effectiveRange()).toBe('7d');
+    });
+  });
+
+  it('leaves PRO ranges unlocked for a paid plan', () => {
+    resetPlanStore({ enabled: true, plan: 'pro' });
+    withLock('30d', (lock) => {
+      expect(lock.isFreePlan()).toBe(false);
+      expect(lock.isProRangeLocked('30d')).toBe(false);
+      expect(lock.effectiveRange()).toBe('30d');
+    });
+  });
+
+  it('leaves PRO ranges unlocked when billing is disabled or unresolved', () => {
+    resetPlanStore({ enabled: false, plan: 'free' });
+    withLock('365d', (lock) => {
+      expect(lock.effectiveRange()).toBe('365d');
+    });
+    resetPlanStore();
+    withLock('365d', (lock) => {
+      expect(lock.isFreePlan()).toBe(false);
+      expect(lock.effectiveRange()).toBe('365d');
+    });
+  });
+
+  it('reacts to range changes and never clamps non-PRO ranges', () => {
+    resetPlanStore({ enabled: true, plan: 'free' });
+    withLock('24h', (lock, setRange) => {
+      expect(lock.effectiveRange()).toBe('24h');
+      setRange('30d');
+      expect(lock.effectiveRange()).toBe('7d');
+      setRange('7d');
+      expect(lock.effectiveRange()).toBe('7d');
+    });
+  });
+
+  it('re-clamps reactively when the plan store updates mid-session', () => {
+    withLock('30d', (lock) => {
+      expect(lock.effectiveRange()).toBe('30d');
+      resetPlanStore({ enabled: true, plan: 'free' });
+      expect(lock.effectiveRange()).toBe('7d');
+    });
+  });
+});

--- a/packages/frontend/tests/services/plan-store.test.ts
+++ b/packages/frontend/tests/services/plan-store.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadPlan, isFreePlan, planStatus, resetPlanStore } from '../../src/services/plan-store.js';
+
+const mockGetBillingPlan = vi.fn();
+vi.mock('../../src/services/api/billing.js', () => ({
+  getBillingPlan: (...args: unknown[]) => mockGetBillingPlan(...args),
+}));
+
+describe('plan store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetPlanStore();
+  });
+
+  it('resolves and caches the plan on first load', async () => {
+    mockGetBillingPlan.mockResolvedValue({ enabled: true, plan: 'pro' });
+    await expect(loadPlan()).resolves.toEqual({ enabled: true, plan: 'pro' });
+    await expect(loadPlan()).resolves.toEqual({ enabled: true, plan: 'pro' });
+    expect(mockGetBillingPlan).toHaveBeenCalledTimes(1);
+    expect(planStatus()).toEqual({ enabled: true, plan: 'pro' });
+  });
+
+  it('dedupes concurrent loads onto one request', async () => {
+    let resolve!: (v: { enabled: boolean; plan: string }) => void;
+    mockGetBillingPlan.mockReturnValue(new Promise((r) => (resolve = r)));
+    const [a, b] = [loadPlan(), loadPlan()];
+    resolve({ enabled: true, plan: 'free' });
+    await expect(a).resolves.toEqual({ enabled: true, plan: 'free' });
+    await expect(b).resolves.toEqual({ enabled: true, plan: 'free' });
+    expect(mockGetBillingPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open (billing disabled) when the lookup errors, without caching failure', async () => {
+    mockGetBillingPlan.mockRejectedValueOnce(new Error('boom'));
+    await expect(loadPlan()).resolves.toEqual({ enabled: false, plan: 'free' });
+    expect(isFreePlan()).toBe(false);
+    // A later boot (store reset) retries instead of serving the failed value.
+    resetPlanStore();
+    mockGetBillingPlan.mockResolvedValue({ enabled: true, plan: 'free' });
+    await expect(loadPlan()).resolves.toEqual({ enabled: true, plan: 'free' });
+  });
+
+  it('derives isFreePlan only for an enabled free plan', () => {
+    expect(isFreePlan()).toBe(false); // unresolved
+    resetPlanStore({ enabled: false, plan: 'free' });
+    expect(isFreePlan()).toBe(false); // billing off (self-hosted)
+    resetPlanStore({ enabled: true, plan: 'pro' });
+    expect(isFreePlan()).toBe(false);
+    resetPlanStore({ enabled: true, plan: 'free' });
+    expect(isFreePlan()).toBe(true);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -164,6 +164,7 @@ export {
 } from './plan-limits';
 export type {
   BillingEmailPreferences,
+  BillingPlanStatus,
   BillingPrice,
   BillingStatus,
   Plan,

--- a/packages/shared/src/plan-limits.ts
+++ b/packages/shared/src/plan-limits.ts
@@ -27,6 +27,16 @@ export interface BillingEmailPreferences {
   usageAlerts: boolean;
 }
 
+/**
+ * Light plan lookup for surfaces that only gate UI on the tenant's plan
+ * (range locks, AuthGuard bootstrap). Deliberately excludes usage and price —
+ * consumers that render those use the full {@link BillingStatus}.
+ */
+export interface BillingPlanStatus {
+  enabled: boolean;
+  plan: Plan;
+}
+
 export interface BillingStatus {
   enabled: boolean;
   plan: Plan;


### PR DESCRIPTION
## Summary

Fixes the ~28s `/api/v1/billing/status` stall introduced by #2608 and removes the dashboards' dependency on billing status entirely.

**Backend (commit 1):**
- `/api/v1/billing/status` was waiting on the one-shot historical `tenant_request_usage` baseline COUNT whenever `baseline_counted` was still false. On high-volume tenants that scan takes tens of seconds (observed ~28s TTFB), blocking Overview load and free-tier admission.
- Return the live post-cutover counter immediately and schedule the baseline init in the background (single-flight, fail-open undercount until it lands).
- Run usage lookup and Stripe price fetch in parallel.

**Frontend + plan endpoint (commit 2):**
- Overview, Global Overview, and the Requests log only ever needed billing for one question: is this tenant on the Free plan (PRO range locks). They each fetched the fat `/billing/status` and gated chart fetches on `billing.loading`, so every range-keyed resource fetched twice per mount (clamped `7d` first, real range after billing resolved) and the picker flashed disabled PRO options.
- New light `GET /api/v1/billing/plan` returns `{enabled, plan}` from the snapshot query alone: no usage counter, no Stripe.
- AuthGuard resolves it once at login into a plan store; pages read it synchronously through a shared `usePlanRangeLock` hook. Every dashboard resource now fetches exactly once at the right range; nothing waits on billing; nothing flickers.
- `/billing/status` remains for the surfaces that render usage (sidebar usage bar, limit banner, Account, Upgrade).

## Test plan

- [x] `packages/backend` billing suites: 131/131 (incl. new `getPlanStatus` + controller specs)
- [x] `packages/frontend` full suite: 4158/4158; `plan-store.ts` and `plan-range-lock.ts` at 100% line/branch coverage
- [x] Free tenant: PRO ranges disabled synchronously, deep-linked `?range=365d` clamps to `7d` before any fetch, URL rewritten
- [ ] Open Overview as a free tenant with `baseline_counted = false` for the current window: `/billing/status` returns quickly; sidebar usage may briefly undercount then correct after background init
- [ ] Confirm free-tier proxy admission still enforces the limit after baseline lands (fails open while undercounting)
- [ ] Pro tenant with a stored 30d/90d range: charts load once at that range, no 7d flash
