### PR TITLE
fix: avoid repeated model refreshes in picker

### DIFF
--- a/.changeset/cached-routing-model-picker.md
+++ b/.changeset/cached-routing-model-picker.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Open routing model pickers from cached provider models and refresh stale catalogs only once per browser session each day.

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -119,7 +119,6 @@ const ModelPickerModal: Component<Props> = (props) => {
     props.requiredCapability ? new Set([props.requiredCapability]) : new Set(),
   );
   const [refreshingProvId, setRefreshingProvId] = createSignal<string | null>(null);
-  const [refreshingAll, setRefreshingAll] = createSignal(false);
   // Parent callbacks refetch resources read inside this modal's Suspense
   // boundary. Keep the current picker visible until those resources settle.
   const notifyProviderRefreshed = () => startTransition(() => props.onProviderRefreshed?.());
@@ -136,17 +135,14 @@ const ModelPickerModal: Component<Props> = (props) => {
     );
     if (!needsRefresh) return;
 
-    setRefreshingAll(true);
-    void (async () => {
-      try {
-        await refreshModels(agentName);
-        await notifyProviderRefreshed();
-      } catch {
-        // network/server error toast already raised by fetchMutate
-      } finally {
-        setRefreshingAll(false);
-      }
-    })();
+    const refreshKey = `manifest:routing-model-refresh:${agentName}`;
+    const today = now.toDateString();
+    if (sessionStorage.getItem(refreshKey) === today) return;
+    sessionStorage.setItem(refreshKey, today);
+
+    void refreshModels(agentName)
+      .then(() => notifyProviderRefreshed())
+      .catch(() => undefined);
   });
 
   const toggleCapability = (cap: ModelCapability) => {
@@ -622,7 +618,7 @@ const ModelPickerModal: Component<Props> = (props) => {
                   <Show when={props.agentName && !group.provId.startsWith('custom:')}>
                     <button
                       class="routing-modal__group-refresh"
-                      disabled={refreshingAll() || refreshingProvId() !== null}
+                      disabled={refreshingProvId() !== null}
                       onClick={(e) => {
                         e.stopPropagation();
                         void handleRefreshGroup(group.provId, group.name);
@@ -642,7 +638,7 @@ const ModelPickerModal: Component<Props> = (props) => {
                         aria-hidden="true"
                         classList={{
                           'routing-modal__group-refresh-icon--spinning':
-                            refreshingAll() || refreshingProvId() === group.provId,
+                            refreshingProvId() === group.provId,
                         }}
                       >
                         <path d="M21 12a9 9 0 1 1-3-6.7L21 8" />

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -162,6 +162,7 @@ const tiers: TierAssignment[] = [
 describe('ModelPickerModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
     mockRefreshModels.mockResolvedValue({ ok: true });
     mockRefreshProviderModels.mockResolvedValue({
       ok: true,
@@ -172,14 +173,14 @@ describe('ModelPickerModal', () => {
   });
 
   describe('automatic daily refresh', () => {
-    it('refreshes all provider models when the popup first opens with stale models', async () => {
+    it('refreshes stale models only once per agent and browser session each day', async () => {
       const onProviderRefreshed = vi.fn();
       const staleProviders = apiKeyOnly.map((provider) => ({
         ...provider,
         models_fetched_at: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
       }));
 
-      render(() => (
+      const first = render(() => (
         <ModelPickerModal
           tierId="default"
           agentName="demo-agent"
@@ -197,21 +198,35 @@ describe('ModelPickerModal', () => {
         expect(mockRefreshModels).toHaveBeenCalledWith('demo-agent');
         expect(onProviderRefreshed).toHaveBeenCalledOnce();
       });
-    });
 
-    it('does not refresh again when provider models were already fetched today', async () => {
-      const currentProviders = apiKeyOnly.map((provider) => ({
-        ...provider,
-        models_fetched_at: new Date().toISOString(),
-      }));
-
+      first.unmount();
       render(() => (
         <ModelPickerModal
           tierId="default"
           agentName="demo-agent"
           models={baseModels}
           tiers={[]}
-          connectedProviders={currentProviders}
+          connectedProviders={staleProviders}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+          onProviderRefreshed={onProviderRefreshed}
+        />
+      ));
+
+      await Promise.resolve();
+      expect(mockRefreshModels).toHaveBeenCalledOnce();
+      expect(onProviderRefreshed).toHaveBeenCalledOnce();
+      expect(screen.getByRole('dialog')).toBeDefined();
+    });
+
+    it('does not refresh when provider models were already fetched today', async () => {
+      render(() => (
+        <ModelPickerModal
+          tierId="default"
+          agentName="demo-agent"
+          models={baseModels}
+          tiers={[]}
+          connectedProviders={apiKeyOnly}
           onSelect={vi.fn()}
           onClose={vi.fn()}
         />
@@ -219,6 +234,43 @@ describe('ModelPickerModal', () => {
 
       await Promise.resolve();
       expect(mockRefreshModels).not.toHaveBeenCalled();
+    });
+
+    it('does not retry a failed refresh when the picker reopens that day', async () => {
+      mockRefreshModels.mockRejectedValueOnce(new Error('refresh failed'));
+      const staleProviders = apiKeyOnly.map((provider) => ({
+        ...provider,
+        models_fetched_at: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+      }));
+
+      const first = render(() => (
+        <ModelPickerModal
+          tierId="default"
+          agentName="demo-agent"
+          models={baseModels}
+          tiers={[]}
+          connectedProviders={staleProviders}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+      await waitFor(() => expect(mockRefreshModels).toHaveBeenCalledOnce());
+
+      first.unmount();
+      render(() => (
+        <ModelPickerModal
+          tierId="default"
+          agentName="demo-agent"
+          models={baseModels}
+          tiers={[]}
+          connectedProviders={staleProviders}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+
+      await Promise.resolve();
+      expect(mockRefreshModels).toHaveBeenCalledOnce();
     });
 
     it('stays open while refreshed model data is loading after the user scrolls', async () => {


### PR DESCRIPTION
### ✨ What changed
- Cache automatic model refresh attempts per agent and day.
- Keep cached picker content interactive during background refresh.

### 💭 Why
Stale providers caused model discovery on every picker opening.

### 👤 For users
The picker opens immediately while catalogs still refresh automatically once daily.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop repeated model discovery when opening the routing model picker by caching auto-refresh attempts per agent/day. The modal opens immediately and stays interactive while catalogs refresh in the background.

- **Bug Fixes**
  - Cache auto refreshes in `sessionStorage` using `manifest:routing-model-refresh:${agentName}` set to today’s date.
  - Remove the global “refresh all” lock; only the active provider button is disabled during its refresh.
  - Expand tests to cover once-per-agent/day behavior and keep the picker open while data reloads.

<sup>Written for commit f73771e697495391d9cbea3e3b9f36a8d98ef6d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

