### PR TITLE
chore: remove legacy Auto-fix rollout state

### DIFF
--- a/.changeset/retire-autofix-rollout-state.md
+++ b/.changeset/retire-autofix-rollout-state.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Remove the legacy Auto-fix tenant rollout columns after general availability.

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -37,6 +37,7 @@ import { AddTenantRequestUsage1801300000000 } from './migrations/1801300000000-A
 import { AddRequestRecordings1801300000000 } from './migrations/1801300000000-AddRequestRecordings';
 import { MoveRecordingsToProviderAttempts1801400000000 } from './migrations/1801400000000-MoveRecordingsToProviderAttempts';
 import { EnableRecordingForNewAgents1801500000000 } from './migrations/1801500000000-EnableRecordingForNewAgents';
+import { DropLegacyAutofixRolloutColumns1801600000000 } from './migrations/1801600000000-DropLegacyAutofixRolloutColumns';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -312,4 +313,5 @@ export const migrations = [
   AddRequestRecordings1801300000000,
   MoveRecordingsToProviderAttempts1801400000000,
   EnableRecordingForNewAgents1801500000000,
+  DropLegacyAutofixRolloutColumns1801600000000,
 ];

--- a/packages/backend/src/database/migrations/1801600000000-DropLegacyAutofixRolloutColumns.spec.ts
+++ b/packages/backend/src/database/migrations/1801600000000-DropLegacyAutofixRolloutColumns.spec.ts
@@ -1,0 +1,52 @@
+import { DropLegacyAutofixRolloutColumns1801600000000 } from './1801600000000-DropLegacyAutofixRolloutColumns';
+
+describe('DropLegacyAutofixRolloutColumns1801600000000', () => {
+  const migration = new DropLegacyAutofixRolloutColumns1801600000000();
+  const query = jest.fn().mockResolvedValue([]);
+  const queryRunner = { query } as never;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('drops both obsolete tenant rollout columns under a bounded lock wait', async () => {
+    await migration.up(queryRunner);
+
+    expect(query).toHaveBeenCalledTimes(3);
+    const statements = query.mock.calls.map(([sql]) => sql);
+    const sql = statements.join(' ');
+    expect(statements[0]).toContain("SET lock_timeout = '5s'");
+    expect(statements.at(-1)).toContain('RESET lock_timeout');
+    expect(sql).toContain('ALTER TABLE "tenants"');
+    expect(sql).toContain('DROP COLUMN IF EXISTS "autofix_waitlist_at"');
+    expect(sql).toContain('DROP COLUMN IF EXISTS "autofix_access_granted_at"');
+    expect(sql).not.toContain('waitlist_claims');
+  });
+
+  it('restores nullable rollout columns on rollback', async () => {
+    await migration.down(queryRunner);
+
+    expect(query).toHaveBeenCalledTimes(3);
+    const statements = query.mock.calls.map(([sql]) => sql);
+    const sql = statements.join(' ');
+    expect(statements[0]).toContain("SET lock_timeout = '5s'");
+    expect(statements.at(-1)).toContain('RESET lock_timeout');
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "autofix_waitlist_at" TIMESTAMP WITH TIME ZONE',
+    );
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "autofix_access_granted_at" TIMESTAMP WITH TIME ZONE',
+    );
+    expect(sql).not.toContain('waitlist_claims');
+  });
+
+  it('restores the session lock timeout when the schema change fails', async () => {
+    const failure = new Error('lock timeout');
+    query
+      .mockImplementationOnce(async () => [])
+      .mockImplementationOnce(async () => {
+        throw failure;
+      });
+
+    await expect(migration.up(queryRunner)).rejects.toBe(failure);
+    expect(query.mock.calls.at(-1)?.[0]).toContain('RESET lock_timeout');
+  });
+});

--- a/packages/backend/src/database/migrations/1801600000000-DropLegacyAutofixRolloutColumns.ts
+++ b/packages/backend/src/database/migrations/1801600000000-DropLegacyAutofixRolloutColumns.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Auto-fix is generally available, so tenant rollout timestamps no longer
+ * affect access. Historical waitlist claims are intentionally retained until
+ * their separate compatibility and data-retention window closes.
+ */
+export class DropLegacyAutofixRolloutColumns1801600000000 implements MigrationInterface {
+  name = 'DropLegacyAutofixRolloutColumns1801600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET lock_timeout = '5s'`);
+    try {
+      await queryRunner.query(`
+        ALTER TABLE "tenants"
+          DROP COLUMN IF EXISTS "autofix_waitlist_at",
+          DROP COLUMN IF EXISTS "autofix_access_granted_at"
+      `);
+    } finally {
+      await queryRunner.query(`RESET lock_timeout`);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET lock_timeout = '5s'`);
+    try {
+      await queryRunner.query(`
+        ALTER TABLE "tenants"
+          ADD COLUMN IF NOT EXISTS "autofix_waitlist_at" TIMESTAMP WITH TIME ZONE,
+          ADD COLUMN IF NOT EXISTS "autofix_access_granted_at" TIMESTAMP WITH TIME ZONE
+      `);
+    } finally {
+      await queryRunner.query(`RESET lock_timeout`);
+    }
+  }
+}


### PR DESCRIPTION
### ✨ What changed
- Drop obsolete Auto-fix rollout timestamps from tenants.
- Bound the schema lock wait to five seconds.
- Retain historical waitlist claims and the compatibility endpoint.

### 💭 Why
Auto-fix is generally available, so tenant rollout state no longer controls access.

### 🔧 For operators
`AUTOFIX_ROLLOUT` is removed from production. The migration takes one metadata-only lock on `tenants`.

### 📝 Notes
Closes #2669.

Validated on a sanitized PostgreSQL 17 production clone with 5,723 tenants. Up, idempotent rerun, rollback, and final rerun passed in one second.

Historical `waitlist_claims` data stays until its compatibility and retention window closes. Follow-up: #2671.
