### PR TITLE
fix: route Bedrock models to compatible APIs

### DIFF
--- a/.changeset/bedrock-model-api-surfaces.md
+++ b/.changeset/bedrock-model-api-surfaces.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Route Bedrock OpenAI and Anthropic models through their compatible Responses and Messages API surfaces.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1,6 +1,6 @@
 import { ProviderClient } from '../provider-client';
 import { ManifestError } from '../../../common/errors/manifest-error';
-import { buildCustomEndpoint } from '../provider-endpoints';
+import { buildCustomEndpoint, buildEndpointOverride } from '../provider-endpoints';
 import { ThinkingBlockCache, type ThinkingBlockRouteContext } from '../thinking-block-cache';
 import type { ProviderModelRegistryService } from '../../../model-discovery/provider-model-registry.service';
 
@@ -435,6 +435,95 @@ describe('ProviderClient', () => {
       expect(sentBody.stream).toBe(false);
       expect(result.isAnthropic).toBe(false);
       expect(result.isGoogle).toBe(false);
+    });
+
+    it('routes Bedrock OpenAI models through the Responses API', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'bedrock',
+        apiKey: 'bedrock-api-key-test',
+        model: 'openai.gpt-5.6-luna',
+        body: { ...body, max_tokens: 1024 },
+        stream: false,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://bedrock-mantle.us-east-1.api.aws/v1/responses',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer bedrock-api-key-test',
+            'Content-Type': 'application/json',
+          },
+        }),
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('openai.gpt-5.6-luna');
+      expect(sentBody.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+      ]);
+      expect(sentBody.max_output_tokens).toBe(1024);
+      expect(sentBody.messages).toBeUndefined();
+      expect(sentBody.stream).toBe(false);
+      expect(result.isChatGpt).toBe(true);
+      expect(result.wireApiMode).toBe('responses');
+    });
+
+    it('preserves Bedrock Responses conversion for a selected region', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'bedrock',
+        apiKey: 'bedrock-api-key-test',
+        model: 'openai.gpt-5.6-luna',
+        body: { ...body, max_tokens: 1024 },
+        stream: false,
+        customEndpoint: buildEndpointOverride(
+          'https://bedrock-mantle.eu-west-1.api.aws',
+          'bedrock-responses',
+        ),
+      });
+
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        'https://bedrock-mantle.eu-west-1.api.aws/v1/responses',
+      );
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.max_output_tokens).toBe(1024);
+      expect(sentBody.stream).toBe(false);
+    });
+
+    it('routes Bedrock Anthropic models through the Messages API', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'bedrock',
+        apiKey: 'bedrock-api-key-test',
+        model: 'anthropic.claude-sonnet-5',
+        body,
+        stream: false,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'x-api-key': 'bedrock-api-key-test',
+            'Content-Type': 'application/json',
+            'anthropic-version': '2023-06-01',
+          },
+        }),
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('anthropic.claude-sonnet-5');
+      expect(sentBody.messages).toEqual([
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      ]);
+      expect(result.isAnthropic).toBe(true);
+      expect(result.wireApiMode).toBe('messages');
     });
 
     it('builds correct URL for moonshot', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -2,6 +2,7 @@ import { PROVIDER_REGISTRY } from '../../../common/constants/providers';
 import {
   buildCustomEndpoint,
   buildEndpointOverride,
+  resolveBedrockEndpointKey,
   resolveEndpointKey,
   PROVIDER_ENDPOINTS,
 } from '../provider-endpoints';
@@ -225,6 +226,26 @@ describe('resolveEndpointKey', () => {
         expect(resolveEndpointKey(alias)).not.toBeNull();
       }
     }
+  });
+});
+
+describe('resolveBedrockEndpointKey', () => {
+  it.each(['openai.gpt-5.6-luna', 'us.openai.gpt-5.6-luna', 'bedrock/openai.gpt-5.6-luna'])(
+    'routes %s through Responses',
+    (model) => {
+      expect(resolveBedrockEndpointKey(model)).toBe('bedrock-responses');
+    },
+  );
+
+  it.each(['anthropic.claude-sonnet-5', 'us.anthropic.claude-sonnet-5'])(
+    'routes %s through Messages',
+    (model) => {
+      expect(resolveBedrockEndpointKey(model)).toBe('bedrock-anthropic');
+    },
+  );
+
+  it('keeps other Bedrock model families on Chat Completions', () => {
+    expect(resolveBedrockEndpointKey('mistral.ministral-3-8b-instruct')).toBe('bedrock');
   });
 });
 

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
@@ -168,6 +168,33 @@ describe('resolveForwardEndpoint', () => {
     });
     expect(out.forwardModel).toBe('mistral.ministral-3-8b-instruct');
     expect(out.customEndpoint?.baseUrl).toBe('https://bedrock-mantle.eu-west-1.api.aws');
+    expect(out.customEndpoint?.buildPath(out.forwardModel)).toBe('/v1/chat/completions');
+  });
+
+  it('keeps the selected Bedrock region for OpenAI Responses models', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'bedrock',
+      authType: 'api_key',
+      model: 'openai.gpt-5.6-luna',
+      providerRegion: 'eu-west-1',
+    });
+
+    expect(out.customEndpoint?.baseUrl).toBe('https://bedrock-mantle.eu-west-1.api.aws');
+    expect(out.customEndpoint?.format).toBe('chatgpt');
+    expect(out.customEndpoint?.buildPath(out.forwardModel)).toBe('/v1/responses');
+  });
+
+  it('keeps the selected Bedrock region for Anthropic Messages models', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'bedrock',
+      authType: 'api_key',
+      model: 'anthropic.claude-sonnet-5',
+      providerRegion: 'ap-southeast-2',
+    });
+
+    expect(out.customEndpoint?.baseUrl).toBe('https://bedrock-mantle.ap-southeast-2.api.aws');
+    expect(out.customEndpoint?.format).toBe('anthropic');
+    expect(out.customEndpoint?.buildPath(out.forwardModel)).toBe('/anthropic/v1/messages');
   });
 
   it('sets no qwen override for an unresolved region', () => {

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
@@ -15,6 +15,7 @@ import type { Logger } from '@nestjs/common';
 import {
   buildCustomEndpoint,
   buildEndpointOverride,
+  resolveBedrockEndpointKey,
   resolveEndpointKey,
   type ProviderEndpoint,
 } from './provider-endpoints';
@@ -117,7 +118,10 @@ export function resolveForwardEndpoint(
       forwardModel = CustomProviderService.rawModelName(model);
     }
   } else if (resolveEndpointKey(provider) === 'bedrock' && isBedrockRegion(providerRegion)) {
-    customEndpoint = buildEndpointOverride(getBedrockMantleBaseUrl(providerRegion), 'bedrock');
+    customEndpoint = buildEndpointOverride(
+      getBedrockMantleBaseUrl(providerRegion),
+      resolveBedrockEndpointKey(model),
+    );
   } else if (resolveEndpointKey(provider) === 'qwen' && isQwenResolvedEndpoint(providerRegion)) {
     customEndpoint = buildEndpointOverride(getQwenCompatibleBaseUrl(providerRegion), 'qwen');
   } else if (authType === 'subscription' && lower === 'minimax') {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -2,7 +2,12 @@ import { createHash } from 'crypto';
 import { HttpStatus, Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { OPENAI_RESPONSES_ONLY_RE, stripVendorPrefix } from '../../common/constants/openai-models';
 import { XAI_RESPONSES_ONLY_RE } from '../../common/constants/xai-models';
-import { PROVIDER_ENDPOINTS, ProviderEndpoint, resolveEndpointKey } from './provider-endpoints';
+import {
+  PROVIDER_ENDPOINTS,
+  ProviderEndpoint,
+  resolveBedrockEndpointKey,
+  resolveEndpointKey,
+} from './provider-endpoints';
 import { validatePublicUrl } from '../../common/utils/url-validation';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import { resolveSubscriptionEndpointKey } from './provider-hooks';
@@ -409,6 +414,9 @@ export class ProviderClient {
       const override = resolveSubscriptionEndpointKey(resolved);
       if (override) resolved = override;
     }
+    if (resolved === 'bedrock') {
+      resolved = resolveBedrockEndpointKey(model);
+    }
     if (resolved === 'qwen-subscription') {
       const bareQwenModel = stripVendorPrefix(model);
       if (apiMode === 'responses' || QWEN_TOKEN_PLAN_RESPONSES_RE.test(bareQwenModel)) {
@@ -638,7 +646,9 @@ export class ProviderClient {
             })
           : toResponsesRequest(requestSource, bareModel, {
               stream:
-                endpointKey === 'openai-responses' || endpointKey === 'xai-responses'
+                endpointKey === 'openai-responses' ||
+                endpointKey === 'xai-responses' ||
+                endpoint.forwardResponsesStream
                   ? ctx.stream
                   : undefined,
               // The ChatGPT subscription backend rejects max_output_tokens with
@@ -646,7 +656,8 @@ export class ProviderClient {
               mapMaxOutputTokens:
                 endpointKey === 'openai-responses' ||
                 endpointKey === 'copilot-responses' ||
-                endpointKey === 'xai-responses',
+                endpointKey === 'xai-responses' ||
+                endpoint.acceptsMaxOutputTokens,
               // OpenAI and xAI /responses endpoints accept prompt_cache_key.
               // Other Responses-shaped backends may 400 on unknown params.
               forwardPromptCacheKey:

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -3,6 +3,7 @@ import {
   MANAGED_FREE_PROVIDER_CONFIGS,
 } from '../../common/constants/managed-free-providers';
 import { OLLAMA_CLOUD_HOST, OLLAMA_HOST } from '../../common/constants/ollama';
+import { stripVendorPrefix } from '../../common/constants/openai-models';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
 import {
   CODEX_CLI_ORIGINATOR,
@@ -59,6 +60,10 @@ export interface ProviderEndpoint {
    * endpoints that only reuse the Anthropic protocol shape.
    */
   skipSubscriptionIdentity?: boolean;
+  /** Forward the caller's streaming choice to a Responses-shaped endpoint. */
+  forwardResponsesStream?: boolean;
+  /** Map Chat Completions token caps to `max_output_tokens`. */
+  acceptsMaxOutputTokens?: boolean;
 }
 
 const openaiStreamUsage = { streamUsageReporting: 'openai_stream_options' as const };
@@ -74,6 +79,17 @@ const pioneerHeaders = (apiKey: string) => ({
 });
 
 const openaiPath = () => '/v1/chat/completions';
+const BEDROCK_OPENAI_MODEL_RE = /(?:^|\.)openai\./i;
+const BEDROCK_ANTHROPIC_MODEL_RE = /(?:^|\.)anthropic\./i;
+
+export function resolveBedrockEndpointKey(
+  model: string,
+): 'bedrock' | 'bedrock-responses' | 'bedrock-anthropic' {
+  const bareModel = stripVendorPrefix(model);
+  if (BEDROCK_OPENAI_MODEL_RE.test(bareModel)) return 'bedrock-responses';
+  if (BEDROCK_ANTHROPIC_MODEL_RE.test(bareModel)) return 'bedrock-anthropic';
+  return 'bedrock';
+}
 
 const anthropicHeaders = (apiKey: string, authType?: string): Record<string, string> => {
   if (authType === 'subscription') {
@@ -181,6 +197,21 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: openaiPath,
     format: 'openai',
     ...openaiStreamUsage,
+  },
+  'bedrock-responses': {
+    baseUrl: getBedrockMantleBaseUrl(),
+    buildHeaders: openaiHeaders,
+    buildPath: () => '/v1/responses',
+    format: 'chatgpt',
+    forwardResponsesStream: true,
+    acceptsMaxOutputTokens: true,
+  },
+  'bedrock-anthropic': {
+    baseUrl: getBedrockMantleBaseUrl(),
+    buildHeaders: anthropicApiKeyHeaders,
+    buildPath: () => '/anthropic/v1/messages',
+    format: 'anthropic',
+    skipSubscriptionIdentity: true,
   },
   deepseek: {
     baseUrl: 'https://api.deepseek.com',


### PR DESCRIPTION
### ✨ What changed
- Route Bedrock OpenAI models through Responses.
- Route Bedrock Anthropic models through Messages.
- Preserve model-specific routing for selected regions.

### 💭 Why
Bedrock rejects these models on Chat Completions because they require another API surface.

### 👤 For users
OpenAI and Anthropic Bedrock models no longer fail with an incompatible endpoint error.

### 📝 Notes
Closes #2657

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bedrock routing: OpenAI models now use the Responses API and Anthropic models use the Messages API, preventing incompatible endpoint errors while keeping selected regions. Closes #2657.

- **Bug Fixes**
  - Added Bedrock endpoint keys for Responses and Anthropic Messages with correct paths, headers, and formats.
  - Resolved Bedrock endpoint per model family in the forward resolver and provider client; preserves selected region in overrides.
  - Forwarded stream choice and mapped `max_tokens` to `max_output_tokens` for Bedrock Responses models.
  - Expanded tests to cover model-family routing and regional overrides.

<sup>Written for commit 54ee729c2b55771116bf49b97f0be817fa95556d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

