### PR TITLE
fix: decide the reasoning dialect from the model catalog

### DIFF
--- a/.changeset/zen-reasoning-dialect.md
+++ b/.changeset/zen-reasoning-dialect.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep `reasoning_content` on OpenCode Zen requests. The reasoning dialect is now decided by the models.dev reasoning capability instead of a model-family regex, so Zen's DeepSeek and codename reasoning models replay their thinking while Claude/GPT/Gemini/Grok slugs keep stripping it.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -1296,3 +1296,45 @@ describe('provider-client-converters', () => {
     });
   });
 });
+
+describe('sanitizeOpenAiBody reasoning dialect', () => {
+  const zenCatalog = {
+    isReasoningModel: (_endpointKey: string, model: string) =>
+      model.toLowerCase().endsWith('big-pickle') ? true : undefined,
+  };
+
+  const bodyWithReasoning = () => ({
+    messages: [
+      {
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'upstream thinking',
+        tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+      },
+    ],
+  });
+
+  it('keeps reasoning_content for a Zen model the catalog marks as reasoning', () => {
+    const result = sanitizeOpenAiBody(
+      bodyWithReasoning(),
+      'opencode-zen',
+      'opencode-zen/big-pickle',
+      zenCatalog,
+    );
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBe('upstream thinking');
+  });
+
+  it('still strips reasoning_content for a Zen slug nothing vouches for', () => {
+    const result = sanitizeOpenAiBody(
+      bodyWithReasoning(),
+      'opencode-zen',
+      'opencode-zen/mystery-slug',
+      zenCatalog,
+    );
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBeUndefined();
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -4752,3 +4752,61 @@ describe('ProviderClient', () => {
     });
   });
 });
+
+describe('ProviderClient reasoning catalog', () => {
+  const previousMode = process.env['MANIFEST_MODE'];
+
+  beforeEach(() => {
+    process.env['MANIFEST_MODE'] = 'selfhosted';
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env['MANIFEST_MODE'];
+    else process.env['MANIFEST_MODE'] = previousMode;
+  });
+
+  const reasoningBody = {
+    messages: [
+      {
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'upstream thinking',
+        tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+      },
+    ],
+  };
+
+  it('forwards reasoning_content to Zen when the injected catalog vouches for the model', async () => {
+    const catalogClient = new ProviderClient(undefined, undefined, undefined, {
+      isReasoningModel: () => true,
+    });
+
+    await catalogClient.forward({
+      provider: 'opencode-zen',
+      apiKey: 'zen-token',
+      model: 'opencode-zen/big-pickle',
+      body: reasoningBody,
+      stream: false,
+    });
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.messages[0].reasoning_content).toBe('upstream thinking');
+  });
+
+  it('strips reasoning_content for Zen when no catalog is wired', async () => {
+    const bareClient = new ProviderClient();
+
+    await bareClient.forward({
+      provider: 'opencode-zen',
+      apiKey: 'zen-token',
+      model: 'opencode-zen/big-pickle',
+      body: reasoningBody,
+      stream: false,
+    });
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.messages[0].reasoning_content).toBeUndefined();
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -1461,6 +1461,39 @@ describe('proxy-response-handler', () => {
       );
     });
 
+    it('normalizes Zen reasoning streams when the cache exposes a model catalog', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta({ provider: 'opencode-zen', model: 'opencode-zen/big-pickle' });
+      const reasoningCache = {
+        store: jest.fn(),
+        modelCatalog: { isReasoningModel: () => true },
+      };
+      client.createReasoningContentStreamTransformer.mockReturnValue(jest.fn());
+
+      await handleStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        'sess-zen-stream',
+        undefined,
+        'chat_completions',
+        reasoningCache as any,
+      );
+
+      expect(client.createReasoningContentStreamTransformer).toHaveBeenCalledWith(
+        expect.any(Function),
+        {
+          outputStreamDeltaPaths: ['reasoning_content'],
+          clientStreamDeltaPath: 'reasoning_content',
+        },
+      );
+    });
+
     it('does not configure assistant-message reasoning cache callbacks for streams without tool calls', async () => {
       const { res } = mockResponse();
       const forward = mockForward();
@@ -2166,6 +2199,51 @@ describe('proxy-response-handler', () => {
         'I should call the tool.',
       );
       expect(res.json).toHaveBeenCalledWith(body);
+    });
+
+    it('caches Zen reasoning_content when the cache exposes a model catalog', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const reasoningCache = {
+        store: jest.fn(),
+        modelCatalog: { isReasoningModel: () => true },
+      };
+      const body = {
+        id: 'chatcmpl-zen',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '',
+              reasoning_content: 'zen thinking',
+              tool_calls: [
+                { id: 'call_zen', type: 'function', function: { name: 'x', arguments: '{}' } },
+              ],
+            },
+          },
+        ],
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta({ provider: 'opencode-zen', model: 'opencode-zen/big-pickle' });
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        'sess-zen-json',
+        undefined,
+        'chat_completions',
+        reasoningCache as any,
+      );
+
+      expect(reasoningCache.store).toHaveBeenCalledWith(
+        'sess-zen-json',
+        'call_zen',
+        'zen thinking',
+      );
     });
 
     it('does not cache reasoning_content from compatible non-stream assistant responses without tool calls', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
@@ -3,6 +3,8 @@ import { ModelsDevSyncService } from '../../../database/models-dev-sync.service'
 import { ProviderClient } from '../provider-client';
 import { ReasoningContentCache } from '../reasoning-content-cache';
 import { ModelsDevReasoningCatalog } from '../reasoning-model-catalog';
+import { ProxyModule } from '../proxy.module';
+import { ModelPricesModule } from '../../../model-prices/model-prices.module';
 
 describe('reasoning catalog dependency injection', () => {
   it('hands the models.dev catalog to the cache and the provider client', async () => {
@@ -20,5 +22,23 @@ describe('reasoning catalog dependency injection', () => {
     expect(
       (moduleRef.get(ProviderClient) as unknown as { reasoningCatalog?: unknown }).reasoningCatalog,
     ).toBe(catalog);
+  });
+});
+
+describe('ProxyModule wiring', () => {
+  it('registers the catalog and imports the module that supplies its dependency', () => {
+    // The synthetic module above proves the injection tokens line up. This one
+    // guards the real graph: drop the provider from ProxyModule, or stop
+    // ModelPricesModule exporting ModelsDevSyncService, and every gateway
+    // request silently reverts to the family-regex fallback with no test
+    // failing anywhere else.
+    const providers = Reflect.getMetadata('providers', ProxyModule) as unknown[];
+    expect(providers).toContain(ModelsDevReasoningCatalog);
+
+    const imports = Reflect.getMetadata('imports', ProxyModule) as unknown[];
+    expect(imports).toContain(ModelPricesModule);
+
+    const exported = Reflect.getMetadata('exports', ModelPricesModule) as unknown[];
+    expect(exported).toContain(ModelsDevSyncService);
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-catalog-di.spec.ts
@@ -1,0 +1,24 @@
+import { Test } from '@nestjs/testing';
+import { ModelsDevSyncService } from '../../../database/models-dev-sync.service';
+import { ProviderClient } from '../provider-client';
+import { ReasoningContentCache } from '../reasoning-content-cache';
+import { ModelsDevReasoningCatalog } from '../reasoning-model-catalog';
+
+describe('reasoning catalog dependency injection', () => {
+  it('hands the models.dev catalog to the cache and the provider client', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ReasoningContentCache,
+        ProviderClient,
+        ModelsDevReasoningCatalog,
+        { provide: ModelsDevSyncService, useValue: { lookupModel: () => null } },
+      ],
+    }).compile();
+
+    const catalog = moduleRef.get(ModelsDevReasoningCatalog);
+    expect(moduleRef.get(ReasoningContentCache).modelCatalog).toBe(catalog);
+    expect(
+      (moduleRef.get(ProviderClient) as unknown as { reasoningCatalog?: unknown }).reasoningCatalog,
+    ).toBe(catalog);
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -350,3 +350,62 @@ describe('ReasoningContentCache', () => {
     Date.now = realNow;
   });
 });
+
+describe('ReasoningContentCache catalog wiring', () => {
+  const zenCatalog = {
+    isReasoningModel: (_endpointKey: string, model: string) =>
+      model.toLowerCase().endsWith('big-pickle') ? true : undefined,
+  };
+
+  it('prepares Zen codename tool turns the catalog marks as reasoning', async () => {
+    const cache = new ReasoningContentCache(undefined, zenCatalog);
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.prepareRequest(
+      body,
+      'session-1',
+      'opencode-zen',
+      'opencode-zen/big-pickle',
+    );
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBe('');
+  });
+
+  it('leaves Zen slugs alone when the catalog does not know them', async () => {
+    const cache = new ReasoningContentCache(undefined, zenCatalog);
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await cache.prepareRequest(
+      body,
+      'session-1',
+      'opencode-zen',
+      'opencode-zen/mystery-slug',
+    );
+
+    expect(result).toBe(body);
+  });
+
+  it('answers the reasoning-dialect question for the response handler', () => {
+    const cache = new ReasoningContentCache(undefined, zenCatalog);
+
+    expect(cache.supportsFor('opencode-zen', 'opencode-zen/big-pickle')).toBe(true);
+    expect(cache.supportsFor('opencode-zen', 'opencode-zen/mystery-slug')).toBe(false);
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -401,11 +401,4 @@ describe('ReasoningContentCache catalog wiring', () => {
 
     expect(result).toBe(body);
   });
-
-  it('answers the reasoning-dialect question for the response handler', () => {
-    const cache = new ReasoningContentCache(undefined, zenCatalog);
-
-    expect(cache.supportsFor('opencode-zen', 'opencode-zen/big-pickle')).toBe(true);
-    expect(cache.supportsFor('opencode-zen', 'opencode-zen/mystery-slug')).toBe(false);
-  });
 });

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-format.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-format.spec.ts
@@ -1,0 +1,141 @@
+import {
+  getOpenAiReasoningStreamFormat,
+  supportsReasoningContent,
+  type ReasoningModelCatalog,
+} from '../reasoning-format';
+
+/**
+ * Stub catalog standing in for the models.dev sync cache. `undefined` means the
+ * catalog has never heard of the model, which is what the family-regex fallback
+ * exists for.
+ */
+function catalogOf(entries: Record<string, boolean>): ReasoningModelCatalog {
+  return {
+    isReasoningModel: (_endpointKey: string, model: string) => entries[model.toLowerCase()],
+  };
+}
+
+describe('supportsReasoningContent', () => {
+  describe('opencode-zen', () => {
+    it('preserves reasoning_content for a Zen DeepSeek slug', () => {
+      expect(
+        supportsReasoningContent(
+          'opencode-zen',
+          'opencode-zen/deepseek-v4-flash-free',
+          catalogOf({ 'opencode-zen/deepseek-v4-flash-free': true }),
+        ),
+      ).toBe(true);
+    });
+
+    it('preserves reasoning_content for a Zen codename the catalog marks as reasoning', () => {
+      expect(
+        supportsReasoningContent(
+          'opencode-zen',
+          'opencode-zen/big-pickle',
+          catalogOf({ 'opencode-zen/big-pickle': true }),
+        ),
+      ).toBe(true);
+    });
+
+    it('strips reasoning_content for Zen slugs backed by a translated dialect', () => {
+      const catalog = catalogOf({
+        'opencode-zen/claude-opus-5': true,
+        'opencode-zen/gpt-5.4': true,
+        'opencode-zen/gemini-3-pro': true,
+        'opencode-zen/grok-4.5': true,
+      });
+      for (const model of [
+        'opencode-zen/claude-opus-5',
+        'opencode-zen/gpt-5.4',
+        'opencode-zen/gemini-3-pro',
+        'opencode-zen/grok-4.5',
+      ]) {
+        expect(supportsReasoningContent('opencode-zen', model, catalog)).toBe(false);
+      }
+    });
+
+    it('strips reasoning_content for models the catalog marks as non-reasoning', () => {
+      expect(
+        supportsReasoningContent(
+          'opencode-zen',
+          'opencode-zen/kimi-k2',
+          catalogOf({ 'opencode-zen/kimi-k2': false }),
+        ),
+      ).toBe(false);
+    });
+
+    it('falls back to the reasoning model families when the catalog is unavailable', () => {
+      expect(supportsReasoningContent('opencode-zen', 'opencode-zen/deepseek-v4-flash-free')).toBe(
+        true,
+      );
+      expect(supportsReasoningContent('opencode-zen', 'opencode-zen/big-pickle')).toBe(false);
+    });
+  });
+
+  describe('custom providers', () => {
+    it('preserves reasoning_content for a Kimi slug the catalog marks as reasoning', () => {
+      expect(
+        supportsReasoningContent(
+          'custom:5000149d-71a2-4741-bc52-6a074096e91c',
+          'moonshotai/kimi-k3-free',
+          catalogOf({ 'moonshotai/kimi-k3-free': true }),
+        ),
+      ).toBe(true);
+    });
+
+    it('falls back to the reasoning model families for unknown Kimi slugs', () => {
+      expect(
+        supportsReasoningContent(
+          'custom:5000149d-71a2-4741-bc52-6a074096e91c',
+          'moonshotai/kimi-k3-free',
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('existing behaviour', () => {
+    it('always preserves on the native deepseek and moonshot endpoints', () => {
+      expect(supportsReasoningContent('deepseek', 'deepseek-reasoner')).toBe(true);
+      expect(supportsReasoningContent('moonshot', 'kimi-k2.5')).toBe(true);
+    });
+
+    it('never preserves on strict OpenAI-compatible endpoints', () => {
+      expect(
+        supportsReasoningContent(
+          'mistral',
+          'deepseek-r1-distill',
+          catalogOf({ 'deepseek-r1-distill': true }),
+        ),
+      ).toBe(false);
+    });
+
+    it('preserves OpenRouter moonshotai and deepseek slugs', () => {
+      expect(supportsReasoningContent('openrouter', 'moonshotai/kimi-k2-thinking')).toBe(true);
+      expect(supportsReasoningContent('openrouter', 'deepseek/deepseek-r1')).toBe(true);
+    });
+
+    it('preserves the opencode-go reasoning families', () => {
+      expect(supportsReasoningContent('opencode-go', 'opencode-go/glm-5')).toBe(true);
+      expect(supportsReasoningContent('opencode-go', 'opencode-go/claude-opus-5')).toBe(false);
+    });
+  });
+
+  describe('stream format', () => {
+    it('normalizes reasoning deltas for a Zen model the catalog vouches for', () => {
+      expect(
+        getOpenAiReasoningStreamFormat(
+          'opencode-zen',
+          'opencode-zen/big-pickle',
+          catalogOf({ 'opencode-zen/big-pickle': true }),
+        ),
+      ).toEqual({
+        outputStreamDeltaPaths: ['reasoning_content'],
+        clientStreamDeltaPath: 'reasoning_content',
+      });
+    });
+
+    it('leaves uncatalogued Zen codenames without a reasoning stream format', () => {
+      expect(getOpenAiReasoningStreamFormat('opencode-zen', 'opencode-zen/big-pickle')).toBeNull();
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-format.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-format.spec.ts
@@ -109,6 +109,16 @@ describe('supportsReasoningContent', () => {
       ).toBe(false);
     });
 
+    it('lets the catalog strip an OpenRouter moonshotai model it marks non-reasoning', () => {
+      expect(
+        supportsReasoningContent(
+          'openrouter',
+          'moonshotai/kimi-k2',
+          catalogOf({ 'moonshotai/kimi-k2': false }),
+        ),
+      ).toBe(false);
+    });
+
     it('preserves OpenRouter moonshotai and deepseek slugs', () => {
       expect(supportsReasoningContent('openrouter', 'moonshotai/kimi-k2-thinking')).toBe(true);
       expect(supportsReasoningContent('openrouter', 'deepseek/deepseek-r1')).toBe(true);

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-model-catalog.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-model-catalog.spec.ts
@@ -81,6 +81,21 @@ describe('ModelsDevReasoningCatalog', () => {
     expect(sync.crossProviderLookups).toContain('kimi-k3');
   });
 
+  it('falls back to the cross-provider lookup for aggregators the catalog does not key', () => {
+    // models.dev has no `openrouter` provider, so the endpoint-scoped lookup
+    // always misses; the vendor prefix is what resolves it.
+    const sync = new FakeSync({}, { 'deepseek/deepseek-r1': entry(true) });
+
+    expect(catalogWith(sync).isReasoningModel('openrouter', 'deepseek/deepseek-r1')).toBe(true);
+    expect(sync.crossProviderLookups).toContain('deepseek/deepseek-r1');
+  });
+
+  it('reports an aggregator model the catalog marks non-reasoning as false', () => {
+    const sync = new FakeSync({}, { 'moonshotai/kimi-k2': entry(false) });
+
+    expect(catalogWith(sync).isReasoningModel('openrouter', 'moonshotai/kimi-k2')).toBe(false);
+  });
+
   it('returns undefined when no sync service is wired', () => {
     expect(new ModelsDevReasoningCatalog().isReasoningModel('opencode-zen', 'anything')).toBe(
       undefined,

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-model-catalog.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-model-catalog.spec.ts
@@ -21,7 +21,13 @@ class FakeSync {
   constructor(
     private readonly byProvider: Record<string, ModelsDevModelEntry> = {},
     private readonly byModel: Record<string, ModelsDevModelEntry> = {},
+    /** models.dev keys these endpoints; anything else has no catalog of its own. */
+    private readonly supportedProviders: string[] = ['opencode-zen', 'opencode-go'],
   ) {}
+
+  isProviderSupported(providerId: string): boolean {
+    return this.supportedProviders.includes(providerId);
+  }
 
   lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null {
     this.providerLookups.push([providerId, modelId]);
@@ -94,6 +100,18 @@ describe('ModelsDevReasoningCatalog', () => {
     const sync = new FakeSync({}, { 'moonshotai/kimi-k2': entry(false) });
 
     expect(catalogWith(sync).isReasoningModel('openrouter', 'moonshotai/kimi-k2')).toBe(false);
+  });
+
+  it('stays silent for a gateway models.dev keys, rather than guessing across providers', () => {
+    // A same-named model under an unrelated provider must not answer for Zen:
+    // a definitive false here would strip the field that the family fallback
+    // would have preserved.
+    const sync = new FakeSync({}, { 'glm-5': entry(false) });
+
+    expect(catalogWith(sync).isReasoningModel('opencode-zen', 'opencode-zen/glm-5')).toBe(
+      undefined,
+    );
+    expect(sync.crossProviderLookups).toEqual([]);
   });
 
   it('returns undefined when no sync service is wired', () => {

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-model-catalog.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-model-catalog.spec.ts
@@ -1,0 +1,89 @@
+import { ModelsDevReasoningCatalog } from '../reasoning-model-catalog';
+import type { ModelsDevModelEntry } from '../../../database/models-dev-sync.service';
+
+function entry(reasoning: boolean): ModelsDevModelEntry {
+  return {
+    id: 'stub',
+    name: 'stub',
+    reasoning,
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    capabilities: [],
+    inputModalities: [],
+    outputModalities: [],
+  };
+}
+
+class FakeSync {
+  readonly providerLookups: Array<[string, string]> = [];
+  readonly crossProviderLookups: string[] = [];
+
+  constructor(
+    private readonly byProvider: Record<string, ModelsDevModelEntry> = {},
+    private readonly byModel: Record<string, ModelsDevModelEntry> = {},
+  ) {}
+
+  lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null {
+    this.providerLookups.push([providerId, modelId]);
+    return this.byProvider[`${providerId}:${modelId}`] ?? null;
+  }
+
+  lookupModelAcrossProviders(modelId: string): ModelsDevModelEntry | null {
+    this.crossProviderLookups.push(modelId);
+    return this.byModel[modelId] ?? null;
+  }
+}
+
+function catalogWith(sync: FakeSync): ModelsDevReasoningCatalog {
+  return new ModelsDevReasoningCatalog(sync as never);
+}
+
+describe('ModelsDevReasoningCatalog', () => {
+  it('resolves a gateway slug after stripping the gateway prefix', () => {
+    const sync = new FakeSync({ 'opencode-zen:big-pickle': entry(true) });
+
+    expect(catalogWith(sync).isReasoningModel('opencode-zen', 'opencode-zen/big-pickle')).toBe(
+      true,
+    );
+  });
+
+  it('reports a catalogued non-reasoning model as false', () => {
+    const sync = new FakeSync({ 'opencode-zen:kimi-k2': entry(false) });
+
+    expect(catalogWith(sync).isReasoningModel('opencode-zen', 'opencode-zen/kimi-k2')).toBe(false);
+  });
+
+  it('returns undefined when the catalog has never seen the model', () => {
+    const sync = new FakeSync();
+
+    expect(catalogWith(sync).isReasoningModel('opencode-zen', 'opencode-zen/unknown-slug')).toBe(
+      undefined,
+    );
+  });
+
+  it('keeps the vendor prefix for OpenRouter before falling back to the bare id', () => {
+    const sync = new FakeSync({ 'openrouter:deepseek/deepseek-r1': entry(true) });
+
+    expect(catalogWith(sync).isReasoningModel('openrouter', 'deepseek/deepseek-r1')).toBe(true);
+    expect(sync.providerLookups[0]).toEqual(['openrouter', 'deepseek/deepseek-r1']);
+  });
+
+  it('falls back to the bare id when the vendor-prefixed id is not catalogued', () => {
+    const sync = new FakeSync({ 'opencode-go:glm-5': entry(true) });
+
+    expect(catalogWith(sync).isReasoningModel('opencode-go', 'opencode-go/glm-5')).toBe(true);
+  });
+
+  it('looks a custom provider model up across providers', () => {
+    const sync = new FakeSync({}, { 'kimi-k3': entry(true) });
+
+    expect(catalogWith(sync).isReasoningModel('custom:5000149d', 'moonshotai/kimi-k3')).toBe(true);
+    expect(sync.crossProviderLookups).toContain('kimi-k3');
+  });
+
+  it('returns undefined when no sync service is wired', () => {
+    expect(new ModelsDevReasoningCatalog().isReasoningModel('opencode-zen', 'anything')).toBe(
+      undefined,
+    );
+  });
+});

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -24,6 +24,7 @@ import {
   normalizeOpenAiReasoningDelta,
   type OpenAiReasoningStreamFormat,
   supportsReasoningContent,
+  type ReasoningModelCatalog,
 } from './reasoning-format';
 
 /** Convert a ChatGPT Responses API response to OpenAI format. */
@@ -210,10 +211,15 @@ function supportsReasoningDetails(endpointKey: string): boolean {
   return endpointKey === 'openrouter';
 }
 
-function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: string): unknown {
+function sanitizeOpenAiMessages(
+  messages: unknown,
+  endpointKey: string,
+  model: string,
+  catalog?: ReasoningModelCatalog,
+): unknown {
   if (!Array.isArray(messages)) return messages;
 
-  const preserveReasoningContent = supportsReasoningContent(endpointKey, model);
+  const preserveReasoningContent = supportsReasoningContent(endpointKey, model, catalog);
   const preserveReasoningDetails = supportsReasoningDetails(endpointKey);
   const isMistral = endpointKey === 'mistral';
   const mistralIdMap = new Map<string, string>();
@@ -331,6 +337,7 @@ export function sanitizeOpenAiBody(
   body: Record<string, unknown>,
   endpointKey: string,
   model: string,
+  catalog?: ReasoningModelCatalog,
 ): Record<string, unknown> {
   const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
@@ -343,7 +350,7 @@ export function sanitizeOpenAiBody(
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
     if (key === 'messages') {
-      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model);
+      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model, catalog);
       continue;
     }
     // Rewrite max_tokens → max_completion_tokens for OpenAI-backed endpoints that

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { HttpStatus, Injectable, Logger, Optional } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { OPENAI_RESPONSES_ONLY_RE, stripVendorPrefix } from '../../common/constants/openai-models';
 import { XAI_RESPONSES_ONLY_RE } from '../../common/constants/xai-models';
 import { PROVIDER_ENDPOINTS, ProviderEndpoint, resolveEndpointKey } from './provider-endpoints';
@@ -7,6 +7,8 @@ import { validatePublicUrl } from '../../common/utils/url-validation';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import { resolveSubscriptionEndpointKey } from './provider-hooks';
 import { injectOpenAiMessageCacheControl, injectOpenRouterCacheControl } from './cache-injection';
+import type { ReasoningModelCatalog } from './reasoning-format';
+import { ModelsDevReasoningCatalog } from './reasoning-model-catalog';
 import {
   applyAnthropicAutomaticCacheControl,
   applyAnthropicMessagesMutations,
@@ -230,6 +232,9 @@ export class ProviderClient {
     private readonly modelRegistry?: ProviderModelRegistryService,
     @Optional()
     codexAffinity?: CodexSessionAffinity,
+    @Optional()
+    @Inject(ModelsDevReasoningCatalog)
+    private readonly reasoningCatalog?: ReasoningModelCatalog,
   ) {
     this.codexAffinity = codexAffinity ?? new CodexSessionAffinity();
   }
@@ -670,7 +675,12 @@ export class ProviderClient {
     }
 
     // OpenAI-compatible path (default)
-    const sanitized = sanitizeOpenAiBody(requestSource, endpointKey, ctx.model);
+    const sanitized = sanitizeOpenAiBody(
+      requestSource,
+      endpointKey,
+      ctx.model,
+      this.reasoningCatalog,
+    );
     if (stream && endpoint.streamUsageReporting === 'openai_stream_options') {
       const existing =
         typeof sanitized.stream_options === 'object' && sanitized.stream_options !== null

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -640,7 +640,11 @@ export async function handleStreamResponse(
       relayOptions,
     );
   }
-  const reasoningStreamFormat = getOpenAiReasoningStreamFormat(meta.provider, meta.model);
+  const reasoningStreamFormat = getOpenAiReasoningStreamFormat(
+    meta.provider,
+    meta.model,
+    reasoningCache?.modelCatalog,
+  );
   if (reasoningStreamFormat) {
     const onReasoningContent =
       reasoningCache && sessionKey
@@ -768,7 +772,7 @@ export async function handleNonStreamResponse(
     responseBody = providerClient.collectChatGptSseResponse(sseText, meta.model);
   } else {
     responseBody = await forward.response.json();
-    if (supportsReasoningContent(meta.provider, meta.model)) {
+    if (supportsReasoningContent(meta.provider, meta.model, reasoningCache?.modelCatalog)) {
       cacheReasoningContent(responseBody, reasoningCache, sessionKey);
     }
   }

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -25,6 +25,7 @@ import { CopilotTokenService } from './copilot-token.service';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { ReasoningContentCache } from './reasoning-content-cache';
+import { ModelsDevReasoningCatalog } from './reasoning-model-catalog';
 import { CodexSessionAffinity } from './codex-session-affinity';
 import { ProxyExceptionFilter } from './proxy-exception.filter';
 import { AttemptRecordingService } from './attempt-recording.service';
@@ -56,6 +57,7 @@ import { AttemptRecordingService } from './attempt-recording.service';
     ThoughtSignatureCache,
     ThinkingBlockCache,
     ReasoningContentCache,
+    ModelsDevReasoningCatalog,
     CodexSessionAffinity,
     ProxyExceptionFilter,
     AttemptRecordingService,

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -1,8 +1,9 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { ReasoningContentCacheEntry } from '../../entities/reasoning-content-cache-entry.entity';
-import { supportsReasoningContent } from './reasoning-format';
+import { supportsReasoningContent, type ReasoningModelCatalog } from './reasoning-format';
+import { ModelsDevReasoningCatalog } from './reasoning-model-catalog';
 
 interface CachedReasoningContent {
   content: string;
@@ -41,7 +42,19 @@ export class ReasoningContentCache {
     @Optional()
     @InjectRepository(ReasoningContentCacheEntry)
     private readonly repo?: Repository<ReasoningContentCacheEntry>,
+    @Optional()
+    @Inject(ModelsDevReasoningCatalog)
+    readonly modelCatalog?: ReasoningModelCatalog,
   ) {}
+
+  /**
+   * Whether this (endpoint, model) pair speaks the `reasoning_content`
+   * dialect. The cache owns the question because it owns the catalog handle —
+   * the response handler asks rather than re-deriving it.
+   */
+  supportsFor(endpointKey: string, model: string): boolean {
+    return supportsReasoningContent(endpointKey, model, this.modelCatalog);
+  }
 
   /** Store the reasoning_content string for an assistant tool-call turn. */
   store(sessionKey: string, firstToolCallId: string, content: string): void {
@@ -119,7 +132,7 @@ export class ReasoningContentCache {
     endpointKey: string | null,
     model: string,
   ): Promise<Record<string, unknown>> {
-    if (!endpointKey || !supportsReasoningContent(endpointKey, model)) return body;
+    if (!endpointKey || !this.supportsFor(endpointKey, model)) return body;
     const messages = body.messages;
     if (!Array.isArray(messages)) return body;
 

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -42,19 +42,14 @@ export class ReasoningContentCache {
     @Optional()
     @InjectRepository(ReasoningContentCacheEntry)
     private readonly repo?: Repository<ReasoningContentCacheEntry>,
+    /**
+     * Read by the response handler too, which needs it for the stream-format
+     * question `supportsReasoningContent` alone can't answer.
+     */
     @Optional()
     @Inject(ModelsDevReasoningCatalog)
     readonly modelCatalog?: ReasoningModelCatalog,
   ) {}
-
-  /**
-   * Whether this (endpoint, model) pair speaks the `reasoning_content`
-   * dialect. The cache owns the question because it owns the catalog handle —
-   * the response handler asks rather than re-deriving it.
-   */
-  supportsFor(endpointKey: string, model: string): boolean {
-    return supportsReasoningContent(endpointKey, model, this.modelCatalog);
-  }
 
   /** Store the reasoning_content string for an assistant tool-call turn. */
   store(sessionKey: string, firstToolCallId: string, content: string): void {
@@ -132,7 +127,9 @@ export class ReasoningContentCache {
     endpointKey: string | null,
     model: string,
   ): Promise<Record<string, unknown>> {
-    if (!endpointKey || !this.supportsFor(endpointKey, model)) return body;
+    if (!endpointKey || !supportsReasoningContent(endpointKey, model, this.modelCatalog)) {
+      return body;
+    }
     const messages = body.messages;
     if (!Array.isArray(messages)) return body;
 

--- a/packages/backend/src/routing/proxy/reasoning-format.ts
+++ b/packages/backend/src/routing/proxy/reasoning-format.ts
@@ -96,11 +96,13 @@ export function supportsReasoningContent(
   // are handled.)
   const bare = model.toLowerCase().split('/').pop() ?? '';
   if (TRANSLATED_DIALECT_FAMILY_RE.test(bare)) return false;
+  const catalogued = catalog?.isReasoningModel(endpointKey, model);
+  if (catalogued !== undefined) return catalogued;
+  // Kimi speaks the dialect, so an uncatalogued OpenRouter `moonshotai/*` slug
+  // is preserved. The catalog outranks this: it is a fallback, not an override.
   if (key === 'openrouter' && model.toLowerCase().startsWith('moonshotai/')) {
     return true;
   }
-  const catalogued = catalog?.isReasoningModel(endpointKey, model);
-  if (catalogued !== undefined) return catalogued;
   // OpenRouter exposes community fine-tunes under vendor prefixes, so an
   // uncatalogued slug only counts when the DeepSeek engine is named outright.
   if (key === 'openrouter') return bare.includes('deepseek');

--- a/packages/backend/src/routing/proxy/reasoning-format.ts
+++ b/packages/backend/src/routing/proxy/reasoning-format.ts
@@ -32,10 +32,31 @@ const COPILOT_REASONING_STREAM_FORMAT: OpenAiReasoningStreamFormat = Object.free
  * strict OpenAI-compatible hosts that happen to serve a reasoning-derived
  * community slug and would reject the unknown message field.
  */
-const REASONING_CONTENT_AWARE_ENDPOINTS = new Set(['openrouter', 'opencode-go', 'custom']);
+const REASONING_CONTENT_AWARE_ENDPOINTS = new Set([
+  'openrouter',
+  'opencode-go',
+  'opencode-zen',
+  'custom',
+]);
 
-const OPENCODE_GO_REASONING_MODEL_FAMILY_RE =
-  /^(?:deepseek|kimi|glm|qwen|minimax|mimo)(?:[-_.\d]|$)/i;
+const REASONING_MODEL_FAMILY_RE = /^(?:deepseek|kimi|glm|qwen|minimax|mimo)(?:[-_.\d]|$)/i;
+
+/**
+ * Families a gateway serves by translating to the vendor's own protocol. The
+ * upstream owns the reasoning trace (Anthropic thinking blocks, OpenAI/Gemini
+ * reasoning items) and rejects `reasoning_content` as an unknown message field,
+ * so they are excluded before any capability check — models.dev marks them
+ * `reasoning: true` (they do think), which says nothing about the wire dialect.
+ */
+const TRANSLATED_DIALECT_FAMILY_RE = /^(?:claude|gpt|o\d|gemini|grok)(?:[-_.\d]|$)/i;
+
+/**
+ * Reasoning capability as the model catalog knows it. `undefined` means the
+ * catalog has no entry, which hands the decision back to the family fallback.
+ */
+export interface ReasoningModelCatalog {
+  isReasoningModel(endpointKey: string, model: string): boolean | undefined;
+}
 
 const UNSAFE_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
 
@@ -43,14 +64,23 @@ const UNSAFE_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
  * Some reasoning APIs reject follow-up turns that don't echo back the previous
  * assistant's `reasoning_content`. Preserve it for:
  *  - the native `deepseek` and `moonshot` endpoints (always)
- *  - OpenCode Go's known reasoning model families
- *  - aggregator/proxy endpoints whose `deepseek-*` slugs forward to a DeepSeek
- *    engine, or whose `moonshotai/*` slugs forward to Kimi
- *    (OpenRouter `deepseek/*` / `moonshotai/*` and DeepSeek custom providers).
+ *  - aggregator/gateway endpoints (OpenRouter, OpenCode Go, OpenCode Zen and
+ *    custom OpenAI-compatible providers) serving a reasoning model over the
+ *    DeepSeek dialect.
  * Strict OpenAI-compatible endpoints (Mistral, native OpenAI, etc.) keep
  * stripping the field even if a community fine-tune slug contains "deepseek".
+ *
+ * On a gateway the slug alone can't answer this — Zen serves `big-pickle`
+ * (DeepSeek dialect) and `claude-opus-5` (translated) off the same endpoint —
+ * so the decision is: never for a translated family, then the catalog's
+ * reasoning capability, then the known reasoning families for slugs the
+ * catalog has never seen.
  */
-export function supportsReasoningContent(endpointKey: string, model: string): boolean {
+export function supportsReasoningContent(
+  endpointKey: string,
+  model: string,
+  catalog?: ReasoningModelCatalog,
+): boolean {
   const normalizedEndpoint = endpointKey.toLowerCase();
   const key = normalizedEndpoint.startsWith('custom:') ? 'custom' : normalizedEndpoint;
   if (key === 'deepseek') return true;
@@ -65,23 +95,29 @@ export function supportsReasoningContent(endpointKey: string, model: string): bo
   // practice the custom path passes the already-bare model -- both shapes
   // are handled.)
   const bare = model.toLowerCase().split('/').pop() ?? '';
-  if (key === 'opencode-go') {
-    return OPENCODE_GO_REASONING_MODEL_FAMILY_RE.test(bare);
-  }
+  if (TRANSLATED_DIALECT_FAMILY_RE.test(bare)) return false;
   if (key === 'openrouter' && model.toLowerCase().startsWith('moonshotai/')) {
     return true;
   }
-  return bare.includes('deepseek');
+  const catalogued = catalog?.isReasoningModel(endpointKey, model);
+  if (catalogued !== undefined) return catalogued;
+  // OpenRouter exposes community fine-tunes under vendor prefixes, so an
+  // uncatalogued slug only counts when the DeepSeek engine is named outright.
+  if (key === 'openrouter') return bare.includes('deepseek');
+  return REASONING_MODEL_FAMILY_RE.test(bare);
 }
 
 export function getOpenAiReasoningStreamFormat(
   endpointKey: string,
   model: string,
+  catalog?: ReasoningModelCatalog,
 ): OpenAiReasoningStreamFormat | null {
   const normalizedEndpoint = endpointKey.toLowerCase();
   const key = normalizedEndpoint.startsWith('custom:') ? 'custom' : normalizedEndpoint;
   if (key === 'copilot') return COPILOT_REASONING_STREAM_FORMAT;
-  if (supportsReasoningContent(endpointKey, model)) return STANDARD_OPENAI_REASONING_STREAM_FORMAT;
+  if (supportsReasoningContent(endpointKey, model, catalog)) {
+    return STANDARD_OPENAI_REASONING_STREAM_FORMAT;
+  }
   return null;
 }
 

--- a/packages/backend/src/routing/proxy/reasoning-model-catalog.ts
+++ b/packages/backend/src/routing/proxy/reasoning-model-catalog.ts
@@ -39,10 +39,17 @@ export class ModelsDevReasoningCatalog implements ReasoningModelCatalog {
     const scoped = this.modelsDev.lookupModel(normalizedEndpoint, bare);
     if (scoped) return reasoningOf(scoped);
 
-    // Not every aggregator is a models.dev provider — OpenRouter has no entry of
-    // its own, so an endpoint-scoped lookup can only ever miss. Its ids carry the
-    // vendor prefix (`deepseek/deepseek-r1`), which the cross-provider lookup
-    // resolves against the underlying maker's catalog.
+    // A gateway models.dev keys has already given its answer: a miss means the
+    // catalog does not know this slug, and staying silent hands the decision to
+    // the reasoning-family fallback. Guessing across providers here would let a
+    // same-named model under an unrelated maker return a definitive `false` and
+    // strip a field the fallback would have kept.
+    if (this.modelsDev.isProviderSupported(normalizedEndpoint)) return undefined;
+
+    // Endpoints models.dev does not key at all (OpenRouter) can only ever miss
+    // the scoped lookup. Their ids carry the vendor prefix
+    // (`deepseek/deepseek-r1`), which the cross-provider lookup resolves against
+    // the underlying maker's catalog.
     return reasoningOf(this.modelsDev.lookupModelAcrossProviders(model.toLowerCase()));
   }
 }

--- a/packages/backend/src/routing/proxy/reasoning-model-catalog.ts
+++ b/packages/backend/src/routing/proxy/reasoning-model-catalog.ts
@@ -36,7 +36,14 @@ export class ModelsDevReasoningCatalog implements ReasoningModelCatalog {
     // (`deepseek/deepseek-r1`), the OpenCode gateways don't (`glm-5`).
     const prefixed = this.modelsDev.lookupModel(normalizedEndpoint, model.toLowerCase());
     if (prefixed) return reasoningOf(prefixed);
-    return reasoningOf(this.modelsDev.lookupModel(normalizedEndpoint, bare));
+    const scoped = this.modelsDev.lookupModel(normalizedEndpoint, bare);
+    if (scoped) return reasoningOf(scoped);
+
+    // Not every aggregator is a models.dev provider — OpenRouter has no entry of
+    // its own, so an endpoint-scoped lookup can only ever miss. Its ids carry the
+    // vendor prefix (`deepseek/deepseek-r1`), which the cross-provider lookup
+    // resolves against the underlying maker's catalog.
+    return reasoningOf(this.modelsDev.lookupModelAcrossProviders(model.toLowerCase()));
   }
 }
 

--- a/packages/backend/src/routing/proxy/reasoning-model-catalog.ts
+++ b/packages/backend/src/routing/proxy/reasoning-model-catalog.ts
@@ -1,0 +1,46 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
+import type { ReasoningModelCatalog } from './reasoning-format';
+
+/**
+ * Answers "is this a reasoning model?" from the models.dev cache so gateway
+ * endpoints don't have to guess the engine behind a slug. Zen's `big-pickle`
+ * is a reasoning model no family regex can recognise; `kimi-k2` is a slug that
+ * looks like a reasoning family but isn't one.
+ *
+ * The lookup is synchronous — `ModelsDevSyncService` serves an in-memory map
+ * refreshed daily — so it is safe on the forward path. An unknown model
+ * returns `undefined`, never `false`: "the catalog is silent" and "the catalog
+ * says no" lead to different decisions in `supportsReasoningContent`.
+ */
+@Injectable()
+export class ModelsDevReasoningCatalog implements ReasoningModelCatalog {
+  constructor(
+    @Optional()
+    private readonly modelsDev?: ModelsDevSyncService,
+  ) {}
+
+  isReasoningModel(endpointKey: string, model: string): boolean | undefined {
+    if (!this.modelsDev) return undefined;
+
+    const normalizedEndpoint = endpointKey.toLowerCase();
+    const bare = model.toLowerCase().split('/').pop() ?? '';
+
+    // A custom provider has no models.dev provider id of its own, so fall back
+    // to the conservative model-only lookup.
+    if (normalizedEndpoint.startsWith('custom:')) {
+      return reasoningOf(this.modelsDev.lookupModelAcrossProviders(bare));
+    }
+
+    // Aggregators publish ids both ways: OpenRouter keeps the vendor prefix
+    // (`deepseek/deepseek-r1`), the OpenCode gateways don't (`glm-5`).
+    const prefixed = this.modelsDev.lookupModel(normalizedEndpoint, model.toLowerCase());
+    if (prefixed) return reasoningOf(prefixed);
+    return reasoningOf(this.modelsDev.lookupModel(normalizedEndpoint, bare));
+  }
+}
+
+function reasoningOf(entry: { reasoning?: boolean } | null): boolean | undefined {
+  if (!entry) return undefined;
+  return entry.reasoning === true;
+}


### PR DESCRIPTION
### ✨ What changed

`supportsReasoningContent` now asks the models.dev catalog whether a model reasons, instead of matching the slug against a family regex. Gateway endpoints (OpenRouter, OpenCode Go, OpenCode Zen, custom) first exclude the families a gateway serves by translation (`claude`, `gpt`, `o<n>`, `gemini`, `grok`), then take the catalog's `reasoning` capability, then fall back to the known families for slugs the catalog has never seen. `opencode-zen` joins the aware endpoint set.

The catalog reaches three call paths, wired through an injected `ModelsDevReasoningCatalog`: the strip path (`sanitizeOpenAiMessages`), the replay path (`prepareRequest`), and the stream-capture path (`getOpenAiReasoningStreamFormat`).

### 💭 Why

`opencode-zen` is a separate endpoint key from `opencode-go` and was never in `REASONING_CONTENT_AWARE_ENDPOINTS`, so `sanitizeOpenAiMessages` deleted `reasoning_content` from every Zen request, including the client's own echo. DeepSeek-dialect models on Zen then rejected the follow-up turn with "The `reasoning_content` in the thinking mode must be passed back to the API": 74 failures across 4 tenants in the last three days of prod.

A family regex cannot fix this. Zen serves `big-pickle` (DeepSeek dialect) and `claude-opus-5` (translated) off one endpoint, and codename slugs match no family. The catalog knows `big-pickle` reasons, but it also marks Zen's Claude, GPT and Gemini slugs as reasoning, which is why the translated families are excluded before the capability is consulted.

Skipping the stream-capture path would leave the cache empty, so replay could only ever echo empty strings.

### 👤 For users

Agents on Zen reasoning models keep their thinking across tool turns instead of failing the next request. Zen's Claude, GPT, Gemini and Grok slugs are untouched.

OpenRouter behaviour changes too, beyond the original report. models.dev has no `openrouter` provider, so the endpoint-scoped lookup could only miss and every OpenRouter request fell through to the old `includes('deepseek')` heuristic. Its ids carry the vendor prefix, so the cross-provider lookup now resolves them against the maker's catalog: `qwen/*` thinking models and `z-ai/glm-4.6` preserve `reasoning_content` where they were stripped before, and `moonshotai/kimi-k2` strips because the catalog marks it non-reasoning. Prod shows 1 OpenRouter reasoning error in the last two weeks, so the exposure is small.

### 📝 Notes

Verified against the live models.dev payload and the exact model ids from prod. Nest cannot inject an interface type, so the explicit `@Inject(ModelsDevReasoningCatalog)` token is load-bearing; a test asserts the real `ProxyModule` metadata registers the provider and imports the module that supplies its dependency, checked by removing each in turn.