### PR TITLE
fix: simplify model parameter requests

### DIFF
--- a/.changeset/quick-modelparams-request.md
+++ b/.changeset/quick-modelparams-request.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Simplify model parameter requests with a prefilled GitHub issue.

--- a/packages/frontend/src/components/ModelParamsAffordance.tsx
+++ b/packages/frontend/src/components/ModelParamsAffordance.tsx
@@ -60,12 +60,11 @@ const ModelParamsAffordance: Component<Props> = (props) => {
   const requestUrl = () => {
     if (!props.provider || !props.authType) return undefined;
     const authTypeLabel = props.authType === 'subscription' ? 'Subscription' : 'API key';
+    const modelLabel = `${props.provider}/${props.model}`;
     const params = new URLSearchParams({
-      template: 'parameter-request.yml',
-      title: `${props.provider}/${props.model}: parameter coverage`,
-      provider: props.provider,
-      model: props.model,
-      'auth-type': authTypeLabel,
+      title: `Parameters: ${modelLabel}`,
+      labels: 'parameters',
+      body: `Model: \`${modelLabel}\`\nAuth type: ${authTypeLabel}\n\nPlease add the configurable request parameters for this model.`,
     });
     return `https://github.com/mnfst/modelparams.dev/issues/new?${params.toString()}`;
   };

--- a/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
@@ -61,7 +61,7 @@ describe('ModelParamsAffordance', () => {
     expect(findButton(container)).not.toBeNull();
   });
 
-  it('opens a model with no parameters and links to the request template', async () => {
+  it('opens a model with no parameters and links to a prefilled request', async () => {
     mockGetSpecs.mockResolvedValue([]);
     const { container } = render(() => (
       <ModelParamsAffordance {...baseProps} provider="openai" model="gpt-4o" slotLabel="gpt-4o" />
@@ -86,14 +86,15 @@ describe('ModelParamsAffordance', () => {
     expect(`${url.origin}${url.pathname}`).toBe(
       'https://github.com/mnfst/modelparams.dev/issues/new',
     );
-    expect(url.searchParams.get('template')).toBe('parameter-request.yml');
-    expect(url.searchParams.get('title')).toBe('openai/gpt-4o: parameter coverage');
-    expect(url.searchParams.get('provider')).toBe('openai');
-    expect(url.searchParams.get('model')).toBe('gpt-4o');
-    expect(url.searchParams.get('auth-type')).toBe('API key');
+    expect(url.searchParams.get('template')).toBeNull();
+    expect(url.searchParams.get('title')).toBe('Parameters: openai/gpt-4o');
+    expect(url.searchParams.get('labels')).toBe('parameters');
+    expect(url.searchParams.get('body')).toBe(
+      'Model: `openai/gpt-4o`\nAuth type: API key\n\nPlease add the configurable request parameters for this model.',
+    );
   });
 
-  it('prefills subscription auth type in the request template', async () => {
+  it('prefills subscription auth type in the request body', async () => {
     mockGetSpecs.mockResolvedValue([]);
     const { container } = render(() => (
       <ModelParamsAffordance
@@ -117,8 +118,8 @@ describe('ModelParamsAffordance', () => {
       }),
     )) as HTMLAnchorElement;
     const url = new URL(link.href);
-    expect(url.searchParams.get('title')).toBe('anthropic/claude-sonnet-4-6: parameter coverage');
-    expect(url.searchParams.get('auth-type')).toBe('Subscription');
+    expect(url.searchParams.get('title')).toBe('Parameters: anthropic/claude-sonnet-4-6');
+    expect(url.searchParams.get('body')).toContain('Auth type: Subscription');
   });
 
   it('does not render the button when authType is missing', () => {


### PR DESCRIPTION
### ✨ What changed
- Replace the required parameter form with a prefilled blank modelparams issue.

### 💭 Why
Requesters should not need provider documentation or parameter details.

### 👤 For users
The signed-in GitHub user reviews and submits the prefilled issue.

### 📝 Notes
Closes #2613

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies model parameter requests by replacing the template-based form with a prefilled GitHub issue, so users can submit requests without reading provider docs.

- **New Features**
  - `ModelParamsAffordance` now links to `issues/new` with title "Parameters: provider/model", `labels=parameters`, and a prefilled body with model and auth type.
  - Updated tests to assert the new URL and body format; removed reliance on `parameter-request.yml`.

<sup>Written for commit aee5455690c17d714289455c9ac16944e5ac6333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

