### PR TITLE
feat: request message drawer improvements

### DIFF
--- a/.changeset/request-drawer-improvements.md
+++ b/.changeset/request-drawer-improvements.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Improve request message drawer: markdown rendering, JSON syntax highlighting, gear icon for tool calls, wider drawer, Tools tab shows called and available tools separately.

--- a/packages/frontend/src/components/JsonBlock.tsx
+++ b/packages/frontend/src/components/JsonBlock.tsx
@@ -1,0 +1,43 @@
+import { Show, type Component } from 'solid-js';
+import { highlight } from '../services/syntax-highlight.js';
+
+const MAX_HIGHLIGHT_BYTES = 50_000;
+
+function serialize(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+interface Props {
+  value: unknown;
+  class?: string;
+}
+
+const JsonBlock: Component<Props> = (props) => {
+  const json = () => serialize(props.value);
+  const tooLarge = () => json().length > MAX_HIGHLIGHT_BYTES;
+  const html = () => (tooLarge() ? null : highlight(json(), 'json'));
+  const kb = () => Math.round(json().length / 1024);
+
+  return (
+    <div class={`json-block-wrap${props.class ? ` ${props.class}` : ''}`}>
+      <Show when={tooLarge()}>
+        <div class="json-block__size-notice">
+          Highlighting skipped — payload is {kb()} KB. Showing plain text.
+        </div>
+      </Show>
+      <pre class="json-block">
+        {html() != null ? (
+          <code class="hljs language-json" innerHTML={html()!} />
+        ) : (
+          <code class="hljs">{json()}</code>
+        )}
+      </pre>
+    </div>
+  );
+};
+
+export default JsonBlock;

--- a/packages/frontend/src/components/RequestMessages.tsx
+++ b/packages/frontend/src/components/RequestMessages.tsx
@@ -9,6 +9,8 @@ import {
   type ToolCall,
 } from 'manifest-shared';
 import type { AttemptRecording } from '../services/api/messages.js';
+import MarkdownContent from './playground/MarkdownContent.js';
+import JsonBlock from './JsonBlock.js';
 
 type Recording = AttemptRecording;
 export type RecordingView = 'messages' | 'tools' | 'raw';
@@ -87,6 +89,16 @@ const MessageTurn: Component<{
   const role = () => normalizeRole(props.message.role);
   const content = () => coerceContentToText(props.message.content);
   const toolCalls = () => props.message.tool_calls ?? [];
+
+  const parsedJson = () => {
+    const text = content().trim();
+    if (!text.startsWith('{') && !text.startsWith('[')) return null;
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      return null;
+    }
+  };
   const preview = () => previewStr(content());
   const isCappable = () => content().length > CAP_CHARS || toolCalls().length > 3;
 
@@ -138,7 +150,11 @@ const MessageTurn: Component<{
           classList={{ 'request-message__body--capped': isCappable() && capped() }}
         >
           <Show when={content()}>
-            <div class="request-message__content">{content()}</div>
+            {parsedJson() != null ? (
+              <JsonBlock class="request-message__content" value={parsedJson()} />
+            ) : (
+              <MarkdownContent class="request-message__content" text={content()} />
+            )}
           </Show>
           <Show when={toolCalls().length > 0}>
             <ToolCalls calls={toolCalls()} />
@@ -392,11 +408,11 @@ const RequestMessages: Component<{ recording: Recording | null; view?: Recording
               <div class="request-messages__raw">
                 <section>
                   <h4>Request</h4>
-                  <pre>{pretty(recording().request_body)}</pre>
+                  <JsonBlock value={recording().request_body} />
                 </section>
                 <section>
                   <h4>Response</h4>
-                  <pre>{pretty(recording().response_body)}</pre>
+                  <JsonBlock value={recording().response_body} />
                 </section>
               </div>
             </div>

--- a/packages/frontend/src/components/RequestMessages.tsx
+++ b/packages/frontend/src/components/RequestMessages.tsx
@@ -1,10 +1,12 @@
 import { For, Show, createMemo, createSignal, onCleanup, type Component } from 'solid-js';
+import { Portal } from 'solid-js/web';
 import {
   coerceContentToText,
   extractRecordedConversationMessages,
-  extractResponseToolCalls,
+  extractRequestTools,
   normalizeRole,
   type ChatMessage,
+  type ChatTool,
   type Role,
   type ToolCall,
 } from 'manifest-shared';
@@ -54,22 +56,71 @@ function approxTokens(text: string): number {
   return Math.max(1, Math.round(text.length / 4));
 }
 
+const TruncatedId: Component<{ id: string }> = (props) => {
+  const [pos, setPos] = createSignal<{ top: number; left: number } | null>(null);
+  let ref: HTMLElement | undefined;
+
+  const show = () => {
+    if (!ref) return;
+    const r = ref.getBoundingClientRect();
+    setPos({ top: r.top - 8, left: r.left + r.width / 2 });
+  };
+  const hide = () => setPos(null);
+  onCleanup(hide);
+
+  return (
+    <code
+      ref={ref}
+      class="request-messages__tool-id"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+    >
+      {props.id}
+      <Show when={pos()}>
+        <Portal>
+          <span
+            class="info-tooltip__bubble"
+            role="tooltip"
+            style={{
+              position: 'fixed',
+              top: `${pos()!.top}px`,
+              left: `${pos()!.left}px`,
+              transform: 'translate(-50%, -100%)',
+              'font-family': 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+              'word-break': 'break-all',
+              'max-width': '320px',
+            }}
+          >
+            {props.id}
+          </span>
+        </Portal>
+      </Show>
+    </code>
+  );
+};
+
+const ToolIcon = () => (
+  <span class="request-messages__tool-icon" aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M12 15.5A3.5 3.5 0 0 1 8.5 12 3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5 3.5 3.5 0 0 1-3.5 3.5m7.43-2.92c.04-.3.07-.61.07-.93s-.03-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.3-.07.62-.07.94s.03.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.21.07-.47-.12-.61l-2.01-1.58z" />
+    </svg>
+  </span>
+);
+
 const ToolCalls: Component<{ calls: ToolCall[] }> = (props) => (
   <div class="request-messages__tool-calls">
     <For each={props.calls}>
       {(call) => (
         <div class="request-messages__tool-call">
           <div class="request-messages__tool-call-head">
-            <span class="request-messages__tool-icon" aria-hidden="true">
-              ↳
-            </span>
-            <strong>{call.function?.name ?? 'Unknown tool'}</strong>
+            <ToolIcon />
+            <strong class="request-messages__tool-name">{call.function?.name ?? 'Unknown tool'}</strong>
             <Show when={call.id}>
-              <code>{call.id}</code>
+              <TruncatedId id={call.id!} />
             </Show>
           </div>
           <Show when={call.function?.arguments != null}>
-            <pre>{pretty(call.function?.arguments)}</pre>
+            <JsonBlock value={toolArguments(call.function?.arguments)} />
           </Show>
         </div>
       )}
@@ -342,7 +393,10 @@ const RequestMessages: Component<{ recording: Recording | null; view?: Recording
         )
       : [],
   );
-  const toolCalls = createMemo(() => extractResponseToolCalls(props.recording?.response_body));
+  const toolCalls = createMemo(() => messages().flatMap((m) => m.tool_calls ?? []));
+  const availableTools = createMemo(() =>
+    props.recording ? extractRequestTools(props.recording.request_body) : [],
+  );
 
   return (
     <Show
@@ -374,32 +428,82 @@ const RequestMessages: Component<{ recording: Recording | null; view?: Recording
 
           <Show when={view() === 'tools'}>
             <div class="request-messages__scroll-area">
-              <Show
-                when={toolCalls().length > 0}
-                fallback={<div class="request-messages__empty">No tools were called.</div>}
-              >
-                <div class="request-messages__tools">
-                  <For each={toolCalls()}>
-                    {(call) => (
-                      <article class="request-tool">
-                        <div class="request-tool__head">
-                          <span class="request-messages__tool-icon" aria-hidden="true">
-                            ↳
-                          </span>
-                          <strong>{call.function?.name ?? 'Unknown tool'}</strong>
-                          <span class="request-tool__type">{call.type ?? 'function'}</span>
-                          <Show when={call.id}>
-                            <code>{call.id}</code>
-                          </Show>
-                        </div>
-                        <Show when={call.function?.arguments != null}>
-                          <pre>{pretty(toolArguments(call.function?.arguments))}</pre>
-                        </Show>
-                      </article>
-                    )}
-                  </For>
-                </div>
-              </Show>
+              <div class="request-messages__tools-page">
+                {/* Called tools */}
+                <section class="request-tools-section">
+                  <h4 class="request-tools-section__title">
+                    Called
+                    <span class="request-tools-section__count">{toolCalls().length}</span>
+                  </h4>
+                  <Show
+                    when={toolCalls().length > 0}
+                    fallback={
+                      <div class="request-messages__empty request-messages__empty--sm">
+                        No tools were called in this conversation.
+                      </div>
+                    }
+                  >
+                    <div class="request-messages__tools">
+                      <For each={toolCalls()}>
+                        {(call) => (
+                          <article class="request-tool">
+                            <div class="request-tool__head">
+                              <ToolIcon />
+                              <strong class="request-messages__tool-name">
+                                {call.function?.name ?? 'Unknown tool'}
+                              </strong>
+                              <span class="request-tool__type">{call.type ?? 'function'}</span>
+                              <Show when={call.id}>
+                                <TruncatedId id={call.id!} />
+                              </Show>
+                            </div>
+                            <Show when={call.function?.arguments != null}>
+                              <JsonBlock value={toolArguments(call.function?.arguments)} />
+                            </Show>
+                          </article>
+                        )}
+                      </For>
+                    </div>
+                  </Show>
+                </section>
+
+                {/* Available tools */}
+                <section class="request-tools-section">
+                  <h4 class="request-tools-section__title">
+                    Available
+                    <span class="request-tools-section__count">{availableTools().length}</span>
+                  </h4>
+                  <Show
+                    when={availableTools().length > 0}
+                    fallback={
+                      <div class="request-messages__empty request-messages__empty--sm">
+                        No tools were offered in this request.
+                      </div>
+                    }
+                  >
+                    <div class="request-messages__tools">
+                      <For each={availableTools()}>
+                        {(tool: ChatTool) => (
+                          <article class="request-tool request-tool--available">
+                            <div class="request-tool__head">
+                              <strong class="request-messages__tool-name">
+                                {tool.function?.name ?? 'Unknown tool'}
+                              </strong>
+                              <span class="request-tool__type">{tool.type ?? 'function'}</span>
+                            </div>
+                            <Show when={tool.function?.description}>
+                              <p class="request-tool__description">{tool.function!.description}</p>
+                            </Show>
+                            <Show when={tool.function?.parameters != null}>
+                              <JsonBlock value={tool.function?.parameters} />
+                            </Show>
+                          </article>
+                        )}
+                      </For>
+                    </div>
+                  </Show>
+                </section>
+              </div>
             </div>
           </Show>
 

--- a/packages/frontend/src/styles/request-drawer.css
+++ b/packages/frontend/src/styles/request-drawer.css
@@ -720,8 +720,95 @@
   color: hsl(var(--foreground));
   font-size: var(--font-size-sm);
   line-height: 1.6;
-  white-space: pre-wrap;
   word-break: break-word;
+}
+.request-message__content > :first-child {
+  margin-top: 0;
+}
+.request-message__content > :last-child {
+  margin-bottom: 0;
+}
+.request-message__content p {
+  margin: 0 0 10px;
+}
+.request-message__content h1,
+.request-message__content h2,
+.request-message__content h3,
+.request-message__content h4,
+.request-message__content h5,
+.request-message__content h6 {
+  margin: 14px 0 6px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: hsl(var(--foreground));
+}
+.request-message__content h1 { font-size: 17px; }
+.request-message__content h2 { font-size: 15px; }
+.request-message__content h3 { font-size: 13px; }
+.request-message__content h4,
+.request-message__content h5,
+.request-message__content h6 { font-size: 12px; }
+.request-message__content strong { font-weight: 600; }
+.request-message__content em { font-style: italic; }
+.request-message__content ul,
+.request-message__content ol {
+  margin: 0 0 10px;
+  padding-left: 20px;
+}
+.request-message__content li { margin: 2px 0; }
+.request-message__content li > p { margin: 0; }
+.request-message__content a {
+  color: hsl(var(--primary));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.request-message__content blockquote {
+  margin: 0 0 10px;
+  padding: 4px 12px;
+  border-left: 3px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+}
+.request-message__content code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  background: hsl(var(--muted));
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.request-message__content pre {
+  margin: 0 0 10px;
+  padding: 10px 12px;
+  background: hsl(var(--muted));
+  border-radius: var(--radius);
+  overflow-x: auto;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.request-message__content pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+.request-message__content hr {
+  border: 0;
+  border-top: 1px solid hsl(var(--border));
+  margin: 14px 0;
+}
+.request-message__content table {
+  border-collapse: collapse;
+  margin: 0 0 10px;
+  font-size: 12px;
+}
+.request-message__content th,
+.request-message__content td {
+  border: 1px solid hsl(var(--border));
+  padding: 4px 8px;
+  text-align: left;
+}
+.request-message__content th {
+  background: hsl(var(--muted));
+  font-weight: 600;
 }
 .request-messages__tool-calls {
   display: flex;
@@ -840,4 +927,75 @@
     padding: 6px 10px;
     border-radius: 8px;
   }
+}
+
+/* ── JsonBlock ── */
+.json-block-wrap {
+  display: flex;
+  flex-direction: column;
+}
+.json-block__size-notice {
+  padding: 4px 10px;
+  font-size: 11px;
+  color: hsl(var(--muted-foreground));
+  background: hsl(var(--muted) / 0.4);
+  border-bottom: 1px solid hsl(var(--border) / 0.4);
+}
+.json-block {
+  margin: 0;
+  padding: 12px 14px;
+  background: hsl(var(--muted) / 0.6);
+  border: 1px solid hsl(var(--border) / 0.5);
+  border-radius: var(--radius);
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+}
+.json-block code {
+  background: transparent;
+  padding: 0;
+  font-size: inherit;
+  font-family: inherit;
+}
+.request-message__content .json-block-wrap .json-block {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background: hsl(var(--muted) / 0.4);
+}
+.request-messages__raw .json-block-wrap .json-block {
+  border-radius: var(--radius-sm);
+}
+
+/* ── JSON-specific token colors ── */
+/* Keys get a distinct teal so they pop from string values */
+.hljs-attr {
+  color: hsl(187 60% 38%);
+  font-weight: 500;
+}
+.dark .hljs-attr {
+  color: hsl(187 70% 58%);
+}
+/* String values: warm amber, visually separate from keys */
+.language-json .hljs-string {
+  color: hsl(24 80% 44%);
+}
+.dark .language-json .hljs-string {
+  color: hsl(24 90% 65%);
+}
+/* Numbers */
+.language-json .hljs-number {
+  color: hsl(260 60% 52%);
+}
+.dark .language-json .hljs-number {
+  color: hsl(260 80% 75%);
+}
+/* true / false / null */
+.language-json .hljs-literal {
+  color: hsl(340 65% 45%);
+  font-weight: 500;
+}
+.dark .language-json .hljs-literal {
+  color: hsl(340 75% 68%);
 }

--- a/packages/frontend/src/styles/request-drawer.css
+++ b/packages/frontend/src/styles/request-drawer.css
@@ -385,6 +385,56 @@
   flex-direction: column;
   gap: 10px;
 }
+.request-messages__tools-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 14px;
+}
+.request-tools-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.request-tools-section__title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.request-tools-section__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9999px;
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+.request-tool--available .request-tool__head {
+  background: transparent;
+}
+.request-tool__description {
+  margin: 0;
+  padding: 0 10px 8px 10px;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+}
+.request-messages__empty--sm {
+  padding: 10px 0;
+  font-size: var(--font-size-xs);
+}
 
 /* ── Conversation split (rail + resize handle + turns) ── */
 .conv-split {
@@ -716,7 +766,7 @@
   text-decoration: underline;
 }
 .request-message__content {
-  padding: 12px;
+  padding: 0;
   color: hsl(var(--foreground));
   font-size: var(--font-size-sm);
   line-height: 1.6;
@@ -776,14 +826,17 @@
   border-radius: 4px;
 }
 .request-message__content pre {
-  margin: 0 0 10px;
+  margin: 6px 0;
   padding: 10px 12px;
-  background: hsl(var(--muted));
-  border-radius: var(--radius);
+  background: hsl(var(--muted) / 0.7);
+  border: 1px solid hsl(var(--border) / 0.5);
+  border-radius: var(--radius-sm);
   overflow-x: auto;
   font-size: 12px;
   line-height: 1.5;
 }
+.request-message__content > pre:first-child { margin-top: 0; }
+.request-message__content > pre:last-child { margin-bottom: 0; }
 .request-message__content pre code {
   background: transparent;
   padding: 0;
@@ -830,17 +883,37 @@
   padding: 8px 10px;
   color: hsl(var(--foreground));
   font-size: var(--font-size-xs);
+  overflow: hidden;
+  min-width: 0;
+}
+.request-messages__tool-name {
+  flex-shrink: 0;
+  max-width: 50%;
+}
+.request-messages__tool-id {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex-shrink: 1;
+  cursor: default;
+  color: hsl(var(--muted-foreground));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
 }
 .request-messages__tool-icon {
   display: inline-grid;
+  flex-shrink: 0;
   width: 20px;
   height: 20px;
   place-items: center;
   border-radius: 5px;
   background: hsl(36 80% 50% / 0.14);
   color: hsl(36 80% 40%);
-  font-family: var(--font-mono);
-  font-weight: 700;
+}
+.request-messages__tool-icon svg {
+  width: 14px;
+  height: 14px;
 }
 .request-tool__type {
   margin-left: auto;
@@ -848,7 +921,7 @@
   font-family: var(--font-mono);
   font-size: 10px;
 }
-.request-tool p {
+.request-tool p:not(.request-tool__description) {
   margin: 0;
   padding: 0 10px 10px 37px;
   color: hsl(var(--muted-foreground));
@@ -966,6 +1039,13 @@
 }
 .request-messages__raw .json-block-wrap .json-block {
   border-radius: var(--radius-sm);
+}
+.request-messages__tool-call .json-block-wrap .json-block,
+.request-tool .json-block-wrap .json-block {
+  border: none;
+  border-top: 1px solid hsl(36 80% 50% / 0.2);
+  border-radius: 0;
+  background: hsl(36 80% 50% / 0.04);
 }
 
 /* ── JSON-specific token colors ── */

--- a/packages/frontend/src/styles/request-drawer.css
+++ b/packages/frontend/src/styles/request-drawer.css
@@ -6,8 +6,8 @@
   right: 0;
   bottom: 0;
   width: 55%;
-  min-width: 600px;
-  max-width: 1284px;
+  min-width: 650px;
+  max-width: 1334px;
   background: hsl(var(--card));
   border-left: 1px solid hsl(var(--border));
   z-index: 200;

--- a/packages/frontend/tests/components/RequestMessages.test.tsx
+++ b/packages/frontend/tests/components/RequestMessages.test.tsx
@@ -32,7 +32,7 @@ describe('RequestMessages', () => {
     expect(getAllByText('Sunny.')).toHaveLength(2);
   });
 
-  it('shows only tool calls emitted by the selected attempt', () => {
+  it('shows called and available tools in the tools tab', () => {
     const calledRecording = {
       ...recording,
       response_body: {
@@ -56,13 +56,17 @@ describe('RequestMessages', () => {
         },
       },
     };
-    const { getByText, queryByText } = render(() => (
+    const { getAllByText, getByText } = render(() => (
       <RequestMessages recording={calledRecording} view="tools" />
     ));
-    expect(getByText('weather')).toBeTruthy();
+    // 'weather' appears once in Called and once in Available
+    expect(getAllByText('weather')).toHaveLength(2);
     expect(getByText('call-1')).toBeTruthy();
-    expect(getByText(/"city": "Paris"/)).toBeTruthy();
-    expect(queryByText('Read the forecast')).toBeNull();
+    // JSON arguments are syntax-highlighted (hljs splits across spans), check body text
+    expect(document.body.textContent).toContain('"city"');
+    expect(document.body.textContent).toContain('"Paris"');
+    // Available section shows the tool description
+    expect(getByText('Read the forecast')).toBeTruthy();
   });
 
   it('shows raw payloads when view is raw', () => {
@@ -102,7 +106,9 @@ describe('RequestMessages', () => {
     // Turns are open by default — tool call content is already visible.
     expect(getByText('Unknown tool')).toBeTruthy();
     expect(getAllByText('call-1')).toHaveLength(2);
-    expect(getByText('[object Object]')).toBeTruthy();
+    // Circular reference serialises to '[object Object]' which hljs may split across spans;
+    // verify the text is present anywhere in the rendered output.
+    expect(document.body.textContent).toContain('[object Object]');
     expect(getAllByText('Tool complete')).toHaveLength(2);
   });
 
@@ -120,7 +126,7 @@ describe('RequestMessages', () => {
     const { getByText: getText2 } = render(() => (
       <RequestMessages recording={emptyRecording} view="tools" />
     ));
-    expect(getText2('No tools were called.')).toBeTruthy();
+    expect(getText2('No tools were called in this conversation.')).toBeTruthy();
   });
 
   it('explains when recording was disabled', () => {

--- a/packages/frontend/tests/components/RequestMessages.test.tsx
+++ b/packages/frontend/tests/components/RequestMessages.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@solidjs/testing-library';
+import { cleanup, fireEvent, render } from '@solidjs/testing-library';
 import { afterEach, describe, expect, it } from 'vitest';
 import RequestMessages from '../../src/components/RequestMessages';
 
@@ -132,5 +132,38 @@ describe('RequestMessages', () => {
   it('explains when recording was disabled', () => {
     const { getByText } = render(() => <RequestMessages recording={null} />);
     expect(getByText('No messages recorded')).toBeTruthy();
+  });
+
+  it('shows and hides tooltip on TruncatedId hover', () => {
+    const calledRecording = {
+      ...recording,
+      response_body: {
+        type: 'json' as const,
+        body: {
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call-tooltip-test',
+                    type: 'function',
+                    function: { name: 'weather', arguments: '{}' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+    render(() => <RequestMessages recording={calledRecording} view="tools" />);
+    const idEl = document.querySelector('.request-messages__tool-id')!;
+    expect(idEl).toBeTruthy();
+    fireEvent.mouseEnter(idEl);
+    expect(document.querySelector('[role="tooltip"]')).toBeTruthy();
+    fireEvent.mouseLeave(idEl);
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
   });
 });


### PR DESCRIPTION
✨ What changed
- Markdown messages now render with real heading styles, paragraphs and lists instead of raw text
- JSON content in messages, tool arguments and the Raw tab gets syntax highlighting with colors
- Tool calls show a gear icon instead of the arrow character, with a hover tooltip for long call IDs
- Tools tab now shows two sections: called tools (from the full conversation) and available tools (from the request)
- Request detail drawer is 50px wider

💭 Why
The drawer was showing raw text for markdown and unformatted JSON blobs, making it hard to read recorded conversations. The Tools tab only scanned the current response for tool calls, missing any calls from earlier turns in the conversation context.

👤 For users
Recorded message details are easier to read: formatted markdown, colored JSON, clearer tool call display with called vs. available tools separated.

🔧 For operators
No operator impact.

🧪 How to test
1. Open a request detail with recorded messages
2. Check the Messages tab: markdown content renders with headings and paragraphs, JSON blocks have syntax highlighting
3. Open the Tools tab: "Called" section lists tool calls from all conversation turns, "Available" section lists tools declared in the request
4. Hover a tool call ID to see the full ID in a tooltip

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render Markdown and colorized JSON in the request message drawer, with a clearer Tools tab and a wider layout.

- **New Features**
  - Messages render as Markdown; JSON is auto-detected and syntax-highlighted in messages, tool args, and the Raw tab (skip >50 KB with a notice).
  - Tools tab is split into Called (from the conversation) and Available (from the request), each with counts; shows tool types and descriptions.
  - Tool calls use a gear icon; IDs truncate with a hover tooltip to view the full ID.
  - Drawer width increased by 50px.

- **Bug Fixes**
  - Tools tab scans all conversation turns for called tools.
  - Fixed overflow in tool call headers; refined Markdown code block styling and available tool description padding.

<sup>Written for commit af37534e12f339212eb727f4e73be89b13c78f22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

