### PR TITLE
fix: preserve DeepSeek reasoning tool turns

### DIFF
--- a/.changeset/clean-reasoning-replay.md
+++ b/.changeset/clean-reasoning-replay.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Prepare DeepSeek reasoning tool turns once before each provider attempt.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -405,12 +405,13 @@ describe('provider-client-converters', () => {
       }
     });
 
-    it('re-injects cached reasoning_content for compatible assistant tool-call messages', () => {
+    it('preserves prepared reasoning_content for compatible assistant tool-call messages', () => {
       const body = {
         messages: [
           {
             role: 'assistant',
             content: '',
+            reasoning_content: '',
             tool_calls: [
               {
                 id: 'call_1',
@@ -422,34 +423,13 @@ describe('provider-client-converters', () => {
         ],
       };
 
-      const lookup = jest.fn((id: string) => (id === 'call_1' ? 'cached reasoning' : null));
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat');
       const messages = result.messages as any[];
 
-      expect(lookup).toHaveBeenCalledWith('call_1');
-      expect(messages[0]).toHaveProperty('reasoning_content', 'cached reasoning');
-    });
-
-    it('injects empty reasoning_content for compatible tool-call messages when no reasoning is recoverable', () => {
-      const body = {
-        messages: [
-          {
-            role: 'assistant',
-            content: '',
-            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
-          },
-        ],
-      };
-
-      const lookup = jest.fn(() => null);
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-v4-flash', lookup);
-      const messages = result.messages as any[];
-
-      expect(lookup).toHaveBeenCalledWith('call_1');
       expect(messages[0]).toHaveProperty('reasoning_content', '');
     });
 
-    it('does not map reasoning aliases to reasoning_content for compatible tool-call messages', () => {
+    it('does not map reasoning aliases to reasoning_content during sanitization', () => {
       const body = {
         messages: [
           {
@@ -465,7 +445,7 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-v4-flash');
       const messages = result.messages as any[];
 
-      expect(messages[0]).toHaveProperty('reasoning_content', '');
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
       expect(messages[0]).not.toHaveProperty('reasoning');
       expect(messages[0]).not.toHaveProperty('reasoning_text');
     });
@@ -492,11 +472,11 @@ describe('provider-client-converters', () => {
       const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-v4-flash');
       const messages = result.messages as any[];
 
-      expect(messages[0]).toHaveProperty('reasoning_content', '');
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
       expect(messages[0]).not.toHaveProperty('reasoning_details');
     });
 
-    it('does not re-inject cached reasoning_content for strict providers', () => {
+    it('does not add reasoning_content to strict providers', () => {
       const body = {
         messages: [
           {
@@ -507,11 +487,9 @@ describe('provider-client-converters', () => {
         ],
       };
 
-      const lookup = jest.fn(() => 'cached reasoning');
-      const result = sanitizeOpenAiBody(body, 'mistral', 'mistral-large', lookup);
+      const result = sanitizeOpenAiBody(body, 'mistral', 'mistral-large');
       const messages = result.messages as any[];
 
-      expect(lookup).not.toHaveBeenCalled();
       expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
@@ -536,7 +514,7 @@ describe('provider-client-converters', () => {
       expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
-    it('does not replace existing reasoning_content during re-injection', () => {
+    it('does not replace existing reasoning_content during sanitization', () => {
       const body = {
         messages: [
           {
@@ -548,45 +526,10 @@ describe('provider-client-converters', () => {
         ],
       };
 
-      const lookup = jest.fn(() => 'cached reasoning');
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat');
       const messages = result.messages as any[];
 
-      expect(lookup).not.toHaveBeenCalled();
       expect(messages[0]).toHaveProperty('reasoning_content', 'client reasoning');
-    });
-
-    it('replaces empty reasoning_content with cached reasoning when available', () => {
-      const body = {
-        messages: [
-          {
-            role: 'assistant',
-            content: '',
-            reasoning_content: '',
-            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
-          },
-        ],
-      };
-
-      const lookup = jest.fn(() => 'cached reasoning');
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-v4-flash', lookup);
-      const messages = result.messages as any[];
-
-      expect(lookup).toHaveBeenCalledWith('call_1');
-      expect(messages[0]).toHaveProperty('reasoning_content', 'cached reasoning');
-    });
-
-    it('does not re-inject cached reasoning_content without tool calls', () => {
-      const body = {
-        messages: [{ role: 'assistant', content: 'Hi' }],
-      };
-
-      const lookup = jest.fn(() => 'cached reasoning');
-      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
-      const messages = result.messages as any[];
-
-      expect(lookup).not.toHaveBeenCalled();
-      expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
     /* ── Message sanitization: reasoning_details ── */

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm';
 import type { ModelRoute } from 'manifest-shared';
 import { ProxyFallbackService } from '../proxy-fallback.service';
+import { ReasoningContentCache } from '../reasoning-content-cache';
 import { ProviderKeyService } from '../../routing-core/provider-key.service';
 import { CustomProvider } from '../../../entities/custom-provider.entity';
 import { OpenaiOauthService } from '../../oauth/openai/openai-oauth.service';
@@ -140,6 +141,7 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
         getSpecs: jest.fn().mockResolvedValue([]),
         list: jest.fn().mockResolvedValue([]),
       } as unknown as ProviderParamSpecService,
+      new ReasoningContentCache(),
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm';
 import type { ModelRoute } from 'manifest-shared';
 import { ProxyFallbackService } from '../proxy-fallback.service';
+import { ReasoningContentCache } from '../reasoning-content-cache';
 import { ProviderKeyService } from '../../routing-core/provider-key.service';
 import { CustomProvider } from '../../../entities/custom-provider.entity';
 import { OpenaiOauthService } from '../../oauth/openai/openai-oauth.service';
@@ -156,6 +157,7 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
       pricingCache,
       modelParamsService,
       providerParamSpecs,
+      new ReasoningContentCache(),
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -51,7 +51,7 @@ describe('ProxyFallbackService', () => {
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
   let modelParamsService: jest.Mocked<AgentModelParamsService>;
   let providerParamSpecs: jest.Mocked<ProviderParamSpecService>;
-  let reasoningCache: jest.Mocked<Pick<ReasoningContentCache, 'reinjectMissingReasoningContent'>>;
+  let reasoningCache: jest.Mocked<Pick<ReasoningContentCache, 'prepareRequest'>>;
 
   beforeEach(() => {
     providerKeyService = {
@@ -161,7 +161,7 @@ describe('ProxyFallbackService', () => {
     } as unknown as jest.Mocked<ProviderParamSpecService>;
 
     reasoningCache = {
-      reinjectMissingReasoningContent: jest.fn(
+      prepareRequest: jest.fn(
         async (
           requestBody: Record<string, unknown>,
           _sessionKey: string,
@@ -724,7 +724,7 @@ describe('ProxyFallbackService', () => {
           },
         ],
       };
-      reasoningCache.reinjectMissingReasoningContent.mockResolvedValueOnce(enrichedBody);
+      reasoningCache.prepareRequest.mockResolvedValueOnce(enrichedBody);
 
       await service.tryForwardToProvider({
         provider: 'deepseek',
@@ -736,7 +736,7 @@ describe('ProxyFallbackService', () => {
         authType: 'api_key',
       });
 
-      expect(reasoningCache.reinjectMissingReasoningContent).toHaveBeenCalledWith(
+      expect(reasoningCache.prepareRequest).toHaveBeenCalledWith(
         requestBody,
         'sess-1',
         'deepseek',

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -20,7 +20,6 @@ import type { LimitCheckService } from '../../../notifications/services/limit-ch
 import type { ProxyFallbackService } from '../proxy-fallback.service';
 import type { ThoughtSignatureCache } from '../thought-signature-cache';
 import type { ThinkingBlockCache } from '../thinking-block-cache';
-import type { ReasoningContentCache } from '../reasoning-content-cache';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
 import type { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
 import type { AutofixService } from '../../autofix/autofix.service';
@@ -116,7 +115,6 @@ describe('ProxyService — orchestration', () => {
   let configService: ConfigService;
   let signatureCache: ThoughtSignatureCache;
   let thinkingCache: ThinkingBlockCache;
-  let reasoningCache: ReasoningContentCache;
   let modelParamsService: { get: jest.Mock; list: jest.Mock; set: jest.Mock; delete: jest.Mock };
   let providerParamSpecs: { getSpecs: jest.Mock; list: jest.Mock };
   let autofixService: { maybeHeal: jest.Mock };
@@ -185,10 +183,6 @@ describe('ProxyService — orchestration', () => {
       retrieve: jest.fn().mockReturnValue(null),
     } as unknown as ThoughtSignatureCache;
     thinkingCache = { retrieve: jest.fn().mockReturnValue(null) } as unknown as ThinkingBlockCache;
-    reasoningCache = {
-      retrieve: jest.fn().mockReturnValue(null),
-    } as unknown as ReasoningContentCache;
-
     modelParamsService = {
       get: jest.fn().mockResolvedValue(null),
       list: jest.fn().mockResolvedValue([]),
@@ -219,7 +213,6 @@ describe('ProxyService — orchestration', () => {
       configService,
       signatureCache,
       thinkingCache,
-      reasoningCache,
       modelParamsService as unknown as AgentModelParamsService,
       providerParamSpecs as unknown as ProviderParamSpecService,
       autofixService as unknown as AutofixService,
@@ -2965,7 +2958,7 @@ describe('ProxyService — orchestration', () => {
       expect(resolveService.resolve).toHaveBeenCalled();
     });
 
-    it('exercises the per-request signature, thinking, and reasoning lookup closures', async () => {
+    it('exercises the per-request signature and thinking lookup closures', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         route: route('openai', 'api_key', 'gpt-4o'),
@@ -2978,7 +2971,6 @@ describe('ProxyService — orchestration', () => {
         // Invoke the lookups so coverage hits the closure bodies.
         opts.signatureLookup?.('tool-call-1');
         opts.thinkingLookup?.('first-use-1');
-        opts.reasoningContentLookup?.('reasoning-call-1');
         return {
           response: okResponse(),
           isGoogle: false,
@@ -2990,7 +2982,6 @@ describe('ProxyService — orchestration', () => {
       await svc.proxyRequest(baseOpts());
       expect(signatureCache.retrieve).toHaveBeenCalledWith('cache-sess-1', 'tool-call-1');
       expect(thinkingCache.retrieve).toHaveBeenCalledWith('cache-sess-1', 'first-use-1');
-      expect(reasoningCache.retrieve).toHaveBeenCalledWith('cache-sess-1', 'reasoning-call-1');
     });
 
     it('strips system / developer roles when scoring', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -168,6 +168,14 @@ describe('ReasoningContentCache', () => {
     expect((body.messages[0] as Record<string, unknown>).reasoning_content).toBeUndefined();
   });
 
+  it('leaves request bodies without messages unchanged', async () => {
+    const body = { prompt: 'The answer is 42.' };
+
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
+
+    expect(result).toBe(body);
+  });
+
   it('synthesizes empty reasoning_content when the client dropped it and no cache exists', async () => {
     const body = {
       messages: [
@@ -184,6 +192,22 @@ describe('ReasoningContentCache', () => {
     const messages = result.messages as Array<Record<string, unknown>>;
     expect(messages[0].reasoning_content).toBe('');
     expect(result).not.toBe(body);
+  });
+
+  it('keeps an existing empty fallback without copying the request', async () => {
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          reasoning_content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
+
+    expect(result).toBe(body);
   });
 
   it('keeps exact client reasoning_content without copying the request', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -149,12 +149,7 @@ describe('ReasoningContentCache', () => {
       ],
     };
 
-    const result = await sharedCache.reinjectMissingReasoningContent(
-      body,
-      'session-1',
-      'deepseek',
-      'deepseek-chat',
-    );
+    const result = await sharedCache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-chat');
 
     const messages = result.messages as Array<Record<string, unknown>>;
     const originalMessages = body.messages as Array<Record<string, unknown>>;
@@ -167,18 +162,81 @@ describe('ReasoningContentCache', () => {
       messages: [{ role: 'assistant', content: 'The answer is 42.' }],
     };
 
-    const result = await cache.reinjectMissingReasoningContent(
-      body,
-      'session-1',
-      'deepseek',
-      'deepseek-v4-flash',
-    );
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
 
     expect(result).toBe(body);
     expect((body.messages[0] as Record<string, unknown>).reasoning_content).toBeUndefined();
   });
 
-  it('does not re-inject cached reasoning_content when a tool call id is repeated in one request', async () => {
+  it('synthesizes empty reasoning_content when the client dropped it and no cache exists', async () => {
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBe('');
+    expect(result).not.toBe(body);
+  });
+
+  it('keeps exact client reasoning_content without copying the request', async () => {
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          reasoning_content: 'client thinking',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
+
+    expect(result).toBe(body);
+  });
+
+  it('replaces empty client reasoning_content with an exact cache hit', async () => {
+    cache.store('session-1', 'call_1', 'cached thinking');
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          reasoning_content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBe('cached thinking');
+  });
+
+  it('synthesizes empty reasoning_content when the first tool call has no cache key', async () => {
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          tool_calls: [{ type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBe('');
+  });
+
+  it('uses empty reasoning_content when a tool call id is ambiguous in one request', async () => {
     cache.store('session-1', 'call_1', 'cached thinking');
     const body = {
       messages: [
@@ -196,17 +254,12 @@ describe('ReasoningContentCache', () => {
       ],
     };
 
-    const result = await cache.reinjectMissingReasoningContent(
-      body,
-      'session-1',
-      'deepseek',
-      'deepseek-v4-flash',
-    );
+    const result = await cache.prepareRequest(body, 'session-1', 'deepseek', 'deepseek-v4-flash');
 
     const messages = result.messages as Array<Record<string, unknown>>;
-    expect(messages[0].reasoning_content).toBeUndefined();
-    expect(messages[2].reasoning_content).toBeUndefined();
-    expect(result).toBe(body);
+    expect(messages[0].reasoning_content).toBe('');
+    expect(messages[2].reasoning_content).toBe('');
+    expect(result).not.toBe(body);
   });
 
   it('does not re-inject reasoning_content into strict providers', async () => {
@@ -220,12 +273,7 @@ describe('ReasoningContentCache', () => {
       ],
     };
 
-    const result = await cache.reinjectMissingReasoningContent(
-      body,
-      'session-1',
-      'mistral',
-      'mistral-large',
-    );
+    const result = await cache.prepareRequest(body, 'session-1', 'mistral', 'mistral-large');
 
     expect(result).toBe(body);
     expect((body.messages[0] as Record<string, unknown>).reasoning_content).toBeUndefined();
@@ -243,12 +291,7 @@ describe('ReasoningContentCache', () => {
       ],
     };
 
-    const result = await sharedCache.reinjectMissingReasoningContent(
-      body,
-      'session-1',
-      'mistral',
-      'mistral-large',
-    );
+    const result = await sharedCache.prepareRequest(body, 'session-1', 'mistral', 'mistral-large');
 
     expect(result).toBe(body);
     expect(repo.find).not.toHaveBeenCalled();

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -85,7 +85,7 @@ export {
 };
 export type { GoogleStreamChunkResult } from './google-adapter';
 export type { ThinkingBlocksCallback } from './anthropic-adapter';
-export type { SignatureLookup, ThinkingBlockLookup, ReasoningContentLookup } from './proxy-types';
+export type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
 
 // ─── OpenAI body sanitization (used by ProviderClient.forward) ───────────────
 
@@ -210,12 +210,7 @@ function supportsReasoningDetails(endpointKey: string): boolean {
   return endpointKey === 'openrouter';
 }
 
-function sanitizeOpenAiMessages(
-  messages: unknown,
-  endpointKey: string,
-  model: string,
-  reasoningContentLookup?: (firstToolCallId: string) => string | null,
-): unknown {
+function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: string): unknown {
   if (!Array.isArray(messages)) return messages;
 
   const preserveReasoningContent = supportsReasoningContent(endpointKey, model);
@@ -294,26 +289,6 @@ function sanitizeOpenAiMessages(
       delete cleaned.reasoning_details;
     }
 
-    if (
-      preserveReasoningContent &&
-      Array.isArray(cleaned.tool_calls) &&
-      cleaned.tool_calls.length > 0 &&
-      !hasNonEmptyReasoningContent(cleaned)
-    ) {
-      const firstToolCall = cleaned.tool_calls[0];
-      const firstToolCallId =
-        firstToolCall && typeof firstToolCall === 'object' && !Array.isArray(firstToolCall)
-          ? (firstToolCall as Record<string, unknown>).id
-          : undefined;
-      if (reasoningContentLookup && typeof firstToolCallId === 'string') {
-        const cached = reasoningContentLookup(firstToolCallId);
-        if (cached) cleaned.reasoning_content = cached;
-      }
-      if (!hasNonEmptyReasoningContent(cleaned)) {
-        cleaned.reasoning_content = '';
-      }
-    }
-
     if (isMistral && Array.isArray(cleaned.tool_calls)) {
       cleaned.tool_calls = cleaned.tool_calls.map((toolCall) => {
         if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) {
@@ -331,10 +306,6 @@ function sanitizeOpenAiMessages(
 
     return cleaned;
   });
-}
-
-function hasNonEmptyReasoningContent(message: Record<string, unknown>): boolean {
-  return typeof message.reasoning_content === 'string' && message.reasoning_content.length > 0;
 }
 
 function normalizeDeepSeekMaxTokens(body: Record<string, unknown>): void {
@@ -360,7 +331,6 @@ export function sanitizeOpenAiBody(
   body: Record<string, unknown>,
   endpointKey: string,
   model: string,
-  reasoningContentLookup?: (firstToolCallId: string) => string | null,
 ): Record<string, unknown> {
   const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
@@ -373,7 +343,7 @@ export function sanitizeOpenAiBody(
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
     if (key === 'messages') {
-      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model, reasoningContentLookup);
+      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model);
       continue;
     }
     // Rewrite max_tokens → max_completion_tokens for OpenAI-backed endpoints that

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -314,7 +314,6 @@ export class ProviderClient {
       signatureLookup: opts.signatureLookup,
       thinkingLookup: opts.thinkingLookup,
       thinkingRouteContext: opts.thinkingRouteContext,
-      reasoningContentLookup: opts.reasoningContentLookup,
       providerResource: opts.providerResource,
       sessionKey: opts.sessionKey,
       providerCacheKey: opts.providerCacheKey,
@@ -538,7 +537,6 @@ export class ProviderClient {
     signatureLookup?: ForwardOptions['signatureLookup'];
     thinkingLookup?: ForwardOptions['thinkingLookup'];
     thinkingRouteContext?: ForwardOptions['thinkingRouteContext'];
-    reasoningContentLookup?: ForwardOptions['reasoningContentLookup'];
     providerResource?: string;
     sessionKey?: string;
     providerCacheKey?: string;
@@ -672,12 +670,7 @@ export class ProviderClient {
     }
 
     // OpenAI-compatible path (default)
-    const sanitized = sanitizeOpenAiBody(
-      requestSource,
-      endpointKey,
-      ctx.model,
-      ctx.reasoningContentLookup,
-    );
+    const sanitized = sanitizeOpenAiBody(requestSource, endpointKey, ctx.model);
     if (stream && endpoint.streamUsageReporting === 'openai_stream_options') {
       const existing =
         typeof sanitized.stream_options === 'object' && sanitized.stream_options !== null

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -41,7 +41,6 @@ interface ForwardProviderOptions {
   apiMode?: ProxyApiMode;
   signatureLookup?: SignatureLookup;
   thinkingLookup?: ThinkingBlockLookup;
-  reasoningContentLookup?: ReasoningContentLookup;
   paramMergeContext?: ParamMergeContext;
   tenantProviderId?: string | null;
   startProviderAttempt?: StartProviderAttempt;
@@ -74,7 +73,6 @@ import {
 import type {
   SignatureLookup,
   ThinkingBlockLookup,
-  ReasoningContentLookup,
   ResolveChatBody,
   ProviderAttemptRef,
   StartProviderAttempt,
@@ -144,7 +142,7 @@ export class ProxyFallbackService {
     private readonly pricingCache: ModelPricingCacheService,
     private readonly modelParamsService: AgentModelParamsService,
     private readonly providerParamSpecs: ProviderParamSpecService,
-    private readonly reasoningCache?: ReasoningContentCache,
+    private readonly reasoningCache: ReasoningContentCache,
   ) {}
 
   /**
@@ -193,7 +191,6 @@ export class ProxyFallbackService {
     resolveChatBody?: ResolveChatBody,
     fallbackRoutes?: ModelRoute[] | null,
     paramMergeContext?: ParamMergeContext,
-    reasoningContentLookup?: ReasoningContentLookup,
     startProviderAttempt?: StartProviderAttempt,
     /** Dashboard URL embedded in mid-chain M100/M102 credential failure bodies. */
     credentialDashboardUrl?: string,
@@ -322,7 +319,6 @@ export class ProxyFallbackService {
         providerRegion: credentials.providerRegion,
         signatureLookup,
         thinkingLookup,
-        reasoningContentLookup,
         paramMergeContext,
         tenantProviderId,
         startProviderAttempt,
@@ -632,7 +628,6 @@ export class ProxyFallbackService {
       providerRegion,
       signatureLookup,
       thinkingLookup,
-      reasoningContentLookup,
     } = opts;
     // Per-attempt merge: ask the model-params service for this iteration's
     // (provider, auth_type, model) config. Storage is model-scoped on the
@@ -696,27 +691,23 @@ export class ProxyFallbackService {
               authType,
               opts.model,
             );
-            if (this.reasoningCache) {
-              resolved = await this.reasoningCache.reinjectMissingReasoningContent(
-                resolved,
-                opts.sessionKey,
-                reasoningEndpointKey,
-                forwardModel,
-              );
-            }
+            resolved = await this.reasoningCache.prepareRequest(
+              resolved,
+              opts.sessionKey,
+              reasoningEndpointKey,
+              forwardModel,
+            );
             return resolved;
           })();
           return resolvedChatBody;
         }
       : undefined;
-    if (this.reasoningCache) {
-      body = await this.reasoningCache.reinjectMissingReasoningContent(
-        body,
-        opts.sessionKey,
-        reasoningEndpointKey,
-        forwardModel,
-      );
-    }
+    body = await this.reasoningCache.prepareRequest(
+      body,
+      opts.sessionKey,
+      reasoningEndpointKey,
+      forwardModel,
+    );
 
     // For Gemini OAuth, the OAuth blob's `u` field is the
     // CodeAssist project id (not a URL). It must be forwarded so the
@@ -756,7 +747,6 @@ export class ProxyFallbackService {
               },
             }
           : {}),
-        reasoningContentLookup,
         providerResource,
         attempt,
       });

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -22,13 +22,6 @@ export type ThinkingBlockLookup = (
   routeContext?: ThinkingBlockRouteContext,
 ) => ThinkingBlock[] | null;
 
-/**
- * Optional lookup to re-inject cached reasoning_content strings that were
- * stripped by OpenAI-compatible clients. Called with the first tool_call id
- * from the assistant turn; returns the cached reasoning_content or null.
- */
-export type ReasoningContentLookup = (firstToolCallId: string) => string | null;
-
 export type ProxyApiMode = 'chat_completions' | 'responses' | 'messages';
 
 /** Lazily derive the Chat Completions view used by legacy routing or cross-protocol adapters. */
@@ -111,8 +104,6 @@ export interface ForwardOptions {
   thinkingLookup?: ThinkingBlockLookup;
   /** Route scope used to decide whether cached Anthropic thinking can be replayed. */
   thinkingRouteContext?: ThinkingBlockRouteContext;
-  /** Lookup for re-injecting cached reasoning_content (DeepSeek-compatible providers). */
-  reasoningContentLookup?: ReasoningContentLookup;
   /**
    * Provider-specific routing field carried in the OAuth token blob's `u`
    * slot. For Gemini OAuth this is the CodeAssist

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -40,14 +40,12 @@ import {
   ProxyRequestOptions,
   SignatureLookup,
   ThinkingBlockLookup,
-  ReasoningContentLookup,
   ResolveChatBody,
   ProviderAttemptRef,
   StartProviderAttempt,
 } from './proxy-types';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
-import { ReasoningContentCache } from './reasoning-content-cache';
 import { AgentModelParamsService } from '../routing-core/agent-model-params.service';
 import { ProviderParamSpecService } from '../routing-core/provider-param-spec.service';
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
@@ -187,7 +185,6 @@ interface HealedReforwardContext {
   headers?: ProxyRequestOptions['headers'];
   signatureLookup: SignatureLookup;
   thinkingLookup: ThinkingBlockLookup;
-  reasoningContentLookup: ReasoningContentLookup;
   startProviderAttempt?: StartProviderAttempt;
   provider: string;
   apiKey: string;
@@ -221,7 +218,6 @@ export class ProxyService {
     private readonly config: ConfigService,
     private readonly signatureCache: ThoughtSignatureCache,
     private readonly thinkingCache: ThinkingBlockCache,
-    private readonly reasoningCache: ReasoningContentCache,
     private readonly modelParamsService: AgentModelParamsService,
     private readonly providerParamSpecs: ProviderParamSpecService,
     private readonly autofixService: AutofixService,
@@ -296,8 +292,7 @@ export class ProxyService {
       `Proxy: tier=${resolved.tier} model=${primaryModel} provider=${route.provider} auth_type=${route.authType} confidence=${resolved.confidence}`,
     );
 
-    const { signatureLookup, thinkingLookup, reasoningContentLookup } =
-      this.buildCacheLookups(sessionCacheKey);
+    const { signatureLookup, thinkingLookup } = this.buildCacheLookups(sessionCacheKey);
 
     // Per-attempt param-defaults merge happens inside the fallback service
     // so each forward (primary + every fallback iteration) looks up its
@@ -395,7 +390,6 @@ export class ProxyService {
           signal,
           signatureLookup,
           thinkingLookup,
-          reasoningContentLookup,
           apiMode,
           paramMergeContext,
           primaryTenantProviderId: credentials.tenantProviderId,
@@ -433,7 +427,6 @@ export class ProxyService {
       providerRegion: credentials.providerRegion,
       signatureLookup,
       thinkingLookup,
-      reasoningContentLookup,
       paramMergeContext,
       tenantProviderId: credentials.tenantProviderId,
       startProviderAttempt,
@@ -489,7 +482,6 @@ export class ProxyService {
                 paramMergeContext,
                 signatureLookup,
                 thinkingLookup,
-                reasoningContentLookup,
                 tenantProviderId: credentials.tenantProviderId,
                 startProviderAttempt,
               }),
@@ -519,7 +511,6 @@ export class ProxyService {
         signal,
         signatureLookup,
         thinkingLookup,
-        reasoningContentLookup,
         apiMode,
         paramMergeContext,
         primaryTenantProviderId: credentials.tenantProviderId,
@@ -622,7 +613,6 @@ export class ProxyService {
           signal,
           signatureLookup,
           thinkingLookup,
-          reasoningContentLookup,
           apiMode,
           paramMergeContext,
           primaryTenantProviderId: credentials.tenantProviderId,
@@ -789,7 +779,6 @@ export class ProxyService {
       providerRegion: credentials.providerRegion,
       signatureLookup: ctx.signatureLookup,
       thinkingLookup: ctx.thinkingLookup,
-      reasoningContentLookup: ctx.reasoningContentLookup,
       paramMergeContext: explicitModelOverride ? undefined : { agentId: ctx.agentId, scopeKey },
       tenantProviderId: credentials.tenantProviderId,
       startProviderAttempt: ctx.startProviderAttempt,
@@ -1121,7 +1110,6 @@ export class ProxyService {
     signal?: AbortSignal;
     signatureLookup: SignatureLookup;
     thinkingLookup: ThinkingBlockLookup;
-    reasoningContentLookup: ReasoningContentLookup;
     apiMode: ProxyApiMode;
     paramMergeContext: ParamMergeContext;
     /** Primary connection id, carried so a fallback-success flow can attribute
@@ -1177,7 +1165,6 @@ export class ProxyService {
       resolveChatBody,
       fallbackRoutes,
       args.paramMergeContext,
-      args.reasoningContentLookup,
       args.startProviderAttempt,
       args.credentialDashboardUrl,
       providerCacheKey,
@@ -1423,7 +1410,6 @@ export class ProxyService {
   private buildCacheLookups(sessionKey: string): {
     signatureLookup: SignatureLookup;
     thinkingLookup: ThinkingBlockLookup;
-    reasoningContentLookup: ReasoningContentLookup;
   } {
     return {
       signatureLookup: (toolCallId) => this.signatureCache.retrieve(sessionKey, toolCallId),
@@ -1431,8 +1417,6 @@ export class ProxyService {
         routeContext
           ? this.thinkingCache.retrieve(sessionKey, firstToolUseId, routeContext)
           : this.thinkingCache.retrieve(sessionKey, firstToolUseId),
-      reasoningContentLookup: (firstToolCallId) =>
-        this.reasoningCache.retrieve(sessionKey, firstToolCallId),
     };
   }
 }

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -113,7 +113,7 @@ export class ReasoningContentCache {
     return result;
   }
 
-  async reinjectMissingReasoningContent(
+  async prepareRequest(
     body: Record<string, unknown>,
     sessionKey: string,
     endpointKey: string | null,
@@ -123,21 +123,24 @@ export class ReasoningContentCache {
     const messages = body.messages;
     if (!Array.isArray(messages)) return body;
 
-    const keysByIndex = messages.map((message) => reasoningReplayKeyMissingReasoning(message));
-    const keys = keysByIndex.filter((id): id is string => typeof id === 'string');
-    if (keys.length === 0) return body;
-    const repeatedKeys = repeatedReplayKeys(keys);
+    const candidates = messages.map(reasoningReplayCandidate);
+    if (!candidates.some(Boolean)) return body;
 
-    const cached = await this.retrieveMany(sessionKey, keys);
-    if (cached.size === 0) return body;
+    const keys = candidates.flatMap((candidate) =>
+      candidate?.cacheKey ? [candidate.cacheKey] : [],
+    );
+    const repeatedKeys = repeatedReplayKeys(keys);
+    const cached = keys.length > 0 ? await this.retrieveMany(sessionKey, keys) : new Map();
 
     let changed = false;
     const nextMessages = messages.map((message, index) => {
-      const key = keysByIndex[index];
-      if (!key) return message;
-      if (repeatedKeys.has(key)) return message;
-      const content = cached.get(key);
-      if (!content) return message;
+      const candidate = candidates[index];
+      if (!candidate) return message;
+      const content =
+        candidate.cacheKey && !repeatedKeys.has(candidate.cacheKey)
+          ? (cached.get(candidate.cacheKey) ?? '')
+          : '';
+      if ((message as Record<string, unknown>).reasoning_content === content) return message;
       changed = true;
       return { ...(message as Record<string, unknown>), reasoning_content: content };
     });
@@ -229,21 +232,21 @@ export class ReasoningContentCache {
   }
 }
 
-function firstToolCallIdMissingReasoning(message: unknown): string | null {
+interface ReasoningReplayCandidate {
+  cacheKey: string | null;
+}
+
+function reasoningReplayCandidate(message: unknown): ReasoningReplayCandidate | null {
   if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
   const record = message as Record<string, unknown>;
   if (typeof record.reasoning_content === 'string' && record.reasoning_content) return null;
   if (!Array.isArray(record.tool_calls) || record.tool_calls.length === 0) return null;
   const firstToolCall = record.tool_calls[0];
   if (!firstToolCall || typeof firstToolCall !== 'object' || Array.isArray(firstToolCall)) {
-    return null;
+    return { cacheKey: null };
   }
   const id = (firstToolCall as Record<string, unknown>).id;
-  return typeof id === 'string' && id ? id : null;
-}
-
-function reasoningReplayKeyMissingReasoning(message: unknown): string | null {
-  return firstToolCallIdMissingReasoning(message);
+  return { cacheKey: typeof id === 'string' && id ? id : null };
 }
 
 function repeatedReplayKeys(keys: string[]): Set<string> {


### PR DESCRIPTION
### ✨ What changed
- Prepare DeepSeek reasoning replay once before each provider attempt.
- Restore exact cached content and preserve client-provided reasoning.
- Remove duplicate synchronous lookup plumbing from request conversion.

### 💭 Why
DeepSeek rejects thinking-mode tool continuations when assistant reasoning content is missing.

### 👤 For users
DeepSeek tool loops can continue when clients omit the provider-specific reasoning field.

### 📝 Notes
Live DeepSeek validation still needs provider credentials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves DeepSeek reasoning tool turns by preparing reasoning replay once per provider attempt and restoring exact cached `reasoning_content`. Tool loops continue even when clients drop the provider-specific reasoning field.

- **Bug Fixes**
  - Restores cached `reasoning_content` for DeepSeek assistant tool-call turns; synthesizes '' when none is recoverable, when IDs are missing, or when IDs are duplicated, so continuations are accepted.
  - Leaves client-provided `reasoning_content` as-is; never adds `reasoning_content` for strict providers; leaves bodies without `messages` unchanged.

- **Refactors**
  - Centralized reasoning replay in `ReasoningContentCache.prepareRequest`; removed `reasoningContentLookup` from routing/types/provider client; sanitization no longer reinjects or alias-maps reasoning fields.
  - `ProxyFallbackService` now always runs `prepareRequest` per attempt (including lazy `resolveChatBody`); tests updated to cover guard cases.

<sup>Written for commit 223ffeb0bd8e60265cc112660985b248309c71d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

