### PR TITLE
fix: always report autofix retry outcomes to Phoenix

### DIFF
--- a/.changeset/autofix-outcome-delivery.md
+++ b/.changeset/autofix-outcome-delivery.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Auto-fix always closes the evidence loop with Phoenix: a retry that dies mid-flight is reported as a synthetic 499 instead of leaving the heal attempt pending, and a dropped outcome report is resent before giving up

--- a/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
+++ b/packages/backend/src/routing/autofix/__tests__/autofix.service.spec.ts
@@ -32,7 +32,8 @@ type HealingClientMock = {
 function makeHealingClient(): HealingClientMock {
   return {
     heal: jest.fn(),
-    reportOutcome: jest.fn().mockResolvedValue(null),
+    // A landed report (null means "didn't reach Phoenix" and triggers resends).
+    reportOutcome: jest.fn().mockResolvedValue({ healAttemptId: 'heal-1', status: 'succeeded' }),
   };
 }
 
@@ -1106,23 +1107,75 @@ describe('AutofixService', () => {
   // reportOutcome — fire-and-forget error handling
   // -------------------------------------------------------------------------
   describe('reportOutcome fire-and-forget', () => {
-    it('does not throw out of maybeHeal when reportOutcome rejects', async () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('does not throw out of maybeHeal when reportOutcome rejects, and resends', async () => {
+      jest.useFakeTimers();
       const client = makeHealingClient();
       client.heal.mockResolvedValue(patchedHeal());
       client.reportOutcome.mockRejectedValueOnce(new Error('report exploded'));
       const reforward = jest.fn().mockResolvedValue(makeForward('{"ok":true}', 200));
       const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
-      // Silence the expected "reportOutcome ... failed" warning from the .catch handler.
+      // Silence the expected "reportOutcome ... failed" warning from the catch.
       jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
       const service = makeService({ client: client as unknown as HealingClient, repo });
 
-      // Should resolve normally (the .catch handles the rejection).
+      // Should resolve normally (the delivery loop handles the rejection).
       const result = await service.maybeHeal(makeParams({ reforward }));
       expect(result!.record.outcome).toBe('healed');
 
-      // Let the fire-and-forget .catch run; must not surface as an unhandled rejection.
-      await flushMicrotasks();
+      // Let the fire-and-forget catch run; must not surface as an unhandled rejection.
+      await jest.advanceTimersByTimeAsync(0);
       expect(client.reportOutcome).toHaveBeenCalledWith('heal-1', { retryStatusCode: 200 });
+
+      // The rejected send is retried after the first resend delay and lands.
+      await jest.advanceTimersByTimeAsync(1_000);
+      expect(client.reportOutcome).toHaveBeenCalledTimes(2);
+    });
+
+    it('resends a report the healer dropped, then stops once it lands', async () => {
+      jest.useFakeTimers();
+      const client = makeHealingClient();
+      client.heal.mockResolvedValue(patchedHeal());
+      // null = the PATCH did not land (transport failure or non-2xx).
+      client.reportOutcome
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ healAttemptId: 'heal-1', status: 'succeeded' });
+      const reforward = jest.fn().mockResolvedValue(makeForward('{"ok":true}', 200));
+      const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
+      const service = makeService({ client: client as unknown as HealingClient, repo });
+
+      await service.maybeHeal(makeParams({ reforward }));
+      expect(client.reportOutcome).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(1_000);
+      expect(client.reportOutcome).toHaveBeenCalledTimes(2);
+
+      // Landed on the second send — the schedule stops, no further resends.
+      await jest.advanceTimersByTimeAsync(60_000);
+      expect(client.reportOutcome).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up once the resend schedule is exhausted', async () => {
+      jest.useFakeTimers();
+      const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+      const client = makeHealingClient();
+      client.heal.mockResolvedValue(patchedHeal());
+      client.reportOutcome.mockResolvedValue(null);
+      const reforward = jest.fn().mockResolvedValue(makeForward('{"ok":true}', 200));
+      const { repo } = makeAgentRepo(() => ({ autofix_enabled: true }));
+      const service = makeService({ client: client as unknown as HealingClient, repo });
+
+      await service.maybeHeal(makeParams({ reforward }));
+      await jest.advanceTimersByTimeAsync(1_000);
+      await jest.advanceTimersByTimeAsync(5_000);
+      await jest.advanceTimersByTimeAsync(60_000);
+
+      // Initial send + one resend per schedule slot, then a loud give-up.
+      expect(client.reportOutcome).toHaveBeenCalledTimes(3);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('giving up after 3 sends'));
     });
   });
 
@@ -1167,8 +1220,16 @@ describe('AutofixService', () => {
       expect(result!.record.chain[0].patch_worked).toBe(false);
       expect(typeof result!.record.groupId).toBe('string');
 
-      // A reforward (provider) failure is not a Phoenix failure — no outcome report.
-      expect(client.reportOutcome).not.toHaveBeenCalled();
+      // The evidence loop still closes: a dead retry has no provider status to
+      // send, so the death is reported as a synthetic 499 — otherwise the served
+      // attempt dangles `pending` until Phoenix's sweeper expires it.
+      expect(client.reportOutcome).toHaveBeenCalledWith('heal-1', {
+        retryStatusCode: 499,
+        error: {
+          message: 'patched retry never completed: socket hang up',
+          type: 'retry_not_completed',
+        },
+      });
 
       // The returned forward is the rebuilt original — still readable downstream.
       expect(result!.forward.response.status).toBe(400);

--- a/packages/backend/src/routing/autofix/autofix.service.ts
+++ b/packages/backend/src/routing/autofix/autofix.service.ts
@@ -54,6 +54,13 @@ const CONFIG_CACHE_MAX = 5_000;
 // repairable 4xx BEFORE the fallback chain (the next safety net) gets to run.
 const HEAL_FAILURE_THRESHOLD = 3;
 const BREAKER_COOLDOWN_MS = 30_000;
+/**
+ * Delays between outcome-report resends. A lost report leaves the heal attempt
+ * dangling `pending` on Phoenix until a sweeper expires it an hour later — the
+ * adjudication evidence is gone for good — so a transient failure gets spaced
+ * resends before we give up.
+ */
+const OUTCOME_RESEND_DELAYS_MS = [1_000, 5_000];
 
 function parseStatuses(raw: string | undefined): Set<number> {
   const source = raw && raw.trim().length > 0 ? raw : DEFAULT_REPAIRABLE_STATUSES;
@@ -454,13 +461,24 @@ export class AutofixService {
     try {
       next = await params.reforward(healedBody);
     } catch (err) {
-      // The patched resend threw (a provider transport error, NOT a Phoenix
-      // failure — so it must not trip the heal breaker). Preserve the audit chain
-      // (the original error plus the Phoenix issue/patch ids already stamped on
-      // `entry`) instead of dropping it, and degrade to the original provider
-      // error; the fallback chain is the next safety net.
+      // The patched resend threw (a provider transport error or the caller
+      // aborting mid-retry, NOT a Phoenix failure — so it must not trip the
+      // heal breaker). Preserve the audit chain (the original error plus the
+      // Phoenix issue/patch ids already stamped on `entry`) instead of dropping
+      // it, and degrade to the original provider error; the fallback chain is
+      // the next safety net. Still close the evidence loop: without a report
+      // the served attempt dangles `pending` until Phoenix's sweeper expires
+      // it, so the death is reported as a synthetic 499 (retry never completed
+      // — no provider status exists to send).
       this.logger.warn(`autofix reforward failed, using original error: ${(err as Error).message}`);
       entry.patch_worked = false;
+      this.reportOutcome(healAttemptId, {
+        retryStatusCode: 499,
+        error: {
+          message: `patched retry never completed: ${(err as Error).message}`,
+          type: 'retry_not_completed',
+        },
+      });
       return {
         forward: originalForward,
         record: { groupId, outcome: 'unfixable', original_http_status: status, chain },
@@ -537,8 +555,29 @@ export class AutofixService {
 
   /** Fire-and-forget the learning signal so it never delays the client. */
   private reportOutcome(healAttemptId: string, outcome: HealOutcome): void {
-    void this.client.reportOutcome(healAttemptId, outcome).catch((err: unknown) => {
-      this.logger.warn(`reportOutcome ${healAttemptId} failed: ${(err as Error).message}`);
-    });
+    void this.deliverOutcome(healAttemptId, outcome);
+  }
+
+  /**
+   * Deliver the outcome report, resending when it didn't land. The client
+   * resolves `null` for a report that never reached Phoenix (transport failure
+   * or a non-2xx), and an unreported attempt costs the adjudication evidence —
+   * Phoenix can only expire it. Spaced resends ride out a blip; only a process
+   * death still loses a report.
+   */
+  private async deliverOutcome(healAttemptId: string, outcome: HealOutcome): Promise<void> {
+    for (let send = 0; ; send++) {
+      try {
+        if ((await this.client.reportOutcome(healAttemptId, outcome)) !== null) return;
+      } catch (err) {
+        this.logger.warn(`reportOutcome ${healAttemptId} failed: ${(err as Error).message}`);
+      }
+      const delay = OUTCOME_RESEND_DELAYS_MS[send];
+      if (delay === undefined) {
+        this.logger.warn(`reportOutcome ${healAttemptId}: giving up after ${send + 1} sends`);
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
   }
 }


### PR DESCRIPTION
### ✨ What changed
- When the patched resend throws (provider transport death or the caller aborting mid-retry), Manifest now reports a synthetic 499 outcome (`retry_not_completed`) to Phoenix instead of reporting nothing.
- The outcome report is no longer one-shot: a report the healer dropped (transport failure or non-2xx) is resent after 1s and 5s before giving up loudly.

### 💭 Why
A served heal attempt with no outcome report dangles `pending` on Phoenix until a sweeper expires it an hour later, and the adjudication evidence is gone for good. In production 127 of the 132 expired attempts since launch came from one issue whose interactive callers aborted mid-retry, hitting the reforward catch that skipped reporting. The only remaining loss is a process death between retry and report.

### 👤 For users
Phoenix's heal metrics stop under-counting: every served fix gets a verdict, so patch quality is judged on complete evidence instead of losing the retries that died in flight.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always report autofix retry outcomes to Phoenix. If the patched resend dies or the caller aborts, we send a synthetic 499 (`retry_not_completed`) and retry dropped reports before giving up.

- **Bug Fixes**
  - Resend outcome reports after 1s and 5s when delivery didn’t land; log and stop after 3 sends.
  - Deliver `reportOutcome` in the background so `maybeHeal` never throws on report failures.
  - Send synthetic 499 when a retry never completes to close the evidence loop.
  - Added tests for resend behavior and 499 reporting.

<sup>Written for commit 7c93ae9782bf7277528d339405518fa4c5051ae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

