### PR TITLE
fix: honor provider key-label pin on explicit-model requests

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -504,4 +504,42 @@ describe('ProxyFallbackService.tryFallbacks — failure chain by status code', (
     expect(result.failures[0].errorBody).toContain('openai: model_not_found');
     expect(result.failures[1].errorBody).toContain('anthropic: not_found_error');
   });
+
+  it('records each failed hop against its own pinned connection', async () => {
+    providerClient.forward
+      .mockResolvedValueOnce({
+        response: new Response('{"error":"boom"}', { status: 502 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response('{"error":"boom"}', { status: 502 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+
+    const routes: ModelRoute[] = [
+      { ...route('openai', 'gpt-4o-mini'), keyLabel: 'Work' },
+      { ...route('anthropic', 'claude-haiku-3.5'), keyLabel: 'Personal' },
+    ];
+    const result = await runFallbacks(['gpt-4o-mini', 'claude-haiku-3.5'], routes);
+
+    expect(result.success).toBeNull();
+    // Each hop carries its own label; without it the recorder would stamp the
+    // primary's connection on every failed fallback row.
+    expect(result.failures.map((f) => f.keyLabel)).toEqual(['Work', 'Personal']);
+  });
+
+  it('keeps the pinned label on a hop that never got credentials', async () => {
+    providerKeyService.getProviderApiKey.mockResolvedValue(null);
+
+    const routes: ModelRoute[] = [{ ...route('openai', 'gpt-4o-mini'), keyLabel: 'Work' }];
+    const result = await runFallbacks(['gpt-4o-mini'], routes);
+
+    expect(providerClient.forward).not.toHaveBeenCalled();
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatchObject({ keyLabel: 'Work', status: 401 });
+  });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -1300,14 +1300,18 @@ describe('ProxyFallbackService', () => {
         model: 'gpt-4o',
         authType: 'api_key',
         tenantProviderId: 'connection-1',
+        providerKeyLabel: 'Work',
         startProviderAttempt,
       });
 
+      // The retry rides the same connection as the original call, so the
+      // pending attempt row it opens must name that connection's label too.
       expect(startProviderAttempt).toHaveBeenCalledWith({
         provider: 'openai',
         model: 'gpt-4o',
         authType: 'api_key',
         tenantProviderId: 'connection-1',
+        keyLabel: 'Work',
       });
       expect(result.attempt).toBe(attempt);
       expect(result.providerCallStarted).toBe(true);

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -101,6 +101,7 @@ describe('ProxyMessageRecorder', () => {
           model: 'gpt-4o',
           authType: 'api_key',
           tenantProviderId: 'connection-1',
+          keyLabel: 'Work',
         }),
       ).resolves.toBe(true);
       await recorder.completePendingProviderFailure(attempt, 429, 'rate limited', true);
@@ -113,6 +114,7 @@ describe('ProxyMessageRecorder', () => {
           status: 'pending',
           auth_type: 'api_key',
           tenant_provider_id: 'connection-1',
+          provider_key_label: 'Work',
         }),
       );
       expect(updateMock).toHaveBeenCalledWith(
@@ -201,6 +203,7 @@ describe('ProxyMessageRecorder', () => {
           provider: 'openai',
           model: 'gpt-5',
           authType: 'subscription',
+          keyLabel: 'Work',
         },
         requestDurationMs: 150,
         traceId: 'trace-cancelled',
@@ -215,6 +218,9 @@ describe('ProxyMessageRecorder', () => {
           provider: 'openai',
           model: 'gpt-5',
           auth_type: 'subscription',
+          // A cancelled row has no terminal writer to fill this in, so it has
+          // to come from the attempt start.
+          provider_key_label: 'Work',
           duration_ms: 125,
         }),
       );
@@ -969,6 +975,53 @@ describe('ProxyMessageRecorder', () => {
       );
     });
 
+    // Connection attribution on failure rows: the label must follow the key
+    // each hop actually used, and only fall back to the primary's for legacy
+    // rows that carry none.
+    it('stamps each failed fallback with its own connection label', async () => {
+      const failures = [
+        {
+          model: 'claude-sonnet-4',
+          provider: 'anthropic',
+          status: 502,
+          errorBody: 'boom',
+          fallbackIndex: 0,
+          keyLabel: 'Personal',
+        },
+        {
+          model: 'gemini-2.5-flash',
+          provider: 'gemini',
+          status: 502,
+          errorBody: 'boom',
+          fallbackIndex: 1,
+        },
+      ];
+
+      await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures, {
+        providerKeyLabel: 'Work',
+      });
+
+      const rows = insertMock.mock.calls[0][0];
+      expect(rows[0]).toMatchObject({ provider: 'anthropic', provider_key_label: 'Personal' });
+      expect(rows[1]).toMatchObject({ provider: 'gemini', provider_key_label: 'Work' });
+    });
+
+    it('leaves provider_key_label null when neither the hop nor the primary has one', async () => {
+      const failures = [
+        {
+          model: 'claude-sonnet-4',
+          provider: 'anthropic',
+          status: 502,
+          errorBody: 'boom',
+          fallbackIndex: 0,
+        },
+      ];
+
+      await recorder.recordFailedFallbacks(ctx, 'standard', 'primary-model', failures);
+
+      expect(insertMock.mock.calls[0][0][0]).toMatchObject({ provider_key_label: null });
+    });
+
     it('stamps error_code on mid-chain Manifest credential failures', async () => {
       const failures = [
         {
@@ -1285,6 +1338,36 @@ describe('ProxyMessageRecorder', () => {
         provider: 'openai',
       });
       expect(insertMock.mock.calls[0][0].error_message).toContain('M102');
+    });
+
+    it('stamps the connection label on the failed primary row', async () => {
+      await recorder.recordPrimaryFailure(
+        ctx,
+        'default',
+        'gpt-4o',
+        'upstream error',
+        '2025-01-01T00:00:00.000Z',
+        'api_key',
+        { provider: 'openai', tenantProviderId: 'up-work', providerKeyLabel: 'Work' },
+      );
+
+      expect(insertMock.mock.calls[0][0]).toMatchObject({
+        status: 'failed',
+        tenant_provider_id: 'up-work',
+        provider_key_label: 'Work',
+      });
+    });
+
+    it('leaves provider_key_label null when the primary failure carries no label', async () => {
+      await recorder.recordPrimaryFailure(
+        ctx,
+        'default',
+        'gpt-4o',
+        'upstream error',
+        '2025-01-01T00:00:00.000Z',
+      );
+
+      expect(insertMock.mock.calls[0][0]).toMatchObject({ provider_key_label: null });
     });
 
     it('persists the provider column when passed a provider', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -284,7 +284,7 @@ describe('proxy-response-handler', () => {
     it('should handle fallback exhausted when failedFallbacks present and no fallbackFromModel', async () => {
       const { res, headers } = mockResponse();
       const recorder = mockRecorder();
-      const meta = makeMeta(); // no fallbackFromModel
+      const meta = makeMeta({ provider_key_label: 'Work' }); // no fallbackFromModel
       const metaHeaders = buildMetaHeaders(meta);
       const failedFallbacks: FailedFallback[] = [
         {
@@ -309,6 +309,24 @@ describe('proxy-response-handler', () => {
 
       expect(recorder.recordFailedFallbacks).toHaveBeenCalled();
       expect(recorder.recordPrimaryFailure).toHaveBeenCalled();
+      // Exhausted chain: meta still describes the primary, so both failure
+      // recorders get its connection label.
+      expect(recorder.recordFailedFallbacks).toHaveBeenCalledWith(
+        testCtx,
+        'standard',
+        'gpt-4o',
+        failedFallbacks,
+        expect.objectContaining({ providerKeyLabel: 'Work' }),
+      );
+      expect(recorder.recordPrimaryFailure).toHaveBeenCalledWith(
+        testCtx,
+        'standard',
+        'gpt-4o',
+        'Bad Gateway',
+        expect.any(String),
+        undefined,
+        expect.objectContaining({ providerKeyLabel: 'Work' }),
+      );
       expect(res.setHeader).toHaveBeenCalledWith('X-Manifest-Fallback-Exhausted', 'true');
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -2660,6 +2678,62 @@ describe('proxy-response-handler', () => {
         'claude-sonnet-4',
         failedFallbacks,
         expect.objectContaining({ reason: 'header-match' }),
+      );
+    });
+
+    it('recordFallbackFailures attributes the primary label, not the winning fallback one', () => {
+      // In a fallback-success flow meta.provider_key_label holds the connection
+      // that RECOVERED the request; the primary-failure row must keep the one
+      // that actually failed (mirrors primaryTenantProviderId).
+      const recorder = mockRecorder();
+      const meta = makeMeta({
+        fallbackFromModel: 'claude-sonnet-4',
+        primaryProvider: 'anthropic',
+        provider_key_label: 'Fallback key',
+        primaryKeyLabel: 'Primary key',
+      });
+      const failedFallbacks: FailedFallback[] = [
+        { model: 'x', provider: 'y', fallbackIndex: 0, status: 500, errorBody: '' },
+      ];
+
+      recordFallbackFailures(testCtx, meta, failedFallbacks, recorder as any);
+
+      expect(recorder.recordPrimaryFailure).toHaveBeenCalledWith(
+        testCtx,
+        'standard',
+        'claude-sonnet-4',
+        expect.any(String),
+        expect.any(String),
+        undefined,
+        expect.objectContaining({ providerKeyLabel: 'Primary key' }),
+      );
+      expect(recorder.recordFailedFallbacks).toHaveBeenCalledWith(
+        testCtx,
+        'standard',
+        'claude-sonnet-4',
+        failedFallbacks,
+        expect.objectContaining({ providerKeyLabel: 'Primary key' }),
+      );
+    });
+
+    it('recordFallbackFailures falls back to provider_key_label when no primary label was preserved', () => {
+      const recorder = mockRecorder();
+      const meta = makeMeta({
+        fallbackFromModel: 'claude-sonnet-4',
+        primaryProvider: 'anthropic',
+        provider_key_label: 'Only key',
+      });
+
+      recordFallbackFailures(testCtx, meta, [], recorder as any);
+
+      expect(recorder.recordPrimaryFailure).toHaveBeenCalledWith(
+        testCtx,
+        'standard',
+        'claude-sonnet-4',
+        expect.any(String),
+        expect.any(String),
+        undefined,
+        expect.objectContaining({ providerKeyLabel: 'Only key' }),
       );
     });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -742,6 +742,40 @@ describe('proxy-response-handler', () => {
       );
     });
 
+    it('attributes the Auto-fix original row to the primary connection label', () => {
+      // The retry that failed ran on the PRIMARY connection; meta.provider_key_label
+      // already names the fallback that recovered the request, so the
+      // autofix_role='original' row must read primaryKeyLabel instead —
+      // otherwise it pairs the primary's tenant_provider_id with the
+      // fallback's label.
+      const recorder = mockRecorder();
+      const meta = makeMeta({
+        fallbackFromModel: 'gpt-4o',
+        primaryProvider: 'openai',
+        primaryAuthType: 'api_key',
+        primaryTenantProviderId: 'up-work',
+        primaryKeyLabel: 'Work',
+        provider: 'anthropic',
+        model: 'claude-sonnet',
+        provider_key_label: 'Personal',
+      });
+      const autofix = failedAutofixRetry();
+
+      recordFallbackFailures(testCtx, meta, undefined, recorder as any, null, null, autofix);
+
+      expect(recorder.recordAutofixOriginal).toHaveBeenCalledWith(
+        testCtx,
+        'gpt-4o',
+        'standard',
+        autofix,
+        expect.objectContaining({
+          provider: 'openai',
+          tenantProviderId: 'up-work',
+          providerKeyLabel: 'Work',
+        }),
+      );
+    });
+
     it('does not attribute the Auto-fix original to the fallback provider', () => {
       const recorder = mockRecorder();
       const meta = makeMeta({

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -84,7 +84,10 @@ const specCatalog: ProviderParamSpecCatalog = [
 
 describe('ProxyService — orchestration', () => {
   let resolveService: jest.Mocked<
-    Pick<ResolveService, 'resolve' | 'resolveLazy' | 'resolveForTier' | 'resolveHeaderTier'>
+    Pick<
+      ResolveService,
+      'resolve' | 'resolveLazy' | 'resolveForTier' | 'resolveHeaderTier' | 'pinRouteKeyLabel'
+    >
   >;
   let providerKeyService: jest.Mocked<
     Pick<
@@ -141,6 +144,9 @@ describe('ProxyService — orchestration', () => {
       }),
       resolveForTier: jest.fn(),
       resolveHeaderTier: jest.fn().mockResolvedValue(null),
+      // Default: no connection pin configured — the route passes through.
+      // Tests that exercise pinning override this per case.
+      pinRouteKeyLabel: jest.fn(async (_agentId, _tenantId, route: ModelRoute) => route),
     };
     modelDiscovery = {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
@@ -1640,6 +1646,92 @@ describe('ProxyService — orchestration', () => {
         model: 'gpt-4o-mini',
       });
       expect(result.meta.fallbackFromModel).toBeUndefined();
+    });
+
+    /**
+     * Regression (#key-label-pin): an explicit `model` bypasses tier
+     * resolution, so it used to drop the operator's connection pin and bill
+     * whichever key sorted first.
+     */
+    describe('connection pin', () => {
+      const connections = [
+        { id: 'up-default', label: 'Default', priority: 0, apiKey: 'sk-default', region: null },
+        { id: 'up-work', label: 'Work', priority: 1, apiKey: 'sk-work', region: null },
+      ];
+
+      beforeEach(() => {
+        modelDiscovery.getModelsForAgent.mockResolvedValue([
+          discoveredModel({ id: 'gpt-4o-mini', provider: 'openai', authType: 'api_key' }),
+        ]);
+        // Mirrors ProviderKeyService.selectProviderKey: case-insensitive label
+        // match, else the first (priority-ordered) key.
+        providerKeyService.selectProviderKey.mockImplementation(
+          async (_tenantId, _provider, _authType, label) =>
+            connections.find((c) => c.label.toLowerCase() === label?.toLowerCase()) ??
+            connections[0],
+        );
+      });
+
+      it("uses the default tier's pinned connection for a concrete model name", async () => {
+        resolveService.pinRouteKeyLabel.mockImplementation(async (_a, _t, route) => ({
+          ...route,
+          keyLabel: 'Work',
+        }));
+
+        const result = await svc.proxyRequest(
+          baseOpts({
+            body: { model: 'openai/gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] },
+          }),
+        );
+
+        expect(resolveService.pinRouteKeyLabel).toHaveBeenCalledWith(
+          'agent-1',
+          'tenant-1',
+          expect.objectContaining({ provider: 'openai', authType: 'api_key' }),
+        );
+        expect(providerKeyService.selectProviderKey).toHaveBeenCalledWith(
+          'tenant-1',
+          'openai',
+          'api_key',
+          'Work',
+          'agent-1',
+        );
+        expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+          expect.objectContaining({
+            apiKey: 'sk-work',
+            providerKeyLabel: 'Work',
+            tenantProviderId: 'up-work',
+          }),
+        );
+        expect(result.meta).toMatchObject({
+          provider_key_label: 'Work',
+          tenantProviderId: 'up-work',
+        });
+      });
+
+      // A pin naming a renamed/deleted connection still serves the default key
+      // (selectProviderKey's documented fallback) — the recorded label must
+      // then name the row that was really used, not the dangling pin.
+      it('records the connection actually used when the pin is stale', async () => {
+        resolveService.pinRouteKeyLabel.mockImplementation(async (_a, _t, route) => ({
+          ...route,
+          keyLabel: 'Retired',
+        }));
+
+        const result = await svc.proxyRequest(
+          baseOpts({
+            body: { model: 'openai/gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] },
+          }),
+        );
+
+        expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+          expect.objectContaining({ apiKey: 'sk-default', tenantProviderId: 'up-default' }),
+        );
+        expect(result.meta).toMatchObject({
+          provider_key_label: 'Default',
+          tenantProviderId: 'up-default',
+        });
+      });
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/route-credentials.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/route-credentials.spec.ts
@@ -58,6 +58,7 @@ describe('route-credentials', () => {
         model: 'gpt-5.5',
         authType: 'api_key',
         tenantProviderId: null,
+        keyLabel: 'Work',
         presentation,
         startProviderAttempt,
       });
@@ -68,7 +69,7 @@ describe('route-credentials', () => {
       expect(forward.attempt?.completedAtMs).toBeDefined();
       expect(await forward.response.text()).toContain('M100');
       expect(startProviderAttempt).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: 'openai', model: 'gpt-5.5' }),
+        expect.objectContaining({ provider: 'openai', model: 'gpt-5.5', keyLabel: 'Work' }),
       );
     });
 
@@ -79,6 +80,7 @@ describe('route-credentials', () => {
         fallbackIndex: 0,
         authType: 'api_key',
         tenantProviderId: null,
+        keyLabel: 'Backup',
         presentation,
       });
 
@@ -88,6 +90,9 @@ describe('route-credentials', () => {
         fallbackIndex: 0,
         status: 401,
         providerCallStarted: true,
+        // The failed hop names its own connection instead of inheriting the
+        // primary's label at record time.
+        keyLabel: 'Backup',
       });
       expect(entry.errorBody).toBe(presentation.errorBody);
     });
@@ -187,6 +192,52 @@ describe('route-credentials', () => {
         tenantProviderId: 'up-1',
         keyLabel: 'Work',
       });
+    });
+
+    // The returned label is what gets recorded, so it must name the row
+    // `tenantProviderId` points at — never the pin that failed to match.
+    it('reports the selected row label when the pin matched no connection', async () => {
+      providerKeyService.selectProviderKey.mockResolvedValue({
+        apiKey: 'sk-live',
+        id: 'up-default',
+        region: null,
+        label: 'Default',
+        priority: 0,
+      });
+
+      const result = await resolveRouteCredentials(
+        { providerKeyService, oauth },
+        {
+          agentId: 'a1',
+          tenantId: 't1',
+          provider: 'openai',
+          authType: 'api_key',
+          providerKeyLabel: 'Retired',
+        },
+      );
+
+      expect(result).toMatchObject({
+        ok: true,
+        tenantProviderId: 'up-default',
+        keyLabel: 'Default',
+      });
+    });
+
+    it('reports the selected row label when no pin was supplied', async () => {
+      providerKeyService.selectProviderKey.mockResolvedValue({
+        apiKey: 'sk-live',
+        id: 'up-work',
+        region: null,
+        label: 'Work',
+        priority: 1,
+      });
+
+      const result = await resolveRouteCredentials(
+        { providerKeyService, oauth },
+        { agentId: 'a1', tenantId: 't1', provider: 'openai', authType: 'api_key' },
+      );
+
+      expect(result).toMatchObject({ ok: true, tenantProviderId: 'up-work', keyLabel: 'Work' });
     });
   });
 });

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -296,7 +296,9 @@ export class ProxyFallbackService {
         );
         continue;
       }
-      providerKeyLabel = credentials.keyLabel ?? providerKeyLabel;
+      // resolveRouteCredentials always reports the row it selected, which may
+      // differ from the pin when the pin matched nothing.
+      providerKeyLabel = credentials.keyLabel;
       const tenantProviderId = credentials.tenantProviderId;
 
       this.logger.log(
@@ -338,10 +340,7 @@ export class ProxyFallbackService {
             authType,
             // Label of the connection row that served the attempt — stamped
             // alongside its tenant_provider_id so the pair always matches.
-            // Synthetic rows (Ollama) keep the pinned label, if any.
-            keyLabel: tenantProviderId
-              ? (credentials.keyLabel ?? providerKeyLabel)
-              : providerKeyLabel,
+            keyLabel: providerKeyLabel,
             tenantProviderId,
           },
           failures,

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -117,6 +117,9 @@ export interface FailedFallback {
   // The tenant_providers row that served this failed attempt, so the recorded
   // error row is scoped to the right connection. NULL for local/Ollama.
   tenantProviderId?: string | null;
+  // Label of that same connection, so a failed hop records the key it used
+  // instead of inheriting the primary's label.
+  keyLabel?: string;
   attempt?: ProviderAttemptRef;
   /** False when the route was rejected locally (for example by a cooldown). */
   providerCallStarted?: boolean;
@@ -282,6 +285,7 @@ export class ProxyFallbackService {
             fallbackIndex: i,
             authType,
             tenantProviderId: credentials.tenantProviderId,
+            keyLabel: providerKeyLabel,
             presentation: presentCredentialFailure(
               credentials.reason,
               provider,
@@ -354,6 +358,9 @@ export class ProxyFallbackService {
         errorBody,
         authType,
         tenantProviderId,
+        // Selected-row label (credentials.keyLabel already folded in above),
+        // so this row's label and tenant_provider_id name the same connection.
+        keyLabel: providerKeyLabel,
         attempt: forward.attempt,
         providerCallStarted: forward.providerCallStarted,
       });
@@ -420,7 +427,13 @@ export class ProxyFallbackService {
     healedBody: Record<string, unknown>,
     opts?: Pick<
       ForwardProviderOptions,
-      'provider' | 'model' | 'authType' | 'tenantProviderId' | 'startProviderAttempt' | 'signal'
+      | 'provider'
+      | 'model'
+      | 'authType'
+      | 'tenantProviderId'
+      | 'providerKeyLabel'
+      | 'startProviderAttempt'
+      | 'signal'
     >,
   ): Promise<ForwardResult> {
     if (!forward.retryWireBody) {
@@ -432,6 +445,7 @@ export class ProxyFallbackService {
       model: opts.model,
       authType: opts.authType,
       tenantProviderId: opts.tenantProviderId,
+      keyLabel: opts.providerKeyLabel,
     });
     try {
       const retried = await forward.retryWireBody(healedBody, attempt);
@@ -720,6 +734,7 @@ export class ProxyFallbackService {
       model: opts.model,
       authType,
       tenantProviderId: opts.tenantProviderId,
+      keyLabel: opts.providerKeyLabel,
     });
     try {
       const forward = await this.providerClient.forward({

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -557,6 +557,9 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         provider: canonical.provider,
         auth_type: start.authType ?? null,
         tenant_provider_id: start.tenantProviderId ?? null,
+        // Stamped from the start so an attempt that never reaches a terminal
+        // writer still names the connection it used.
+        provider_key_label: start.keyLabel ?? null,
       }),
     );
     return true;
@@ -575,6 +578,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       model: opts.attemptStart?.model ?? null,
       auth_type: opts.attemptStart?.authType ?? null,
       tenant_provider_id: opts.attemptStart?.tenantProviderId ?? null,
+      provider_key_label: opts.attemptStart?.keyLabel ?? null,
       error_message: null,
       error_http_status: null,
     });
@@ -792,6 +796,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       markHandled?: boolean;
       lastAsError?: boolean;
       authType?: string;
+      /** Primary connection label, used only for failures with no label of their own. */
+      providerKeyLabel?: string;
       reason?: string;
       callerAttribution?: CallerAttribution | null;
       requestHeaders?: Record<string, string> | null;
@@ -809,6 +815,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       markHandled = false,
       lastAsError = false,
       authType,
+      providerKeyLabel,
       reason,
       callerAttribution,
       requestHeaders,
@@ -878,6 +885,9 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
           auth_type: recordedAuth,
           // Per-failure connection: each failed fallback carries its own key id.
           tenant_provider_id: f.tenantProviderId ?? null,
+          // Same rule for the label: the hop's own connection first, the
+          // primary's only for rows that predate per-failure labels.
+          provider_key_label: f.keyLabel ?? providerKeyLabel ?? null,
           caller_attribution: callerAttribution ?? null,
           request_headers: requestHeaders ?? null,
           request_params: requestParams ?? null,
@@ -918,6 +928,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       requestDurationMs?: number;
       reason?: string;
       tenantProviderId?: string | null;
+      /** Label of that same connection, so the failed primary names the key it used. */
+      providerKeyLabel?: string;
       callerAttribution?: CallerAttribution | null;
       requestHeaders?: Record<string, string> | null;
       requestParams?: RequestParamDefaults | null;
@@ -965,6 +977,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       fallback_index: null,
       auth_type: authType ?? null,
       tenant_provider_id: opts?.tenantProviderId ?? null,
+      provider_key_label: opts?.providerKeyLabel ?? null,
       caller_attribution: opts?.callerAttribution ?? null,
       request_headers: opts?.requestHeaders ?? null,
       request_params: opts?.requestParams ?? null,

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -135,7 +135,12 @@ function recordAutofixOriginalIfRetried(
       requestHeaders,
       requestParams: meta.request_params,
       specificityCategory: meta.specificity_category,
-      providerKeyLabel: meta.provider_key_label,
+      // Same rule as tenantProviderId below: on a fallback-success flow
+      // `provider_key_label` names the connection that RECOVERED the request,
+      // while this row belongs to the primary that failed. The direct-success
+      // call site is guarded by `!meta.fallbackFromModel`, so primaryKeyLabel
+      // is absent there and the meta label is already the right one.
+      providerKeyLabel: meta.primaryKeyLabel ?? meta.provider_key_label,
       tenantProviderId:
         route?.tenantProviderId === undefined ? meta.tenantProviderId : route.tenantProviderId,
       headerTierId: meta.header_tier_id,

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -323,6 +323,7 @@ function handleFallbackExhausted(
       markHandled: true,
       lastAsError: true,
       authType: meta.auth_type,
+      providerKeyLabel: meta.provider_key_label,
       reason: meta.reason,
       callerAttribution,
       requestHeaders,
@@ -353,6 +354,7 @@ function handleFallbackExhausted(
         reason: meta.reason,
         // Exhausted chain: primary connection (meta.tenantProviderId holds it here).
         tenantProviderId: meta.tenantProviderId,
+        providerKeyLabel: meta.provider_key_label,
         callerAttribution,
         requestHeaders,
         requestParams: meta.request_params,
@@ -456,6 +458,9 @@ export function recordFallbackFailures(
           meta.primaryTenantProviderId === undefined
             ? meta.tenantProviderId
             : meta.primaryTenantProviderId,
+        // meta.provider_key_label holds the winning fallback's label in this
+        // flow, so prefer the preserved primary label (mirrors the id above).
+        providerKeyLabel: meta.primaryKeyLabel ?? meta.provider_key_label,
         callerAttribution,
         requestHeaders,
         requestParams: meta.request_params,
@@ -479,6 +484,7 @@ export function recordFallbackFailures(
         baseTimeMs: fallbackBaseTime,
         markHandled: true,
         authType: primaryAuthType,
+        providerKeyLabel: meta.primaryKeyLabel ?? meta.provider_key_label,
         reason: meta.reason,
         callerAttribution,
         requestHeaders,

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -46,6 +46,12 @@ export interface ProviderAttemptStart {
   model: string;
   authType?: string;
   tenantProviderId?: string | null;
+  /**
+   * Label of the connection serving this attempt. Carried from the start so a
+   * row that never reaches a terminal writer (a cancelled request) still names
+   * the connection it was billed against.
+   */
+  keyLabel?: string;
 }
 
 /** Identity and measured start of one persisted pending Provider Attempt. */

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -429,7 +429,9 @@ export class ProxyService {
       agentId,
       tenantId,
       rawApiKey: credentials.rawApiKey,
-      providerKeyLabel: credentials.keyLabel ?? route.keyLabel ?? undefined,
+      // Always the selected row's label (see resolveRouteCredentials), so the
+      // forwarded connection and the recorded one can never diverge.
+      providerKeyLabel: credentials.keyLabel,
       authType: route.authType,
       apiMode,
       resourceUrl: credentials.resourceUrl,
@@ -479,12 +481,9 @@ export class ProxyService {
                 apiKey: credentials.apiKey,
                 rawApiKey: credentials.rawApiKey,
                 model: primaryModel,
-                // Use the resolved (unpinned-subscription-pinned) label so the
-                // healed-retry row stamps the same connection its
-                // tenant_provider_id points at — otherwise a null/blank label
-                // rides next to the selected connection id (the divergence the
-                // primary forward already avoids).
-                keyLabel: credentials.keyLabel ?? route.keyLabel ?? undefined,
+                // The selected row's label, so the healed-retry row stamps the
+                // same connection its tenant_provider_id points at.
+                keyLabel: credentials.keyLabel,
                 authType: route.authType,
                 resourceUrl: credentials.resourceUrl,
                 providerRegion: credentials.providerRegion,
@@ -787,9 +786,9 @@ export class ProxyService {
       agentId: ctx.agentId,
       tenantId: ctx.tenantId,
       rawApiKey: credentials.rawApiKey,
-      // Resolved label (pins an unpinned subscription to the selected row) so
-      // the recorded connection matches credentials.tenantProviderId.
-      providerKeyLabel: credentials.keyLabel ?? route.keyLabel ?? undefined,
+      // Selected row's label so the recorded connection matches
+      // credentials.tenantProviderId.
+      providerKeyLabel: credentials.keyLabel,
       authType: route.authType,
       apiMode: ctx.apiMode,
       resourceUrl: credentials.resourceUrl,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -139,6 +139,13 @@ export interface RoutingMeta {
    */
   primaryTenantProviderId?: string | null;
   /**
+   * The primary's connection label when a fallback ultimately succeeded.
+   * Same reason as primaryTenantProviderId: `provider_key_label` then names the
+   * winning fallback's connection, and the primary-failure row must not inherit
+   * a label belonging to a different key.
+   */
+  primaryKeyLabel?: string;
+  /**
    * Effective request body parameters for this attempt: client body values,
    * route-scoped `agent_model_params`, and MPS provider param defaults.
    * Persisted on `agent_messages.request_params` so the dashboard can show
@@ -370,6 +377,7 @@ export class ProxyService {
         model: primaryModel,
         authType: route.authType,
         tenantProviderId: credentials.tenantProviderId,
+        keyLabel: route.keyLabel ?? undefined,
         presentation: credentialFailure,
         startProviderAttempt: willRunChain ? startProviderAttempt : undefined,
       });
@@ -393,6 +401,7 @@ export class ProxyService {
           apiMode,
           paramMergeContext,
           primaryTenantProviderId: credentials.tenantProviderId,
+          primaryKeyLabel: route.keyLabel ?? undefined,
           startProviderAttempt,
           credentialDashboardUrl: dashboardUrl,
         });
@@ -514,6 +523,7 @@ export class ProxyService {
         apiMode,
         paramMergeContext,
         primaryTenantProviderId: credentials.tenantProviderId,
+        primaryKeyLabel: credentials.keyLabel,
         startProviderAttempt,
         credentialDashboardUrl: dashboardUrl,
       });
@@ -564,6 +574,9 @@ export class ProxyService {
           meta: this.buildBaseMeta(resolved, primaryModel, {
             request_params: primaryRequestParams,
             tenantProviderId: credentials.tenantProviderId,
+            // Label of the row actually selected — a stale pin resolves to the
+            // default key, and the recorded label must follow the key used.
+            provider_key_label: credentials.keyLabel,
             attempt: forward.attempt,
             providerCallStarted: forward.providerCallStarted,
             autofixOriginalAttempt,
@@ -616,6 +629,7 @@ export class ProxyService {
           apiMode,
           paramMergeContext,
           primaryTenantProviderId: credentials.tenantProviderId,
+          primaryKeyLabel: credentials.keyLabel,
           startProviderAttempt,
           credentialDashboardUrl: dashboardUrl,
         });
@@ -641,6 +655,7 @@ export class ProxyService {
         meta: this.buildBaseMeta(resolved, primaryModel, {
           request_params: primaryRequestParams,
           tenantProviderId: credentials.tenantProviderId,
+          provider_key_label: credentials.keyLabel,
           attempt: forward.attempt,
           providerCallStarted: forward.providerCallStarted,
           autofixOriginalAttempt,
@@ -657,6 +672,7 @@ export class ProxyService {
       meta: this.buildBaseMeta(resolved, primaryModel, {
         request_params: primaryRequestParams,
         tenantProviderId: credentials.tenantProviderId,
+        provider_key_label: credentials.keyLabel,
         attempt: forward.attempt,
         providerCallStarted: forward.providerCallStarted,
         autofixOriginalAttempt,
@@ -708,6 +724,7 @@ export class ProxyService {
       signal: ctx.signal,
       authType: ctx.authType,
       tenantProviderId: ctx.tenantProviderId,
+      providerKeyLabel: ctx.keyLabel,
       startProviderAttempt: ctx.startProviderAttempt,
     });
   }
@@ -810,6 +827,7 @@ export class ProxyService {
       signal: ctx.signal,
       authType: ctx.authType,
       tenantProviderId: ctx.tenantProviderId,
+      providerKeyLabel: ctx.keyLabel,
       startProviderAttempt: ctx.startProviderAttempt,
     });
   }
@@ -963,7 +981,7 @@ export class ProxyService {
 
     const models = await this.modelDiscovery.getModelsForAgent(tenantId, agentId);
     const catalogRoute = routeForOpenAiModelId(requestedModel, models);
-    if (catalogRoute) return this.explicitRouting(catalogRoute);
+    if (catalogRoute) return this.explicitRouting(agentId, tenantId, catalogRoute);
 
     // A bare ID already present under multiple connections is ambiguous, not
     // undiscovered. Preserve M302 instead of silently picking an auth type.
@@ -981,7 +999,7 @@ export class ProxyService {
       return null;
     }
 
-    return this.explicitRouting(route);
+    return this.explicitRouting(agentId, tenantId, route);
   }
 
   /**
@@ -1031,10 +1049,21 @@ export class ProxyService {
     return connected.length === 1 ? connected[0].route : null;
   }
 
-  private explicitRouting(route: NonNullable<ResolvedRouting['route']>): ResolvedRouting {
+  /**
+   * The single funnel for both explicit-model branches (catalog match and
+   * uncatalogued passthrough). Neither branch knows about connections, so the
+   * route arrives without a `keyLabel` and would resolve to the first key of
+   * the provider. Pin it here — through the same logic tier routing uses — so
+   * an operator's connection choice survives a request that names a model.
+   */
+  private async explicitRouting(
+    agentId: string,
+    tenantId: string,
+    route: NonNullable<ResolvedRouting['route']>,
+  ): Promise<ResolvedRouting> {
     return {
       tier: 'default' as const,
-      route,
+      route: await this.resolveService.pinRouteKeyLabel(agentId, tenantId, route),
       fallback_routes: null,
       response_mode: DEFAULT_RESPONSE_MODE,
       confidence: 1,
@@ -1115,6 +1144,8 @@ export class ProxyService {
     /** Primary connection id, carried so a fallback-success flow can attribute
      * its recorded primary-failure row to the connection that actually failed. */
     primaryTenantProviderId: string | null;
+    /** Label of that same primary connection, for the same attribution reason. */
+    primaryKeyLabel?: string;
     startProviderAttempt?: StartProviderAttempt;
     /** Dashboard URL embedded in mid-chain M100/M102 credential failure bodies. */
     credentialDashboardUrl?: string;
@@ -1206,6 +1237,7 @@ export class ProxyService {
           // buildBaseMeta would otherwise stamp the PRIMARY route's label
           // next to the fallback's tenant_provider_id.
           provider_key_label: success.keyLabel,
+          primaryKeyLabel: args.primaryKeyLabel,
           fallbackFromModel: primaryModel,
           fallbackIndex: success.fallbackIndex,
           primaryErrorStatus: primaryStatus,
@@ -1273,6 +1305,7 @@ export class ProxyService {
         request_params: exhaustedRequestParams,
         // Exhausted chain is recorded against the primary connection.
         tenantProviderId: args.primaryTenantProviderId,
+        provider_key_label: args.primaryKeyLabel ?? resolved.route?.keyLabel ?? undefined,
         primaryAttempt: forward.attempt,
         primaryProviderCallStarted: forward.providerCallStarted,
         attempt: failures[failures.length - 1]?.attempt ?? forward.attempt,

--- a/packages/backend/src/routing/proxy/route-credentials.ts
+++ b/packages/backend/src/routing/proxy/route-credentials.ts
@@ -49,8 +49,13 @@ export type ResolvedRouteCredentials =
       resourceUrl?: string;
       providerRegion?: string | null;
       tenantProviderId: string | null;
-      /** Effective key label after unpinned subscription resolution. */
-      keyLabel?: string;
+      /**
+       * Label of the `tenant_providers` row that was actually selected — the
+       * same row `tenantProviderId` points at, never the requested pin. A pin
+       * that matched nothing falls back to the default key, and the recorded
+       * label has to name the connection that really served the call.
+       */
+      keyLabel: string;
     }
   | {
       ok: false;
@@ -105,6 +110,7 @@ export function startCredentialFailureAttempt(
     model: string;
     authType?: string;
     tenantProviderId?: string | null;
+    keyLabel?: string;
   },
 ): ProviderAttemptRef | undefined {
   const attempt = startProviderAttempt?.(start);
@@ -121,6 +127,8 @@ export function buildCredentialFailureForward(opts: {
   model: string;
   authType?: AuthType;
   tenantProviderId: string | null;
+  /** Pinned connection label, so the failed attempt row still names a connection. */
+  keyLabel?: string;
   presentation: CredentialFailurePresentation;
   startProviderAttempt?: StartProviderAttempt;
 }): ForwardResult {
@@ -129,6 +137,7 @@ export function buildCredentialFailureForward(opts: {
     model: opts.model,
     authType: opts.authType,
     tenantProviderId: opts.tenantProviderId,
+    keyLabel: opts.keyLabel,
   });
   return {
     response: new Response(opts.presentation.errorBody, {
@@ -153,6 +162,8 @@ export function buildCredentialFailureFallback(opts: {
   fallbackIndex: number;
   authType?: AuthType;
   tenantProviderId: string | null;
+  /** Pinned connection label, so the failed hop row still names a connection. */
+  keyLabel?: string;
   presentation: CredentialFailurePresentation;
   startProviderAttempt?: StartProviderAttempt;
 }): {
@@ -163,6 +174,7 @@ export function buildCredentialFailureFallback(opts: {
   errorBody: string;
   authType?: AuthType;
   tenantProviderId: string | null;
+  keyLabel?: string;
   attempt?: ProviderAttemptRef;
   providerCallStarted: true;
 } {
@@ -171,6 +183,7 @@ export function buildCredentialFailureFallback(opts: {
     model: opts.model,
     authType: opts.authType,
     tenantProviderId: opts.tenantProviderId,
+    keyLabel: opts.keyLabel,
   });
   return {
     model: opts.model,
@@ -180,6 +193,7 @@ export function buildCredentialFailureFallback(opts: {
     errorBody: opts.presentation.errorBody,
     authType: opts.authType,
     tenantProviderId: opts.tenantProviderId,
+    keyLabel: opts.keyLabel,
     attempt,
     providerCallStarted: true,
   };
@@ -272,6 +286,8 @@ export async function resolveRouteCredentials(
     resourceUrl: unwrapped.resourceUrl,
     providerRegion: key.region,
     tenantProviderId,
-    keyLabel: providerKeyLabel,
+    // The selected row's own label, not `args.providerKeyLabel`: selection may
+    // have fallen back to the default key when the pin matched nothing.
+    keyLabel: key.label,
   };
 }

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -1074,4 +1074,115 @@ describe('ResolveService', () => {
       expect(result.reason).toBe('default');
     });
   });
+
+  /**
+   * Shared with the proxy's explicit-model path: a request that names a
+   * concrete model skips tier resolution, so this is the only place its route
+   * can pick up the connection the operator pinned.
+   */
+  describe('pinRouteKeyLabel', () => {
+    const defaultTier = (override: ModelRoute | null): TierAssignment =>
+      ({
+        tier: 'default',
+        override_route: override,
+        auto_assigned_route: null,
+        fallback_routes: null,
+      }) as TierAssignment;
+
+    it('keeps a label the route already pins', async () => {
+      const pinned = { ...route('openai', 'api_key', 'gpt-4o'), keyLabel: 'Explicit' };
+
+      const result = await svc.pinRouteKeyLabel('agent-1', 'tenant-1', pinned);
+
+      expect(result).toBe(pinned);
+      expect(tierService.getTiers).not.toHaveBeenCalled();
+    });
+
+    it('adopts the default tier pin when provider and auth match', async () => {
+      tierService.getTiers.mockResolvedValue([
+        defaultTier({ ...route('OpenAI', 'api_key', 'gpt-4o-mini'), keyLabel: 'Work' }),
+      ]);
+
+      const result = await svc.pinRouteKeyLabel(
+        'agent-1',
+        'tenant-1',
+        route('openai', 'api_key', 'gpt-4o'),
+      );
+
+      // Model differs on purpose: the pin follows the connection, not the model.
+      expect(result).toEqual({ ...route('openai', 'api_key', 'gpt-4o'), keyLabel: 'Work' });
+      expect(providerKeyService.getDefaultKeyLabel).not.toHaveBeenCalled();
+    });
+
+    it('ignores a default tier pin for a different provider', async () => {
+      tierService.getTiers.mockResolvedValue([
+        defaultTier({ ...route('anthropic', 'api_key', 'claude-sonnet-4-5'), keyLabel: 'Work' }),
+      ]);
+      providerKeyService.getDefaultKeyLabel.mockResolvedValue('Default');
+
+      const result = await svc.pinRouteKeyLabel(
+        'agent-1',
+        'tenant-1',
+        route('openai', 'api_key', 'gpt-4o'),
+      );
+
+      expect(result).toEqual({ ...route('openai', 'api_key', 'gpt-4o'), keyLabel: 'Default' });
+    });
+
+    it('ignores a default tier pin for a different auth type', async () => {
+      tierService.getTiers.mockResolvedValue([
+        defaultTier({ ...route('openai', 'subscription', 'gpt-5.5'), keyLabel: 'Work' }),
+      ]);
+      providerKeyService.getDefaultKeyLabel.mockResolvedValue('Default');
+
+      const result = await svc.pinRouteKeyLabel(
+        'agent-1',
+        'tenant-1',
+        route('openai', 'api_key', 'gpt-4o'),
+      );
+
+      expect(result).toEqual({ ...route('openai', 'api_key', 'gpt-4o'), keyLabel: 'Default' });
+    });
+
+    it('falls back to the default connection label when the default tier pins nothing', async () => {
+      tierService.getTiers.mockResolvedValue([
+        defaultTier(route('openai', 'api_key', 'gpt-4o-mini')),
+      ]);
+      providerKeyService.getDefaultKeyLabel.mockResolvedValue('Default');
+
+      const result = await svc.pinRouteKeyLabel(
+        'agent-1',
+        'tenant-1',
+        route('openai', 'api_key', 'gpt-4o'),
+      );
+
+      expect(result).toEqual({ ...route('openai', 'api_key', 'gpt-4o'), keyLabel: 'Default' });
+    });
+
+    it('falls back to the default connection label when there is no default tier row', async () => {
+      tierService.getTiers.mockResolvedValue([]);
+      providerKeyService.getDefaultKeyLabel.mockResolvedValue('Only');
+
+      const result = await svc.pinRouteKeyLabel(
+        'agent-1',
+        'tenant-1',
+        route('openai', 'api_key', 'gpt-4o'),
+      );
+
+      expect(result).toEqual({ ...route('openai', 'api_key', 'gpt-4o'), keyLabel: 'Only' });
+    });
+
+    it('leaves the route unlabelled when no connection resolves at all', async () => {
+      tierService.getTiers.mockResolvedValue([defaultTier(null)]);
+      providerKeyService.getDefaultKeyLabel.mockResolvedValue(undefined);
+
+      const result = await svc.pinRouteKeyLabel(
+        'agent-1',
+        'tenant-1',
+        route('openai', 'api_key', 'gpt-4o'),
+      );
+
+      expect(result).toEqual(route('openai', 'api_key', 'gpt-4o'));
+    });
+  });
 });

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -20,7 +20,7 @@ import { scoreRequest, ScorerInput, MomentumInput, scanMessages } from '../../sc
 import { ResolveResponse } from '../dto/resolve-response';
 import { inferProviderFromModelName } from '../../common/utils/provider-aliases';
 import { Agent } from '../../entities/agent.entity';
-import { DEFAULT_RESPONSE_MODE, DEFAULT_OUTPUT_MODALITY } from 'manifest-shared';
+import { DEFAULT_RESPONSE_MODE, DEFAULT_OUTPUT_MODALITY, DEFAULT_TIER_SLOT } from 'manifest-shared';
 import type {
   AuthType,
   ModelRoute,
@@ -465,6 +465,47 @@ export class ResolveService {
       }
     }
     return { primaryRoute: null, fallbackRoutes: null };
+  }
+
+  /**
+   * Public so the proxy can pin an explicit-model route the same way the
+   * automatic path pins a tier route.
+   *
+   * A request that names a concrete model bypasses tier resolution entirely,
+   * so it never sees the connection the operator pinned on the default tier.
+   * With two connections for one provider that means the *first* key wins and
+   * the pin is silently ignored. Adopt the default tier's `override_route`
+   * label when that override addresses the same (provider, authType) as the
+   * resolved route, then fall back to the default-connection label.
+   */
+  async pinRouteKeyLabel(
+    agentId: string,
+    tenantId: string,
+    route: ModelRoute,
+  ): Promise<ModelRoute> {
+    if (route.keyLabel) return route;
+    const pinned = await this.defaultTierKeyLabel(agentId, route);
+    if (pinned) return { ...route, keyLabel: pinned };
+    return this.enrichRouteKeyLabel(agentId, tenantId, route);
+  }
+
+  /**
+   * The default tier's pinned connection label when its override addresses the
+   * same connection family as `route`. A pin only carries over when both the
+   * provider and the auth mode match — the same label on a different auth
+   * mode is a different `tenant_providers` row.
+   */
+  private async defaultTierKeyLabel(
+    agentId: string,
+    route: ModelRoute,
+  ): Promise<string | undefined> {
+    const tiers = await this.tierService.getTiers(agentId);
+    const assignment = tiers.find((t) => t.tier === DEFAULT_TIER_SLOT);
+    const override = assignment ? readOverrideRoute(assignment) : null;
+    if (!override?.keyLabel) return undefined;
+    if (override.provider.toLowerCase() !== route.provider.toLowerCase()) return undefined;
+    if (override.authType !== route.authType) return undefined;
+    return override.keyLabel;
   }
 
   /**

--- a/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
@@ -79,6 +79,45 @@ describe('ProviderKeyService — selection projections', () => {
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('"Default"'));
     });
 
+    it('throttles repeated warnings for the same stale pin', async () => {
+      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
+      const warn = jest
+        .spyOn(svc['logger'], 'warn')
+        .mockImplementation(() => undefined as unknown as void);
+
+      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired', 'agent-1');
+      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired', 'agent-1');
+
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('warns again after the stale-pin throttle window', async () => {
+      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
+      const warn = jest
+        .spyOn(svc['logger'], 'warn')
+        .mockImplementation(() => undefined as unknown as void);
+      const now = jest.spyOn(Date, 'now');
+      now.mockReturnValueOnce(1_000).mockReturnValueOnce(61_000);
+
+      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired', 'agent-1');
+      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired', 'agent-1');
+
+      expect(warn).toHaveBeenCalledTimes(2);
+      now.mockRestore();
+    });
+
+    it('bounds stale-pin warning keys', async () => {
+      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
+      jest.spyOn(svc['logger'], 'warn').mockImplementation(() => undefined as unknown as void);
+
+      for (let i = 0; i < 257; i++) {
+        await svc.selectProviderKey('u', 'openai', 'api_key', `Retired-${i}`, 'agent-1');
+      }
+
+      expect(svc['stalePinWarnings'].size).toBe(256);
+      expect(svc['stalePinWarnings'].has('u\0agent-1\0openai\0api_key\0retired-0')).toBe(false);
+    });
+
     it('names the auth type as "any" in the warning when none was requested', async () => {
       jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
       const warn = jest

--- a/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
@@ -90,6 +90,33 @@ describe('ProviderKeyService — selection projections', () => {
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('authType=any'));
     });
 
+    it('sanitizes a label that carries control characters into the log line', async () => {
+      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
+      const warn = jest
+        .spyOn(svc['logger'], 'warn')
+        .mockImplementation(() => undefined as unknown as void);
+
+      // A newline in a user-authored label would otherwise forge a log line.
+      await svc.selectProviderKey('u', 'openai', 'api_key', 'Work\nWARN fake entry');
+
+      const line = warn.mock.calls[0][0] as string;
+      expect(line).not.toContain('\n');
+      expect(line).toContain('Work WARN fake entry');
+    });
+
+    it('truncates an over-long label in the log line', async () => {
+      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
+      const warn = jest
+        .spyOn(svc['logger'], 'warn')
+        .mockImplementation(() => undefined as unknown as void);
+
+      await svc.selectProviderKey('u', 'openai', 'api_key', 'L'.repeat(200));
+
+      const line = warn.mock.calls[0][0] as string;
+      expect(line).toContain(`${'L'.repeat(64)}…`);
+      expect(line).not.toContain('L'.repeat(65));
+    });
+
     it('does not warn when the label matches', async () => {
       jest
         .spyOn(svc, 'getProviderKeys')

--- a/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
@@ -63,6 +63,46 @@ describe('ProviderKeyService — selection projections', () => {
       expect(sel?.id).toBe('up-default');
     });
 
+    // Serving the default key silently bills a connection the operator never
+    // chose. The fallback stays (traffic keeps flowing) but it must be visible.
+    it('warns when a supplied label matches no connection', async () => {
+      jest
+        .spyOn(svc, 'getProviderKeys')
+        .mockResolvedValue([key({ id: 'up-default', label: 'Default' })]);
+      const warn = jest
+        .spyOn(svc['logger'], 'warn')
+        .mockImplementation(() => undefined as unknown as void);
+
+      await svc.selectProviderKey('u', 'openai', 'api_key', 'Retired');
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('"Retired"'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('"Default"'));
+    });
+
+    it('names the auth type as "any" in the warning when none was requested', async () => {
+      jest.spyOn(svc, 'getProviderKeys').mockResolvedValue([key({ label: 'Default' })]);
+      const warn = jest
+        .spyOn(svc['logger'], 'warn')
+        .mockImplementation(() => undefined as unknown as void);
+
+      await svc.selectProviderKey('u', 'openai', undefined, 'Retired');
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('authType=any'));
+    });
+
+    it('does not warn when the label matches', async () => {
+      jest
+        .spyOn(svc, 'getProviderKeys')
+        .mockResolvedValue([key({ id: 'up-default' }), key({ id: 'up-work', label: 'Work' })]);
+      const warn = jest
+        .spyOn(svc['logger'], 'warn')
+        .mockImplementation(() => undefined as unknown as void);
+
+      await svc.selectProviderKey('u', 'openai', 'api_key', 'Work');
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
     it('returns the first key when no label is given', async () => {
       jest
         .spyOn(svc, 'getProviderKeys')

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -105,6 +105,13 @@ export class ProviderKeyService {
     if (label) {
       const match = keys.find((k) => k.label.toLowerCase() === label.toLowerCase());
       if (match) return match;
+      // A pin that names no connection is a stale route (the key was renamed
+      // or deleted). Serving the default keeps traffic flowing, but it silently
+      // bills a connection the operator did not choose — say so.
+      this.logger.warn(
+        `Key label "${label}" matches no ${provider} connection for tenant=${tenantId} ` +
+          `authType=${authType ?? 'any'} — falling back to "${keys[0].label}"`,
+      );
     }
     return keys[0];
   }

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -25,6 +25,8 @@ export const SYNTHETIC_OLLAMA_PROVIDER_ID = 'ollama';
 
 /** Longest connection label echoed into a log line. */
 const MAX_LOGGED_LABEL_LENGTH = 64;
+const STALE_PIN_WARN_WINDOW_MS = 60_000;
+const MAX_STALE_PIN_WARNING_KEYS = 256;
 
 /**
  * Connection labels are user-authored text. Strip control characters (a
@@ -46,6 +48,7 @@ function forLog(label: string): string {
 @Injectable()
 export class ProviderKeyService {
   private readonly logger = new Logger(ProviderKeyService.name);
+  private readonly stalePinWarnings = new Map<string, number>();
 
   constructor(
     @InjectRepository(TenantProvider)
@@ -127,11 +130,26 @@ export class ProviderKeyService {
       if (match) return match;
       // A pin that names no connection is a stale route (the key was renamed
       // or deleted). Serving the default keeps traffic flowing, but it silently
-      // bills a connection the operator did not choose — say so.
-      this.logger.warn(
-        `Key label "${forLog(label)}" matches no ${provider} connection for tenant=${tenantId} ` +
-          `authType=${authType ?? 'any'} — falling back to "${forLog(keys[0].label)}"`,
-      );
+      // bills a connection the operator did not choose. Throttle identical
+      // warnings so subscription re-reads and fallback retries stay diagnosable
+      // without producing one log line per lookup.
+      const warningKey = [tenantId, agentId ?? '', provider.toLowerCase(), authType ?? '', label]
+        .join('\0')
+        .toLowerCase();
+      const now = Date.now();
+      const warnedAt = this.stalePinWarnings.get(warningKey);
+      if (warnedAt === undefined || now - warnedAt >= STALE_PIN_WARN_WINDOW_MS) {
+        this.stalePinWarnings.delete(warningKey);
+        this.stalePinWarnings.set(warningKey, now);
+        if (this.stalePinWarnings.size > MAX_STALE_PIN_WARNING_KEYS) {
+          const oldest = this.stalePinWarnings.keys().next().value as string | undefined;
+          if (oldest !== undefined) this.stalePinWarnings.delete(oldest);
+        }
+        this.logger.warn(
+          `Key label "${forLog(label)}" matches no ${provider} connection for tenant=${tenantId} ` +
+            `authType=${authType ?? 'any'} — falling back to "${forLog(keys[0].label)}"`,
+        );
+      }
     }
     return keys[0];
   }

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -23,6 +23,26 @@ import { isManifestUsableProvider } from '../../common/utils/subscription-suppor
  */
 export const SYNTHETIC_OLLAMA_PROVIDER_ID = 'ollama';
 
+/** Longest connection label echoed into a log line. */
+const MAX_LOGGED_LABEL_LENGTH = 64;
+
+/**
+ * Connection labels are user-authored text. Strip control characters (a
+ * newline would let a label forge extra log lines) and cap the length before
+ * interpolating one into a log message.
+ */
+function forLog(label: string): string {
+  const cleaned = [...label]
+    .map((c) => {
+      const code = c.codePointAt(0) ?? 0;
+      return code < 0x20 || code === 0x7f ? ' ' : c;
+    })
+    .join('');
+  return cleaned.length > MAX_LOGGED_LABEL_LENGTH
+    ? `${cleaned.slice(0, MAX_LOGGED_LABEL_LENGTH)}…`
+    : cleaned;
+}
+
 @Injectable()
 export class ProviderKeyService {
   private readonly logger = new Logger(ProviderKeyService.name);
@@ -109,8 +129,8 @@ export class ProviderKeyService {
       // or deleted). Serving the default keeps traffic flowing, but it silently
       // bills a connection the operator did not choose — say so.
       this.logger.warn(
-        `Key label "${label}" matches no ${provider} connection for tenant=${tenantId} ` +
-          `authType=${authType ?? 'any'} — falling back to "${keys[0].label}"`,
+        `Key label "${forLog(label)}" matches no ${provider} connection for tenant=${tenantId} ` +
+          `authType=${authType ?? 'any'} — falling back to "${forLog(keys[0].label)}"`,
       );
     }
     return keys[0];


### PR DESCRIPTION
### ✨ What changed
- Explicit-model requests honor matching default-route key-label pins.
- Request logs record the connection actually selected.
- Pending, failed, cancelled, fallback, and Auto-fix attempts retain that label.
- Stale-pin warnings are throttled while preserving fallback behavior.

### 💭 Why
Concrete-model SDK requests skipped the configured pin and could bill the wrong connection while recording an inaccurate label.

### 👤 For users
Explicit-model traffic now uses the pinned connection when provider and authentication type match.

### 🔧 For operators
No migration or configuration change. Per-label usage becomes accurate for new requests after deployment.

### 📝 Notes
Header-tier and complexity-tier pins remain out of scope for explicit-model requests.
