### PR TITLE
feat: record the API surface on each request

### DIFF
--- a/packages/backend/src/analytics/services/messages-query.requests.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.requests.spec.ts
@@ -172,6 +172,7 @@ describe('MessagesQueryService request-first queries', () => {
     expect(requestQb.setQueryRunner).toHaveBeenCalledWith(runner);
     expect(legacyCountQb.setQueryRunner).toHaveBeenCalledWith(runner);
     expect(legacyDataQb.setQueryRunner).toHaveBeenCalledWith(runner);
+    expect(legacyDataQb.addSelect).toHaveBeenCalledWith('NULL', 'api_mode');
     expect(runner.commitTransaction).toHaveBeenCalledTimes(1);
     expect(runner.rollbackTransaction).not.toHaveBeenCalled();
     expect(runner.release).toHaveBeenCalledTimes(1);

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -551,6 +551,7 @@ export class MessagesQueryService {
       .addSelect('at.cache_read_tokens', 'cache_read_tokens')
       .addSelect('at.cache_creation_tokens', 'cache_creation_tokens')
       .addSelect('at.duration_ms', 'duration_ms')
+      .addSelect('NULL', 'api_mode')
       .addSelect('1', 'attempt_count');
     this.applyCursor(legacyDataQb, params.cursor);
 

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -469,6 +469,7 @@ export class MessagesQueryService {
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'total_tokens')
       .addSelect(`COALESCE(SUM(${safeCost}), 0)`, 'cost')
       .addSelect('r.status', 'status')
+      .addSelect('r.api_mode', 'api_mode')
       .addSelect('r.error_message', 'error_message')
       .addSelect('r.error_code', 'error_code')
       .addSelect('r.error_origin', 'error_origin')

--- a/packages/backend/src/database/data-source-definitions.ts
+++ b/packages/backend/src/database/data-source-definitions.ts
@@ -38,6 +38,7 @@ import { AddRequestRecordings1801300000000 } from './migrations/1801300000000-Ad
 import { MoveRecordingsToProviderAttempts1801400000000 } from './migrations/1801400000000-MoveRecordingsToProviderAttempts';
 import { EnableRecordingForNewAgents1801500000000 } from './migrations/1801500000000-EnableRecordingForNewAgents';
 import { DropLegacyAutofixRolloutColumns1801600000000 } from './migrations/1801600000000-DropLegacyAutofixRolloutColumns';
+import { AddRequestApiMode1801720000000 } from './migrations/1801720000000-AddRequestApiMode';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
 import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
@@ -314,4 +315,5 @@ export const migrations = [
   MoveRecordingsToProviderAttempts1801400000000,
   EnableRecordingForNewAgents1801500000000,
   DropLegacyAutofixRolloutColumns1801600000000,
+  AddRequestApiMode1801720000000,
 ];

--- a/packages/backend/src/database/migrations/1801720000000-AddRequestApiMode.spec.ts
+++ b/packages/backend/src/database/migrations/1801720000000-AddRequestApiMode.spec.ts
@@ -1,0 +1,58 @@
+import { AddRequestApiMode1801720000000 } from './1801720000000-AddRequestApiMode';
+
+describe('AddRequestApiMode1801720000000', () => {
+  const migration = new AddRequestApiMode1801720000000();
+  const query = jest.fn().mockResolvedValue([]);
+  const queryRunner = { query } as never;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('adds the nullable api_mode column under a bounded lock wait', async () => {
+    await migration.up(queryRunner);
+
+    expect(query).toHaveBeenCalledTimes(3);
+    const statements = query.mock.calls.map(([sql]) => sql);
+    const sql = statements.join(' ');
+    expect(statements[0]).toContain("SET lock_timeout = '5s'");
+    expect(statements.at(-1)).toContain('RESET lock_timeout');
+    expect(sql).toContain('ALTER TABLE "requests"');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "api_mode" character varying');
+    expect(sql).not.toContain('service_type');
+  });
+
+  it('drops the column on rollback', async () => {
+    await migration.down(queryRunner);
+
+    expect(query).toHaveBeenCalledTimes(3);
+    const statements = query.mock.calls.map(([sql]) => sql);
+    const sql = statements.join(' ');
+    expect(statements[0]).toContain("SET lock_timeout = '5s'");
+    expect(statements.at(-1)).toContain('RESET lock_timeout');
+    expect(sql).toContain('DROP COLUMN IF EXISTS "api_mode"');
+    expect(sql).not.toContain('service_type');
+  });
+
+  it('restores the session lock timeout when the schema change fails', async () => {
+    const failure = new Error('lock timeout');
+    query
+      .mockImplementationOnce(async () => [])
+      .mockImplementationOnce(async () => {
+        throw failure;
+      });
+
+    await expect(migration.up(queryRunner)).rejects.toBe(failure);
+    expect(query.mock.calls.at(-1)?.[0]).toContain('RESET lock_timeout');
+  });
+
+  it('restores the session lock timeout when the rollback fails', async () => {
+    const failure = new Error('lock timeout');
+    query
+      .mockImplementationOnce(async () => [])
+      .mockImplementationOnce(async () => {
+        throw failure;
+      });
+
+    await expect(migration.down(queryRunner)).rejects.toBe(failure);
+    expect(query.mock.calls.at(-1)?.[0]).toContain('RESET lock_timeout');
+  });
+});

--- a/packages/backend/src/database/migrations/1801720000000-AddRequestApiMode.spec.ts
+++ b/packages/backend/src/database/migrations/1801720000000-AddRequestApiMode.spec.ts
@@ -10,11 +10,10 @@ describe('AddRequestApiMode1801720000000', () => {
   it('adds the nullable api_mode column under a bounded lock wait', async () => {
     await migration.up(queryRunner);
 
-    expect(query).toHaveBeenCalledTimes(3);
+    expect(query).toHaveBeenCalledTimes(2);
     const statements = query.mock.calls.map(([sql]) => sql);
     const sql = statements.join(' ');
-    expect(statements[0]).toContain("SET lock_timeout = '5s'");
-    expect(statements.at(-1)).toContain('RESET lock_timeout');
+    expect(statements[0]).toContain("SET LOCAL lock_timeout = '5s'");
     expect(sql).toContain('ALTER TABLE "requests"');
     expect(sql).toContain('ADD COLUMN IF NOT EXISTS "api_mode" character varying');
     expect(sql).not.toContain('service_type');
@@ -23,16 +22,15 @@ describe('AddRequestApiMode1801720000000', () => {
   it('drops the column on rollback', async () => {
     await migration.down(queryRunner);
 
-    expect(query).toHaveBeenCalledTimes(3);
+    expect(query).toHaveBeenCalledTimes(2);
     const statements = query.mock.calls.map(([sql]) => sql);
     const sql = statements.join(' ');
-    expect(statements[0]).toContain("SET lock_timeout = '5s'");
-    expect(statements.at(-1)).toContain('RESET lock_timeout');
+    expect(statements[0]).toContain("SET LOCAL lock_timeout = '5s'");
     expect(sql).toContain('DROP COLUMN IF EXISTS "api_mode"');
     expect(sql).not.toContain('service_type');
   });
 
-  it('restores the session lock timeout when the schema change fails', async () => {
+  it('preserves the schema-change error without querying the aborted transaction', async () => {
     const failure = new Error('lock timeout');
     query
       .mockImplementationOnce(async () => [])
@@ -41,10 +39,10 @@ describe('AddRequestApiMode1801720000000', () => {
       });
 
     await expect(migration.up(queryRunner)).rejects.toBe(failure);
-    expect(query.mock.calls.at(-1)?.[0]).toContain('RESET lock_timeout');
+    expect(query).toHaveBeenCalledTimes(2);
   });
 
-  it('restores the session lock timeout when the rollback fails', async () => {
+  it('preserves the rollback error without querying the aborted transaction', async () => {
     const failure = new Error('lock timeout');
     query
       .mockImplementationOnce(async () => [])
@@ -53,6 +51,6 @@ describe('AddRequestApiMode1801720000000', () => {
       });
 
     await expect(migration.down(queryRunner)).rejects.toBe(failure);
-    expect(query.mock.calls.at(-1)?.[0]).toContain('RESET lock_timeout');
+    expect(query).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/backend/src/database/migrations/1801720000000-AddRequestApiMode.ts
+++ b/packages/backend/src/database/migrations/1801720000000-AddRequestApiMode.ts
@@ -9,26 +9,18 @@ export class AddRequestApiMode1801720000000 implements MigrationInterface {
   name = 'AddRequestApiMode1801720000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`SET lock_timeout = '5s'`);
-    try {
-      await queryRunner.query(`
-        ALTER TABLE "requests"
-          ADD COLUMN IF NOT EXISTS "api_mode" character varying
-      `);
-    } finally {
-      await queryRunner.query(`RESET lock_timeout`);
-    }
+    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+    await queryRunner.query(`
+      ALTER TABLE "requests"
+        ADD COLUMN IF NOT EXISTS "api_mode" character varying
+    `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`SET lock_timeout = '5s'`);
-    try {
-      await queryRunner.query(`
-        ALTER TABLE "requests"
-          DROP COLUMN IF EXISTS "api_mode"
-      `);
-    } finally {
-      await queryRunner.query(`RESET lock_timeout`);
-    }
+    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+    await queryRunner.query(`
+      ALTER TABLE "requests"
+        DROP COLUMN IF EXISTS "api_mode"
+    `);
   }
 }

--- a/packages/backend/src/database/migrations/1801720000000-AddRequestApiMode.ts
+++ b/packages/backend/src/database/migrations/1801720000000-AddRequestApiMode.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Persist which API surface each Manifest Request arrived on
+ * ('chat_completions' | 'responses' | 'messages'). The proxy already tracked it
+ * in memory; the request log could not show it because it was never written.
+ */
+export class AddRequestApiMode1801720000000 implements MigrationInterface {
+  name = 'AddRequestApiMode1801720000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET lock_timeout = '5s'`);
+    try {
+      await queryRunner.query(`
+        ALTER TABLE "requests"
+          ADD COLUMN IF NOT EXISTS "api_mode" character varying
+      `);
+    } finally {
+      await queryRunner.query(`RESET lock_timeout`);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET lock_timeout = '5s'`);
+    try {
+      await queryRunner.query(`
+        ALTER TABLE "requests"
+          DROP COLUMN IF EXISTS "api_mode"
+      `);
+    } finally {
+      await queryRunner.query(`RESET lock_timeout`);
+    }
+  }
+}

--- a/packages/backend/src/entities/request.entity.ts
+++ b/packages/backend/src/entities/request.entity.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { timestampType } from '../common/utils/postgres-sql';
 import type { CallerAttribution } from '../routing/proxy/caller-classifier';
+import type { ProxyApiMode } from '../routing/proxy/proxy-types';
 import type { AutofixStatus } from 'manifest-shared';
 
 /**
@@ -73,6 +74,14 @@ export class ManifestRequest {
   /** Model requested by the caller, before routing and fallbacks. */
   @Column('varchar', { nullable: true })
   requested_model!: string | null;
+
+  /**
+   * Which Manifest API surface the caller used: 'chat_completions'
+   * (/v1/chat/completions), 'responses' (/v1/responses), or 'messages'
+   * (/v1/messages). NULL when the surface was not known at write time.
+   */
+  @Column('varchar', { nullable: true })
+  api_mode!: ProxyApiMode | null;
 
   @Column('simple-json', { nullable: true })
   caller_attribution!: CallerAttribution | null;

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -487,6 +487,9 @@ export class PlaygroundService {
           error_origin: null,
           error_class: null,
           requested_model: dto.model,
+          // The Playground calls a provider directly; it never enters through
+          // one of the proxy's public API surfaces.
+          api_mode: null,
           caller_attribution: null,
           request_headers: null,
           request_params: null,
@@ -562,6 +565,9 @@ export class PlaygroundService {
           error_origin: errorOrigin,
           error_class: null,
           requested_model: dto.model,
+          // The Playground calls a provider directly; it never enters through
+          // one of the proxy's public API surfaces.
+          api_mode: null,
           caller_attribution: null,
           request_headers: null,
           request_params: null,

--- a/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
@@ -52,6 +52,7 @@ describe('ProxyMessageRecorder request parents', () => {
       requestId: 'request-1',
       provider: 'openai',
       model: 'gpt-4o',
+      apiMode: 'responses',
     });
 
     expect(execute).toHaveBeenCalledTimes(1);
@@ -61,9 +62,28 @@ describe('ProxyMessageRecorder request parents', () => {
         status: 'failed',
         autofix_status: null,
         error_origin: 'transport',
+        api_mode: 'responses',
       }),
     );
     expect(insert).toHaveBeenCalledWith(expect.objectContaining({ request_id: 'request-1' }));
+    recorder.onModuleDestroy();
+  });
+
+  it('stamps api_mode when a success terminal write creates the Request', async () => {
+    const { recorder, requestValues } = setup();
+
+    await recorder.recordSuccessMessage(
+      ctx,
+      'gpt-4o',
+      'standard',
+      'scored',
+      { prompt_tokens: 10, completion_tokens: 5 },
+      { requestId: 'request-success-first', provider: 'openai', apiMode: 'messages' },
+    );
+
+    expect(requestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'request-success-first', api_mode: 'messages' }),
+    );
     recorder.onModuleDestroy();
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-request-recorder.spec.ts
@@ -121,6 +121,97 @@ describe('ProxyMessageRecorder request parents', () => {
     recorder.onModuleDestroy();
   });
 
+  it.each(['chat_completions', 'responses', 'messages'] as const)(
+    'stamps the %s API surface on the pending Request',
+    async (apiMode) => {
+      const { recorder, requestValues } = setup();
+
+      await recorder.recordPendingRequest(ctx, {
+        requestId: `request-${apiMode}`,
+        timestamp: '2026-07-16T12:00:00.000Z',
+        apiMode,
+      });
+
+      expect(requestValues).toHaveBeenCalledWith(
+        expect.objectContaining({ id: `request-${apiMode}`, status: 'pending', api_mode: apiMode }),
+      );
+      recorder.onModuleDestroy();
+    },
+  );
+
+  it('leaves api_mode null when the surface was not supplied', async () => {
+    const { recorder, requestValues } = setup();
+
+    await recorder.recordPendingRequest(ctx, {
+      requestId: 'request-no-surface',
+      timestamp: '2026-07-16T12:00:00.000Z',
+    });
+
+    expect(requestValues).toHaveBeenCalledWith(expect.objectContaining({ api_mode: null }));
+    recorder.onModuleDestroy();
+  });
+
+  it.each([true, false] as const)(
+    'preserves the ingress api_mode through the terminal write (success=%s)',
+    async (succeeded) => {
+      const { recorder, requestValues, requestQb } = setup();
+      const requestId = `request-terminal-${succeeded}`;
+
+      await recorder.recordPendingRequest(ctx, {
+        requestId,
+        timestamp: '2026-07-16T12:00:00.000Z',
+        apiMode: 'messages',
+      });
+      if (succeeded) {
+        await recorder.recordSuccessMessage(
+          ctx,
+          'claude-sonnet',
+          'standard',
+          'scored',
+          { prompt_tokens: 10, completion_tokens: 5 },
+          { requestId, provider: 'anthropic' },
+        );
+      } else {
+        await recorder.recordProviderError(ctx, 503, 'upstream down', {
+          requestId,
+          provider: 'anthropic',
+          model: 'claude-sonnet',
+        });
+      }
+
+      expect(requestValues).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ status: 'pending', api_mode: 'messages' }),
+      );
+      expect(requestValues).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ status: succeeded ? 'success' : 'failed' }),
+      );
+      // The terminal upsert must not list api_mode, or a writer without the
+      // surface in scope would null out what ingress already recorded.
+      const updatedColumns = requestQb.orUpdate.mock.calls[0][0] as string[];
+      expect(updatedColumns).not.toContain('api_mode');
+      recorder.onModuleDestroy();
+    },
+  );
+
+  it('stamps the API surface on a Manifest-blocked Request', async () => {
+    const { recorder, requestValues } = setup();
+
+    await recorder.recordManifestBlockedRequest(ctx, {
+      requestId: 'request-blocked-surface',
+      reason: 'no_provider_key',
+      errorMessage: 'No provider key',
+      errorCode: 'M100',
+      apiMode: 'responses',
+    });
+
+    expect(requestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'request-blocked-surface', api_mode: 'responses' }),
+    );
+    recorder.onModuleDestroy();
+  });
+
   it.each([
     [
       'no_patch',

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -162,6 +162,12 @@ describe('proxy-response-handler', () => {
         undefined,
         recorder as any,
         'trace-1',
+        undefined,
+        undefined,
+        undefined,
+        'request-1',
+        undefined,
+        'responses',
       );
 
       expect(recorder.recordProviderError).toHaveBeenCalledWith(
@@ -179,6 +185,7 @@ describe('proxy-response-handler', () => {
           authType: undefined,
           reason: 'auto',
           specificityCategory: undefined,
+          apiMode: 'responses',
         }),
       );
       expect(res.status).toHaveBeenCalledWith(500);
@@ -2287,7 +2294,22 @@ describe('proxy-response-handler', () => {
       const meta = makeMeta();
       const usage: StreamUsage = { prompt_tokens: 100, completion_tokens: 50 };
 
-      recordSuccess(testCtx, meta, usage, undefined, recorder as any, 'trace-1', 'session-1', 1000);
+      recordSuccess(
+        testCtx,
+        meta,
+        usage,
+        undefined,
+        recorder as any,
+        'trace-1',
+        'session-1',
+        1000,
+        undefined,
+        undefined,
+        undefined,
+        'request-1',
+        1,
+        'messages',
+      );
 
       expect(recorder.recordSuccessMessage).toHaveBeenCalledWith(
         testCtx,
@@ -2304,6 +2326,7 @@ describe('proxy-response-handler', () => {
           sessionKey: 'session-1',
           durationMs: expect.any(Number),
           specificityCategory: undefined,
+          apiMode: 'messages',
         }),
       );
     });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -577,6 +577,38 @@ describe('ProxyController', () => {
     expect(headers['X-Manifest-Reason']).toBe('scored');
   });
 
+  it.each([
+    ['chatCompletions', 'chat_completions', { messages: [{ role: 'user', content: 'hi' }] }],
+    ['responses', 'responses', { input: 'hi' }],
+    ['messages', 'messages', { max_tokens: 8, messages: [{ role: 'user', content: 'hi' }] }],
+  ] as const)(
+    'stamps the API surface of /v1/%s on the pending Request',
+    async (route, expectedApiMode, body) => {
+      const mockProviderResp = new Response(
+        JSON.stringify({ choices: [{ message: { content: 'hello' } }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+      proxyService.proxyRequest.mockResolvedValue({
+        forward: {
+          response: mockProviderResp,
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        },
+        meta: { tier: 'simple', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9 },
+      });
+      const pending = jest.spyOn(recorder, 'recordPendingRequest').mockResolvedValue(undefined);
+      const { res } = mockResponse();
+
+      await controller[route](mockRequest({ ...body }) as never, res as never);
+
+      expect(pending).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ apiMode: expectedApiMode }),
+      );
+    },
+  );
+
   it('records the exact provider request and response on its Provider Attempt', async () => {
     recordingCache.isRecording.mockResolvedValue(true);
     const responseBody = {

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -21,7 +21,7 @@ import { StreamUsage } from './stream-writer';
 import { computeTokenCost } from '../../common/utils/cost-calculator';
 import { scrubSecrets } from '../../common/utils/secret-scrub';
 import { CallerAttribution } from './caller-classifier';
-import type { ProviderAttemptRef, ProviderAttemptStart } from './proxy-types';
+import type { ProviderAttemptRef, ProviderAttemptStart, ProxyApiMode } from './proxy-types';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
@@ -173,6 +173,12 @@ export interface ManifestBlockedRequestOpts {
   autofix?: AutofixRecord;
   /** End-to-end time until Manifest returned the rejection. */
   durationMs?: number;
+  /**
+   * The Manifest API surface the caller used. Stamped so a rejection that never
+   * got a pending row (the guard-level M004 path writes the terminal row first)
+   * still names its surface.
+   */
+  apiMode?: ProxyApiMode;
 }
 
 export interface PendingRequestOpts {
@@ -183,6 +189,8 @@ export interface PendingRequestOpts {
   requestedModel?: string;
   callerAttribution?: CallerAttribution | null;
   requestHeaders?: Record<string, string> | null;
+  /** The Manifest API surface the caller used. Persisted to requests.api_mode. */
+  apiMode?: ProxyApiMode;
 }
 
 export interface CancelledRequestOpts {
@@ -329,6 +337,7 @@ function buildRequestRow(
   attempt: Partial<AgentMessage>,
   terminal: boolean,
   autofix?: AutofixRecord,
+  apiMode?: ProxyApiMode,
 ): ManifestRequest {
   const classified = classifyRow(attempt);
   // classifyRow above reads the rich attempt status; the request row stores the
@@ -360,6 +369,7 @@ function buildRequestRow(
     error_origin: terminal ? classified.error_origin : null,
     error_class: terminal ? classified.error_class : null,
     requested_model: attempt.fallback_from_model ?? attempt.model ?? null,
+    api_mode: apiMode ?? null,
     caller_attribution: attempt.caller_attribution ?? null,
     request_headers: attempt.request_headers ?? null,
     request_params: attempt.request_params ?? null,
@@ -439,6 +449,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     attempt: Partial<AgentMessage>,
     terminal: boolean,
     autofix?: AutofixRecord,
+    apiMode?: ProxyApiMode,
   ): Promise<boolean> {
     // Unit-test repository doubles predate the request table. Production
     // repositories always expose manager.getRepository().
@@ -446,9 +457,12 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     if (!getRepository) return false;
     const repo = getRepository(ManifestRequest);
     if (typeof repo.createQueryBuilder !== 'function') return false;
-    const row = buildRequestRow(ctx, requestId, attempt, terminal, autofix);
+    const row = buildRequestRow(ctx, requestId, attempt, terminal, autofix, apiMode);
     const insert = repo.createQueryBuilder().insert().into(ManifestRequest).values(row);
     if (terminal) {
+      // `api_mode` is deliberately absent from the update list: the surface is
+      // known at ingress and never changes, so the pending row's value wins over
+      // a terminal writer that may not have it in scope.
       await insert
         .orUpdate(
           [
@@ -531,6 +545,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
         request_headers: opts.requestHeaders ?? null,
       },
       false,
+      undefined,
+      opts.apiMode,
     );
   }
 
@@ -730,6 +746,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       autofix,
       durationMs,
       attempt,
+      apiMode,
     } = opts;
 
     const canonical = await this.customProviders.canonicalizeAgentMessageKeys(
@@ -768,7 +785,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     // A Manifest-level rejection normally has zero provider attempts. An M302
     // patched retry is real provider work, though, even when Manifest ultimately
     // returns its friendly stub; finish that pending Attempt from the audit.
-    const wroteRequest = await this.persistRequest(ctx, requestId, row, true, autofix);
+    const wroteRequest = await this.persistRequest(ctx, requestId, row, true, autofix, apiMode);
     const retry = getAutofixRetry(autofix);
     if (attempt && retry?.error) {
       await attempt.completeFailure?.({

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -141,6 +141,8 @@ export interface ProviderErrorOpts extends HeaderTierRef {
   requestParams?: RequestParamDefaults | null;
   /** Auto-fix audit when this error was the terminal outcome after healing. */
   autofix?: AutofixRecord;
+  /** API surface to retain when this terminal write creates the Request. */
+  apiMode?: ProxyApiMode;
 }
 
 export type { ManifestBlockedRequestReason };
@@ -236,6 +238,8 @@ export interface FallbackSuccessOpts extends HeaderTierRef {
   requestParams?: RequestParamDefaults | null;
   /** Request-level Auto-fix outcome when a failed retry later fell back. */
   autofix?: AutofixRecord;
+  /** API surface to retain when this terminal write creates the Request. */
+  apiMode?: ProxyApiMode;
 }
 
 export interface SuccessMessageOpts extends HeaderTierRef {
@@ -260,6 +264,8 @@ export interface SuccessMessageOpts extends HeaderTierRef {
   requestParams?: RequestParamDefaults | null;
   /** Auto-fix audit when a healed request succeeded. */
   autofix?: AutofixRecord;
+  /** API surface to retain when this terminal write creates the Request. */
+  apiMode?: ProxyApiMode;
 }
 
 export interface AutofixOriginalOpts extends HeaderTierRef {
@@ -660,6 +666,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       headerTierName,
       headerTierColor,
       autofix,
+      apiMode,
     } = opts ?? {};
     // A real Auto-fix retry must never disappear behind the generic 429
     // deduplication window; it is required to complete the linked attempt story.
@@ -711,7 +718,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       header_tier_name: headerTierName ?? null,
       header_tier_color: headerTierColor ?? null,
     });
-    await this.persistRequest(ctx, requestId, row, true, autofix);
+    await this.persistRequest(ctx, requestId, row, true, autofix, apiMode);
     if (!skipAttempt) await this.persistAttempt(row, attempt);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }
@@ -1048,6 +1055,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       headerTierName,
       headerTierColor,
       autofix,
+      apiMode,
     } = opts ?? {};
 
     const inputTokens = usage?.prompt_tokens ?? 0;
@@ -1104,7 +1112,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       header_tier_name: headerTierName ?? null,
       header_tier_color: headerTierColor ?? null,
     });
-    await this.persistRequest(ctx, requestId, row, true, autofix);
+    await this.persistRequest(ctx, requestId, row, true, autofix, apiMode);
     await this.persistAttempt(row, attempt);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }
@@ -1136,6 +1144,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       headerTierName,
       headerTierColor,
       autofix,
+      apiMode,
     } = opts ?? {};
     const requestId = providedRequestId ?? uuid();
 
@@ -1198,7 +1207,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       header_tier_color: headerTierColor ?? null,
       ...autofixColumns(autofix, 'retry'),
     });
-    await this.persistRequest(ctx, requestId, requestRow, true, autofix);
+    await this.persistRequest(ctx, requestId, requestRow, true, autofix, apiMode);
     await this.persistAttempt(requestRow, attempt);
     this.eventBus.emit(ctx.tenantId, 'message', ctx.userId);
   }

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -225,6 +225,7 @@ export async function handleProviderError(
   autofix?: AutofixRecord,
   requestId: string = uuid(),
   requestDurationMs?: number,
+  apiMode?: ProxyApiMode,
 ): Promise<void> {
   recordAutofixOriginalIfRetried(
     ctx,
@@ -282,6 +283,7 @@ export async function handleProviderError(
       headerTierName: meta.header_tier_name,
       headerTierColor: meta.header_tier_color,
       autofix,
+      apiMode,
     }),
     'provider error',
   );
@@ -845,6 +847,7 @@ export function recordSuccess(
   autofix?: AutofixRecord,
   requestId: string = uuid(),
   attemptNumber: number = currentPrimaryAttemptNumber(autofix),
+  apiMode?: ProxyApiMode,
 ): void {
   if (meta.fallbackFromModel && fallbackSuccessTs) {
     const requestDurationMs = startTime == null ? undefined : Date.now() - startTime;
@@ -871,6 +874,7 @@ export function recordSuccess(
         headerTierName: meta.header_tier_name,
         headerTierColor: meta.header_tier_color,
         autofix,
+        apiMode,
       }),
       'fallback success',
     );
@@ -897,6 +901,7 @@ export function recordSuccess(
         headerTierName: meta.header_tier_name,
         headerTierColor: meta.header_tier_color,
         autofix,
+        apiMode,
       }),
       'success message',
     );

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -263,6 +263,7 @@ export class ProxyController {
         requestedModel: this.extractRequestedModel(body),
         callerAttribution,
         requestHeaders,
+        apiMode,
       })
       .catch((e) => this.logger.warn(`Failed to record pending Request: ${e}`));
 
@@ -341,6 +342,7 @@ export class ProxyController {
           callerAttribution,
           requestHeaders,
           'plan_request_limit_exceeded',
+          apiMode,
           HttpStatus.PAYMENT_REQUIRED,
           'M204',
           Date.now() - startTime,
@@ -524,6 +526,7 @@ export class ProxyController {
           requestHeaders,
           autofix,
           Date.now() - startTime,
+          apiMode,
         );
       } else {
         recordSuccess(
@@ -582,6 +585,7 @@ export class ProxyController {
     requestHeaders: ReturnType<typeof sanitizeRequestHeaders>,
     autofix: AutofixRecord | undefined,
     durationMs: number,
+    apiMode: ProxyApiMode,
   ): void {
     const code = meta.manifest_error_code;
     if (!code || !isRecordableManifestCode(code)) return;
@@ -600,6 +604,7 @@ export class ProxyController {
         autofix,
         attempt: meta.attempt,
         durationMs,
+        apiMode,
       })
       .catch((e) => this.logger.warn(`Failed to record Manifest stub: ${e}`));
   }
@@ -665,6 +670,7 @@ export class ProxyController {
           callerAttribution,
           requestHeaders,
           MANIFEST_CODE_TO_REASON[err.code],
+          apiMode,
           status,
           err.code,
           startTime == null ? undefined : Date.now() - startTime,
@@ -684,6 +690,7 @@ export class ProxyController {
         callerAttribution,
         requestHeaders,
         MANIFEST_CODE_TO_REASON.M500,
+        apiMode,
         status,
         'M500',
         startTime == null ? undefined : Date.now() - startTime,
@@ -874,6 +881,7 @@ export class ProxyController {
     callerAttribution: ReturnType<typeof classifyCaller>,
     requestHeaders: ReturnType<typeof sanitizeRequestHeaders>,
     reason: ManifestBlockedRequestReason,
+    apiMode: ProxyApiMode,
     httpStatus?: number,
     errorCode?: ManifestErrorCode,
     durationMs?: number,
@@ -894,6 +902,7 @@ export class ProxyController {
         callerAttribution,
         requestHeaders,
         durationMs,
+        apiMode,
       })
       .catch((e) => this.logger.warn(`Failed to record Manifest-blocked request: ${e}`));
   }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -460,6 +460,7 @@ export class ProxyController {
           autofix,
           requestId,
           Date.now() - startTime,
+          apiMode,
         );
         return;
       }
@@ -544,6 +545,7 @@ export class ProxyController {
           requestId,
           currentPrimaryAttemptNumber(autofix) +
             (meta.fallbackFromModel ? (failedFallbacks?.length ?? 0) + 1 : 0),
+          apiMode,
         );
       }
     } catch (err: unknown) {
@@ -724,6 +726,7 @@ export class ProxyController {
           callerAttribution,
           requestHeaders,
           requestDurationMs: startTime == null ? undefined : Date.now() - startTime,
+          apiMode,
         })
         .catch((e) => this.logger.warn(`Failed to record provider error: ${e}`));
     }

--- a/packages/backend/test/message-count-consistency.e2e-spec.ts
+++ b/packages/backend/test/message-count-consistency.e2e-spec.ts
@@ -10,16 +10,18 @@ import { createTestApp, TEST_API_KEY, TEST_TENANT_ID, TEST_AGENT_ID } from './he
 
 const OK_COUNT = 5;
 const ERROR_STATUSES = ['error', 'fallback_error', 'rate_limited'] as const;
+// One row per surface, plus a pre-feature row that predates the column.
+const ERROR_API_MODES = ['responses', 'messages', null] as const;
 const REQUEST_COUNT = OK_COUNT + ERROR_STATUSES.length;
 
 let app: INestApplication;
 
-async function insertMessage(ds: DataSource, status: string) {
+async function insertMessage(ds: DataSource, status: string, apiMode: string | null = null) {
   const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
   const requestId = uuid();
   await ds.query(
-    `INSERT INTO requests (id, tenant_id, agent_id, timestamp, status, requested_model, agent_name, user_id)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+    `INSERT INTO requests (id, tenant_id, agent_id, timestamp, status, requested_model, agent_name, user_id, api_mode)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
     [
       requestId,
       TEST_TENANT_ID,
@@ -29,6 +31,7 @@ async function insertMessage(ds: DataSource, status: string) {
       'gpt-4o',
       'test-agent',
       'test-user-001',
+      apiMode,
     ],
   );
   await ds.query(
@@ -58,9 +61,10 @@ beforeAll(async () => {
   app = await createTestApp();
   const ds = app.get(DataSource);
   // Five successful requests…
-  for (let i = 0; i < OK_COUNT; i++) await insertMessage(ds, 'ok');
+  for (let i = 0; i < OK_COUNT; i++) await insertMessage(ds, 'ok', 'chat_completions');
   // …plus one of every error status, each still a caller request.
-  for (const status of ERROR_STATUSES) await insertMessage(ds, status);
+  for (const [i, status] of ERROR_STATUSES.entries())
+    await insertMessage(ds, status, ERROR_API_MODES[i]);
 });
 
 afterAll(async () => {
@@ -100,5 +104,27 @@ describe('message-count consistency (F1)', () => {
       .set('x-api-key', TEST_API_KEY)
       .expect(200);
     expect(res.body.total_count).toBe(REQUEST_COUNT);
+  });
+
+  it('Messages log rows carry the API surface each request came in on', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/messages?range=24h&agent_name=test-agent&limit=50')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    const items = res.body.items as Array<{ api_mode: string | null }>;
+    expect(items).toHaveLength(REQUEST_COUNT);
+    const counts = items.reduce<Record<string, number>>((acc, item) => {
+      const key = item.api_mode ?? 'null';
+      acc[key] = (acc[key] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(counts).toEqual({
+      chat_completions: OK_COUNT,
+      responses: 1,
+      messages: 1,
+      // Rows written before the column existed stay NULL rather than guessing.
+      null: 1,
+    });
   });
 });


### PR DESCRIPTION
### ✨ What changed
- `requests.api_mode` (nullable varchar) stores which proxy surface the request came in on: `chat_completions`, `responses` or `messages`.
- All three proxy routes and the Manifest-blocked/stub writers stamp it; the terminal upsert preserves the ingress value.
- The request log (`GET /api/v1/messages`) returns the field.

### 💭 Why
The surface only existed in proxy memory, so the log could not answer "did this agent hit /v1/messages or /v1/chat/completions". That makes cross-surface debugging (and verifying a platform's integration actually uses its intended API) guess-work, and the old `service_type` column is dead weight with no writer.

### 👤 For users
Request log rows now say which API the caller used. Older rows stay NULL.

### 🔧 For operators
One additive migration (`ADD COLUMN IF NOT EXISTS`, lock_timeout-guarded). No backfill, no env change.

### 📝 Notes
- Stacked on #2676 (same recorder files); merge order #2675 → #2676 → this.
- NULL where the surface is genuinely unknown: guard-level M004 rejections and Playground runs.
- The migration timestamp deliberately skips past the two used by #2673.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the API surface used for each request and include it in the Messages log to help debug cross-surface calls and verify platform integrations. Stamped at ingress and preserved through terminal writes.

- **New Features**
  - Store `api_mode` on requests: `chat_completions`, `responses`, or `messages`.
  - Stamp it at ingress across all proxy routes and Manifest-blocked/stub paths; thread through controller/handler and preserve through terminal upsert.
  - Return `api_mode` in `GET /api/v1/messages` (NULL for legacy rows and Playground runs).

- **Migration**
  - Add nullable `requests.api_mode` (varchar) with a guarded `lock_timeout`.
  - No backfill; older rows stay null. No env changes.

<sup>Written for commit 42702d1669b3eb816bffc2fd665b3f6a2558c8fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

