### PR TITLE
fix: retry healed models on the original provider transport

### DIFF
--- a/.changeset/autofix-healed-transport-fallback.md
+++ b/.changeset/autofix-healed-transport-fallback.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Auto-fix retries a healed model on the original provider transport when routing cannot resolve it (stale tenant model cache), instead of synthesizing a 502

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -570,12 +570,16 @@ describe('ProxyService — orchestration', () => {
       );
     });
 
-    it('returns a synthetic 502 (without throwing) when the heal changes to a model that no longer resolves (M5 no-route)', async () => {
+    it('retries on the original transport when the heal changes to a model that no longer resolves (M5 no-route)', async () => {
       routableResolve();
-      fallbackService.tryForwardToProvider.mockResolvedValueOnce(fwd(400));
-      // No discovered models → the healed model resolves to no route, and the
-      // configured routing it falls back to has none either, so reforwardHealed
-      // surfaces a synthetic 502 forward. The primary forward resolved first.
+      const failed = fwd(400);
+      const healed = fwd(200);
+      fallbackService.tryForwardToProvider.mockResolvedValueOnce(failed);
+      fallbackService.retryWireBody.mockResolvedValueOnce(healed);
+      // No discovered models → the healed model resolves to no route (a stale
+      // per-tenant catalog, typically — the provider may still serve it). The
+      // original forward's transport is proven, so the reforward pins the healed
+      // body there instead of synthesizing a 502.
       modelDiscovery.getModelsForAgent.mockResolvedValue([]);
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
@@ -602,34 +606,69 @@ describe('ProxyService — orchestration', () => {
             model: 'ghost/unknown-model',
             max_output_tokens: 5,
           });
-          // The healing loop treats this as a failed retry and degrades to the
-          // original error; the record's outcome is exhausted.
           return {
             forward: reforwardResult,
-            record: { outcome: 'exhausted', attempts: 0, original_http_status: 400, chain: [] },
+            record: { outcome: 'healed', attempts: 1, original_http_status: 400, chain: [] },
           };
         },
       );
 
       const result = await svc.proxyRequest(baseOpts());
 
-      // The reforward itself produced the synthetic 502.
-      expect(reforwardResult!.response.status).toBe(502);
-      // Only the primary forward reached the fallback service — the re-resolve
-      // bailed before forwarding because no route was found.
+      // The healed body went out on the original provider's transport with the
+      // healed model pinned — the provider judges the model, not the cache.
+      expect(reforwardResult).toBe(healed);
+      expect(fallbackService.retryWireBody).toHaveBeenCalledWith(
+        failed,
+        { model: 'ghost/unknown-model', max_output_tokens: 5 },
+        expect.objectContaining({
+          provider: 'openai',
+          model: 'ghost/unknown-model',
+          authType: 'api_key',
+        }),
+      );
+      // Only the primary forward reached tryForwardToProvider — the re-resolve
+      // found no route and fell back to the pinned wire retry.
       expect(fallbackService.tryForwardToProvider).toHaveBeenCalledTimes(1);
-      // The caller handled the 502 without throwing and produced a result.
       expect(result.forward).toBeDefined();
-      const body = await reforwardResult!.response.text();
-      expect(body).toContain('Auto-fix');
     });
 
-    it('returns a synthetic 502 when the re-resolved model has a route but no provider key (M5 no-credentials)', async () => {
+    it('keeps the synthetic 502 when the original forward has no wire transport to pin', async () => {
+      // Unreachable via proxyRequest (the maybeHeal gate requires retryWireBody)
+      // but the fallback guards it type-level: no transport → no invented
+      // provider call, surface the synthetic 502.
+      const failed = { ...fwd(400), retryWireBody: undefined };
+      const result = await (
+        svc as unknown as {
+          retryHealedOnOriginalTransport: (
+            healedBody: Record<string, unknown>,
+            originalForward: unknown,
+            ctx: { provider: string; model: string },
+            reason: string,
+          ) => Promise<{ response: Response }>;
+        }
+      ).retryHealedOnOriginalTransport(
+        { model: 'ghost/unknown-model' },
+        failed,
+        { provider: 'openai', model: 'gpt-4o' },
+        'no route resolved for the healed model',
+      );
+
+      expect(result.response.status).toBe(502);
+      expect(fallbackService.retryWireBody).not.toHaveBeenCalled();
+      expect(await result.response.text()).toContain('Auto-fix');
+    });
+
+    it('retries on the original transport when the re-resolved model has a route but no provider key (M5 no-credentials)', async () => {
       routableResolve();
-      fallbackService.tryForwardToProvider.mockResolvedValueOnce(fwd(400));
+      const failed = fwd(400);
+      const healed = fwd(200);
+      fallbackService.tryForwardToProvider.mockResolvedValueOnce(failed);
+      fallbackService.retryWireBody.mockResolvedValueOnce(healed);
       // The healed model DOES resolve to a route, but the connection for it is
       // gone: selectProviderKey succeeds for the primary attempt, then returns
-      // null on the re-resolve so resolveCredentials yields no key.
+      // null on the re-resolve so resolveCredentials yields no key. The original
+      // transport still holds a working credential — retry there.
       modelDiscovery.getModelsForAgent.mockResolvedValue([
         discoveredModel({ id: 'gpt-4o-mini', provider: 'openai', authType: 'api_key' }),
       ]);
@@ -653,7 +692,7 @@ describe('ProxyService — orchestration', () => {
           });
           return {
             forward: reforwardResult,
-            record: { outcome: 'exhausted', attempts: 0, original_http_status: 400, chain: [] },
+            record: { outcome: 'healed', attempts: 1, original_http_status: 400, chain: [] },
           };
         },
       );
@@ -661,14 +700,20 @@ describe('ProxyService — orchestration', () => {
       const result = await svc.proxyRequest(baseOpts());
 
       // A route was found (getModelsForAgent + a second selectProviderKey call),
-      // but the missing key short-circuits to the synthetic 502.
-      expect(reforwardResult!.response.status).toBe(502);
+      // but the missing key falls back to the pinned wire retry, not a 502.
+      expect(reforwardResult).toBe(healed);
       expect(providerKeyService.selectProviderKey).toHaveBeenCalledTimes(2);
-      // No forward for the healed model — credentials failed first.
+      expect(fallbackService.retryWireBody).toHaveBeenCalledWith(
+        failed,
+        { model: 'openai/gpt-4o-mini', max_output_tokens: 5 },
+        expect.objectContaining({
+          provider: 'openai',
+          model: 'openai/gpt-4o-mini',
+          authType: 'api_key',
+        }),
+      );
       expect(fallbackService.tryForwardToProvider).toHaveBeenCalledTimes(1);
       expect(result.forward).toBeDefined();
-      const body = await reforwardResult!.response.text();
-      expect(body).toContain('no provider key');
     });
 
     it('takes the same-model branch when the heal drops the model field entirely', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -659,6 +659,38 @@ describe('ProxyService — orchestration', () => {
       expect(await result.response.text()).toContain('Auto-fix');
     });
 
+    it('uses the original model when a pinned healed retry omits the model', async () => {
+      const failed = fwd(400);
+      const healed = fwd(200);
+      fallbackService.retryWireBody.mockResolvedValueOnce(healed);
+
+      const result = await (
+        svc as unknown as {
+          retryHealedOnOriginalTransport: (
+            healedBody: Record<string, unknown>,
+            originalForward: unknown,
+            ctx: { provider: string; model: string },
+            reason: string,
+          ) => Promise<{ response: Response }>;
+        }
+      ).retryHealedOnOriginalTransport(
+        { max_output_tokens: 5 },
+        failed,
+        { provider: 'openai', model: 'gpt-4o' },
+        'no route resolved for the healed model',
+      );
+
+      expect(result).toBe(healed);
+      expect(fallbackService.retryWireBody).toHaveBeenCalledWith(
+        failed,
+        { max_output_tokens: 5 },
+        expect.objectContaining({
+          provider: 'openai',
+          model: 'gpt-4o',
+        }),
+      );
+    });
+
     it('retries on the original transport when the re-resolved model has a route but no provider key (M5 no-credentials)', async () => {
       routableResolve();
       const failed = fwd(400);

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -710,7 +710,7 @@ export class ProxyService {
     const originalModel = originalForward.wireRequestBody?.model;
     const healedModel = typeof healedBody.model === 'string' ? healedBody.model : undefined;
     if (healedModel && healedModel !== originalModel) {
-      return this.forwardResolvedHealed(healedBody, ctx);
+      return this.forwardResolvedHealed(healedBody, originalForward, ctx);
     }
     return this.fallbackService.retryWireBody(originalForward, healedBody, {
       provider: ctx.provider,
@@ -724,6 +724,7 @@ export class ProxyService {
 
   private async forwardResolvedHealed(
     healedBody: Record<string, unknown>,
+    originalForward: ForwardResult,
     ctx: HealedReforwardContext,
   ): Promise<ForwardResult> {
     const resolveChatBody = this.createChatBodyResolver(ctx.apiMode, healedBody);
@@ -738,13 +739,27 @@ export class ProxyService {
       ctx.apiMode,
     );
     const route = resolved.route;
-    if (!route) return this.autofixReforwardError('no route resolved for the healed model');
+    if (!route) {
+      return this.retryHealedOnOriginalTransport(
+        healedBody,
+        originalForward,
+        ctx,
+        'no route resolved for the healed model',
+      );
+    }
     const credentials = await this.resolveCredentials(ctx.agentId, ctx.tenantId, {
       provider: route.provider,
       auth_type: route.authType,
       provider_key_label: route.keyLabel ?? undefined,
     });
-    if (!credentials.ok) return this.autofixReforwardError('no provider key for the healed model');
+    if (!credentials.ok) {
+      return this.retryHealedOnOriginalTransport(
+        healedBody,
+        originalForward,
+        ctx,
+        'no provider key for the healed model',
+      );
+    }
     const model = normalizeProviderModel(route.provider, route.model);
     const explicitModelOverride = resolved.explicit_model_override === true;
     const scopeKey = modelParamsScopeForRouting({
@@ -777,6 +792,35 @@ export class ProxyService {
       reasoningContentLookup: ctx.reasoningContentLookup,
       paramMergeContext: explicitModelOverride ? undefined : { agentId: ctx.agentId, scopeKey },
       tenantProviderId: credentials.tenantProviderId,
+      startProviderAttempt: ctx.startProviderAttempt,
+    });
+  }
+
+  /**
+   * The healed model didn't re-resolve for this tenant — usually a stale
+   * `cached_models` snapshot, not a genuinely missing provider: the original
+   * request already reached a provider over a working connection. Retry the
+   * healed body on that same transport and let the provider judge the model,
+   * instead of synthesizing a 502 the caller can't act on. Only a
+   * Manifest-blocked original (no wire transport to reuse) keeps the
+   * synthetic 502.
+   */
+  private retryHealedOnOriginalTransport(
+    healedBody: Record<string, unknown>,
+    originalForward: ForwardResult,
+    ctx: HealedReforwardContext,
+    reason: string,
+  ): Promise<ForwardResult> {
+    if (!originalForward.retryWireBody) {
+      return Promise.resolve(this.autofixReforwardError(reason));
+    }
+    const healedModel = typeof healedBody.model === 'string' ? healedBody.model : ctx.model;
+    return this.fallbackService.retryWireBody(originalForward, healedBody, {
+      provider: ctx.provider,
+      model: healedModel,
+      signal: ctx.signal,
+      authType: ctx.authType,
+      tenantProviderId: ctx.tenantProviderId,
       startProviderAttempt: ctx.startProviderAttempt,
     });
   }


### PR DESCRIPTION
### ✨ What changed
- When an Auto-fix healed model does not re-resolve (no route or no provider key), the retry now goes out on the original forward's provider transport with the healed body, instead of returning a synthetic 502.
- The synthetic 502 remains only when the original never reached a provider, so no provider call is invented.

### 💭 Why
Route resolution rejects healed models missing from the tenant's cached_models even when the provider serves them (stale catalog). Since launch, 2,821 healed retries died on `Auto-fix: no route resolved for the healed model` without any provider being contacted. The original transport is already proven, and the provider is authoritative on whether the model exists, same reasoning as #2639 for direct calls.

### 👤 For users
Auto-fix remaps to valid models now succeed instead of failing with an opaque 502, and bad remaps surface the provider's real error, which Phoenix can adjudicate honestly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-fix now retries healed models on the original provider transport when re-resolve fails (no route or no provider key), avoiding opaque 502s and letting the provider return the real error.

- **Bug Fixes**
  - Implemented `retryHealedOnOriginalTransport` and updated `ProxyService` to use it; retries on the original provider transport when the healed model can’t re-resolve or lacks credentials, and keeps a synthetic 502 only when the original had no wire transport.
  - Defaults the pinned retry to the original model when the healed body omits `model`; added tests for no-route, no-credentials, and missing-model cases.
  - Published a patch changeset for `manifest`.

<sup>Written for commit 5ff8c384dcca0571e5a5c7a453063013342e337c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

