### PR TITLE
fix: show complete Gemini request messages

### DIFF
--- a/.changeset/show-gemini-request-messages.md
+++ b/.changeset/show-gemini-request-messages.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show complete Gemini request messages, including system instructions.

--- a/packages/shared/__tests__/chat-message.spec.ts
+++ b/packages/shared/__tests__/chat-message.spec.ts
@@ -174,9 +174,12 @@ describe('recorded chat message helpers', () => {
     ]);
   });
 
-  it('reads Gemini contents and normalizes model roles', () => {
+  it('reads Gemini system instructions and normalizes model roles', () => {
     expect(
       extractRequestMessages({
+        systemInstruction: {
+          parts: [{ text: 'Be concise.' }, { text: 'Use metric units.' }],
+        },
         contents: [
           { role: 'model', parts: [{ text: 'Answer' }] },
           { role: 'custom', parts: [{ text: 'Custom' }] },
@@ -185,9 +188,26 @@ describe('recorded chat message helpers', () => {
         ],
       }),
     ).toEqual([
+      { role: 'system', content: 'Be concise.\nUse metric units.' },
       { role: 'assistant', content: [{ text: 'Answer' }] },
       { role: 'custom', content: [{ text: 'Custom' }] },
       { role: 'user', content: [{ text: 'Prompt' }] },
+    ]);
+  });
+
+  it('unwraps Gemini CodeAssist request envelopes', () => {
+    expect(
+      extractRequestMessages({
+        model: 'gemini-2.5-pro',
+        project: 'project-id',
+        request: {
+          systemInstruction: { parts: [{ text: 'Answer in French.' }] },
+          contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+        },
+      }),
+    ).toEqual([
+      { role: 'system', content: 'Answer in French.' },
+      { role: 'user', content: [{ text: 'Hello' }] },
     ]);
   });
 

--- a/packages/shared/src/chat-message.ts
+++ b/packages/shared/src/chat-message.ts
@@ -201,11 +201,17 @@ export function extractRequestMessages(
   requestBody: Record<string, unknown> | null | undefined,
 ): ChatMessage[] {
   if (!requestBody) return [];
+  if (isRecord(requestBody.request) && Array.isArray(requestBody.request.contents)) {
+    requestBody = requestBody.request;
+  }
   const messages: ChatMessage[] = [];
 
   if (requestBody.system != null) messages.push(...systemMessages(requestBody.system));
   if (typeof requestBody.instructions === 'string' && requestBody.instructions.trim()) {
     messages.push({ role: 'system', content: requestBody.instructions });
+  }
+  if (isRecord(requestBody.systemInstruction)) {
+    messages.push(...systemMessages(requestBody.systemInstruction.parts));
   }
 
   if (Array.isArray(requestBody.messages)) {


### PR DESCRIPTION
### ✨ What changed
- Parse Gemini system instructions in recorded Provider Attempts.
- Unwrap Gemini CodeAssist request envelopes.

### 💭 Why
Gemini recordings showed streamed responses but omitted system prompts. CodeAssist attempts omitted the request conversation.

### 👤 For users
Provider Attempt messages now show the complete Gemini conversation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show complete Gemini request conversations in Provider Attempt recordings by parsing system instructions and unwrapping CodeAssist request envelopes. Fixes missing system prompts and incomplete conversations for Gemini models.

- **Bug Fixes**
  - Parse `systemInstruction.parts` into system messages.
  - Unwrap CodeAssist `request` envelope to read `contents`.
  - Add tests in `packages/shared/__tests__/chat-message.spec.ts`.

<sup>Written for commit 5ed9c1bdaed13e4538fc41a857e1ccde5277b1ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

