### PR TITLE
fix: redirect to plan picker after onboarding instead of upgrade page

### DIFF
--- a/packages/frontend/src/components/AuthGuard.tsx
+++ b/packages/frontend/src/components/AuthGuard.tsx
@@ -21,8 +21,8 @@ const AuthGuard: ParentComponent = (props) => {
     }
     const userId = s.data.user?.id;
     if (planChecked()) return;
-    // /upgrade is the plan selection destination — never intercept it.
-    if (location.pathname === '/upgrade') {
+    // /register?step=plan is the plan selection destination — never intercept it.
+    if (location.pathname === '/register') {
       setPlanChecked(true);
       return;
     }
@@ -38,7 +38,7 @@ const AuthGuard: ParentComponent = (props) => {
     getBillingStatus()
       .then((status) => {
         if (status?.enabled && status.plan !== 'pro') {
-          navigate('/upgrade', { replace: true });
+          navigate('/register?step=plan', { replace: true });
         } else {
           if (userId) markPlanChosen(userId);
           setPlanChecked(true);

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -121,7 +121,7 @@ const Register: Component = () => {
   const handlePlanSelect = async (plan: PlanId) => {
     if (plan === 'free') {
       markPlanChosen(userId());
-      window.location.replace('/welcome');
+      window.location.replace('/');
       return;
     }
     if (plan === 'enterprise') {

--- a/packages/frontend/src/pages/Welcome.tsx
+++ b/packages/frontend/src/pages/Welcome.tsx
@@ -712,16 +712,13 @@ const Welcome: Component = () => {
   const skipOnboarding = () => {
     const uid = userId();
     if (uid) markOnboardingDone(uid);
-    navigate('/upgrade');
+    navigate('/register?step=plan');
   };
 
   const openOnboardingPaywall = () => {
     const uid = userId();
     if (uid) markOnboardingDone(uid);
-    const params = new URLSearchParams({ from: 'onboarding' });
-    const slug = harnessSlug();
-    if (slug) params.set('harness', slug);
-    navigate(`/upgrade?${params.toString()}`);
+    navigate('/register?step=plan');
   };
 
   // Which steps are completed, for the sidebar checkmarks. Steps without

--- a/packages/frontend/tests/components/AuthGuard.test.tsx
+++ b/packages/frontend/tests/components/AuthGuard.test.tsx
@@ -59,7 +59,7 @@ describe('AuthGuard', () => {
     expect(mockGetBillingStatus).not.toHaveBeenCalled();
   });
 
-  it('redirects authenticated free users to /upgrade after onboarding', async () => {
+  it('redirects authenticated free users to /register?step=plan after onboarding', async () => {
     localStorage.setItem('manifest_onboarding_done_u1', '1');
     mockGetBillingStatus.mockResolvedValue({ enabled: true, plan: 'free' });
     render(() => (
@@ -69,7 +69,7 @@ describe('AuthGuard', () => {
     ));
 
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/upgrade', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/register?step=plan', { replace: true });
     });
   });
 
@@ -85,9 +85,9 @@ describe('AuthGuard', () => {
     expect(mockGetBillingStatus).not.toHaveBeenCalled();
   });
 
-  it('skips billing check and renders children when on /upgrade', async () => {
+  it('skips billing check and renders children when on /register', async () => {
     localStorage.setItem('manifest_onboarding_done_u1', '1');
-    mockLocation = { pathname: '/upgrade', search: '' };
+    mockLocation = { pathname: '/register', search: '?step=plan' };
     mockGetBillingStatus.mockResolvedValue({ enabled: true, plan: 'free' });
     render(() => (
       <AuthGuard>

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -259,7 +259,7 @@ describe('Register', () => {
     fireEvent.click(freeCard);
     fireEvent.click(container.querySelector('.plan-picker__cta')!);
 
-    expect(replace).toHaveBeenCalledWith('/welcome');
+    expect(replace).toHaveBeenCalledWith('/');
     locationSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

After onboarding completes or is skipped, the user was landing on `/upgrade` (the full 3-column pricing page). This was wrong. The intended destination is `/register?step=plan`, which shows the existing compact `PlanPicker` accordion — a single-column card where the user quickly selects a plan before accessing the dashboard.

- `AuthGuard`: exclude `/register` from plan-check interception (anti-loop), redirect plan-less post-onboarding users to `/register?step=plan` instead of `/upgrade`
- `Welcome.tsx`: `skipOnboarding` and `openOnboardingPaywall` navigate to `/register?step=plan`
- `Register.tsx`: free plan selection from the plan step goes to `/` (dashboard) instead of `/welcome`, since onboarding is already complete at that point
- `/upgrade` remains the destination for users who chose free and later want to upgrade

## Flow after this fix

signup → onboarding (`/welcome`) → plan picker compact (`/register?step=plan`) → dashboard (`/`)

## Test plan

- [ ] New signup: complete onboarding → lands on compact plan picker
- [ ] New signup: skip onboarding → lands on compact plan picker
- [ ] Choose Free on plan picker → lands on dashboard
- [ ] Choose Pro on plan picker → Stripe checkout (cancel returns to `/register?step=plan`)
- [ ] Authenticated user without a plan → redirected to `/register?step=plan`, not `/upgrade`
- [ ] `/upgrade` still works for post-onboarding upgrades (usage limit banner, sidebar link)
- [ ] All 4151 frontend tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect post-onboarding users to `/register?step=plan` (compact PlanPicker) instead of `/upgrade`. Selecting the Free plan now takes users to the dashboard; `/upgrade` remains for later upgrades.

- **Bug Fixes**
  - `AuthGuard`: skip plan check on `/register`; redirect plan-less users to `/register?step=plan`.
  - `Welcome`: `skipOnboarding` and paywall actions now navigate to `/register?step=plan`.
  - `Register`: selecting `free` redirects to `/` (dashboard) after the plan step.

<sup>Written for commit ee5d5e304dfd442595426daffa1b9df47334070c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

